### PR TITLE
NAS-141635 / 27.0.0-BETA.1 / fix(banner): use grid layout for responsive action wrapping

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner.component.scss
+++ b/projects/truenas-ui/src/lib/banner/banner.component.scss
@@ -1,5 +1,6 @@
 .tn-banner {
-  display: flex;
+  display: grid;
+  gap: 8px;
   align-items: center;
   padding: 16px;
   border-radius: 6px;
@@ -105,9 +106,7 @@
   &__action {
     display: flex;
     align-items: center;
-    flex-shrink: 0;
-    margin-left: auto;
-    padding-left: 16px;
-    gap: 16px;
+    gap: 8px 16px;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
Before:
<img width="406" height="719" alt="Screenshot 2026-03-06 at 12 36 30" src="https://github.com/user-attachments/assets/a9b6fdc8-2dfa-4b82-8450-41e4eb32ba6b" />


After:
<img width="396" height="250" alt="Screenshot 2026-03-06 at 15 34 05" src="https://github.com/user-attachments/assets/74eef921-44d6-45d1-bf38-e22679fb6f0a" />
