### PR TITLE
feat: add banner action area and button harness

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner.component.html
+++ b/projects/truenas-ui/src/lib/banner/banner.component.html
@@ -3,24 +3,32 @@
   [ngClass]="classes()"
   [attr.role]="ariaRole()"
 >
-  <div class="tn-banner__icon">
-    <tn-icon
-      library="mdi"
-      size="md"
-      aria-hidden="true"
-      [name]="iconName()"
-    />
-  </div>
-
-  <div class="tn-banner__content">
-    <div class="tn-banner__heading">
-      {{ heading() }}
+  <div class="tn-banner__main">
+    <div class="tn-banner__icon">
+      <tn-icon
+        library="mdi"
+        size="md"
+        aria-hidden="true"
+        [name]="iconName()"
+      />
     </div>
 
-    @if (message()) {
-      <div class="tn-banner__message">
-        {{ message() }}
+    <div class="tn-banner__content">
+      <div class="tn-banner__heading">
+        {{ heading() }}
       </div>
-    }
+
+      @if (message()) {
+        <div class="tn-banner__message">
+          {{ message() }}
+        </div>
+      }
+    </div>
   </div>
+
+  @if (hasAction()) {
+    <div class="tn-banner__action">
+      <ng-content select="[tnBannerAction]" />
+    </div>
+  }
 </div>

--- a/projects/truenas-ui/src/lib/banner/banner.component.scss
+++ b/projects/truenas-ui/src/lib/banner/banner.component.scss
@@ -1,7 +1,6 @@
 .tn-banner {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
+  align-items: center;
   padding: 16px;
   border-radius: 6px;
   border-left: 4px solid;
@@ -68,6 +67,14 @@
     }
   }
 
+  &__main {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+  }
+
   &__icon {
     flex-shrink: 0;
     display: flex;
@@ -93,5 +100,13 @@
     color: var(--tn-fg2, #6b7280);
     line-height: 1.5;
     margin-top: 4px;
+  }
+
+  &__action {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-left: auto;
+    padding-left: 16px;
   }
 }

--- a/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
@@ -1,7 +1,29 @@
 import { provideHttpClient } from '@angular/common/http';
+import { Component } from '@angular/core';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
-import { TnBannerComponent } from './banner.component';
+import { TnBannerComponent, TnBannerActionDirective } from './banner.component';
+
+@Component({
+  standalone: true,
+  imports: [TnBannerComponent, TnBannerActionDirective],
+  template: `
+    <tn-banner heading="Test Heading" type="error">
+      <button tnBannerAction>Action Button</button>
+    </tn-banner>
+  `
+})
+class BannerWithActionTestComponent {}
+
+@Component({
+  standalone: true,
+  imports: [TnBannerComponent],
+  template: `
+    <tn-banner heading="Test Heading">
+    </tn-banner>
+  `
+})
+class BannerWithoutActionTestComponent {}
 
 describe('TnBannerComponent', () => {
   let component: TnBannerComponent;
@@ -9,7 +31,7 @@ describe('TnBannerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TnBannerComponent],
+      imports: [TnBannerComponent, BannerWithActionTestComponent, BannerWithoutActionTestComponent],
       providers: [provideHttpClient()]
     }).compileComponents();
 
@@ -18,7 +40,7 @@ describe('TnBannerComponent', () => {
 
     // Set required input
     fixture.componentRef.setInput('heading', 'Test Heading');
-    fixture.detectChanges();
+    fixture.detectChanges(); // Initial render for DOM tests
   });
 
   it('should create', () => {
@@ -32,7 +54,6 @@ describe('TnBannerComponent', () => {
 
     it('should accept custom type', () => {
       fixture.componentRef.setInput('type', 'error');
-      fixture.detectChanges();
       expect(component.type()).toBe('error');
     });
 
@@ -42,7 +63,6 @@ describe('TnBannerComponent', () => {
 
     it('should accept custom message', () => {
       fixture.componentRef.setInput('message', 'Test message');
-      fixture.detectChanges();
       expect(component.message()).toBe('Test message');
     });
   });
@@ -60,21 +80,18 @@ describe('TnBannerComponent', () => {
 
     it('should include warning type class', () => {
       fixture.componentRef.setInput('type', 'warning');
-      fixture.detectChanges();
       const classes = component.classes();
       expect(classes).toContain('tn-banner--warning');
     });
 
     it('should include error type class', () => {
       fixture.componentRef.setInput('type', 'error');
-      fixture.detectChanges();
       const classes = component.classes();
       expect(classes).toContain('tn-banner--error');
     });
 
     it('should include success type class', () => {
       fixture.componentRef.setInput('type', 'success');
-      fixture.detectChanges();
       const classes = component.classes();
       expect(classes).toContain('tn-banner--success');
     });
@@ -93,13 +110,11 @@ describe('TnBannerComponent', () => {
 
     it('should return alert-circle icon for error type', () => {
       fixture.componentRef.setInput('type', 'error');
-      fixture.detectChanges();
       expect(component.iconName()).toBe('alert-circle');
     });
 
     it('should return check-circle icon for success type', () => {
       fixture.componentRef.setInput('type', 'success');
-      fixture.detectChanges();
       expect(component.iconName()).toBe('check-circle');
     });
   });
@@ -117,13 +132,11 @@ describe('TnBannerComponent', () => {
 
     it('should return alert for error type', () => {
       fixture.componentRef.setInput('type', 'error');
-      fixture.detectChanges();
       expect(component.ariaRole()).toBe('alert');
     });
 
     it('should return status for success type', () => {
       fixture.componentRef.setInput('type', 'success');
-      fixture.detectChanges();
       expect(component.ariaRole()).toBe('status');
     });
   });
@@ -136,7 +149,7 @@ describe('TnBannerComponent', () => {
 
     it('should render message when provided', () => {
       fixture.componentRef.setInput('message', 'Test message');
-      fixture.detectChanges();
+      fixture.detectChanges(); // Need to update DOM after input change
 
       const message = fixture.nativeElement.querySelector('.tn-banner__message');
       expect(message).toBeTruthy();
@@ -160,10 +173,41 @@ describe('TnBannerComponent', () => {
 
     it('should apply alert role for error type', () => {
       fixture.componentRef.setInput('type', 'error');
-      fixture.detectChanges();
+      fixture.detectChanges(); // Need to update DOM after input change
 
       const banner = fixture.nativeElement.querySelector('.tn-banner');
       expect(banner.getAttribute('role')).toBe('alert');
+    });
+  });
+
+  describe('action content projection', () => {
+    it('should not render action area when no action content is projected', () => {
+      const hostFixture = TestBed.createComponent(BannerWithoutActionTestComponent);
+      hostFixture.detectChanges();
+
+      const actionArea = hostFixture.nativeElement.querySelector('.tn-banner__action');
+      expect(actionArea).toBeNull();
+    });
+
+    it('should render action area when action content is projected', () => {
+      const hostFixture = TestBed.createComponent(BannerWithActionTestComponent);
+      hostFixture.detectChanges();
+
+      const bannerElement = hostFixture.nativeElement.querySelector('tn-banner');
+      const projectedButton = bannerElement?.querySelector('button');
+      expect(projectedButton).toBeTruthy();
+
+      const actionArea = hostFixture.nativeElement.querySelector('.tn-banner__action');
+      expect(actionArea).toBeTruthy();
+    });
+
+    it('should project action content with tnBannerAction attribute', () => {
+      const hostFixture = TestBed.createComponent(BannerWithActionTestComponent);
+      hostFixture.detectChanges();
+
+      const actionButton = hostFixture.nativeElement.querySelector('[tnBannerAction]');
+      expect(actionButton).toBeTruthy();
+      expect(actionButton.textContent.trim()).toBe('Action Button');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
@@ -19,8 +19,7 @@ class BannerWithActionTestComponent {}
   standalone: true,
   imports: [TnBannerComponent],
   template: `
-    <tn-banner heading="Test Heading">
-    </tn-banner>
+    <tn-banner heading="Test Heading" />
   `
 })
 class BannerWithoutActionTestComponent {}

--- a/projects/truenas-ui/src/lib/banner/banner.component.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, input, inject, computed } from '@angular/core';
+import { Component, input, inject, computed, contentChildren, Directive } from '@angular/core';
 import {
   mdiInformation,
   mdiAlert,
@@ -10,6 +10,23 @@ import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconComponent } from '../icon/icon.component';
 
 export type TnBannerType = 'info' | 'warning' | 'error' | 'success';
+
+/**
+ * Directive to mark an element as a banner action.
+ * Apply this to any element that should appear in the banner's action area.
+ *
+ * @example
+ * ```html
+ * <tn-banner heading="Error">
+ *   <button tnBannerAction>Fix Now</button>
+ * </tn-banner>
+ * ```
+ */
+@Directive({
+  selector: '[tnBannerAction]',
+  standalone: true,
+})
+export class TnBannerActionDirective {}
 
 const ICON_MAP = {
   'info': 'information',
@@ -27,6 +44,12 @@ const ICON_MAP = {
 })
 export class TnBannerComponent {
   private iconRegistry = inject(TnIconRegistryService);
+
+  /** Query for projected action content */
+  private actionContent = contentChildren(TnBannerActionDirective);
+
+  /** Signal indicating whether action content has been projected */
+  protected hasAction = computed(() => this.actionContent().length > 0);
 
   // Signal-based inputs (modern Angular 19+)
   heading = input.required<string>();

--- a/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
@@ -2,7 +2,7 @@ import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { Component, signal } from '@angular/core';
-import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TnBannerComponent } from './banner.component';
 import { TnBannerHarness } from './banner.harness';
@@ -53,8 +53,6 @@ describe('TnBannerHarness', () => {
 
     fixture = TestBed.createComponent(TestHostComponent);
     hostComponent = fixture.componentInstance;
-    fixture.detectChanges();
-
     loader = TestbedHarnessEnvironment.loader(fixture);
   });
 
@@ -63,82 +61,72 @@ describe('TnBannerHarness', () => {
     expect(bannerElement).toBeTruthy();
   });
 
-  it('should load harness', fakeAsync(async () => {
-    flush();
+  it('should load harness', async () => {
     const banner = await loader.getHarness(TnBannerHarness);
     expect(banner).toBeTruthy();
-  }));
+  });
 
-  it('should get text content', fakeAsync(async () => {
+  it('should get text content', async () => {
     hostComponent.heading.set('Error');
     hostComponent.message.set('Connection failed');
-    fixture.detectChanges();
-    flush();
 
     const banner = await loader.getHarness(TnBannerHarness);
     const text = await banner.getText();
     expect(text).toContain('Error');
     expect(text).toContain('Connection failed');
-  }));
+  });
 
-  it('should get text with heading only', fakeAsync(async () => {
+  it('should get text with heading only', async () => {
     hostComponent.heading.set('Success!');
-    fixture.detectChanges();
-    flush();
 
     const banner = await loader.getHarness(TnBannerHarness);
     expect(await banner.getText()).toBe('Success!');
-  }));
+  });
 
-  it('should filter by text content', fakeAsync(async () => {
+  it('should filter by text content', async () => {
     hostComponent.heading.set('Success');
     fixture.detectChanges();
-    flush();
+    await fixture.whenStable();
 
     const banner = await loader.getHarness(
       TnBannerHarness.with({ textContains: 'Success' })
     );
     expect(banner).toBeTruthy();
-  }));
+  });
 
-  it('should support regex matching', fakeAsync(async () => {
+  it('should support regex matching', async () => {
     hostComponent.message.set('Error: timeout occurred');
     fixture.detectChanges();
-    flush();
 
     const banner = await loader.getHarness(
       TnBannerHarness.with({ textContains: /Error:/ })
     );
     expect(banner).toBeTruthy();
-  }));
+  });
 
-  it('should support case-insensitive regex', fakeAsync(async () => {
+  it('should support case-insensitive regex', async () => {
     hostComponent.heading.set('Success');
     fixture.detectChanges();
-    flush();
 
     const banner = await loader.getHarness(
       TnBannerHarness.with({ textContains: /success/i })
     );
     expect(banner).toBeTruthy();
-  }));
+  });
 
-  it('should check if harness exists', fakeAsync(async () => {
+  it('should check if harness exists', async () => {
     hostComponent.heading.set('Info');
-    fixture.detectChanges();
-    flush();
 
     expect(await loader.hasHarness(TnBannerHarness)).toBe(true);
-  }));
+  });
 
-  it('should return false when harness with text does not exist', fakeAsync(async () => {
+  it('should return false when harness with text does not exist', async () => {
     hostComponent.heading.set('Test');
     fixture.detectChanges();
-    flush();
 
     expect(await loader.hasHarness(TnBannerHarness)).toBe(true);
     expect(await loader.hasHarness(
       TnBannerHarness.with({ textContains: 'NonExistentText12345' })
     )).toBe(false);
-  }));
+  });
 });

--- a/projects/truenas-ui/src/lib/button/button.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.spec.ts
@@ -1,0 +1,142 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnButtonComponent } from './button.component';
+import { TnButtonHarness } from './button.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnButtonComponent],
+  template: `<tn-button [label]="label()" [disabled]="disabled()" (onClick)="handleClick($event)" />`
+})
+class TestHostComponent {
+  label = signal('Test Button');
+  disabled = signal(false);
+  clickCount = 0;
+
+  handleClick(_event: MouseEvent): void {
+    this.clickCount++;
+  }
+}
+
+describe('TnButtonHarness', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should verify element exists in DOM', () => {
+    const buttonElement = fixture.nativeElement.querySelector('tn-button');
+    expect(buttonElement).toBeTruthy();
+  });
+
+  it('should load harness', async () => {
+    const button = await loader.getHarness(TnButtonHarness);
+    expect(button).toBeTruthy();
+  });
+
+  describe('getLabel', () => {
+    it('should get button label', async () => {
+      hostComponent.label.set('Save');
+
+      const button = await loader.getHarness(TnButtonHarness);
+      const label = await button.getLabel();
+      expect(label).toBe('Save');
+    });
+
+    it('should get updated label after change', async () => {
+      hostComponent.label.set('Initial');
+
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.getLabel()).toBe('Initial');
+
+      hostComponent.label.set('Updated');
+
+      expect(await button.getLabel()).toBe('Updated');
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('should return false when button is enabled', async () => {
+      hostComponent.disabled.set(false);
+
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.isDisabled()).toBe(false);
+    });
+
+    it('should return true when button is disabled', async () => {
+      hostComponent.disabled.set(true);
+
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('click', () => {
+    it('should trigger click handler', async () => {
+      expect(hostComponent.clickCount).toBe(0);
+
+      const button = await loader.getHarness(TnButtonHarness);
+      await button.click();
+
+      expect(hostComponent.clickCount).toBe(1);
+    });
+
+    it('should trigger multiple clicks', async () => {
+      const button = await loader.getHarness(TnButtonHarness);
+
+      await button.click();
+      await button.click();
+      await button.click();
+
+      expect(hostComponent.clickCount).toBe(3);
+    });
+  });
+
+  describe('with() filter', () => {
+    it('should filter by exact label', async () => {
+      hostComponent.label.set('Delete');
+
+      const button = await loader.getHarness(TnButtonHarness.with({ label: 'Delete' }));
+      expect(button).toBeTruthy();
+    });
+
+    it('should filter by regex pattern', async () => {
+      hostComponent.label.set('Cancel Action');
+
+      const button = await loader.getHarness(TnButtonHarness.with({ label: /Cancel/ }));
+      expect(button).toBeTruthy();
+    });
+
+    it('should support case-insensitive regex', async () => {
+      hostComponent.label.set('SUBMIT');
+
+      const button = await loader.getHarness(TnButtonHarness.with({ label: /submit/i }));
+      expect(button).toBeTruthy();
+    });
+  });
+
+  describe('hasHarness', () => {
+    it('should return true when button exists', async () => {
+      expect(await loader.hasHarness(TnButtonHarness)).toBe(true);
+    });
+
+    it('should return false when button with label does not exist', async () => {
+      hostComponent.label.set('Save');
+
+      expect(await loader.hasHarness(TnButtonHarness.with({ label: 'NonExistent' }))).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/button/button.harness.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.ts
@@ -1,0 +1,109 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with tn-button in tests.
+ * Provides methods for querying button state and simulating user interactions.
+ *
+ * @example
+ * ```typescript
+ * // Find and click a button
+ * const saveBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+ * await saveBtn.click();
+ *
+ * // Check if button is disabled
+ * const submitBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Submit' }));
+ * expect(await submitBtn.isDisabled()).toBe(false);
+ *
+ * // Find button by regex
+ * const cancelBtn = await loader.getHarness(TnButtonHarness.with({ label: /Cancel/i }));
+ * ```
+ */
+export class TnButtonHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnButtonComponent` instance.
+   */
+  static hostSelector = 'tn-button';
+
+  private _button = this.locatorFor('button');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a button
+   * with specific attributes.
+   *
+   * @param options Options for filtering which button instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find button by exact label
+   * const button = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+   *
+   * // Find button with regex pattern
+   * const button = await loader.getHarness(TnButtonHarness.with({ label: /Delete/i }));
+   * ```
+   */
+  static with(options: ButtonHarnessFilters = {}) {
+    return new HarnessPredicate(TnButtonHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabel(), label)
+      );
+  }
+
+  /**
+   * Gets the button's label text.
+   *
+   * @returns Promise resolving to the button's text content.
+   *
+   * @example
+   * ```typescript
+   * const button = await loader.getHarness(TnButtonHarness);
+   * const label = await button.getLabel();
+   * expect(label).toBe('Submit');
+   * ```
+   */
+  async getLabel(): Promise<string> {
+    const button = await this._button();
+    return (await button.text()).trim();
+  }
+
+  /**
+   * Checks whether the button is disabled.
+   *
+   * @returns Promise resolving to true if the button is disabled.
+   *
+   * @example
+   * ```typescript
+   * const button = await loader.getHarness(TnButtonHarness.with({ label: 'Submit' }));
+   * expect(await button.isDisabled()).toBe(false);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const button = await this._button();
+    return (await button.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Clicks the button.
+   *
+   * @returns Promise that resolves when the click action is complete.
+   *
+   * @example
+   * ```typescript
+   * const button = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+   * await button.click();
+   * ```
+   */
+  async click(): Promise<void> {
+    const button = await this._button();
+    return button.click();
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnButtonHarness` instances.
+ */
+export interface ButtonHarnessFilters extends BaseHarnessFilters {
+  /** Filters by button label text. Supports string or regex matching. */
+  label?: string | RegExp;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -6,6 +6,7 @@ export * from './lib/disk-icon/disk-icon.component';
 export * from './lib/banner/banner.component';
 export * from './lib/banner/banner.harness';
 export * from './lib/button/button.component';
+export * from './lib/button/button.harness';
 export * from './lib/icon-button/icon-button.component';
 export * from './lib/input/input.component';
 export * from './lib/input/input.directive';

--- a/projects/truenas-ui/src/stories/banner.stories.ts
+++ b/projects/truenas-ui/src/stories/banner.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
-import { TnBannerComponent } from '../lib/banner/banner.component';
+import { TnBannerComponent, TnBannerActionDirective } from '../lib/banner/banner.component';
+import { TnButtonComponent } from '../lib/button/button.component';
 import { tnIconMarker } from '../lib/icon/icon-marker';
 
 // Mark icons for sprite generation (since they're computed dynamically)
@@ -92,6 +93,40 @@ export const LongContent: Story = {
     message: 'A new system update is available that includes critical security patches, performance improvements, and bug fixes. We recommend installing this update at your earliest convenience to ensure optimal system security and stability. The update process will take approximately 15-20 minutes and may require a system restart.',
     type: 'warning',
   },
+};
+
+export const WithActionButton: Story = {
+  render: () => ({
+    moduleMetadata: {
+      imports: [TnBannerComponent, TnBannerActionDirective, TnButtonComponent],
+    },
+    template: `
+      <tn-banner
+        heading="Disk Error Detected"
+        message="Pool 'tank' has degraded disks that need attention."
+        type="error">
+        <tn-button tnBannerAction label="Show Me" variant="outline" color="warn"></tn-button>
+      </tn-banner>
+    `,
+  }),
+};
+
+export const WithActionLink: Story = {
+  render: () => ({
+    moduleMetadata: {
+      imports: [TnBannerComponent, TnBannerActionDirective],
+    },
+    template: `
+      <tn-banner
+        heading="Learn More About Storage"
+        message="Explore our documentation for best practices."
+        type="info">
+        <a tnBannerAction href="#" style="color: var(--tn-info, #3b82f6); text-decoration: underline;">
+          View Documentation
+        </a>
+      </tn-banner>
+    `,
+  }),
 };
 
 export const MultipleTypes: Story = {

--- a/projects/truenas-ui/src/stories/button.stories.ts
+++ b/projects/truenas-ui/src/stories/button.stories.ts
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, userEvent, within } from 'storybook/test';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
+
+// Load harness documentation
+const harnessDoc = loadHarnessDoc('button');
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
 const meta: Meta<TnButtonComponent> = {
@@ -118,4 +122,22 @@ export const OutlineWarn: Story = {
     await expect(outlineWarnButton.classList.contains('button-outline-warn')).toBe(true);
     await userEvent.click(outlineWarnButton);
   },
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
 };


### PR DESCRIPTION
- Add optional action area to banner component using content projection
- Create TnButtonHarness for testing button components
- Update banner styling to vertically center action buttons with content
- Add banner action examples to Storybook (button and link)
- Simplify test patterns using Component Harness best practices
- Export button harness in public API