### PR TITLE
feat(theme): add OS color scheme detection to TnThemeService

### DIFF
--- a/projects/truenas-ui/src/lib/theme/theme.constants.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.constants.ts
@@ -7,6 +7,11 @@ import { TnTheme } from './theme.interface';
 export const DEFAULT_THEME = TnTheme.Dark;
 
 /**
+ * Light theme used when OS preference is light
+ */
+export const LIGHT_THEME = TnTheme.Blue;
+
+/**
  * localStorage key for storing the current theme name
  */
 export const THEME_STORAGE_KEY = 'tn-theme';

--- a/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
-import { DEFAULT_THEME, THEME_STORAGE_KEY, TN_THEME_DEFINITIONS } from './theme.constants';
+import { DEFAULT_THEME, LIGHT_THEME, THEME_STORAGE_KEY, TN_THEME_DEFINITIONS } from './theme.constants';
 import { TnTheme } from './theme.interface';
 import { TnThemeService } from './theme.service';
 
 describe('TnThemeService', () => {
   let service: TnThemeService;
   let localStorageMock: { [key: string]: string };
+  let matchMediaListeners: Map<string, ((event: MediaQueryListEvent) => void)[]>;
+  let prefersDarkMatch: boolean;
 
   const setupLocalStorageMock = () => {
     localStorageMock = {};
@@ -27,11 +29,49 @@ describe('TnThemeService', () => {
     });
   };
 
+  const setupMatchMediaMock = () => {
+    matchMediaListeners = new Map();
+    prefersDarkMatch = true;
+
+    Object.defineProperty(window, 'matchMedia', {
+      value: (query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)' ? prefersDarkMatch : false,
+        media: query,
+        addEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+          const listeners = matchMediaListeners.get(query) ?? [];
+          listeners.push(listener);
+          matchMediaListeners.set(query, listeners);
+        },
+        removeEventListener: (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+          const listeners = matchMediaListeners.get(query) ?? [];
+          matchMediaListeners.set(query, listeners.filter((l) => l !== listener));
+        },
+      }),
+      writable: true,
+    });
+  };
+
+  const fireColorSchemeChange = (prefersDark: boolean) => {
+    const listeners = matchMediaListeners.get('(prefers-color-scheme: dark)') ?? [];
+    listeners.forEach((listener) => {
+      listener({ matches: prefersDark } as MediaQueryListEvent);
+    });
+  };
+
+  const createService = () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [TnThemeService],
+    });
+    return TestBed.inject(TnThemeService);
+  };
+
   beforeEach(() => {
     setupLocalStorageMock();
+    setupMatchMediaMock();
 
     TestBed.configureTestingModule({
-      providers: [TnThemeService]
+      providers: [TnThemeService],
     });
 
     service = TestBed.inject(TnThemeService);
@@ -49,7 +89,7 @@ describe('TnThemeService', () => {
       expect(service).toBeTruthy();
     });
 
-    it('should initialize with default theme', () => {
+    it('should initialize with default theme when OS prefers dark', () => {
       expect(service.getCurrentTheme()).toBe(DEFAULT_THEME);
     });
 
@@ -60,39 +100,88 @@ describe('TnThemeService', () => {
   });
 
   describe('Theme Initialization', () => {
-    it('should use default theme when localStorage is empty', () => {
-      const currentTheme = service.currentTheme();
-      expect(currentTheme?.name).toBe(DEFAULT_THEME);
+    it('should use dark theme when OS prefers dark and localStorage is empty', () => {
+      prefersDarkMatch = true;
+      const newService = createService();
+      expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+      expect(newService.isUsingSystemTheme()).toBe(true);
+    });
+
+    it('should use light theme when OS prefers light and localStorage is empty', () => {
+      prefersDarkMatch = false;
+      const newService = createService();
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+      expect(newService.isUsingSystemTheme()).toBe(true);
     });
 
     it('should restore theme from localStorage if available', () => {
-      // Set up localStorage before creating service
       localStorageMock[THEME_STORAGE_KEY] = TnTheme.Dracula;
+      const newService = createService();
 
-      // Reset and reconfigure TestBed with new localStorage state
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        providers: [TnThemeService]
-      });
+      expect(newService.getCurrentTheme()).toBe(TnTheme.Dracula);
+      expect(newService.isUsingSystemTheme()).toBe(false);
+    });
 
-      const newService = TestBed.inject(TnThemeService);
+    it('should use OS preference if localStorage contains invalid theme', () => {
+      localStorageMock[THEME_STORAGE_KEY] = 'invalid-theme';
+      prefersDarkMatch = false;
+      const newService = createService();
 
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+      expect(newService.isUsingSystemTheme()).toBe(true);
+    });
+
+    it('should not persist OS-detected theme to localStorage', (done) => {
+      prefersDarkMatch = true;
+      const newService = createService();
+
+      expect(newService.isUsingSystemTheme()).toBe(true);
+
+      setTimeout(() => {
+        expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+        done();
+      }, 0);
+    });
+  });
+
+  describe('OS Color Scheme Changes', () => {
+    it('should follow OS changes when no user preference is set', () => {
+      prefersDarkMatch = true;
+      const newService = createService();
+      expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+
+      fireColorSchemeChange(false);
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+
+      fireColorSchemeChange(true);
+      expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+    });
+
+    it('should ignore OS changes after user explicitly sets a theme', () => {
+      prefersDarkMatch = true;
+      const newService = createService();
+      expect(newService.isUsingSystemTheme()).toBe(true);
+
+      newService.setTheme(TnTheme.Dracula);
+      expect(newService.isUsingSystemTheme()).toBe(false);
+
+      fireColorSchemeChange(false);
       expect(newService.getCurrentTheme()).toBe(TnTheme.Dracula);
     });
 
-    it('should use default theme if localStorage contains invalid theme', () => {
-      // Set up localStorage with invalid theme before creating service
-      localStorageMock[THEME_STORAGE_KEY] = 'invalid-theme';
+    it('should resume following OS changes after clearPreference()', () => {
+      prefersDarkMatch = true;
+      const newService = createService();
 
-      // Reset and reconfigure TestBed with new localStorage state
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        providers: [TnThemeService]
-      });
+      newService.setTheme(TnTheme.Nord);
+      expect(newService.isUsingSystemTheme()).toBe(false);
 
-      const newService = TestBed.inject(TnThemeService);
-
+      newService.clearPreference();
+      expect(newService.isUsingSystemTheme()).toBe(true);
       expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+
+      fireColorSchemeChange(false);
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
     });
   });
 
@@ -123,13 +212,19 @@ describe('TnThemeService', () => {
       const result = service.setTheme('non-existent-theme' as TnTheme);
 
       expect(result).toBe(false);
-      expect(service.getCurrentTheme()).toBe(DEFAULT_THEME);
+    });
+
+    it('should mark theme as user-selected', () => {
+      expect(service.isUsingSystemTheme()).toBe(true);
+
+      service.setTheme(TnTheme.SolarizedDark);
+
+      expect(service.isUsingSystemTheme()).toBe(false);
     });
 
     it('should persist theme to localStorage', (done) => {
       service.setTheme(TnTheme.SolarizedDark);
 
-      // Effects run asynchronously, wait for next tick
       setTimeout(() => {
         expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.SolarizedDark);
         done();
@@ -139,7 +234,6 @@ describe('TnThemeService', () => {
     it('should apply CSS class to document root', (done) => {
       service.setTheme(TnTheme.Midnight);
 
-      // Effects run asynchronously, wait for next tick
       setTimeout(() => {
         const root = document.documentElement;
         expect(root.classList.contains('tn-midnight')).toBe(true);
@@ -237,6 +331,36 @@ describe('TnThemeService', () => {
     });
   });
 
+  describe('clearPreference()', () => {
+    it('should remove theme from localStorage', () => {
+      service.setTheme(TnTheme.Dracula);
+      localStorageMock[THEME_STORAGE_KEY] = TnTheme.Dracula;
+
+      service.clearPreference();
+
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+    });
+
+    it('should revert to OS-detected theme', () => {
+      prefersDarkMatch = false;
+      const newService = createService();
+
+      newService.setTheme(TnTheme.Midnight);
+      expect(newService.getCurrentTheme()).toBe(TnTheme.Midnight);
+
+      newService.clearPreference();
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+    });
+
+    it('should mark theme as system-detected', () => {
+      service.setTheme(TnTheme.Nord);
+      expect(service.isUsingSystemTheme()).toBe(false);
+
+      service.clearPreference();
+      expect(service.isUsingSystemTheme()).toBe(true);
+    });
+  });
+
   describe('hasTheme()', () => {
     it('should return true for valid themes', () => {
       expect(service.hasTheme(TnTheme.Dark)).toBe(true);
@@ -268,11 +392,10 @@ describe('TnThemeService', () => {
       expect(class1).not.toBe(class2);
       expect(class2).toBe('tn-high-contrast');
     });
-
   });
 
   describe('LocalStorage Persistence', () => {
-    it('should save theme preference on every theme change', (done) => {
+    it('should save theme preference on every explicit theme change', (done) => {
       service.setTheme(TnTheme.Blue);
 
       setTimeout(() => {
@@ -291,6 +414,25 @@ describe('TnThemeService', () => {
           }, 10);
         }, 10);
       }, 10);
+    });
+
+    it('should not persist OS-triggered theme changes', (done) => {
+      prefersDarkMatch = true;
+      const newService = createService();
+
+      // OS-detected theme should not be persisted
+      setTimeout(() => {
+        expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+
+        // OS change event should not persist either
+        fireColorSchemeChange(false);
+
+        setTimeout(() => {
+          expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+          expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+          done();
+        }, 0);
+      }, 0);
     });
 
     it('should handle localStorage errors gracefully', () => {

--- a/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
@@ -183,6 +183,27 @@ describe('TnThemeService', () => {
       fireColorSchemeChange(false);
       expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
     });
+
+    it('should follow OS changes after clearPreference() when service started with stored theme', () => {
+      prefersDarkMatch = true;
+      localStorageMock[THEME_STORAGE_KEY] = TnTheme.Dracula;
+      const newService = createService();
+
+      // Service initialized from localStorage — no OS listener attached
+      expect(newService.getCurrentTheme()).toBe(TnTheme.Dracula);
+      expect(newService.isUsingSystemTheme()).toBe(false);
+
+      // clearPreference() should re-subscribe to OS changes
+      newService.clearPreference();
+      expect(newService.isUsingSystemTheme()).toBe(true);
+      expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+
+      fireColorSchemeChange(false);
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
+
+      fireColorSchemeChange(true);
+      expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
+    });
   });
 
   describe('setTheme()', () => {
@@ -301,14 +322,17 @@ describe('TnThemeService', () => {
       expect(service.getCurrentTheme()).toBe(DEFAULT_THEME);
     });
 
-    it('should persist default theme to localStorage', (done) => {
+    it('should clear localStorage and revert to OS detection', (done) => {
       service.setTheme(TnTheme.Nord);
 
       setTimeout(() => {
+        expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Nord);
+
         service.resetToDefault();
 
         setTimeout(() => {
-          expect(localStorageMock[THEME_STORAGE_KEY]).toBe(DEFAULT_THEME);
+          expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+          expect(service.isUsingSystemTheme()).toBe(true);
           done();
         }, 0);
       }, 0);

--- a/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.service.spec.ts
@@ -78,7 +78,6 @@ describe('TnThemeService', () => {
   });
 
   afterEach(() => {
-    // Clean up DOM classes after each test
     TN_THEME_DEFINITIONS.forEach((theme) => {
       document.documentElement.classList.remove(theme.className);
     });
@@ -131,16 +130,13 @@ describe('TnThemeService', () => {
       expect(newService.isUsingSystemTheme()).toBe(true);
     });
 
-    it('should not persist OS-detected theme to localStorage', (done) => {
+    it('should not persist OS-detected theme to localStorage', () => {
       prefersDarkMatch = true;
       const newService = createService();
 
       expect(newService.isUsingSystemTheme()).toBe(true);
-
-      setTimeout(() => {
-        expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
-        done();
-      }, 0);
+      TestBed.flushEffects();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
     });
   });
 
@@ -189,11 +185,9 @@ describe('TnThemeService', () => {
       localStorageMock[THEME_STORAGE_KEY] = TnTheme.Dracula;
       const newService = createService();
 
-      // Service initialized from localStorage — no OS listener attached
       expect(newService.getCurrentTheme()).toBe(TnTheme.Dracula);
       expect(newService.isUsingSystemTheme()).toBe(false);
 
-      // clearPreference() should re-subscribe to OS changes
       newService.clearPreference();
       expect(newService.isUsingSystemTheme()).toBe(true);
       expect(newService.getCurrentTheme()).toBe(DEFAULT_THEME);
@@ -243,38 +237,30 @@ describe('TnThemeService', () => {
       expect(service.isUsingSystemTheme()).toBe(false);
     });
 
-    it('should persist theme to localStorage', (done) => {
+    it('should persist theme to localStorage', () => {
       service.setTheme(TnTheme.SolarizedDark);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.SolarizedDark);
-        done();
-      }, 0);
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.SolarizedDark);
     });
 
-    it('should apply CSS class to document root', (done) => {
+    it('should apply CSS class to document root', () => {
       service.setTheme(TnTheme.Midnight);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        const root = document.documentElement;
-        expect(root.classList.contains('tn-midnight')).toBe(true);
-        done();
-      }, 0);
+      expect(document.documentElement.classList.contains('tn-midnight')).toBe(true);
     });
 
-    it('should remove previous theme class when switching themes', (done) => {
+    it('should remove previous theme class when switching themes', () => {
       service.setTheme(TnTheme.Dracula);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        service.setTheme(TnTheme.Nord);
+      service.setTheme(TnTheme.Nord);
+      TestBed.flushEffects();
 
-        setTimeout(() => {
-          const root = document.documentElement;
-          expect(root.classList.contains('tn-dracula')).toBe(false);
-          expect(root.classList.contains('tn-nord')).toBe(true);
-          done();
-        }, 0);
-      }, 0);
+      const root = document.documentElement;
+      expect(root.classList.contains('tn-dracula')).toBe(false);
+      expect(root.classList.contains('tn-nord')).toBe(true);
     });
 
     it('should handle all 8 theme options', () => {
@@ -315,50 +301,42 @@ describe('TnThemeService', () => {
   });
 
   describe('resetToDefault()', () => {
-    it('should reset theme to default', () => {
+    it('should reset theme to OS-detected default', () => {
       service.setTheme(TnTheme.Dracula);
       service.resetToDefault();
 
       expect(service.getCurrentTheme()).toBe(DEFAULT_THEME);
     });
 
-    it('should clear localStorage and revert to OS detection', (done) => {
+    it('should clear localStorage and revert to OS detection', () => {
       service.setTheme(TnTheme.Nord);
+      TestBed.flushEffects();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Nord);
 
-      setTimeout(() => {
-        expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Nord);
+      service.resetToDefault();
+      TestBed.flushEffects();
 
-        service.resetToDefault();
-
-        setTimeout(() => {
-          expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
-          expect(service.isUsingSystemTheme()).toBe(true);
-          done();
-        }, 0);
-      }, 0);
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+      expect(service.isUsingSystemTheme()).toBe(true);
     });
 
-    it('should apply default theme CSS class to DOM', (done) => {
+    it('should apply default theme CSS class to DOM', () => {
       service.setTheme(TnTheme.Paper);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        service.resetToDefault();
+      service.resetToDefault();
+      TestBed.flushEffects();
 
-        setTimeout(() => {
-          const root = document.documentElement;
-          const defaultThemeClass = service.currentTheme()?.className;
-          expect(root.classList.contains(defaultThemeClass!)).toBe(true);
-          expect(root.classList.contains('tn-paper')).toBe(false);
-          done();
-        }, 0);
-      }, 0);
+      const root = document.documentElement;
+      expect(root.classList.contains(service.currentTheme()!.className)).toBe(true);
+      expect(root.classList.contains('tn-paper')).toBe(false);
     });
   });
 
   describe('clearPreference()', () => {
     it('should remove theme from localStorage', () => {
       service.setTheme(TnTheme.Dracula);
-      localStorageMock[THEME_STORAGE_KEY] = TnTheme.Dracula;
+      TestBed.flushEffects();
 
       service.clearPreference();
 
@@ -419,106 +397,84 @@ describe('TnThemeService', () => {
   });
 
   describe('LocalStorage Persistence', () => {
-    it('should save theme preference on every explicit theme change', (done) => {
+    it('should save theme preference on every explicit theme change', () => {
       service.setTheme(TnTheme.Blue);
+      TestBed.flushEffects();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Blue);
 
-      setTimeout(() => {
-        expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Blue);
+      service.setTheme(TnTheme.Nord);
+      TestBed.flushEffects();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Nord);
 
-        service.setTheme(TnTheme.Nord);
-
-        setTimeout(() => {
-          expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Nord);
-
-          service.setTheme(TnTheme.Paper);
-
-          setTimeout(() => {
-            expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Paper);
-            done();
-          }, 10);
-        }, 10);
-      }, 10);
+      service.setTheme(TnTheme.Paper);
+      TestBed.flushEffects();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBe(TnTheme.Paper);
     });
 
-    it('should not persist OS-triggered theme changes', (done) => {
+    it('should not persist OS-triggered theme changes', () => {
       prefersDarkMatch = true;
       const newService = createService();
+      TestBed.flushEffects();
 
-      // OS-detected theme should not be persisted
-      setTimeout(() => {
-        expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
 
-        // OS change event should not persist either
-        fireColorSchemeChange(false);
+      fireColorSchemeChange(false);
+      TestBed.flushEffects();
 
-        setTimeout(() => {
-          expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
-          expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
-          done();
-        }, 0);
-      }, 0);
+      expect(localStorageMock[THEME_STORAGE_KEY]).toBeUndefined();
+      expect(newService.getCurrentTheme()).toBe(LIGHT_THEME);
     });
 
     it('should handle localStorage errors gracefully', () => {
-      // Override setItem to throw an error
       const originalSetItem = localStorage.setItem;
       localStorage.setItem = () => {
         throw new Error('localStorage is full');
       };
 
-      // Should not throw
       expect(() => service.setTheme(TnTheme.Dracula)).not.toThrow();
 
-      // Restore original
       localStorage.setItem = originalSetItem;
     });
   });
 
   describe('DOM Manipulation', () => {
-    it('should apply only one theme class at a time', (done) => {
+    it('should apply only one theme class at a time', () => {
       service.setTheme(TnTheme.Dracula);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        const root = document.documentElement;
-        const appliedThemeClasses = TN_THEME_DEFINITIONS.filter((theme) =>
-          root.classList.contains(theme.className)
-        );
+      const root = document.documentElement;
+      const appliedThemeClasses = TN_THEME_DEFINITIONS.filter((theme) =>
+        root.classList.contains(theme.className)
+      );
 
-        expect(appliedThemeClasses.length).toBe(1);
-        expect(appliedThemeClasses[0].className).toBe('tn-dracula');
-        done();
-      }, 0);
+      expect(appliedThemeClasses.length).toBe(1);
+      expect(appliedThemeClasses[0].className).toBe('tn-dracula');
     });
 
-    it('should clean up all theme classes before applying new one', (done) => {
-      // Manually add multiple theme classes to simulate a dirty state
+    it('should clean up all theme classes before applying new one', () => {
       document.documentElement.classList.add('tn-nord', 'tn-paper', 'tn-midnight');
 
       service.setTheme(TnTheme.HighContrast);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        const root = document.documentElement;
-        expect(root.classList.contains('tn-nord')).toBe(false);
-        expect(root.classList.contains('tn-paper')).toBe(false);
-        expect(root.classList.contains('tn-midnight')).toBe(false);
-        expect(root.classList.contains('tn-high-contrast')).toBe(true);
-        done();
-      }, 0);
+      const root = document.documentElement;
+      expect(root.classList.contains('tn-nord')).toBe(false);
+      expect(root.classList.contains('tn-paper')).toBe(false);
+      expect(root.classList.contains('tn-midnight')).toBe(false);
+      expect(root.classList.contains('tn-high-contrast')).toBe(true);
     });
   });
 
   describe('Edge Cases', () => {
-    it('should handle rapid theme changes', (done) => {
+    it('should handle rapid theme changes', () => {
       service.setTheme(TnTheme.Dracula);
       service.setTheme(TnTheme.Nord);
       service.setTheme(TnTheme.Paper);
       service.setTheme(TnTheme.Midnight);
+      TestBed.flushEffects();
 
-      setTimeout(() => {
-        expect(service.getCurrentTheme()).toBe(TnTheme.Midnight);
-        expect(service.currentThemeClass()).toBe('tn-midnight');
-        done();
-      }, 50);
+      expect(service.getCurrentTheme()).toBe(TnTheme.Midnight);
+      expect(service.currentThemeClass()).toBe('tn-midnight');
     });
 
     it('should handle setting the same theme multiple times', () => {

--- a/projects/truenas-ui/src/lib/theme/theme.service.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.service.ts
@@ -162,10 +162,10 @@ export class TnThemeService {
   }
 
   /**
-   * Reset theme to default
+   * Reset theme to default by clearing user preference and reverting to OS detection.
    */
   resetToDefault(): void {
-    this.setTheme(DEFAULT_THEME);
+    this.clearPreference();
   }
 
   /**
@@ -182,6 +182,7 @@ export class TnThemeService {
     }
     this.userSelected.set(false);
     this.applySystemTheme();
+    this.listenForColorSchemeChanges();
   }
 
   /**
@@ -236,7 +237,7 @@ export class TnThemeService {
    * Listen for OS color scheme changes and apply them when no user preference is set
    */
   private listenForColorSchemeChanges(): void {
-    if (!this.isBrowser) {
+    if (!this.isBrowser || this.colorSchemeQuery) {
       return;
     }
 

--- a/projects/truenas-ui/src/lib/theme/theme.service.ts
+++ b/projects/truenas-ui/src/lib/theme/theme.service.ts
@@ -1,9 +1,10 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Injectable, signal, computed, effect, PLATFORM_ID, inject } from '@angular/core';
+import { DestroyRef, Injectable, signal, computed, effect, PLATFORM_ID, inject } from '@angular/core';
 import {
   TN_THEME_DEFINITIONS,
   THEME_MAP,
   DEFAULT_THEME,
+  LIGHT_THEME,
   THEME_STORAGE_KEY,
 } from './theme.constants';
 import type { TnThemeDefinition } from './theme.interface';
@@ -14,7 +15,8 @@ import { TnTheme } from './theme.interface';
  *
  * Features:
  * - Signal-based reactive theme state
- * - LocalStorage persistence (key: 'tn-theme')
+ * - OS color scheme detection (prefers-color-scheme)
+ * - LocalStorage persistence for explicit user choices (key: 'tn-theme')
  * - Automatic CSS class application to document root
  * - SSR-safe (checks for browser platform)
  *
@@ -34,8 +36,11 @@ import { TnTheme } from './theme.interface';
  *     // Get current theme (signal)
  *     const currentTheme = this.themeService.currentTheme();
  *
- *     // Set theme using enum (recommended)
+ *     // Set theme using enum (recommended) — persists to localStorage
  *     this.themeService.setTheme(TnTheme.Blue);
+ *
+ *     // Clear user preference and follow OS theme
+ *     this.themeService.clearPreference();
  *
  *     // React to theme changes
  *     effect(() => {
@@ -51,11 +56,32 @@ import { TnTheme } from './theme.interface';
 export class TnThemeService {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private readonly destroyRef = inject(DestroyRef);
 
   /**
    * Internal signal holding the current theme enum value
    */
   private readonly currentThemeSignal = signal<TnTheme>(DEFAULT_THEME);
+
+  /**
+   * Whether the user has explicitly selected a theme (vs OS-detected default).
+   * When true, theme is persisted to localStorage and OS changes are ignored.
+   */
+  private readonly userSelected = signal(false);
+
+  /**
+   * Reference to the prefers-color-scheme media query for cleanup
+   */
+  private colorSchemeQuery: MediaQueryList | null = null;
+
+  /**
+   * Bound listener reference for cleanup
+   */
+  private readonly colorSchemeListener = (event: MediaQueryListEvent): void => {
+    if (!this.userSelected()) {
+      this.currentThemeSignal.set(event.matches ? DEFAULT_THEME : LIGHT_THEME);
+    }
+  };
 
   /**
    * Computed signal that returns the full theme definition for the current theme
@@ -73,12 +99,17 @@ export class TnThemeService {
   });
 
   /**
+   * Whether the current theme is based on OS preference (no explicit user choice)
+   */
+  readonly isUsingSystemTheme = computed<boolean>(() => !this.userSelected());
+
+  /**
    * All available theme definitions in the library (readonly array)
    */
   readonly availableThemes: readonly TnThemeDefinition[] = TN_THEME_DEFINITIONS;
 
   constructor() {
-    // Initialize theme from localStorage or default
+    // Initialize theme from localStorage or OS preference
     this.initializeTheme();
 
     // Effect to apply theme CSS class to document root whenever theme changes
@@ -88,9 +119,9 @@ export class TnThemeService {
       }
     });
 
-    // Effect to persist theme to localStorage whenever it changes
+    // Effect to persist theme to localStorage only for explicit user choices
     effect(() => {
-      if (this.isBrowser) {
+      if (this.isBrowser && this.userSelected()) {
         const theme = this.currentTheme();
         if (theme) {
           this.persistThemeToStorage(theme);
@@ -101,7 +132,8 @@ export class TnThemeService {
 
   /**
    * Set the current theme.
-   * Updates the signal, which triggers effects to apply CSS and save to localStorage.
+   * Marks this as an explicit user choice, persists to localStorage,
+   * and stops following OS color scheme changes.
    *
    * @param theme - The theme to set (use TnTheme enum)
    * @returns true if theme was found and set, false otherwise
@@ -114,6 +146,7 @@ export class TnThemeService {
   setTheme(theme: TnTheme): boolean {
     const themeDefinition = THEME_MAP.get(theme);
     if (themeDefinition) {
+      this.userSelected.set(true);
       this.currentThemeSignal.set(theme);
       return true;
     }
@@ -136,6 +169,22 @@ export class TnThemeService {
   }
 
   /**
+   * Clear user preference and revert to OS-based theme detection.
+   * Removes the stored theme from localStorage and follows the OS color scheme.
+   */
+  clearPreference(): void {
+    if (this.isBrowser) {
+      try {
+        localStorage.removeItem(THEME_STORAGE_KEY);
+      } catch (error) {
+        console.error('[TnThemeService] Error removing from localStorage:', error);
+      }
+    }
+    this.userSelected.set(false);
+    this.applySystemTheme();
+  }
+
+  /**
    * Check if a theme exists
    */
   hasTheme(theme: TnTheme): boolean {
@@ -143,7 +192,7 @@ export class TnThemeService {
   }
 
   /**
-   * Initialize theme from localStorage or use default
+   * Initialize theme from localStorage or OS color scheme preference
    */
   private initializeTheme(): void {
     if (!this.isBrowser) {
@@ -153,14 +202,53 @@ export class TnThemeService {
     try {
       const storedTheme = localStorage.getItem(THEME_STORAGE_KEY) as TnTheme;
       if (storedTheme && this.hasTheme(storedTheme)) {
+        this.userSelected.set(true);
         this.currentThemeSignal.set(storedTheme);
       } else {
-        // If no valid stored theme, use default
-        this.currentThemeSignal.set(DEFAULT_THEME);
+        // No valid stored theme — detect from OS preference
+        this.applySystemTheme();
+        this.listenForColorSchemeChanges();
       }
     } catch (error) {
       console.error('[TnThemeService] Error reading from localStorage:', error);
+      this.applySystemTheme();
+      this.listenForColorSchemeChanges();
+    }
+  }
+
+  /**
+   * Detect OS color scheme preference and apply corresponding theme
+   */
+  private applySystemTheme(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      this.currentThemeSignal.set(prefersDark ? DEFAULT_THEME : LIGHT_THEME);
+    } catch {
       this.currentThemeSignal.set(DEFAULT_THEME);
+    }
+  }
+
+  /**
+   * Listen for OS color scheme changes and apply them when no user preference is set
+   */
+  private listenForColorSchemeChanges(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      this.colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      this.colorSchemeQuery.addEventListener('change', this.colorSchemeListener);
+
+      this.destroyRef.onDestroy(() => {
+        this.colorSchemeQuery?.removeEventListener('change', this.colorSchemeListener);
+      });
+    } catch {
+      // matchMedia not supported — fall through silently
     }
   }
 


### PR DESCRIPTION
Detect prefers-color-scheme when no user preference is stored in localStorage, defaulting to tn-dark or tn-blue accordingly. Track explicit user selections separately so OS changes are followed until the user makes a choice. Add clearPreference() to revert to OS-based detection and isUsingSystemTheme signal for consumers.