### PR TITLE
feat(icon): move sizing to host element and add customSize input

### DIFF
--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
@@ -171,7 +171,7 @@
   <!-- Empty state -->
   @if (filteredFileItems().length === 0) {
     <div class="empty-state">
-      <tn-icon name="folder-open" library="mdi" />
+      <tn-icon name="folder-open" library="mdi" customSize="48px" />
       <p>No items found</p>
     </div>
   }

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -368,7 +368,6 @@ tn-table {
   text-align: center;
 
   tn-icon {
-    font-size: 48px;
     margin-bottom: 16px;
     opacity: 0.5;
   }

--- a/projects/truenas-ui/src/lib/icon/icon.component.html
+++ b/projects/truenas-ui/src/lib/icon/icon.component.html
@@ -1,8 +1,6 @@
 <div
   class="tn-icon"
   role="img"
-  [ngClass]="fullSize() ? 'tn-icon--full' : 'tn-icon--' + size()"
-  [style.color]="color()"
   [attr.aria-label]="effectiveAriaLabel()"
   [attr.title]="tooltip()">
   

--- a/projects/truenas-ui/src/lib/icon/icon.component.scss
+++ b/projects/truenas-ui/src/lib/icon/icon.component.scss
@@ -1,46 +1,59 @@
-.tn-icon {
+// Host element sizing
+// Display and layout properties are set via CSS here.
+// Dimensions use attribute selectors for size presets, with inline style
+// overrides for customSize and fullSize (set via Angular host bindings).
+tn-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   vertical-align: middle;
-  
-  // Size variants using global CSS variables
-  &--xs {
-    width: var(--tn-icon-xs) !important;
-    height: var(--tn-icon-xs) !important;
-    font-size: var(--tn-icon-xs) !important;
-  }
-  
-  &--sm {
-    width: var(--tn-icon-sm) !important;
-    height: var(--tn-icon-sm) !important;
-    font-size: var(--tn-icon-sm) !important;
-  }
-  
-  &--md {
-    width: var(--tn-icon-md) !important;
-    height: var(--tn-icon-md) !important;
-    font-size: var(--tn-icon-md) !important;
-  }
-  
-  &--lg {
-    width: var(--tn-icon-lg) !important;
-    height: var(--tn-icon-lg) !important;
-    font-size: var(--tn-icon-lg) !important;
-  }
-  
-  &--xl {
-    width: var(--tn-icon-xl) !important;
-    height: var(--tn-icon-xl) !important;
-    font-size: var(--tn-icon-xl) !important;
+  color: var(--tn-icon-color, currentColor);
+
+  // Default sizing (fallback when no size attribute matches)
+  width: var(--tn-icon-size, var(--tn-icon-md));
+  height: var(--tn-icon-size, var(--tn-icon-md));
+  font-size: var(--tn-icon-size, var(--tn-icon-md));
+
+  // Size presets via attribute selectors
+  &[size="xs"] {
+    width: var(--tn-icon-xs);
+    height: var(--tn-icon-xs);
+    font-size: var(--tn-icon-xs);
   }
 
-  // Full size - expands to fill container
-  &--full {
-    width: 100% !important;
-    height: 100% !important;
+  &[size="sm"] {
+    width: var(--tn-icon-sm);
+    height: var(--tn-icon-sm);
+    font-size: var(--tn-icon-sm);
   }
-  
+
+  &[size="md"] {
+    width: var(--tn-icon-md);
+    height: var(--tn-icon-md);
+    font-size: var(--tn-icon-md);
+  }
+
+  &[size="lg"] {
+    width: var(--tn-icon-lg);
+    height: var(--tn-icon-lg);
+    font-size: var(--tn-icon-lg);
+  }
+
+  &[size="xl"] {
+    width: var(--tn-icon-xl);
+    height: var(--tn-icon-xl);
+    font-size: var(--tn-icon-xl);
+  }
+}
+
+// Inner container - pass-through that fills the host
+.tn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+
   // Icon content containers
   &__sprite {
     width: 100%;
@@ -63,20 +76,20 @@
       color: inherit;
     }
   }
-  
+
   &__css {
     font-size: inherit;
     line-height: 1;
     color: inherit;
   }
-  
+
   &__unicode {
     font-size: inherit;
     line-height: 1;
     color: inherit;
     text-align: center;
   }
-  
+
   &__text {
     font-size: 0.75em;
     font-weight: 600;
@@ -85,11 +98,4 @@
     text-align: center;
     opacity: 0.7;
   }
-}
-
-// CSS Custom Properties for easy theming
-.tn-icon {
-  width: var(--tn-icon-size, var(--tn-icon-md));
-  height: var(--tn-icon-size, var(--tn-icon-md));
-  color: var(--tn-icon-color, currentColor);
 }

--- a/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
@@ -180,26 +180,63 @@ describe('TnIconComponent - Full Size', () => {
     expect(hostEl.getAttribute('full-size')).toBeNull();
   });
 
-  it('should apply tn-icon--full class when fullSize=true', async () => {
+  it('should set host width and height to 100% when fullSize=true', async () => {
     fixture.componentRef.setInput('name', 'test');
     fixture.componentRef.setInput('fullSize', true);
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const iconDiv = fixture.nativeElement.querySelector('.tn-icon');
-    expect(iconDiv.classList.contains('tn-icon--full')).toBe(true);
-    expect(iconDiv.classList.contains('tn-icon--md')).toBe(false);
+    const hostEl = fixture.nativeElement as HTMLElement;
+    expect(hostEl.style.width).toBe('100%');
+    expect(hostEl.style.height).toBe('100%');
   });
 
-  it('should apply size class when fullSize=false', async () => {
+  it('should not set inline width/height when fullSize=false', async () => {
     fixture.componentRef.setInput('name', 'test');
     fixture.componentRef.setInput('fullSize', false);
     fixture.componentRef.setInput('size', 'lg');
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const iconDiv = fixture.nativeElement.querySelector('.tn-icon');
-    expect(iconDiv.classList.contains('tn-icon--lg')).toBe(true);
-    expect(iconDiv.classList.contains('tn-icon--full')).toBe(false);
+    const hostEl = fixture.nativeElement as HTMLElement;
+    expect(hostEl.style.width).toBe('');
+    expect(hostEl.style.height).toBe('');
+  });
+});
+
+describe('TnIconComponent - Custom Size', () => {
+  let fixture: ComponentFixture<TnIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnIconComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TnIconComponent);
+  });
+
+  it('should set host inline width, height, and font-size from customSize', async () => {
+    fixture.componentRef.setInput('name', 'test');
+    fixture.componentRef.setInput('customSize', '48px');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const hostEl = fixture.nativeElement as HTMLElement;
+    expect(hostEl.style.width).toBe('48px');
+    expect(hostEl.style.height).toBe('48px');
+    expect(hostEl.style.fontSize).toBe('48px');
+  });
+
+  it('should override fullSize when both are set', async () => {
+    fixture.componentRef.setInput('name', 'test');
+    fixture.componentRef.setInput('fullSize', true);
+    fixture.componentRef.setInput('customSize', '48px');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const hostEl = fixture.nativeElement as HTMLElement;
+    expect(hostEl.style.width).toBe('48px');
+    expect(hostEl.style.height).toBe('48px');
   });
 });

--- a/projects/truenas-ui/src/lib/icon/icon.component.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import type { ElementRef } from '@angular/core';
 import { Component, input, computed, effect, signal, ChangeDetectionStrategy, ViewEncapsulation, inject, viewChild } from '@angular/core';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
@@ -17,7 +16,6 @@ export interface IconResult {
 @Component({
   selector: 'tn-icon',
   standalone: true,
-  imports: [CommonModule],
   templateUrl: './icon.component.html',
   styleUrl: './icon.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -27,7 +25,12 @@ export interface IconResult {
     '[attr.library]': 'library()',
     '[attr.size]': 'size()',
     '[attr.color]': 'color()',
-    '[attr.full-size]': 'fullSize() || null'
+    '[attr.full-size]': 'fullSize() || null',
+    '[attr.custom-size]': 'customSize() || null',
+    '[style.width]': 'hostDimension()',
+    '[style.height]': 'hostDimension()',
+    '[style.font-size]': 'hostFontSize()',
+    '[style.color]': 'color() || null',
   }
 })
 export class TnIconComponent {
@@ -43,6 +46,12 @@ export class TnIconComponent {
    * instead of using the fixed size from the `size` input.
    */
   fullSize = input(false);
+
+  /**
+   * Custom size for the icon. Accepts any valid CSS size value (e.g., '64px', '2rem', '3em').
+   * When set, this overrides both the `size` preset and `fullSize` inputs.
+   */
+  customSize = input<string | undefined>(undefined);
 
   svgContainer = viewChild<ElementRef<HTMLDivElement>>('svgContainer');
 
@@ -72,6 +81,19 @@ export class TnIconComponent {
       }
     });
   }
+
+  hostDimension = computed(() => {
+    const custom = this.customSize();
+    if (custom) {return custom;}
+    if (this.fullSize()) {return '100%';}
+    return null;
+  });
+
+  hostFontSize = computed(() => {
+    const custom = this.customSize();
+    if (custom) {return custom;}
+    return null;
+  });
 
   effectiveAriaLabel = computed(() => {
     return this.ariaLabel() || this.name() || 'Icon';

--- a/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
@@ -19,6 +19,7 @@ import { TnIconHarness } from './icon.harness';
     [size]="size()"
     [color]="color()"
     [fullSize]="fullSize()"
+    [customSize]="customSize()"
     (click)="onIconClick()"
   />`
 })
@@ -29,6 +30,7 @@ class TestHostComponent {
   size = signal<IconSize>('md');
   color = signal<string | undefined>(undefined);
   fullSize = signal(false);
+  customSize = signal<string | undefined>(undefined);
   clickCount = 0;
 
   onIconClick(): void {
@@ -216,6 +218,29 @@ describe('TnIconHarness', () => {
     });
   });
 
+  describe('getCustomSize', () => {
+    it('should get custom size when set', async () => {
+      hostComponent.customSize.set('64px');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getCustomSize()).toBe('64px');
+    });
+
+    it('should get updated customSize after change', async () => {
+      hostComponent.customSize.set('32px');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getCustomSize()).toBe('32px');
+
+      hostComponent.customSize.set('2rem');
+      fixture.detectChanges();
+
+      expect(await icon.getCustomSize()).toBe('2rem');
+    });
+  });
+
   describe('with() filter', () => {
     it('should filter by exact name', async () => {
       hostComponent.name.set('check');
@@ -268,6 +293,14 @@ describe('TnIconHarness', () => {
       fixture.detectChanges();
 
       const icon = await loader.getHarness(TnIconHarness.with({ fullSize: false }));
+      expect(icon).toBeTruthy();
+    });
+
+    it('should filter by customSize', async () => {
+      hostComponent.customSize.set('64px');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness.with({ customSize: '64px' }));
       expect(icon).toBeTruthy();
     });
   });

--- a/projects/truenas-ui/src/lib/icon/icon.harness.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.ts
@@ -76,6 +76,9 @@ export class TnIconHarness extends ComponentHarness {
       })
       .addOption('fullSize', options.fullSize, async (harness, fullSize) => {
         return (await harness.isFullSize()) === fullSize;
+      })
+      .addOption('customSize', options.customSize, async (harness, customSize) => {
+        return (await harness.getCustomSize()) === customSize;
       });
   }
 
@@ -166,6 +169,40 @@ export class TnIconHarness extends ComponentHarness {
   }
 
   /**
+   * Gets the icon custom size.
+   *
+   * @returns Promise resolving to the custom size value, or null if not set.
+   *
+   * @example
+   * ```typescript
+   * const icon = await loader.getHarness(TnIconHarness);
+   * const customSize = await icon.getCustomSize();
+   * expect(customSize).toBe('64px');
+   * ```
+   */
+  async getCustomSize(): Promise<string | null> {
+    const host = await this.host();
+    return host.getAttribute('custom-size');
+  }
+
+  /**
+   * Checks if the icon is using a custom size.
+   *
+   * @returns Promise resolving to true if a custom size is set, false otherwise.
+   *
+   * @example
+   * ```typescript
+   * const icon = await loader.getHarness(TnIconHarness);
+   * const hasCustomSize = await icon.hasCustomSize();
+   * expect(hasCustomSize).toBe(true);
+   * ```
+   */
+  async hasCustomSize(): Promise<boolean> {
+    const customSize = await this.getCustomSize();
+    return customSize !== null;
+  }
+
+  /**
    * Clicks the icon.
    *
    * @returns Promise that resolves when the click action is complete.
@@ -194,4 +231,6 @@ export interface IconHarnessFilters extends BaseHarnessFilters {
   size?: string;
   /** Filters by full-size mode. */
   fullSize?: boolean;
+  /** Filters by custom size value. */
+  customSize?: string;
 }

--- a/projects/truenas-ui/src/stories/icon.stories.ts
+++ b/projects/truenas-ui/src/stories/icon.stories.ts
@@ -125,6 +125,10 @@ Then use: \`<tn-icon name="home" library="lucide"></tn-icon>\`
       control: 'boolean',
       description: 'When true, the icon expands to fill its container (100% width and height) instead of using the fixed size',
     },
+    customSize: {
+      control: 'text',
+      description: 'Custom size for the icon. Accepts any valid CSS size value (e.g., "64px", "2rem"). Overrides both size and fullSize when set.',
+    },
   },
   decorators: [
     (story) => {
@@ -467,6 +471,74 @@ export const FullSize: Story = {
 \`\`\`
 
 **Note:** When \`fullSize\` is true, the \`size\` input is ignored.`,
+      },
+    },
+  },
+};
+
+export const CustomSize: Story = {
+  render: () => ({
+    template: `
+      <div style="padding: 20px;">
+        <h4>Custom Size</h4>
+        <p style="margin-bottom: 16px; color: var(--text-secondary, #666);">
+          Use <code>customSize</code> to set an explicit size using any valid CSS value.
+          This overrides both <code>size</code> presets and <code>fullSize</code>.
+        </p>
+
+        <div style="display: flex; align-items: end; gap: 24px; margin-bottom: 24px;">
+          <div style="text-align: center;">
+            <tn-icon name="harddisk" library="mdi" customSize="16px"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">16px</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="harddisk" library="mdi" customSize="32px"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">32px</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="harddisk" library="mdi" customSize="48px"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">48px</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="harddisk" library="mdi" customSize="64px"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">64px</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="harddisk" library="mdi" customSize="96px"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">96px</div>
+          </div>
+        </div>
+
+        <h4>Other CSS Units</h4>
+        <div style="display: flex; align-items: end; gap: 24px;">
+          <div style="text-align: center;">
+            <tn-icon name="server" library="mdi" customSize="2rem"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">2rem</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="server" library="mdi" customSize="3em"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">3em</div>
+          </div>
+          <div style="text-align: center;">
+            <tn-icon name="server" library="mdi" customSize="5vw"></tn-icon>
+            <div style="margin-top: 8px; font-size: 12px;">5vw</div>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: `The \`customSize\` input allows setting an explicit icon size using any valid CSS value.
+
+**Usage:**
+\`\`\`html
+<tn-icon name="harddisk" library="mdi" customSize="64px"></tn-icon>
+<tn-icon name="harddisk" library="mdi" customSize="2rem"></tn-icon>
+\`\`\`
+
+**Priority chain:** \`customSize\` > \`fullSize\` > \`size\` preset > default (md)`,
       },
     },
   },


### PR DESCRIPTION
The tn-icon host element previously had no display style, causing consumer-applied width/height to be silently ignored. This refactor moves dimensional ownership to the host via CSS attribute selectors and adds a customSize input for explicit size overrides.

Priority chain: customSize > fullSize > size preset > default (md)