### PR TITLE
NAS-141638 / 27.0.0-BETA.1 / fix(icon): add missing custom library app- prefix in resolveIcon()

### DIFF
--- a/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
@@ -66,6 +66,39 @@ describe('TnIconComponent - MDI Support', () => {
     expect(iconRegistry.resolveIcon).toHaveBeenCalledWith('delete', expect.any(Object));
   });
 
+  it('should resolve custom library icon with app- prefix', async () => {
+    iconRegistry.resolveIcon.mockImplementation((name: string) => {
+      if (name.startsWith('app-')) {
+        return { source: 'sprite', content: '', spriteUrl: `#icon-${name}` };
+      }
+      return null;
+    });
+
+    fixture.componentRef.setInput('name', 'hdd');
+    fixture.componentRef.setInput('library', 'custom');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(iconRegistry.resolveIcon).toHaveBeenCalledWith('app-hdd', expect.any(Object));
+    expect(component.iconResult().source).toBe('sprite');
+  });
+
+  it('should not double-prefix custom icons already starting with app-', async () => {
+    iconRegistry.resolveIcon.mockImplementation((name: string) => {
+      if (name === 'app-hdd') {
+        return { source: 'sprite', content: '', spriteUrl: '#icon-app-hdd' };
+      }
+      return null;
+    });
+
+    fixture.componentRef.setInput('name', 'app-hdd');
+    fixture.componentRef.setInput('library', 'custom');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(iconRegistry.resolveIcon).toHaveBeenCalledWith('app-hdd', expect.any(Object));
+  });
+
   it('should handle library parameter with fallback', async () => {
     spriteLoader.getIconUrl.mockReturnValue(null);
     iconRegistry.resolveIcon.mockReturnValue(null);

--- a/projects/truenas-ui/src/lib/icon/icon.component.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.ts
@@ -125,6 +125,8 @@ export class TnIconComponent {
     } else if (library === 'lucide' && !name.includes(':')) {
       // Convert to registry format for Lucide icons
       effectiveIconName = `lucide:${name}`;
+    } else if (library === 'custom' && !name.startsWith('app-')) {
+      effectiveIconName = `app-${name}`;
     }
 
     // 1. Try icon registry (libraries and custom icons)


### PR DESCRIPTION
resolveIcon() handled mdi, material, and lucide prefixes but not custom, causing <tn-icon name="hdd" library="custom"> to look up "hdd" instead of "app-hdd" in the sprite, rendering fallback text instead of the icon.

Icons are not shown without this fix:

<img width="491" height="604" alt="Screenshot 2026-03-30 at 22 56 19" src="https://github.com/user-attachments/assets/bf604048-3c9b-4232-b3ff-fbd718360c27" />
