### PR TITLE
feat(select): add CDK component testing harness

### DIFF
--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -1,0 +1,208 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { TnSelectOption } from './select.component';
+import { TnSelectComponent } from './select.component';
+import { TnSelectHarness } from './select.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSelectComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      [options]="options()"
+      [placeholder]="placeholder()"
+      [disabled]="disabled()"
+      (selectionChange)="handleSelection($event)" />
+  `
+})
+class TestHostComponent {
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ]);
+  placeholder = signal('Select a fruit');
+  disabled = signal(false);
+  selectedValue: string | null = null;
+
+  handleSelection(value: string): void {
+    this.selectedValue = value;
+  }
+}
+
+describe('TnSelectHarness', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(select).toBeTruthy();
+  });
+
+  describe('getDisplayText', () => {
+    it('should return placeholder when no option is selected', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      expect(await select.getDisplayText()).toBe('Select a fruit');
+    });
+
+    it('should return selected option label after selection', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.selectOption('Banana');
+      expect(await select.getDisplayText()).toBe('Banana');
+    });
+
+    it('should reflect updated placeholder', async () => {
+      hostComponent.placeholder.set('Pick one');
+
+      const select = await loader.getHarness(TnSelectHarness);
+      expect(await select.getDisplayText()).toBe('Pick one');
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('should return false when select is enabled', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      expect(await select.isDisabled()).toBe(false);
+    });
+
+    it('should return true when select is disabled', async () => {
+      hostComponent.disabled.set(true);
+
+      const select = await loader.getHarness(TnSelectHarness);
+      expect(await select.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('isOpen / open / close', () => {
+    it('should be closed initially', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      expect(await select.isOpen()).toBe(false);
+    });
+
+    it('should open the dropdown', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+      expect(await select.isOpen()).toBe(true);
+    });
+
+    it('should close the dropdown', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+      expect(await select.isOpen()).toBe(true);
+
+      await select.close();
+      expect(await select.isOpen()).toBe(false);
+    });
+
+    it('should be a no-op when opening an already open dropdown', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+      await select.open();
+      expect(await select.isOpen()).toBe(true);
+    });
+
+    it('should be a no-op when closing an already closed dropdown', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.close();
+      expect(await select.isOpen()).toBe(false);
+    });
+  });
+
+  describe('selectOption', () => {
+    it('should select an option by exact text', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.selectOption('Cherry');
+
+      expect(await select.getDisplayText()).toBe('Cherry');
+      expect(hostComponent.selectedValue).toBe('cherry');
+    });
+
+    it('should select an option by regex', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.selectOption(/ban/i);
+
+      expect(await select.getDisplayText()).toBe('Banana');
+      expect(hostComponent.selectedValue).toBe('banana');
+    });
+
+    it('should throw when option is not found', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await expect(select.selectOption('Mango')).rejects.toThrow(
+        'Could not find option matching "Mango"'
+      );
+    });
+  });
+
+  describe('getOptions', () => {
+    it('should return all option labels', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      const options = await select.getOptions();
+      expect(options).toEqual(['Apple', 'Banana', 'Cherry']);
+    });
+
+    it('should reflect updated options', async () => {
+      hostComponent.options.set([
+        { value: 'x', label: 'X' },
+        { value: 'y', label: 'Y' },
+      ]);
+
+      const select = await loader.getHarness(TnSelectHarness);
+      const options = await select.getOptions();
+      expect(options).toEqual(['X', 'Y']);
+    });
+  });
+
+  describe('with() filter', () => {
+    it('should filter by exact display text', async () => {
+      const select = await loader.getHarness(
+        TnSelectHarness.with({ displayText: 'Select a fruit' })
+      );
+      expect(select).toBeTruthy();
+    });
+
+    it('should filter by regex pattern', async () => {
+      const select = await loader.getHarness(
+        TnSelectHarness.with({ displayText: /fruit/i })
+      );
+      expect(select).toBeTruthy();
+    });
+
+    it('should filter by selected option text', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.selectOption('Apple');
+
+      const filtered = await loader.getHarness(
+        TnSelectHarness.with({ displayText: 'Apple' })
+      );
+      expect(filtered).toBeTruthy();
+    });
+  });
+
+  describe('hasHarness', () => {
+    it('should return true when select exists', async () => {
+      expect(await loader.hasHarness(TnSelectHarness)).toBe(true);
+    });
+
+    it('should return false when select with display text does not exist', async () => {
+      expect(
+        await loader.hasHarness(TnSelectHarness.with({ displayText: 'NonExistent' }))
+      ).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/select/select.harness.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.ts
@@ -1,0 +1,216 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with tn-select in tests.
+ * Provides methods for querying select state, opening/closing the dropdown,
+ * and selecting options.
+ *
+ * @example
+ * ```typescript
+ * // Find a select and choose an option
+ * const select = await loader.getHarness(TnSelectHarness);
+ * await select.selectOption('Option 2');
+ *
+ * // Check the displayed text
+ * expect(await select.getDisplayText()).toBe('Option 2');
+ *
+ * // Filter by displayed text
+ * const fruitSelect = await loader.getHarness(
+ *   TnSelectHarness.with({ displayText: /Apple/i })
+ * );
+ *
+ * // Check disabled state
+ * const disabledSelect = await loader.getHarness(TnSelectHarness);
+ * expect(await disabledSelect.isDisabled()).toBe(true);
+ * ```
+ */
+export class TnSelectHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnSelectComponent` instance.
+   */
+  static hostSelector = 'tn-select';
+
+  private _trigger = this.locatorFor('.tn-select-trigger');
+  private _text = this.locatorFor('.tn-select-text');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a select
+   * with specific attributes.
+   *
+   * @param options Options for filtering which select instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find select by exact display text
+   * const select = await loader.getHarness(TnSelectHarness.with({ displayText: 'Apple' }));
+   *
+   * // Find select by regex pattern
+   * const select = await loader.getHarness(TnSelectHarness.with({ displayText: /Option/i }));
+   * ```
+   */
+  static with(options: SelectHarnessFilters = {}) {
+    return new HarnessPredicate(TnSelectHarness, options)
+      .addOption('displayText', options.displayText, (harness, text) =>
+        HarnessPredicate.stringMatches(harness.getDisplayText(), text)
+      );
+  }
+
+  /**
+   * Gets the currently displayed text (selected label or placeholder).
+   *
+   * @returns Promise resolving to the display text content.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * const text = await select.getDisplayText();
+   * expect(text).toBe('Select an option');
+   * ```
+   */
+  async getDisplayText(): Promise<string> {
+    const text = await this._text();
+    return (await text.text()).trim();
+  }
+
+  /**
+   * Checks whether the select is disabled.
+   *
+   * @returns Promise resolving to true if the select trigger has the disabled class.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * expect(await select.isDisabled()).toBe(false);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const trigger = await this._trigger();
+    return trigger.hasClass('disabled');
+  }
+
+  /**
+   * Checks whether the dropdown is currently open.
+   *
+   * @returns Promise resolving to true if the dropdown is open.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * expect(await select.isOpen()).toBe(false);
+   * await select.open();
+   * expect(await select.isOpen()).toBe(true);
+   * ```
+   */
+  async isOpen(): Promise<boolean> {
+    const trigger = await this._trigger();
+    return trigger.hasClass('open');
+  }
+
+  /**
+   * Opens the dropdown. No-op if already open.
+   *
+   * @returns Promise that resolves when the dropdown is open.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * await select.open();
+   * ```
+   */
+  async open(): Promise<void> {
+    if (!(await this.isOpen())) {
+      const trigger = await this._trigger();
+      await trigger.click();
+    }
+  }
+
+  /**
+   * Closes the dropdown. No-op if already closed.
+   *
+   * @returns Promise that resolves when the dropdown is closed.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * await select.open();
+   * await select.close();
+   * expect(await select.isOpen()).toBe(false);
+   * ```
+   */
+  async close(): Promise<void> {
+    if (await this.isOpen()) {
+      const trigger = await this._trigger();
+      await trigger.click();
+    }
+  }
+
+  /**
+   * Selects an option by its label text. Opens the dropdown if needed.
+   *
+   * @param filter The text to match against option labels. Supports string or RegExp.
+   * @returns Promise that resolves when the option has been selected.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   *
+   * // Select by exact text
+   * await select.selectOption('Option 2');
+   *
+   * // Select by regex
+   * await select.selectOption(/option 2/i);
+   * ```
+   */
+  async selectOption(filter: string | RegExp): Promise<void> {
+    await this.open();
+    const options = await this.locatorForAll('.tn-select-option')();
+
+    for (const option of options) {
+      const text = (await option.text()).trim();
+      const matches = filter instanceof RegExp
+        ? filter.test(text)
+        : text === filter;
+
+      if (matches) {
+        await option.click();
+        return;
+      }
+    }
+
+    throw new Error(`Could not find option matching "${filter}"`);
+  }
+
+  /**
+   * Gets the labels of all available options. Opens the dropdown if needed.
+   *
+   * @returns Promise resolving to an array of option label strings.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * const options = await select.getOptions();
+   * expect(options).toEqual(['Option 1', 'Option 2', 'Option 3']);
+   * ```
+   */
+  async getOptions(): Promise<string[]> {
+    await this.open();
+    const options = await this.locatorForAll('.tn-select-option')();
+    const labels: string[] = [];
+
+    for (const option of options) {
+      labels.push((await option.text()).trim());
+    }
+
+    return labels;
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnSelectHarness` instances.
+ */
+export interface SelectHarnessFilters extends BaseHarnessFilters {
+  /** Filters by displayed text (selected label or placeholder). Supports string or regex matching. */
+  displayText?: string | RegExp;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -24,6 +24,7 @@ export * from './lib/menu';
 export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
 export * from './lib/select/select.component';
+export * from './lib/select/select.harness';
 export * from './lib/icon/icon.component';
 export * from './lib/icon/icon.harness';
 export * from './lib/icon/icon-registry.service';

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/angular';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
 import type { TnSelectOption, TnSelectOptionGroup } from '../lib/select/select.component';
 import { TnSelectComponent } from '../lib/select/select.component';
+
+// Load harness documentation
+const harnessDoc = loadHarnessDoc('select');
 
 const meta: Meta<TnSelectComponent> = {
   title: 'Components/Select',
@@ -185,5 +189,24 @@ export const MixedOptionsAndGroups: Story = {
     placeholder: 'Select your favorite',
     disabled: false,
   },
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      story: { height: 'auto' },
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
 };
 


### PR DESCRIPTION
Add TnSelectHarness with methods for querying state (getDisplayText, isDisabled, isOpen), toggling the dropdown (open, close), and selecting options (selectOption, getOptions). Includes filter support, full test suite, public API export, and Storybook harness docs.