### PR TITLE
fix(menu,theme): improve dark mode text contrast and menu UX

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -47,7 +47,13 @@
   --tn-icon-xl: 32px;
 
   /* Dialog content padding */
-  --tn-content-padding: 24px;
+  --tn-content-padding: 16px;
+}
+
+@media (min-width: 768px) {
+  :root {
+    --tn-content-padding: 24px;
+  }
 }
 
 
@@ -61,7 +67,7 @@
   --tn-accent: var(--tn-yellow);
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
-  --tn-fg1: #808080;
+  --tn-fg1: #e0e0e0;
   --tn-fg2: rgba(255,255,255,0.85);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
@@ -530,6 +536,7 @@ tn-dialog-shell {
   overflow-y: auto;
   overflow-x: hidden;
   box-sizing: border-box;
+  padding: var(--tn-content-padding, 16px);
 }
 
 /* Dialog actions */

--- a/projects/truenas-ui/src/lib/menu/menu-trigger.directive.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-trigger.directive.ts
@@ -1,6 +1,6 @@
 import { Overlay, type OverlayRef, type ConnectedPosition } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { ElementRef, ViewContainerRef, Directive, input, signal, inject } from '@angular/core';
+import { ElementRef, ViewContainerRef, Directive, input, signal, inject, type OutputRefSubscription } from '@angular/core';
 import type { TnMenuComponent } from './menu.component';
 
 /**
@@ -21,6 +21,7 @@ export class TnMenuTriggerDirective {
 
   private overlayRef?: OverlayRef;
   private isMenuOpen = signal<boolean>(false);
+  private itemClickSub?: OutputRefSubscription;
 
   private elementRef = inject(ElementRef);
   private overlay = inject(Overlay);
@@ -73,11 +74,18 @@ export class TnMenuTriggerDirective {
       this.closeMenu();
     });
 
+    // Close menu when a leaf item is selected
+    this.itemClickSub = menuComponent.menuItemClick.subscribe(() => {
+      this.closeMenu();
+    });
+
     // Notify menu component
     menuComponent.onMenuOpen();
   }
 
   closeMenu(): void {
+    this.itemClickSub?.unsubscribe();
+    this.itemClickSub = undefined;
     if (this.overlayRef) {
       this.overlayRef.dispose();
       this.overlayRef = undefined;

--- a/projects/truenas-ui/src/lib/menu/menu.component.html
+++ b/projects/truenas-ui/src/lib/menu/menu.component.html
@@ -7,7 +7,7 @@
 
   <!-- Context menu template for overlay -->
   <ng-template #contextMenuTemplate>
-    <div class="tn-menu" cdkMenu>
+    <div class="tn-menu" cdkMenu tnMenuActivateHover>
       @for (item of items(); track trackByItemId($index, item)) {
         @if (item.separator) {
           <div
@@ -138,7 +138,7 @@
 
   <!-- Regular menu template -->
   <ng-template #menuTemplate>
-    <div class="tn-menu" cdkMenu>
+    <div class="tn-menu" cdkMenu tnMenuActivateHover>
       @for (item of items(); track trackByItemId($index, item)) {
         @if (item.separator) {
           <div

--- a/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
@@ -1,125 +1,357 @@
-import type { ComponentFixture} from '@angular/core/testing';
-import { TestBed } from '@angular/core/testing';
+import { Component, viewChild } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { TnMenuTriggerDirective } from './menu-trigger.directive';
 import type { TnMenuItem } from './menu.component';
 import { TnMenuComponent } from './menu.component';
 
-describe('TnMenuComponent', () => {
-  let component: TnMenuComponent;
-  let fixture: ComponentFixture<TnMenuComponent>;
+/**
+ * Helper: query all menu items currently in the DOM (inside the CDK overlay).
+ */
+function getMenuItems(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('.tn-menu-item'));
+}
 
-  const mockMenuItems: TnMenuItem[] = [
-    { id: '1', label: 'Item 1', icon: '🏠', shortcut: '⌘1' },
-    { id: '2', label: 'Item 2', disabled: true, shortcut: '⌘2' },
-    { id: '3', label: 'Item 3', separator: true },
-    { id: '4', label: 'Item 4', action: jest.fn() },
-    { id: '5', label: 'Item 5', children: [
-      { id: '5-1', label: 'Nested Item 1' },
-      { id: '5-2', label: 'Nested Item 2' },
+function getMenuPanel(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('.tn-menu');
+}
+
+function getBackdrop(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('.cdk-overlay-backdrop');
+}
+
+// ---------------------------------------------------------------------------
+// Test host for regular menu (trigger-based)
+// ---------------------------------------------------------------------------
+/* eslint-disable @angular-eslint/component-max-inline-declarations */
+@Component({
+  standalone: true,
+  imports: [TnMenuComponent, TnMenuTriggerDirective],
+  template: `
+    <button class="trigger" [tnMenuTriggerFor]="menu" [tnMenuPosition]="position">Open</button>
+    <tn-menu
+      #menu
+      [items]="items"
+      (menuItemClick)="lastClicked = $event"
+      (menuOpen)="opened = true"
+      (menuClose)="closed = true"
+    />
+  `,
+})
+class MenuTestHostComponent {
+  items: TnMenuItem[] = [
+    { id: 'cut', label: 'Cut', icon: 'content_cut', shortcut: '⌘X' },
+    { id: 'copy', label: 'Copy' },
+    { id: 'disabled', label: 'Disabled', disabled: true },
+    { id: 'sep', label: '', separator: true },
+    { id: 'more', label: 'More', children: [
+      { id: 'child-1', label: 'Child 1' },
+      { id: 'child-2', label: 'Child 2' },
     ]},
   ];
+  position: 'above' | 'below' | 'before' | 'after' = 'below';
+  lastClicked: TnMenuItem | null = null;
+  opened = false;
+  closed = false;
+
+  trigger = viewChild.required(TnMenuTriggerDirective);
+}
+
+// ---------------------------------------------------------------------------
+// Test host for context menu
+// ---------------------------------------------------------------------------
+@Component({
+  standalone: true,
+  imports: [TnMenuComponent],
+  template: `
+    <tn-menu
+      #menu
+      [items]="items"
+      [contextMenu]="true"
+      (menuItemClick)="lastClicked = $event"
+      (menuOpen)="opened = true"
+      (menuClose)="closed = true"
+    >
+      <div class="context-area" style="width:200px;height:200px;">Right-click me</div>
+    </tn-menu>
+  `,
+})
+class ContextMenuTestHostComponent {
+  items: TnMenuItem[] = [
+    { id: 'cut', label: 'Cut' },
+    { id: 'copy', label: 'Copy' },
+  ];
+  lastClicked: TnMenuItem | null = null;
+  opened = false;
+  closed = false;
+
+  menu = viewChild.required(TnMenuComponent);
+}
+
+// ===========================================================================
+// Regular menu tests
+// ===========================================================================
+describe('tn-menu with trigger', () => {
+  let fixture: ComponentFixture<MenuTestHostComponent>;
+  let host: MenuTestHostComponent;
+  let triggerButton: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TnMenuComponent],
+      imports: [MenuTestHostComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(TnMenuComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('items', mockMenuItems);
+    fixture = TestBed.createComponent(MenuTestHostComponent);
+    host = fixture.componentInstance;
     fixture.detectChanges();
+    triggerButton = fixture.nativeElement.querySelector('.trigger');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  afterEach(() => {
+    host.trigger().closeMenu();
   });
 
-  it('should expose menu template', () => {
-    fixture.detectChanges();
-    const template = component.getMenuTemplate();
-    expect(template).toBeTruthy();
-  });
+  // -- Opening & closing --------------------------------------------------
 
-  it('should emit menuItemClick when item is clicked', () => {
-    const onMenuItemClickSpy = jest.spyOn(component.menuItemClick, 'emit');
-    const testItem = mockMenuItems[0];
-    
-    component.onMenuItemClick(testItem);
-    
-    expect(onMenuItemClickSpy).toHaveBeenCalledWith(testItem);
-  });
-
-  it('should not emit menuItemClick when disabled item is clicked', () => {
-    const onMenuItemClickSpy = jest.spyOn(component.menuItemClick, 'emit');
-    const disabledItem = mockMenuItems[1];
-    
-    component.onMenuItemClick(disabledItem);
-    
-    expect(onMenuItemClickSpy).not.toHaveBeenCalled();
-  });
-
-  it('should call item action when item is clicked', () => {
-    const testItem = mockMenuItems[3];
-    const actionSpy = testItem.action as jest.Mock;
-    
-    component.onMenuItemClick(testItem);
-    
-    expect(actionSpy).toHaveBeenCalled();
-  });
-
-  it('should emit menuOpen when menu is opened', () => {
-    const onMenuOpenSpy = jest.spyOn(component.menuOpen, 'emit');
-    
-    component.onMenuOpen();
-    
-    expect(onMenuOpenSpy).toHaveBeenCalled();
-  });
-
-  it('should emit menuClose when menu is closed', () => {
-    const onMenuCloseSpy = jest.spyOn(component.menuClose, 'emit');
-    
-    component.onMenuClose();
-    
-    expect(onMenuCloseSpy).toHaveBeenCalled();
-  });
-
-  it('should return context menu template when contextMenu is true', () => {
-    fixture.componentRef.setInput('contextMenu', true);
+  it('should open menu when trigger is clicked', () => {
+    triggerButton.click();
     fixture.detectChanges();
 
-    const template = component.getMenuTemplate();
-    expect(template).toBe(component.contextMenuTemplate());
+    expect(getMenuPanel()).toBeTruthy();
+    expect(host.opened).toBe(true);
   });
 
-  it('should track items by id', () => {
-    const testItem = mockMenuItems[0];
-    const result = component.trackByItemId(0, testItem);
+  it('should close menu when trigger is clicked again', () => {
+    triggerButton.click();
+    fixture.detectChanges();
 
-    expect(result).toBe(testItem.id);
+    triggerButton.click();
+    fixture.detectChanges();
+
+    expect(getMenuPanel()).toBeFalsy();
+    expect(host.closed).toBe(true);
   });
 
-  it('should detect items with children', () => {
-    const itemWithChildren = mockMenuItems[4];
-    const itemWithoutChildren = mockMenuItems[0];
+  it('should close menu when backdrop is clicked', fakeAsync(() => {
+    triggerButton.click();
+    fixture.detectChanges();
 
-    expect(component.hasChildren()(itemWithChildren)).toBe(true);
-    expect(component.hasChildren()(itemWithoutChildren)).toBe(false);
+    getBackdrop()!.click();
+    flush();
+    fixture.detectChanges();
+
+    expect(getMenuPanel()).toBeFalsy();
+    expect(host.closed).toBe(true);
+  }));
+
+  // -- Rendering ----------------------------------------------------------
+
+  it('should render non-separator items as buttons', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const items = getMenuItems();
+    // 5 items minus 1 separator = 4 buttons (Cut, Copy, Disabled, More)
+    expect(items.length).toBe(4);
   });
 
-  it('should not emit menuItemClick for items with children', () => {
-    const onMenuItemClickSpy = jest.spyOn(component.menuItemClick, 'emit');
-    const itemWithChildren = mockMenuItems[4];
-    
-    component.onMenuItemClick(itemWithChildren);
-    
-    expect(onMenuItemClickSpy).not.toHaveBeenCalled();
+  it('should render separator elements', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const separators = document.querySelectorAll('.tn-menu-separator');
+    expect(separators.length).toBe(1);
   });
 
-  it('should emit menuItemClick for items without children', () => {
-    const onMenuItemClickSpy = jest.spyOn(component.menuItemClick, 'emit');
-    const itemWithoutChildren = mockMenuItems[0];
-    
-    component.onMenuItemClick(itemWithoutChildren);
-    
-    expect(onMenuItemClickSpy).toHaveBeenCalledWith(itemWithoutChildren);
+  it('should render item labels', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const labels = Array.from(document.querySelectorAll('.tn-menu-item-label'));
+    expect(labels.map(el => el.textContent?.trim())).toContain('Cut');
+    expect(labels.map(el => el.textContent?.trim())).toContain('Copy');
   });
+
+  it('should render item shortcuts', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const shortcuts = document.querySelectorAll('.tn-menu-item-shortcut');
+    expect(shortcuts.length).toBeGreaterThanOrEqual(1);
+    expect(shortcuts[0].textContent?.trim()).toBe('⌘X');
+  });
+
+  it('should render icons when provided', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const icons = document.querySelectorAll('.tn-menu-item-icon');
+    expect(icons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render submenu arrow on items with children', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const arrows = document.querySelectorAll('.tn-menu-item-arrow');
+    expect(arrows.length).toBe(1);
+  });
+
+  it('should mark disabled items with disabled attribute', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const disabledItems = document.querySelectorAll('.tn-menu-item[disabled]');
+    expect(disabledItems.length).toBe(1);
+  });
+
+  // -- Selection ----------------------------------------------------------
+
+  it('should emit selected item and close menu on leaf item click', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const copyButton = getMenuItems().find(
+      el => el.textContent?.includes('Copy')
+    )!;
+    copyButton.click();
+    fixture.detectChanges();
+
+    expect(host.lastClicked?.id).toBe('copy');
+    expect(getMenuPanel()).toBeFalsy();
+  });
+
+  it('should not emit click for disabled items', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const disabledButton = getMenuItems().find(
+      el => el.textContent?.includes('Disabled')
+    )!;
+    disabledButton.click();
+    fixture.detectChanges();
+
+    expect(host.lastClicked).toBeNull();
+  });
+
+  it('should not close menu when clicking an item with children', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const moreButton = getMenuItems().find(
+      el => el.textContent?.includes('More')
+    )!;
+    moreButton.click();
+    fixture.detectChanges();
+
+    // Menu should still be open - "More" has children
+    expect(getMenuPanel()).toBeTruthy();
+    expect(host.lastClicked).toBeNull();
+  });
+
+  // -- Positions ----------------------------------------------------------
+
+  for (const position of ['above', 'below', 'before', 'after'] as const) {
+    it(`should open menu with "${position}" position`, () => {
+      host.position = position;
+      fixture.detectChanges();
+
+      triggerButton.click();
+      fixture.detectChanges();
+
+      expect(getMenuPanel()).toBeTruthy();
+    });
+  }
+});
+
+// ===========================================================================
+// Context menu tests
+// ===========================================================================
+describe('tn-menu as context menu', () => {
+  let fixture: ComponentFixture<ContextMenuTestHostComponent>;
+  let host: ContextMenuTestHostComponent;
+  let contextArea: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContextMenuTestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContextMenuTestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    contextArea = fixture.nativeElement.querySelector('.context-area');
+  });
+
+  function rightClick(el: HTMLElement, x = 100, y = 100): void {
+    el.dispatchEvent(new MouseEvent('contextmenu', {
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+      cancelable: true,
+    }));
+  }
+
+  it('should open menu on right-click', fakeAsync(() => {
+    rightClick(contextArea);
+    fixture.detectChanges();
+    flush();
+
+    expect(getMenuPanel()).toBeTruthy();
+    expect(host.opened).toBe(true);
+  }));
+
+  it('should render context menu items', fakeAsync(() => {
+    rightClick(contextArea);
+    fixture.detectChanges();
+    flush();
+
+    const labels = Array.from(document.querySelectorAll('.tn-menu-item-label'))
+      .map(el => el.textContent?.trim());
+    expect(labels).toContain('Cut');
+    expect(labels).toContain('Copy');
+  }));
+
+  it('should close context menu and emit on item click', fakeAsync(() => {
+    rightClick(contextArea);
+    fixture.detectChanges();
+    flush();
+
+    const cutButton = getMenuItems().find(
+      el => el.textContent?.includes('Cut')
+    )!;
+    cutButton.click();
+    fixture.detectChanges();
+    flush();
+
+    expect(host.lastClicked?.id).toBe('cut');
+    expect(host.closed).toBe(true);
+  }));
+
+  it('should close previous context menu when opening a new one', fakeAsync(() => {
+    rightClick(contextArea, 50, 50);
+    fixture.detectChanges();
+    flush();
+
+    rightClick(contextArea, 150, 150);
+    fixture.detectChanges();
+    flush();
+
+    // Only one menu panel should exist
+    const panels = document.querySelectorAll('.tn-menu');
+    expect(panels.length).toBe(1);
+  }));
+
+  it('should close context menu on backdrop click', fakeAsync(() => {
+    rightClick(contextArea);
+    fixture.detectChanges();
+    flush();
+
+    getBackdrop()!.click();
+    flush();
+    fixture.detectChanges();
+
+    expect(getMenuPanel()).toBeFalsy();
+    expect(host.closed).toBe(true);
+  }));
 });

--- a/projects/truenas-ui/src/lib/menu/menu.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.ts
@@ -2,9 +2,38 @@ import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { Overlay, type OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
-import type { TemplateRef} from '@angular/core';
-import { Component, input, output, viewChild, computed, inject, ViewContainerRef } from '@angular/core';
+import type { AfterContentInit, TemplateRef } from '@angular/core';
+import { Component, Directive, ElementRef, input, output, viewChild, computed, inject, ViewContainerRef } from '@angular/core';
 import { TnIconComponent } from '../icon/icon.component';
+
+/**
+ * Activates CDK menu hover-to-open behavior for menus opened via custom overlays.
+ *
+ * CDK's hover-to-open for submenu triggers is guarded by `!menuStack.isEmpty()`.
+ * When a CdkMenu is opened via TnMenuTriggerDirective (custom overlay) instead of
+ * CDK's own CdkMenuTrigger, the menu is considered "inline" and doesn't register
+ * with the stack, disabling hover for its submenu triggers.
+ *
+ * This directive pushes the CdkMenu to its own stack and focuses the element
+ * (to trigger the CdkMenu's focusin host listener, preventing the hasFocus
+ * auto-close subscription from immediately clearing the stack).
+ */
+@Directive({
+  selector: '[tnMenuActivateHover]',
+  standalone: true,
+})
+export class TnMenuActivateHoverDirective implements AfterContentInit {
+  private cdkMenu = inject(CdkMenu);
+  private elementRef = inject(ElementRef);
+
+  ngAfterContentInit(): void {
+    const stack = this.cdkMenu.menuStack;
+    if (stack.isEmpty()) {
+      stack.push(this.cdkMenu);
+      this.elementRef.nativeElement.focus({ preventScroll: true });
+    }
+  }
+}
 
 export interface TnMenuItem {
   id: string;
@@ -21,7 +50,7 @@ export interface TnMenuItem {
 @Component({
   selector: 'tn-menu',
   standalone: true,
-  imports: [CommonModule, CdkMenu, CdkMenuItem, CdkMenuTrigger, TnIconComponent],
+  imports: [CommonModule, CdkMenu, CdkMenuItem, CdkMenuTrigger, TnIconComponent, TnMenuActivateHoverDirective],
   templateUrl: './menu.component.html',
   styleUrls: ['./menu.component.scss'],
 })

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -67,7 +67,7 @@
   --tn-accent: var(--tn-yellow);
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
-  --tn-fg1: #808080;
+  --tn-fg1: #e0e0e0;
   --tn-fg2: rgba(255,255,255,0.85);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;


### PR DESCRIPTION
Brighten --tn-fg1 in tn-dark theme from #808080 to #e0e0e0 (~11:1 contrast) so dialog titles, menu text, and other primary foreground elements are clearly readable.

Fix menu to auto-close on leaf item selection by subscribing to menuItemClick in the trigger directive.

Enable hover-to-open for top-level submenu triggers by pushing the CdkMenu onto its own MenuStack (CDK disables hover when the stack is empty, which happens when opened via a custom overlay).

Rewrite menu tests to drive through DOM interactions instead of calling component internals directly.