### PR TITLE
docs: fix inaccuracies across all dev-facing documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,12 @@ This file helps coding agents quickly find the right documentation for working o
 
 | File | Purpose | Read When | Size |
 |------|---------|-----------|------|
-| `component_creation_checklist.md` | Step-by-step component creation workflow | Creating any new component | ~80 lines |
-| `component_templates.md` | Copy-paste boilerplate code for all file types | Need template code for .ts/.html/.scss/.spec/.stories files | ~400 lines |
-| `component_styling.md` | CSS patterns, theme variables, responsive design | Working on styles or appearance | ~150 lines |
-| `component_testing.md` | Testing patterns, Jest examples, mocking | Writing or debugging tests | ~120 lines |
-| `component_conventions.md` | Naming rules, architecture decisions, patterns | Understanding project structure or design choices | ~100 lines |
-| `harness_documentation.md` | Auto-generating harness API docs in Storybook | Creating harness documentation or integrating into stories | ~650 lines |
+| `component_creation_checklist.md` | Step-by-step component creation workflow | Creating any new component | ~200 lines |
+| `component_templates.md` | Copy-paste boilerplate code for all file types | Need template code for .ts/.html/.scss/.spec/.stories files | ~740 lines |
+| `component_styling.md` | CSS patterns, theme variables, responsive design | Working on styles or appearance | ~480 lines |
+| `component_testing.md` | Testing patterns, Jest examples, mocking | Writing or debugging tests | ~740 lines |
+| `component_conventions.md` | Naming rules, architecture decisions, patterns | Understanding project structure or design choices | ~510 lines |
+| `harness_documentation.md` | Auto-generating harness API docs in Storybook | Creating harness documentation or integrating into stories | ~570 lines |
 
 ## Common Usage Patterns
 
@@ -84,10 +84,10 @@ Storybook is a tool for building and testing UI components in isolation. It prov
 ### Quick Storybook Commands
 ```bash
 # Start Storybook dev server
-npm run storybook
+yarn storybook
 
 # Build Storybook for production
-npm run build-storybook
+yarn build-storybook
 ```
 
 ### Story File Templates
@@ -132,14 +132,16 @@ play: async ({ canvasElement }) => {
 **Icon Marker:**
 For sprite generation in Storybook stories
 ```typescript
+import { tnIconMarker } from '../lib/icon/icon-marker';
+
 tnIconMarker('icon-name', 'library-type');
 ```
 
 ### Existing Examples
 Look at these story files for reference:
-- `projects/truenas-ui/src/stories/tn-button.stories.ts`
-- `projects/truenas-ui/src/stories/tn-card.stories.ts`
-- `projects/truenas-ui/src/stories/tn-menu.stories.ts`
+- `projects/truenas-ui/src/stories/button.stories.ts`
+- `projects/truenas-ui/src/stories/card.stories.ts`
+- `projects/truenas-ui/src/stories/menu.stories.ts`
 
 ## Important Notes for Agents
 
@@ -152,7 +154,6 @@ Look at these story files for reference:
 ## Additional Resources
 
 - `CONTRIBUTE.md` - General contribution guidelines, git workflow, icon system
-- `README.md` - Library usage, installation, consumer documentation
 - `projects/truenas-ui/src/lib/` - Existing component examples
 - `projects/truenas-ui/src/stories/` - Storybook examples
 - **Storybook Docs:** https://storybook.js.org/docs
@@ -160,12 +161,12 @@ Look at these story files for reference:
 ## Quick Reference
 
 **Creating a component checklist:**
-1. Create directory: `projects/truenas-ui/src/lib/tn-[name]/`
-2. Create 4 required files: `.component.ts`, `.component.html`, `.component.scss`, `.component.spec.ts`
+1. Create directory: `projects/truenas-ui/src/lib/[name]/`
+2. Create required files: `[name].component.ts`, `.component.html`, `.component.scss`, `.component.spec.ts`
 3. Export in `public-api.ts`
 4. Create story in `projects/truenas-ui/src/stories/`
-5. Run tests: `npm test`
-6. View in Storybook: `npm run storybook`
+5. Run tests: `yarn test`
+6. View in Storybook: `yarn storybook`
 
 **All components must be:**
 - Standalone (no NgModule)

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -48,13 +48,13 @@ truenas-ui-components/
 ├── projects/truenas-ui/          # Main library source code
 │   ├── src/
 │   │   ├── lib/                  # Component source files
-│   │   │   ├── button/       # Example component
+│   │   │   ├── button/           # Example component
 │   │   │   ├── input/
 │   │   │   └── ...
 │   │   ├── public-api.ts        # Public API exports
 │   │   └── styles/              # Theme CSS files
 │   ├── assets/                  # Library assets
-│   │   └── icons/
+│   │   └── tn-icons/
 │   │       ├── custom/          # Library custom icons (tn- prefix)
 │   │       └── sprite.svg       # Generated icon sprite
 │   ├── scripts/                 # Build scripts
@@ -83,7 +83,7 @@ yarn test-sb          # Run Storybook interaction tests
 
 **Icon Sprite Generation:**
 ```bash
-yarn icons            # Generate icon sprite (runs automatically on build)
+yarn generate-sprite  # Generate icon sprite (runs automatically on build)
 ```
 
 ## Commit Messages & Releases
@@ -230,7 +230,7 @@ To add a new custom icon to the library:
 1. **Add the SVG file:**
    ```bash
    # Place your icon in the library's custom icon directory
-   projects/truenas-ui/assets/icons/custom/my-icon.svg
+   projects/truenas-ui/assets/tn-icons/custom/my-icon.svg
    ```
 
 2. **Use the icon in library code:**
@@ -270,16 +270,13 @@ The sprite generation system automatically:
 
 **Manual sprite generation:**
 ```bash
-yarn icons
+yarn generate-sprite
 ```
 
 **View the generated sprite:**
 ```bash
 # Library sprite
-cat projects/truenas-ui/assets/icons/sprite-config.json
-
-# Consumer app sprite (after running yarn icons in your app)
-cat src/assets/icons/sprite-config.json
+cat projects/truenas-ui/assets/tn-icons/sprite-config.json
 ```
 
 ### Git Hook Enforcement
@@ -327,20 +324,21 @@ tnIconMarker('dataset', 'custom');
 1. **Generate the component structure:**
    ```bash
    cd projects/truenas-ui/src/lib
-   mkdir tn-my-component
-   cd tn-my-component
+   mkdir my-component
+   cd my-component
    ```
 
 2. **Create component files:**
-   - `tn-my-component.component.ts` - Component logic
-   - `tn-my-component.component.html` - Template
-   - `tn-my-component.component.scss` - Styles
-   - `tn-my-component.component.spec.ts` - Tests
+   - `my-component.component.ts` - Component logic
+   - `my-component.component.html` - Template
+   - `my-component.component.scss` - Styles
+   - `my-component.component.spec.ts` - Tests
+   - `my-component.harness.ts` - Test harness (required for new components)
 
 3. **Follow naming conventions:**
-   - Component selector: `tn-my-component`
+   - Component selector: `tn-my-component` (selectors use `tn-` prefix)
    - Component class: `TnMyComponentComponent`
-   - Use `tn-` prefix for all selectors
+   - File/directory names do **not** use the `tn-` prefix
 
 4. **Use standalone components:**
    ```typescript
@@ -350,8 +348,8 @@ tnIconMarker('dataset', 'custom');
      selector: 'tn-my-component',
      standalone: true,
      imports: [],
-     templateUrl: './tn-my-component.component.html',
-     styleUrl: './tn-my-component.component.scss'
+     templateUrl: './my-component.component.html',
+     styleUrl: './my-component.component.scss'
    })
    export class TnMyComponentComponent {
      // Component logic
@@ -361,25 +359,8 @@ tnIconMarker('dataset', 'custom');
 5. **Export the component:**
    Add to `projects/truenas-ui/src/public-api.ts`:
    ```typescript
-   export * from './lib/tn-my-component/tn-my-component.component';
-   ```
-
-6. **Add to module exports:**
-   Update `projects/truenas-ui/src/lib/truenas-ui.module.ts`:
-   ```typescript
-   import { TnMyComponentComponent } from './tn-my-component/tn-my-component.component';
-
-   @NgModule({
-     imports: [
-       // ... other imports
-       TnMyComponentComponent
-     ],
-     exports: [
-       // ... other exports
-       TnMyComponentComponent
-     ]
-   })
-   export class TruenasUiModule {}
+   export * from './lib/my-component/my-component.component';
+   export * from './lib/my-component/my-component.harness';
    ```
 
 ### Creating Storybook Stories
@@ -387,14 +368,14 @@ tnIconMarker('dataset', 'custom');
 1. **Create a story file:**
    ```bash
    # In projects/truenas-ui/src/stories/
-   touch tn-my-component.stories.ts
+   touch my-component.stories.ts
    ```
 
 2. **Write the story:**
    ```typescript
    import type { Meta, StoryObj } from '@storybook/angular';
-   import { TnMyComponentComponent } from '../lib/tn-my-component/tn-my-component.component';
-   import { tnIconMarker } from '../lib/icon-marker';
+   import { TnMyComponentComponent } from '../lib/my-component/my-component.component';
+   import { tnIconMarker } from '../lib/icon/icon-marker';
 
    // Mark any icons used in the story
    tnIconMarker('settings', 'mdi');
@@ -436,7 +417,7 @@ yarn test-coverage     # Run with coverage report
 
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TnMyComponentComponent } from './tn-my-component.component';
+import { TnMyComponentComponent } from './my-component.component';
 
 describe('TnMyComponentComponent', () => {
   let component: TnMyComponentComponent;
@@ -480,7 +461,7 @@ Storybook includes the `@storybook/addon-a11y` addon for accessibility testing. 
 
 ### Angular
 
-- Use standalone components (Angular 19+)
+- Use standalone components (Angular 21+)
 - Use signals for reactive state when appropriate
 - Use OnPush change detection strategy
 - Follow Angular style guide
@@ -494,9 +475,9 @@ Storybook includes the `@storybook/addon-a11y` addon for accessibility testing. 
 - Use the theme variables:
   ```scss
   .my-component {
-    background: var(--bg1);
-    color: var(--fg1);
-    border-color: var(--border);
+    background: var(--tn-bg1);
+    color: var(--tn-fg1);
+    border-color: var(--tn-lines);
   }
   ```
 

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -15,7 +15,7 @@ Naming rules, architecture decisions, and design patterns for TrueNAS UI Compone
 
 ### Component Class Name
 - **Format:** `Tn[Name]Component` (PascalCase)
-- **Prefix:** `Ix`
+- **Prefix:** `Tn`
 - **Suffix:** `Component`
 - **Examples:**
   - `TnButtonComponent`
@@ -27,12 +27,15 @@ Naming rules, architecture decisions, and design patterns for TrueNAS UI Compone
 
 | File Type | Pattern | Example |
 |-----------|---------|---------|
-| Component | `tn-[name].component.ts` | `tn-button.component.ts` |
-| Template | `tn-[name].component.html` | `tn-button.component.html` |
-| Stylesheet | `tn-[name].component.scss` | `tn-button.component.scss` |
-| Test | `tn-[name].component.spec.ts` | `tn-button.component.spec.ts` |
-| Interfaces | `tn-[name].interfaces.ts` | `tn-card.interfaces.ts` |
-| Story | `tn-[name].stories.ts` | `tn-button.stories.ts` |
+| Component | `[name].component.ts` | `button.component.ts` |
+| Template | `[name].component.html` | `button.component.html` |
+| Stylesheet | `[name].component.scss` | `button.component.scss` |
+| Test | `[name].component.spec.ts` | `button.component.spec.ts` |
+| Harness | `[name].harness.ts` | `button.harness.ts` |
+| Interfaces | `[name].interfaces.ts` | `card.interfaces.ts` |
+| Story | `[name].stories.ts` | `button.stories.ts` |
+
+**Note:** The `tn-` prefix is used for component **selectors** (e.g., `tn-button`), not for file or directory names.
 
 ### CSS Class Names (BEM)
 
@@ -111,7 +114,7 @@ valueChange = output<string>();
 **Decision:** All components MUST be standalone.
 
 **Rationale:**
-- Angular 19+ best practice
+- Angular 21+ best practice
 - Simpler imports for consumers
 - No NgModule boilerplate
 - Better tree-shaking
@@ -268,7 +271,7 @@ Use for behavior, not presentation:
 
 ```typescript
 @Directive({
-  selector: '[ixMenuTrigger]',
+  selector: '[tnMenuTrigger]',
   standalone: true,
 })
 export class TnMenuTriggerDirective {
@@ -437,19 +440,13 @@ Use for performance-critical components:
 })
 ```
 
-### TrackBy for *ngFor
-Optimize list rendering:
-
-```typescript
-trackById(index: number, item: any): any {
-  return item.id;
-}
-```
+### Track Expression for @for
+Optimize list rendering with the built-in `track` expression:
 
 ```html
-<div *ngFor="let item of items; trackBy: trackById">
-  {{ item.name }}
-</div>
+@for (item of items(); track item.id) {
+  <div>{{ item.name }}</div>
+}
 ```
 
 ### Lazy Loading
@@ -481,29 +478,29 @@ Defer loading of heavy components when possible.
 ```
 projects/truenas-ui/src/
 ├── lib/
-│   ├── tn-button/
-│   │   ├── tn-button.component.ts
-│   │   ├── tn-button.component.html
-│   │   ├── tn-button.component.scss
-│   │   ├── tn-button.component.spec.ts
+│   ├── button/
+│   │   ├── button.component.ts
+│   │   ├── button.component.html
+│   │   ├── button.component.scss
+│   │   ├── button.component.spec.ts
+│   │   ├── button.harness.ts
 │   │   └── index.ts (optional)
-│   └── tn-card/
-│       ├── tn-card.component.ts
-│       ├── tn-card.component.html
-│       ├── tn-card.component.scss
-│       ├── tn-card.component.spec.ts
-│       ├── tn-card.interfaces.ts
+│   └── card/
+│       ├── card.component.ts
+│       ├── card.component.html
+│       ├── card.component.scss
+│       ├── card.interfaces.ts
 │       └── index.ts
 ├── stories/
-│   ├── tn-button.stories.ts
-│   └── tn-card.stories.ts
+│   ├── button.stories.ts
+│   └── card.stories.ts
 └── public-api.ts
 ```
 
 ## Examples
 
 For real-world examples, examine:
-- **tn-button/** - Simple component pattern
-- **tn-card/** - Complex component with interfaces
-- **tn-menu/** - Component with directives
-- **tn-checkbox/** - Form control integration
+- **button/** - Simple component pattern
+- **card/** - Complex component with interfaces
+- **menu/** - Component with directives
+- **checkbox/** - Form control integration

--- a/docs/component_creation_checklist.md
+++ b/docs/component_creation_checklist.md
@@ -22,29 +22,29 @@ Step-by-step guide for creating new components in TrueNAS UI Components library.
 
 Navigate to your new directory and create these required files:
 
-- [ ] **Component TypeScript file**: `tn-[name].component.ts`
+- [ ] **Component TypeScript file**: `[name].component.ts`
   - See `component_templates.md` for templates
   - Must be standalone component
   - Use `tn-[name]` selector
   - Class name: `Tn[Name]Component`
 
-- [ ] **Component HTML template**: `tn-[name].component.html`
+- [ ] **Component HTML template**: `[name].component.html`
   - See `component_templates.md` for templates
   - Use semantic HTML
   - Include ARIA attributes for accessibility
 
-- [ ] **Component SCSS stylesheet**: `tn-[name].component.scss`
+- [ ] **Component SCSS stylesheet**: `[name].component.scss`
   - See `component_styling.md` for theme variables
   - Use CSS custom properties (e.g., `var(--tn-bg1)`)
   - Follow BEM naming: `.tn-[name]`, `.tn-[name]--modifier`, `.tn-[name]__element`
 
-- [ ] **Component test file**: `tn-[name].component.spec.ts`
+- [ ] **Component test file**: `[name].component.spec.ts`
   - See `component_testing.md` for patterns
   - Test creation, inputs, outputs, and classes
   - Use Jest syntax
   - Include both traditional and harness-based tests
 
-- [ ] **Component harness file** (REQUIRED for NEW components): `tn-[name].harness.ts`
+- [ ] **Component harness file** (REQUIRED for NEW components): `[name].harness.ts`
   - See `component_templates.md` for harness template
   - Extend `ComponentHarness` from `@angular/cdk/testing`
   - Implement minimal API: `getText()` and `with({ containsText })`
@@ -53,25 +53,25 @@ Navigate to your new directory and create these required files:
 
 ### Phase 3: Optional Files
 
-- [ ] **Interfaces file** (if needed): `tn-[name].interfaces.ts`
+- [ ] **Interfaces file** (if needed): `[name].interfaces.ts`
   - Create if component uses complex types
   - Export interfaces and types
 
 - [ ] **Index file** (if needed): `index.ts`
   - Create if you have multiple exports (component + interfaces)
-  - Barrel export pattern: `export * from './tn-[name].component';`
+  - Barrel export pattern: `export * from './[name].component';`
 
 ### Phase 4: Integration
 
 - [ ] **Export in public API**
   - Open: `projects/truenas-ui/src/public-api.ts`
-  - Add: `export * from './lib/tn-[name]/tn-[name].component';`
-  - Add: `export * from './lib/tn-[name]/tn-[name].harness';` ← REQUIRED for new components
-  - If using index.ts: `export * from './lib/tn-[name]';`
-  - If interfaces exist: `export * from './lib/tn-[name]/tn-[name].interfaces';`
+  - Add: `export * from './lib/[name]/[name].component';`
+  - Add: `export * from './lib/[name]/[name].harness';` ← REQUIRED for new components
+  - If using index.ts: `export * from './lib/[name]';`
+  - If interfaces exist: `export * from './lib/[name]/[name].interfaces';`
 
 - [ ] **Create Storybook story**
-  - Create: `projects/truenas-ui/src/stories/tn-[name].stories.ts`
+  - Create: `projects/truenas-ui/src/stories/[name].stories.ts`
   - See `component_templates.md` for story templates
   - Include multiple variants (Default, Primary, Disabled, etc.)
   - Add interaction tests with `play` functions
@@ -81,14 +81,14 @@ Navigate to your new directory and create these required files:
 
 - [ ] **Run unit tests**
   ```bash
-  npm test
+  yarn test
   ```
   - All tests must pass
   - Verify your component tests run
 
 - [ ] **View in Storybook**
   ```bash
-  npm run storybook
+  yarn storybook
   ```
   - Navigate to Components/[Your Component]
   - Test all variants and interactions
@@ -114,21 +114,21 @@ Navigate to your new directory and create these required files:
 After completion, your component should look like:
 
 ```
-projects/truenas-ui/src/lib/tn-[name]/
-├── tn-[name].component.ts         # Component logic
-├── tn-[name].component.html       # Template
-├── tn-[name].component.scss       # Styles
-├── tn-[name].component.spec.ts    # Tests
-├── tn-[name].harness.ts           # Test harness (REQUIRED for new components)
-├── tn-[name].interfaces.ts        # (Optional) Types
-└── index.ts                       # (Optional) Barrel export
+projects/truenas-ui/src/lib/[name]/
+├── [name].component.ts         # Component logic
+├── [name].component.html       # Template
+├── [name].component.scss       # Styles
+├── [name].component.spec.ts    # Tests
+├── [name].harness.ts           # Test harness (REQUIRED for new components)
+├── [name].interfaces.ts        # (Optional) Types
+└── index.ts                    # (Optional) Barrel export
 
 projects/truenas-ui/src/stories/
-└── tn-[name].stories.ts           # Storybook story
+└── [name].stories.ts           # Storybook story
 
 projects/truenas-ui/src/public-api.ts
-├── export * from './lib/tn-[name]/tn-[name].component';
-└── export * from './lib/tn-[name]/tn-[name].harness';  # Public harness export
+├── export * from './lib/[name]/[name].component';
+└── export * from './lib/[name]/[name].harness';  # Public harness export
 ```
 
 ## Where to Find Templates
@@ -162,30 +162,27 @@ projects/truenas-ui/src/public-api.ts
 mkdir projects/truenas-ui/src/lib/[name]
 
 # Run tests
-npm test
-
-# Run tests in watch mode
-npm run test:watch
+yarn test
 
 # Start Storybook
-npm run storybook
+yarn storybook
 
 # Build library
-npm run build
+yarn build
 
 # Run all checks (like pre-commit)
-npm test && npm run build
+yarn test && yarn build
 ```
 
 ## Examples
 
 For reference, look at these existing components:
 
-- **Simple component**: `tn-button/`
-- **Complex component**: `tn-card/`
-- **Form control**: `tn-checkbox/`
-- **With directives**: `tn-menu/`
-- **Harness reference**: `tn-banner/` - Complete harness implementation with minimal API
+- **Simple component**: `button/`
+- **Complex component**: `card/`
+- **Form control**: `checkbox/`
+- **With directives**: `menu/`
+- **Harness reference**: `banner/` - Complete harness implementation with minimal API
 
 ## Next Steps
 

--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -11,7 +11,8 @@ All components MUST use CSS custom properties for theming. Never hardcode colors
 ```scss
 var(--tn-bg1)       // Primary background (main canvas)
 var(--tn-bg2)       // Secondary background (cards, panels)
-var(--bg-hover)  // Hover state background
+var(--tn-alt-bg1)   // Alternate background (hover states, subtle contrast)
+var(--tn-alt-bg2)   // Alternate background 2 (active states)
 ```
 
 ### Foreground Colors (Text)
@@ -44,9 +45,9 @@ var(--tn-blue)      // Info, neutral information
 ```scss
 var(--tn-icon-xs)   // 12px - Very small icons
 var(--tn-icon-sm)   // 16px - Small icons
-var(--tn-icon-md)   // 24px - Medium icons (default)
-var(--tn-icon-lg)   // 32px - Large icons
-var(--tn-icon-xl)   // 48px - Extra large icons
+var(--tn-icon-md)   // 20px - Medium icons (default)
+var(--tn-icon-lg)   // 24px - Large icons
+var(--tn-icon-xl)   // 32px - Extra large icons
 ```
 
 ## BEM Naming Convention
@@ -90,7 +91,7 @@ Use BEM (Block Element Modifier) for CSS class names:
 
   // Hover state
   &:hover {
-    background-color: var(--bg-hover);
+    background-color: var(--tn-alt-bg1);
   }
 
   // Disabled state
@@ -418,10 +419,13 @@ Test components in high contrast mode:
 
 Components automatically work with all themes via CSS variables:
 
-- `tn-dark` - Dark theme
+- `tn-dark` - Dark theme (TrueNAS default)
 - `tn-blue` - Blue theme
 - `tn-dracula` - Dracula theme
 - `tn-nord` - Nord theme
+- `tn-paper` - Paper (light) theme
+- `tn-solarized-dark` - Solarized Dark theme
+- `tn-midnight` - Midnight theme
 - `tn-high-contrast` - High contrast theme
 
 **No theme-specific code needed in components.** Just use CSS variables.

--- a/docs/component_templates.md
+++ b/docs/component_templates.md
@@ -1,6 +1,8 @@
 # Component Templates
 
-Copy-paste templates for creating TrueNAS UI components. Replace `[name]` with your component name (lowercase) and `[Name]` with PascalCase version.
+Copy-paste templates for creating TrueNAS UI components. Replace `[name]` with your component name (lowercase, hyphenated) and `[Name]` with PascalCase version.
+
+**Note:** Component selectors use the `tn-` prefix (e.g., `tn-button`) but file and directory names do **not** (e.g., `button/button.component.ts`).
 
 ## TypeScript Component Templates
 
@@ -14,8 +16,8 @@ import { Component, input, output } from '@angular/core';
   selector: 'tn-[name]',
   standalone: true,
   imports: [CommonModule],
-  templateUrl: './tn-[name].component.html',
-  styleUrls: ['./tn-[name].component.scss'],
+  templateUrl: './[name].component.html',
+  styleUrls: ['./[name].component.scss'],
 })
 export class Tn[Name]Component {
   // Input signals
@@ -44,8 +46,8 @@ import { Component, input } from '@angular/core';
   selector: 'tn-[name]',
   standalone: true,
   imports: [CommonModule],
-  templateUrl: './tn-[name].component.html',
-  styleUrls: ['./tn-[name].component.scss'],
+  templateUrl: './[name].component.html',
+  styleUrls: ['./[name].component.scss'],
 })
 export class Tn[Name]Component {
   // Input signals with types
@@ -69,15 +71,15 @@ export class Tn[Name]Component {
 ```typescript
 import { CommonModule } from '@angular/common';
 import { Component, input } from '@angular/core';
-import { TnButtonComponent } from '../tn-button/tn-button.component';
-import { TnIconComponent } from '../tn-icon/tn-icon.component';
+import { TnButtonComponent } from '../button/button.component';
+import { TnIconComponent } from '../icon/icon.component';
 
 @Component({
   selector: 'tn-[name]',
   standalone: true,
   imports: [CommonModule, TnButtonComponent, TnIconComponent],
-  templateUrl: './tn-[name].component.html',
-  styleUrls: ['./tn-[name].component.scss'],
+  templateUrl: './[name].component.html',
+  styleUrls: ['./[name].component.scss'],
 })
 export class Tn[Name]Component {
   // Input signals
@@ -95,16 +97,16 @@ export class Tn[Name]Component {
 ```typescript
 import { CommonModule } from '@angular/common';
 import { Component, input, inject } from '@angular/core';
-import { TnIconComponent } from '../tn-icon/tn-icon.component';
-import { TnIconRegistryService } from '../tn-icon/tn-icon-registry.service';
+import { TnIconComponent } from '../icon/icon.component';
+import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { mdiClose, mdiCheck } from '@mdi/js';
 
 @Component({
   selector: 'tn-[name]',
   standalone: true,
   imports: [CommonModule, TnIconComponent],
-  templateUrl: './tn-[name].component.html',
-  styleUrls: ['./tn-[name].component.scss'],
+  templateUrl: './[name].component.html',
+  styleUrls: ['./[name].component.scss'],
 })
 export class Tn[Name]Component {
   // Inject services (modern Angular dependency injection)
@@ -147,8 +149,8 @@ import { Component, input, ChangeDetectionStrategy } from '@angular/core';
   selector: 'tn-[name]',
   standalone: true,
   imports: [CommonModule],
-  templateUrl: './tn-[name].component.html',
-  styleUrls: ['./tn-[name].component.scss'],
+  templateUrl: './[name].component.html',
+  styleUrls: ['./[name].component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Tn[Name]Component {
@@ -329,7 +331,7 @@ export class Tn[Name]Component {
 
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Tn[Name]Component } from './tn-[name].component';
+import { Tn[Name]Component } from './[name].component';
 
 describe('Tn[Name]Component', () => {
   let component: Tn[Name]Component;
@@ -368,7 +370,7 @@ describe('Tn[Name]Component', () => {
 
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Tn[Name]Component } from './tn-[name].component';
+import { Tn[Name]Component } from './[name].component';
 
 describe('Tn[Name]Component', () => {
   let component: Tn[Name]Component;
@@ -425,7 +427,7 @@ describe('Tn[Name]Component', () => {
 import type { Meta, StoryObj } from '@storybook/angular';
 import { userEvent, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
-import { Tn[Name]Component } from '../lib/tn-[name]/tn-[name].component';
+import { Tn[Name]Component } from '../lib/[name]/[name].component';
 
 const meta: Meta<Tn[Name]Component> = {
   title: 'Components/[Name]',
@@ -468,7 +470,7 @@ export const Disabled: Story = {
 import type { Meta, StoryObj } from '@storybook/angular';
 import { userEvent, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
-import { Tn[Name]Component } from '../lib/tn-[name]/tn-[name].component';
+import { Tn[Name]Component } from '../lib/[name]/[name].component';
 
 const meta: Meta<Tn[Name]Component> = {
   title: 'Components/[Name]',
@@ -535,8 +537,8 @@ export const Large: Story = {
 
 ```typescript
 import type { Meta, StoryObj } from '@storybook/angular';
-import { Tn[Name]Component } from '../lib/tn-[name]/tn-[name].component';
-import { tnIconMarker } from '../lib/icon-marker';
+import { Tn[Name]Component } from '../lib/[name]/[name].component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
 
 // Mark icons for sprite generation
 tnIconMarker('close', 'mdi');
@@ -584,22 +586,22 @@ export interface Tn[Name]Action {
 ## Index File Template
 
 ```typescript
-export * from './tn-[name].component';
-export * from './tn-[name].interfaces';
+export * from './[name].component';
+export * from './[name].interfaces';
 ```
 
 ## Public API Export Examples
 
 ```typescript
 // Simple component (no index.ts)
-export * from './lib/tn-[name]/tn-[name].component';
+export * from './lib/[name]/[name].component';
 
 // With index.ts
-export * from './lib/tn-[name]';
+export * from './lib/[name]';
 
 // Component + interfaces (no index.ts)
-export * from './lib/tn-[name]/tn-[name].component';
-export * from './lib/tn-[name]/tn-[name].interfaces';
+export * from './lib/[name]/[name].component';
+export * from './lib/[name]/[name].interfaces';
 ```
 
 ## Usage Examples
@@ -739,4 +741,4 @@ const exists = await loader.hasHarness(
 
 ### Reference Implementation
 
-See `tn-banner.harness.ts` for a complete minimal harness example.
+See `banner.harness.ts` for a complete minimal harness example.

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -13,7 +13,7 @@ Testing patterns and best practices for TrueNAS UI Components using Jest.
 
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Tn[Name]Component } from './tn-[name].component';
+import { Tn[Name]Component } from './[name].component';
 
 describe('Tn[Name]Component', () => {
   let component: Tn[Name]Component;
@@ -188,7 +188,7 @@ describe('DOM rendering', () => {
 ```
 
 ### 7. Conditional Rendering
-Test *ngIf and *ngFor:
+Test `@if` and `@for` control flow:
 
 ```typescript
 describe('conditional rendering', () => {
@@ -224,7 +224,7 @@ describe('conditional rendering', () => {
 
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Tn[Name]Component } from './tn-[name].component';
+import { Tn[Name]Component } from './[name].component';
 import { MyService } from '../services/my.service';
 
 describe('Tn[Name]Component', () => {
@@ -423,16 +423,16 @@ expect(fn).toHaveBeenCalledWith('arg1', 'arg2');
 
 ```bash
 # Run all tests
-npm test
+yarn test
 
-# Run tests in watch mode
-npm run test:watch
+# Clear cache and run tests
+yarn test-cc
 
 # Run tests with coverage
-npm run test:coverage
+yarn test-coverage
 
 # Run specific test file
-npm test -- tn-button.component.spec
+yarn test --testPathPatterns="button.component.spec"
 ```
 
 ## Test Coverage Goals
@@ -503,10 +503,10 @@ debugger;
 ## Examples
 
 See these test files for reference:
-- `tn-button.component.spec.ts` - Simple component tests
-- `tn-card.component.spec.ts` - Complex component with children
-- `tn-checkbox.component.spec.ts` - Form control tests
-- `tn-banner.component.spec.ts` - Harness testing examples
+- `button.component.spec.ts` - Simple component tests
+- `card.component.spec.ts` - Complex component with children
+- `checkbox.component.spec.ts` - Form control tests
+- `banner.component.spec.ts` - Harness testing examples
 
 ## Component Harness Testing
 
@@ -537,7 +537,7 @@ Test utilities from Angular CDK that provide a simple, stable API for querying c
 ```typescript
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
-import { TnBannerHarness } from './tn-banner.harness';
+import { TnBannerHarness } from './banner.harness';
 
 describe('Component with Harness', () => {
   let loader: HarnessLoader;
@@ -737,6 +737,6 @@ describe('My Component with TrueNAS Banner', () => {
 
 ### Reference Implementation
 
-See `/Users/aaronervin/Projects/truenas-ui-components/projects/truenas-ui/src/lib/banner/` for complete harness implementation:
-- `tn-banner.harness.ts` - Minimal harness definition
-- `tn-banner.component.spec.ts` - Harness usage examples
+See `projects/truenas-ui/src/lib/banner/` for complete harness implementation:
+- `banner.harness.ts` - Minimal harness definition
+- `banner.component.spec.ts` - Harness usage examples

--- a/docs/harness_documentation.md
+++ b/docs/harness_documentation.md
@@ -303,8 +303,8 @@ The harness documentation will appear:
 The harness documentation regenerates automatically when you:
 
 ```bash
-npm run storybook          # Starts dev server (with docs generation)
-npm run build-storybook    # Builds static Storybook (with docs generation)
+yarn storybook          # Starts dev server (with docs generation)
+yarn build-storybook    # Builds static Storybook (with docs generation)
 ```
 
 ### Manual Generation
@@ -312,7 +312,7 @@ npm run build-storybook    # Builds static Storybook (with docs generation)
 To regenerate docs without starting Storybook:
 
 ```bash
-npm run generate-harness-docs
+yarn generate-harness-docs
 ```
 
 ### Build Scripts
@@ -375,9 +375,9 @@ They're listed in `.gitignore` as build artifacts.
 ### When Documentation Updates
 
 Documentation regenerates when:
-1. You start Storybook (`npm run storybook`)
-2. You build Storybook (`npm run build-storybook`)
-3. You run the generator manually (`npm run generate-harness-docs`)
+1. You start Storybook (`yarn storybook`)
+2. You build Storybook (`yarn build-storybook`)
+3. You run the generator manually (`yarn generate-harness-docs`)
 
 ### What Triggers Regeneration
 
@@ -444,7 +444,7 @@ If issues persist, check for:
 
 ### Build Errors During Generation
 
-**Problem**: `npm run generate-harness-docs` fails with TypeScript errors
+**Problem**: `yarn generate-harness-docs` fails with TypeScript errors
 
 **Causes:**
 - Syntax errors in `*.harness.ts` files
@@ -454,7 +454,7 @@ If issues persist, check for:
 **Fix:**
 1. Check the error message for the file path
 2. Open the harness file and fix TypeScript errors
-3. Run `npm run generate-harness-docs` again
+3. Run `yarn generate-harness-docs` again
 
 **Tip:** The generator uses TypeScript's compiler API, so it validates syntax strictly.
 
@@ -485,7 +485,7 @@ export class TnComponentHarness extends ComponentHarness {
 
 ### Complete Example: tn-banner
 
-**Harness File**: `projects/truenas-ui/src/lib/banner/tn-banner.harness.ts`
+**Harness File**: `projects/truenas-ui/src/lib/banner/banner.harness.ts`
 
 See this file for a complete, working example of:
 - Class-level JSDoc with description
@@ -493,7 +493,7 @@ See this file for a complete, working example of:
 - Interface documentation
 - Filter property descriptions
 
-**Story File**: `projects/truenas-ui/src/stories/tn-banner.stories.ts`
+**Story File**: `projects/truenas-ui/src/stories/banner.stories.ts`
 
 See this file for:
 - Import statement (line 6)


### PR DESCRIPTION
- Fix file/directory naming convention (tn-[name]/ → [name]/, tn-[name].component.ts → [name].component.ts)
- Fix package manager references (npm → yarn) across all docs
- Fix public API export paths to match actual codebase
- Fix class name prefix (Ix → Tn) in component_conventions.md
- Fix non-existent CSS variable --bg-hover → --tn-alt-bg1
- Fix icon size values to match themes.css (md: 20px, lg: 24px, xl: 32px)
- Add missing themes (paper, solarized-dark, midnight)
- Update Angular version references (19+ → 21+)
- Fix import paths (icon-marker, component cross-references)
- Fix non-existent scripts (yarn icons → yarn generate-sprite, test:watch)
- Remove stale NgModule step from CONTRIBUTE.md
- Fix SCSS variable names in CONTRIBUTE.md (--bg1 → --tn-bg1)
- Fix asset directory path (icons/ → tn-icons/)
- Update *ngFor/trackBy to @for/track syntax
- Fix file size estimates in CLAUDE.md
- Remove non-existent README.md reference from CLAUDE.md