### PR TITLE
feat(icon): Add fullSize input to TnIconComponent

### DIFF
--- a/projects/truenas-ui/src/lib/icon/icon.component.html
+++ b/projects/truenas-ui/src/lib/icon/icon.component.html
@@ -1,7 +1,7 @@
 <div
   class="tn-icon"
   role="img"
-  [ngClass]="'tn-icon--' + size()"
+  [ngClass]="fullSize() ? 'tn-icon--full' : 'tn-icon--' + size()"
   [style.color]="color()"
   [attr.aria-label]="effectiveAriaLabel()"
   [attr.title]="tooltip()">

--- a/projects/truenas-ui/src/lib/icon/icon.component.scss
+++ b/projects/truenas-ui/src/lib/icon/icon.component.scss
@@ -34,6 +34,12 @@
     height: var(--tn-icon-xl) !important;
     font-size: var(--tn-icon-xl) !important;
   }
+
+  // Full size - expands to fill container
+  &--full {
+    width: 100% !important;
+    height: 100% !important;
+  }
   
   // Icon content containers
   &__sprite {

--- a/projects/truenas-ui/src/lib/icon/icon.component.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.ts
@@ -27,7 +27,8 @@ export interface IconResult {
     '[attr.name]': 'name()',
     '[attr.library]': 'library()',
     '[attr.size]': 'size()',
-    '[attr.color]': 'color()'
+    '[attr.color]': 'color()',
+    '[attr.full-size]': 'fullSize() || null'
   }
 })
 export class TnIconComponent implements AfterViewInit {
@@ -37,6 +38,12 @@ export class TnIconComponent implements AfterViewInit {
   tooltip = input<string | undefined>(undefined);
   ariaLabel = input<string | undefined>(undefined);
   library = input<IconLibraryType | undefined>(undefined);
+
+  /**
+   * When true, the icon will expand to fill its container (100% width and height)
+   * instead of using the fixed size from the `size` input.
+   */
+  fullSize = input(false);
 
   svgContainer = viewChild<ElementRef<HTMLDivElement>>('svgContainer');
 

--- a/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
@@ -18,6 +18,7 @@ import { TnIconHarness } from './icon.harness';
     [library]="library()"
     [size]="size()"
     [color]="color()"
+    [fullSize]="fullSize()"
     (click)="onIconClick()"
   />`
 })
@@ -27,6 +28,7 @@ class TestHostComponent {
   library = signal<IconLibraryType | undefined>(undefined);
   size = signal<IconSize>('md');
   color = signal<string | undefined>(undefined);
+  fullSize = signal(false);
   clickCount = 0;
 
   onIconClick(): void {
@@ -183,6 +185,37 @@ describe('TnIconHarness', () => {
     });
   });
 
+  describe('isFullSize', () => {
+    it('should return false when fullSize is not set', async () => {
+      hostComponent.fullSize.set(false);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.isFullSize()).toBe(false);
+    });
+
+    it('should return true when fullSize is true', async () => {
+      hostComponent.fullSize.set(true);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.isFullSize()).toBe(true);
+    });
+
+    it('should get updated fullSize after change', async () => {
+      hostComponent.fullSize.set(false);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.isFullSize()).toBe(false);
+
+      hostComponent.fullSize.set(true);
+      fixture.detectChanges();
+
+      expect(await icon.isFullSize()).toBe(true);
+    });
+  });
+
   describe('with() filter', () => {
     it('should filter by exact name', async () => {
       hostComponent.name.set('check');
@@ -219,6 +252,22 @@ describe('TnIconHarness', () => {
         library: 'lucide',
         size: 'lg'
       }));
+      expect(icon).toBeTruthy();
+    });
+
+    it('should filter by fullSize', async () => {
+      hostComponent.fullSize.set(true);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness.with({ fullSize: true }));
+      expect(icon).toBeTruthy();
+    });
+
+    it('should filter by fullSize=false', async () => {
+      hostComponent.fullSize.set(false);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness.with({ fullSize: false }));
       expect(icon).toBeTruthy();
     });
   });

--- a/projects/truenas-ui/src/lib/icon/icon.harness.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.ts
@@ -73,6 +73,9 @@ export class TnIconHarness extends ComponentHarness {
       })
       .addOption('size', options.size, async (harness, size) => {
         return (await harness.getSize()) === size;
+      })
+      .addOption('fullSize', options.fullSize, async (harness, fullSize) => {
+        return (await harness.isFullSize()) === fullSize;
       });
   }
 
@@ -145,6 +148,24 @@ export class TnIconHarness extends ComponentHarness {
   }
 
   /**
+   * Checks if the icon is in full-size mode.
+   *
+   * @returns Promise resolving to true if the icon is full-size, false otherwise.
+   *
+   * @example
+   * ```typescript
+   * const icon = await loader.getHarness(TnIconHarness);
+   * const isFullSize = await icon.isFullSize();
+   * expect(isFullSize).toBe(true);
+   * ```
+   */
+  async isFullSize(): Promise<boolean> {
+    const host = await this.host();
+    const fullSizeAttr = await host.getAttribute('full-size');
+    return fullSizeAttr === 'true';
+  }
+
+  /**
    * Clicks the icon.
    *
    * @returns Promise that resolves when the click action is complete.
@@ -171,4 +192,6 @@ export interface IconHarnessFilters extends BaseHarnessFilters {
   library?: string;
   /** Filters by icon size (xs, sm, md, lg, xl). */
   size?: string;
+  /** Filters by full-size mode. */
+  fullSize?: boolean;
 }

--- a/projects/truenas-ui/src/stories/icon.stories.ts
+++ b/projects/truenas-ui/src/stories/icon.stories.ts
@@ -121,6 +121,10 @@ Then use: \`<tn-icon name="home" library="lucide"></tn-icon>\`
       control: 'text',
       description: 'Accessibility label for screen readers',
     },
+    fullSize: {
+      control: 'boolean',
+      description: 'When true, the icon expands to fill its container (100% width and height) instead of using the fixed size',
+    },
   },
   decorators: [
     (story) => {
@@ -389,6 +393,80 @@ export const SizesAndColors: Story = {
     docs: {
       description: {
         story: 'Demonstration of different sizes and color customization options for MDI icons.',
+      },
+    },
+  },
+};
+
+export const FullSize: Story = {
+  render: () => ({
+    template: `
+      <div style="padding: 20px;">
+        <h4>Full Size Mode</h4>
+        <p style="margin-bottom: 16px; color: var(--text-secondary, #666);">
+          When <code>[fullSize]="true"</code>, the icon expands to fill its container instead of using fixed dimensions.
+          This is useful for logos, splash screens, or when you need the icon to scale with its parent element.
+        </p>
+
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 24px;">
+          <div style="text-align: center;">
+            <div style="width: 48px; height: 48px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+              <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
+            </div>
+            <div style="margin-top: 8px; font-size: 12px;">48×48 container</div>
+          </div>
+          <div style="text-align: center;">
+            <div style="width: 80px; height: 80px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+              <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
+            </div>
+            <div style="margin-top: 8px; font-size: 12px;">80×80 container</div>
+          </div>
+          <div style="text-align: center;">
+            <div style="width: 120px; height: 120px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+              <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
+            </div>
+            <div style="margin-top: 8px; font-size: 12px;">120×120 container</div>
+          </div>
+        </div>
+
+        <h4>Comparison: Fixed Size vs Full Size</h4>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px;">
+          <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+            <h5 style="margin-top: 0;">Fixed Size (default)</h5>
+            <div style="width: 100px; height: 100px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+              <tn-icon name="server" library="mdi" size="lg"></tn-icon>
+            </div>
+            <code style="display: block; margin-top: 8px; font-size: 11px;">size="lg"</code>
+            <div style="font-size: 12px; color: var(--text-secondary, #666);">Icon stays at fixed lg size</div>
+          </div>
+          <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+            <h5 style="margin-top: 0;">Full Size</h5>
+            <div style="width: 100px; height: 100px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+              <tn-icon name="server" library="mdi" [fullSize]="true"></tn-icon>
+            </div>
+            <code style="display: block; margin-top: 8px; font-size: 11px;">[fullSize]="true"</code>
+            <div style="font-size: 12px; color: var(--text-secondary, #666);">Icon fills container</div>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: `The \`fullSize\` input allows the icon to expand to fill its container (100% width and height) instead of using a fixed size.
+
+**Use cases:**
+- Logo displays in headers or splash screens
+- Icons that need to scale with responsive containers
+- Card or tile icons that should fill their allocated space
+
+**Usage:**
+\`\`\`html
+<tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
+\`\`\`
+
+**Note:** When \`fullSize\` is true, the \`size\` input is ignored.`,
       },
     },
   },


### PR DESCRIPTION
- Add fullSize input signal (boolean, default false)
- When true, icon expands to fill container (100% width/height)
- Add tn-icon--full CSS class for full-size styling
- Add isFullSize() method and fullSize filter to TnIconHarness
- Refactor tests to use TnIconTesting.jest.providers()
- Add Storybook story demonstrating fullSize feature