### PR TITLE
feat(empty): add empty state component

### DIFF
--- a/projects/truenas-ui/src/lib/empty/empty.component.html
+++ b/projects/truenas-ui/src/lib/empty/empty.component.html
@@ -1,0 +1,31 @@
+@if (icon()) {
+  <div class="tn-empty__icon">
+    <tn-icon
+      aria-hidden="true"
+      [name]="icon()!"
+      [library]="iconLibrary()"
+      [size]="iconSize()"
+    />
+  </div>
+}
+
+<div class="tn-empty__title">
+  {{ title() }}
+</div>
+
+@if (description()) {
+  <div class="tn-empty__description">
+    {{ description() }}
+  </div>
+}
+
+@if (hasAction()) {
+  <div class="tn-empty__action">
+    <tn-button
+      color="primary"
+      variant="outline"
+      [label]="actionText()!"
+      (onClick)="onAction.emit()"
+    />
+  </div>
+}

--- a/projects/truenas-ui/src/lib/empty/empty.component.scss
+++ b/projects/truenas-ui/src/lib/empty/empty.component.scss
@@ -1,0 +1,54 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 8px;
+  padding: 48px 24px;
+}
+
+:host(.tn-empty--compact) {
+  padding: 24px 16px;
+
+  .tn-empty__title {
+    font-size: 1rem;
+  }
+
+  .tn-empty__description {
+    font-size: 0.8125rem;
+  }
+
+  .tn-empty__icon {
+    margin-bottom: 4px;
+  }
+
+  .tn-empty__action {
+    margin-top: 4px;
+  }
+}
+
+.tn-empty {
+  &__icon {
+    color: var(--tn-fg2, #6b7280);
+    margin-bottom: 8px;
+  }
+
+  &__title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--tn-fg1, #e5e7eb);
+    line-height: 1.4;
+  }
+
+  &__description {
+    font-size: 0.875rem;
+    color: var(--tn-fg2, #6b7280);
+    line-height: 1.5;
+    max-width: 420px;
+  }
+
+  &__action {
+    margin-top: 8px;
+  }
+}

--- a/projects/truenas-ui/src/lib/empty/empty.component.spec.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.component.spec.ts
@@ -1,0 +1,196 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TnEmptyComponent } from './empty.component';
+import type { TnEmptySize } from './empty.component';
+import { TnButtonHarness } from '../button/button.harness';
+import { TnIconTesting } from '../icon/icon-testing';
+import { TnIconHarness } from '../icon/icon.harness';
+
+/* eslint-disable @angular-eslint/component-max-inline-declarations */
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnEmptyComponent],
+  template: `<tn-empty
+    [title]="title()"
+    [description]="description()"
+    [icon]="icon()"
+    [iconLibrary]="iconLibrary()"
+    [actionText]="actionText()"
+    [size]="size()"
+    (onAction)="onActionTriggered()"
+  />`
+})
+/* eslint-enable @angular-eslint/component-max-inline-declarations */
+class TestHostComponent {
+  title = signal('No items found');
+  description = signal<string | undefined>(undefined);
+  icon = signal<string | undefined>(undefined);
+  iconLibrary = signal('mdi');
+  actionText = signal<string | undefined>(undefined);
+  size = signal<TnEmptySize>('default');
+  actionCount = 0;
+
+  onActionTriggered(): void {
+    this.actionCount++;
+  }
+}
+
+describe('TnEmptyComponent', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    const emptyEl = fixture.nativeElement.querySelector('tn-empty');
+    expect(emptyEl).toBeTruthy();
+  });
+
+  describe('host element', () => {
+    it('should have tn-empty base class', () => {
+      const emptyEl = fixture.nativeElement.querySelector('tn-empty');
+      expect(emptyEl.classList.contains('tn-empty')).toBe(true);
+    });
+
+    it('should not have compact class by default', () => {
+      const emptyEl = fixture.nativeElement.querySelector('tn-empty');
+      expect(emptyEl.classList.contains('tn-empty--compact')).toBe(false);
+    });
+
+    it('should have compact class when size is compact', () => {
+      hostComponent.size.set('compact');
+      fixture.detectChanges();
+
+      const emptyEl = fixture.nativeElement.querySelector('tn-empty');
+      expect(emptyEl.classList.contains('tn-empty--compact')).toBe(true);
+    });
+
+    it('should have status role for accessibility', () => {
+      const emptyEl = fixture.nativeElement.querySelector('tn-empty');
+      expect(emptyEl.getAttribute('role')).toBe('status');
+    });
+  });
+
+  describe('title', () => {
+    it('should render title text', () => {
+      const title = fixture.nativeElement.querySelector('.tn-empty__title');
+      expect(title.textContent.trim()).toBe('No items found');
+    });
+
+    it('should update when title changes', () => {
+      hostComponent.title.set('Nothing here');
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector('.tn-empty__title');
+      expect(title.textContent.trim()).toBe('Nothing here');
+    });
+  });
+
+  describe('description', () => {
+    it('should not render when not provided', () => {
+      const desc = fixture.nativeElement.querySelector('.tn-empty__description');
+      expect(desc).toBeNull();
+    });
+
+    it('should render when provided', () => {
+      hostComponent.description.set('Try adjusting your filters');
+      fixture.detectChanges();
+
+      const desc = fixture.nativeElement.querySelector('.tn-empty__description');
+      expect(desc).toBeTruthy();
+      expect(desc.textContent.trim()).toBe('Try adjusting your filters');
+    });
+  });
+
+  describe('icon', () => {
+    it('should not render icon when not provided', async () => {
+      const hasIcon = await loader.hasHarness(TnIconHarness);
+      expect(hasIcon).toBe(false);
+    });
+
+    it('should render icon when provided', async () => {
+      hostComponent.icon.set('folder-open');
+      fixture.detectChanges();
+
+      const hasIcon = await loader.hasHarness(TnIconHarness.with({ name: 'folder-open' }));
+      expect(hasIcon).toBe(true);
+    });
+
+    it('should use specified icon library', async () => {
+      hostComponent.icon.set('inbox');
+      hostComponent.iconLibrary.set('lucide');
+      fixture.detectChanges();
+
+      const hasIcon = await loader.hasHarness(TnIconHarness.with({ name: 'inbox', library: 'lucide' }));
+      expect(hasIcon).toBe(true);
+    });
+
+    it('should use xl size for default empty size', async () => {
+      hostComponent.icon.set('inbox');
+      fixture.detectChanges();
+
+      const hasIcon = await loader.hasHarness(TnIconHarness.with({ size: 'xl' }));
+      expect(hasIcon).toBe(true);
+    });
+
+    it('should use lg size for compact empty size', async () => {
+      hostComponent.icon.set('inbox');
+      hostComponent.size.set('compact');
+      fixture.detectChanges();
+
+      const hasIcon = await loader.hasHarness(TnIconHarness.with({ size: 'lg' }));
+      expect(hasIcon).toBe(true);
+    });
+  });
+
+  describe('action button', () => {
+    it('should not render when actionText is not provided', async () => {
+      const hasButton = await loader.hasHarness(TnButtonHarness);
+      expect(hasButton).toBe(false);
+    });
+
+    it('should render when actionText is provided', async () => {
+      hostComponent.actionText.set('Add Item');
+      fixture.detectChanges();
+
+      const hasButton = await loader.hasHarness(TnButtonHarness.with({ label: 'Add Item' }));
+      expect(hasButton).toBe(true);
+    });
+
+    it('should emit onAction when clicked', async () => {
+      hostComponent.actionText.set('Add Item');
+      fixture.detectChanges();
+
+      const button = await loader.getHarness(TnButtonHarness);
+      await button.click();
+
+      expect(hostComponent.actionCount).toBe(1);
+    });
+
+    it('should emit onAction on multiple clicks', async () => {
+      hostComponent.actionText.set('Add Item');
+      fixture.detectChanges();
+
+      const button = await loader.getHarness(TnButtonHarness);
+      await button.click();
+      await button.click();
+
+      expect(hostComponent.actionCount).toBe(2);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/empty/empty.component.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.component.ts
@@ -1,0 +1,35 @@
+import { Component, input, output, computed } from '@angular/core';
+import { TnButtonComponent } from '../button/button.component';
+import { TnIconComponent } from '../icon/icon.component';
+import type { IconLibraryType } from '../icon/icon.component';
+
+export type TnEmptySize = 'default' | 'compact';
+
+@Component({
+  selector: 'tn-empty',
+  standalone: true,
+  imports: [TnIconComponent, TnButtonComponent],
+  templateUrl: './empty.component.html',
+  styleUrls: ['./empty.component.scss'],
+  host: {
+    'class': 'tn-empty',
+    '[class.tn-empty--compact]': 'size() === "compact"',
+    'role': 'status',
+  },
+})
+export class TnEmptyComponent {
+  title = input.required<string>();
+  description = input<string>();
+  icon = input<string>();
+  iconLibrary = input<IconLibraryType>('mdi');
+  actionText = input<string>();
+  size = input<TnEmptySize>('default');
+
+  onAction = output<void>();
+
+  protected hasAction = computed(() => !!this.actionText());
+
+  iconSize = computed(() => {
+    return this.size() === 'compact' ? 'lg' : 'xl';
+  });
+}

--- a/projects/truenas-ui/src/lib/empty/empty.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.harness.spec.ts
@@ -1,0 +1,185 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TnEmptyComponent } from './empty.component';
+import type { TnEmptySize } from './empty.component';
+import { TnEmptyHarness } from './empty.harness';
+import { TnIconTesting } from '../icon/icon-testing';
+
+/* eslint-disable @angular-eslint/component-max-inline-declarations */
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnEmptyComponent],
+  template: `<tn-empty
+    [title]="title()"
+    [description]="description()"
+    [icon]="icon()"
+    [actionText]="actionText()"
+    [size]="size()"
+    (onAction)="onActionTriggered()"
+  />`
+})
+/* eslint-enable @angular-eslint/component-max-inline-declarations */
+class TestHostComponent {
+  title = signal('No items found');
+  description = signal<string | undefined>(undefined);
+  icon = signal<string | undefined>(undefined);
+  actionText = signal<string | undefined>(undefined);
+  size = signal<TnEmptySize>('default');
+  actionCount = 0;
+
+  onActionTriggered(): void {
+    this.actionCount++;
+  }
+}
+
+@Component({
+  selector: 'tn-test-multi-host',
+  standalone: true,
+  imports: [TnEmptyComponent],
+  template: `
+    <tn-empty title="No files" />
+    <tn-empty title="No messages" description="Check back later" />
+  `
+})
+class MultiEmptyTestComponent {}
+
+describe('TnEmptyHarness', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, MultiEmptyTestComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should load harness', async () => {
+    const harness = await loader.getHarness(TnEmptyHarness);
+    expect(harness).toBeTruthy();
+  });
+
+  describe('getTitle', () => {
+    it('should get title text', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getTitle()).toBe('No items found');
+    });
+
+    it('should get updated title after change', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getTitle()).toBe('No items found');
+
+      hostComponent.title.set('Nothing here');
+      fixture.detectChanges();
+
+      expect(await harness.getTitle()).toBe('Nothing here');
+    });
+  });
+
+  describe('getDescription', () => {
+    it('should return null when description is not set', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getDescription()).toBeNull();
+    });
+
+    it('should get description text when set', async () => {
+      hostComponent.description.set('Try adjusting your filters');
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getDescription()).toBe('Try adjusting your filters');
+    });
+
+    it('should get updated description after change', async () => {
+      hostComponent.description.set('First description');
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getDescription()).toBe('First description');
+
+      hostComponent.description.set('Second description');
+      fixture.detectChanges();
+
+      expect(await harness.getDescription()).toBe('Second description');
+    });
+
+    it('should return null after description is removed', async () => {
+      hostComponent.description.set('Temporary description');
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(TnEmptyHarness);
+      expect(await harness.getDescription()).toBe('Temporary description');
+
+      hostComponent.description.set(undefined);
+      fixture.detectChanges();
+
+      expect(await harness.getDescription()).toBeNull();
+    });
+  });
+
+  describe('getText', () => {
+    it('should return title when only title is set', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness);
+      const text = await harness.getText();
+      expect(text).toContain('No items found');
+    });
+
+    it('should include both title and description', async () => {
+      hostComponent.description.set('Try again later');
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(TnEmptyHarness);
+      const text = await harness.getText();
+      expect(text).toContain('No items found');
+      expect(text).toContain('Try again later');
+    });
+  });
+
+  describe('with() filter', () => {
+    it('should filter by exact title', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness.with({ title: 'No items found' }));
+      expect(harness).toBeTruthy();
+    });
+
+    it('should filter by title regex', async () => {
+      const harness = await loader.getHarness(TnEmptyHarness.with({ title: /no.*found/i }));
+      expect(harness).toBeTruthy();
+    });
+
+    it('should filter among multiple instances', async () => {
+      const multiFixture = TestBed.createComponent(MultiEmptyTestComponent);
+      multiFixture.detectChanges();
+      const multiLoader = TestbedHarnessEnvironment.loader(multiFixture);
+
+      const filesEmpty = await multiLoader.getHarness(TnEmptyHarness.with({ title: 'No files' }));
+      expect(await filesEmpty.getTitle()).toBe('No files');
+
+      const messagesEmpty = await multiLoader.getHarness(TnEmptyHarness.with({ title: 'No messages' }));
+      expect(await messagesEmpty.getDescription()).toBe('Check back later');
+    });
+  });
+
+  describe('hasHarness', () => {
+    it('should return true when empty state exists', async () => {
+      expect(await loader.hasHarness(TnEmptyHarness)).toBe(true);
+    });
+
+    it('should return true for matching title', async () => {
+      expect(await loader.hasHarness(TnEmptyHarness.with({ title: 'No items found' }))).toBe(true);
+    });
+
+    it('should return false for non-matching title', async () => {
+      expect(await loader.hasHarness(TnEmptyHarness.with({ title: 'Does not exist' }))).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/empty/empty.harness.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.harness.ts
@@ -1,0 +1,121 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with tn-empty in tests.
+ * Provides text-based querying for verifying empty state content.
+ *
+ * @example
+ * ```typescript
+ * // Check for existence
+ * const empty = await loader.getHarness(TnEmptyHarness);
+ *
+ * // Find empty state by title
+ * const noItems = await loader.getHarness(
+ *   TnEmptyHarness.with({ title: 'No items found' })
+ * );
+ *
+ * // Check if empty state exists with specific text
+ * const hasEmpty = await loader.hasHarness(
+ *   TnEmptyHarness.with({ title: /no.*found/i })
+ * );
+ * ```
+ */
+export class TnEmptyHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnEmptyComponent` instance.
+   */
+  static hostSelector = 'tn-empty';
+
+  private _title = this.locatorFor('.tn-empty__title');
+  private _description = this.locatorForOptional('.tn-empty__description');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for an empty state
+   * with specific attributes.
+   *
+   * @param options Options for filtering which empty state instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find by title
+   * const empty = await loader.getHarness(
+   *   TnEmptyHarness.with({ title: 'No results' })
+   * );
+   *
+   * // Find by title regex
+   * const empty = await loader.getHarness(
+   *   TnEmptyHarness.with({ title: /empty/i })
+   * );
+   * ```
+   */
+  static with(options: EmptyHarnessFilters = {}) {
+    return new HarnessPredicate(TnEmptyHarness, options)
+      .addOption('title', options.title, (harness, title) =>
+        HarnessPredicate.stringMatches(harness.getTitle(), title)
+      );
+  }
+
+  /**
+   * Gets the title text.
+   *
+   * @returns Promise resolving to the empty state's title text.
+   *
+   * @example
+   * ```typescript
+   * const empty = await loader.getHarness(TnEmptyHarness);
+   * const title = await empty.getTitle();
+   * expect(title).toBe('No items found');
+   * ```
+   */
+  async getTitle(): Promise<string> {
+    const title = await this._title();
+    return (await title.text()).trim();
+  }
+
+  /**
+   * Gets the description text, or null if no description is rendered.
+   *
+   * @returns Promise resolving to the description text, or null.
+   *
+   * @example
+   * ```typescript
+   * const empty = await loader.getHarness(TnEmptyHarness);
+   * const desc = await empty.getDescription();
+   * expect(desc).toBe('Try adjusting your filters');
+   * ```
+   */
+  async getDescription(): Promise<string | null> {
+    const desc = await this._description();
+    if (!desc) {
+      return null;
+    }
+    return (await desc.text()).trim();
+  }
+
+  /**
+   * Gets all text content from the empty state (title + description combined).
+   *
+   * @returns Promise resolving to the full text content, trimmed of whitespace.
+   *
+   * @example
+   * ```typescript
+   * const empty = await loader.getHarness(TnEmptyHarness);
+   * const text = await empty.getText();
+   * expect(text).toContain('No items');
+   * ```
+   */
+  async getText(): Promise<string> {
+    const host = await this.host();
+    return (await host.text()).trim();
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnEmptyHarness` instances.
+ */
+export interface EmptyHarnessFilters extends BaseHarnessFilters {
+  /** Filters by title text. Supports string or regex matching. */
+  title?: string | RegExp;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -78,6 +78,8 @@ export * from './lib/dialog';
 export * from './lib/side-panel';
 export * from './lib/stepper';
 export * from './lib/file-picker';
+export * from './lib/empty/empty.component';
+export * from './lib/empty/empty.harness';
 export * from './lib/services/keyboard-shortcut.service';
 export * from './lib/theme/theme.service';
 export * from './lib/theme/theme.interface';

--- a/projects/truenas-ui/src/stories/empty.stories.ts
+++ b/projects/truenas-ui/src/stories/empty.stories.ts
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { expect, within } from 'storybook/test';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
+import { TnEmptyComponent } from '../lib/empty/empty.component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
+
+tnIconMarker('inbox', 'mdi');
+tnIconMarker('magnify', 'mdi');
+tnIconMarker('folder-open', 'mdi');
+tnIconMarker('alert-circle-outline', 'mdi');
+
+const harnessDoc = loadHarnessDoc('empty');
+
+const meta: Meta<TnEmptyComponent> = {
+  title: 'Components/Empty',
+  component: TnEmptyComponent,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Empty state component for indicating that there is no content to display. Supports an optional icon, description, and call-to-action button.',
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Main heading text (required)',
+    },
+    description: {
+      control: 'text',
+      description: 'Optional secondary text below the title',
+    },
+    icon: {
+      control: 'text',
+      description: 'Optional icon name to display above the title',
+    },
+    iconLibrary: {
+      control: 'select',
+      options: ['mdi', 'material', 'lucide'],
+      description: 'Icon library (defaults to mdi)',
+    },
+    actionText: {
+      control: 'text',
+      description: 'Optional CTA button label. Renders a primary outline button when set.',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'compact'],
+      description: 'Size variant (default or compact)',
+    },
+    onAction: { action: 'onAction' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<TnEmptyComponent>;
+
+export const Default: Story = {
+  args: {
+    icon: 'inbox',
+    title: 'No messages',
+    description: 'Your inbox is empty. Messages you receive will appear here.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText('No messages');
+    await expect(title).toBeInTheDocument();
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: 'folder-open',
+    title: 'No files yet',
+    description: 'Upload your first file to get started.',
+    actionText: 'Upload File',
+  },
+};
+
+export const NoSearchResults: Story = {
+  args: {
+    icon: 'magnify',
+    title: 'No results found',
+    description: 'Try adjusting your search or filter criteria.',
+    actionText: 'Clear Filters',
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    icon: 'inbox',
+    title: 'No items',
+    description: 'This list is empty.',
+    size: 'compact',
+  },
+};
+
+export const CompactWithAction: Story = {
+  args: {
+    icon: 'folder-open',
+    title: 'No files',
+    description: 'Add a file to get started.',
+    actionText: 'Add File',
+    size: 'compact',
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    title: 'Nothing here',
+  },
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    title: 'No data available',
+    description: 'There is currently no data to display in this view.',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    icon: 'alert-circle-outline',
+    title: 'Failed to load data',
+    description: 'Something went wrong while fetching the data. Please try again.',
+    actionText: 'Retry',
+  },
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none',
+      },
+      description: {
+        story: harnessDoc || '',
+      },
+    },
+    controls: { disable: true },
+    layout: 'fullscreen',
+  },
+  render: () => ({ template: '' }),
+};


### PR DESCRIPTION
Standardized empty state for indicating no content (empty lists, no search results, etc.) with optional icon, description, and CTA button.