### PR TITLE
fix: use triple-slash directive instead of importing jest

### DIFF
--- a/projects/truenas-ui/src/lib/icon/icon-testing.ts
+++ b/projects/truenas-ui/src/lib/icon/icon-testing.ts
@@ -1,5 +1,6 @@
+/// <reference types="jest" />
+
 import type { Provider } from '@angular/core';
-import { jest } from '@jest/globals';
 import { TnIconRegistryService } from './icon-registry.service';
 import { TnSpriteLoaderService } from './sprite-loader.service';
 


### PR DESCRIPTION
The previous approach using `import { jest } from '@jest/globals'` created a runtime dependency that failed in consumer applications with: "Do not import @jest/globals outside of the Jest test environment"

The triple-slash directive `/// <reference types="jest" />` provides Jest types during TypeScript compilation without creating a runtime import in the bundled library output. This is the correct approach for testing utilities that are exported from libraries.

Verified:
- Build passes
- All 8 icon-testing tests pass
- No @jest/globals import in dist output