### PR TITLE
feat(checkbox): add content projection for rich label content

### DIFF
--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
@@ -10,6 +10,7 @@
       [required]="required()"
       [indeterminate]="indeterminate()"
       [attr.data-testid]="testId()"
+      [attr.aria-label]="hasProjectedLabel() ? label() : null"
       [attr.aria-describedby]="error() ? id + '-error' : null"
       [attr.aria-invalid]="error() ? 'true' : null"
       (change)="onCheckboxChange($event)"

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
@@ -16,7 +16,13 @@
     />
     <span class="tn-checkbox__checkmark"></span>
     @if (!hideLabel()) {
-      <span class="tn-checkbox__text">{{ label() }}</span>
+      <span class="tn-checkbox__text">
+        @if (hasProjectedLabel()) {
+          <ng-content select="[tnCheckboxLabel]" />
+        } @else {
+          {{ label() }}
+        }
+      </span>
     }
   </label>
 

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.spec.ts
@@ -1,0 +1,239 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnCheckboxComponent, TnCheckboxLabelDirective } from './checkbox.component';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnCheckboxComponent, TnCheckboxLabelDirective, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-checkbox
+      testId="main"
+      [label]="label()"
+      [disabled]="disabled()"
+      [required]="required()"
+      [indeterminate]="indeterminate()"
+      [error]="error()"
+      [hideLabel]="hideLabel()"
+      [formControl]="control" />
+
+    <tn-checkbox testId="projected" [formControl]="projectedControl">
+      <span tnCheckboxLabel>I agree to the <a href="/terms">Terms</a></span>
+    </tn-checkbox>
+  `
+})
+class TestHostComponent {
+  label = signal('Accept');
+  disabled = signal(false);
+  required = signal(false);
+  indeterminate = signal(false);
+  hideLabel = signal(false);
+  error = signal<string | null>(null);
+  control = new FormControl(false);
+  projectedControl = new FormControl(false);
+}
+
+describe('TnCheckboxComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  const getCheckbox = (testId = 'main'): HTMLElement =>
+    fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+
+  const getWrapper = (testId = 'main'): HTMLElement => {
+    const input = getCheckbox(testId);
+    return input.closest('.tn-checkbox') as HTMLElement;
+  };
+
+  const getLabelText = (testId = 'main'): HTMLElement | null =>
+    getWrapper(testId).querySelector('.tn-checkbox__text');
+
+  const getError = (testId = 'main'): HTMLElement | null =>
+    getWrapper(testId).querySelector('.tn-checkbox__error');
+
+  const clickLabel = (testId = 'main') => {
+    const label = getWrapper(testId).querySelector('.tn-checkbox__label') as HTMLElement;
+    label.click();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('rendering', () => {
+    it('should render with label text', () => {
+      expect(getLabelText()?.textContent?.trim()).toBe('Accept');
+    });
+
+    it('should hide label when hideLabel is true', () => {
+      host.hideLabel.set(true);
+      fixture.detectChanges();
+
+      expect(getLabelText()).toBeNull();
+    });
+
+    it('should render projected content via tnCheckboxLabel', () => {
+      const text = getLabelText('projected');
+      expect(text?.textContent).toContain('I agree to the');
+      expect(text?.querySelector('a')).toBeTruthy();
+    });
+  });
+
+  describe('CSS classes', () => {
+    it('should have base class', () => {
+      expect(getWrapper().classList.contains('tn-checkbox')).toBe(true);
+    });
+
+    it('should add disabled class', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(getWrapper().classList.contains('tn-checkbox--disabled')).toBe(true);
+    });
+
+    it('should add error class', () => {
+      host.error.set('Required');
+      fixture.detectChanges();
+
+      expect(getWrapper().classList.contains('tn-checkbox--error')).toBe(true);
+    });
+
+    it('should add indeterminate class', () => {
+      host.indeterminate.set(true);
+      fixture.detectChanges();
+
+      expect(getWrapper().classList.contains('tn-checkbox--indeterminate')).toBe(true);
+    });
+
+    it('should not add modifier classes by default', () => {
+      const wrapper = getWrapper();
+      expect(wrapper.classList.contains('tn-checkbox--disabled')).toBe(false);
+      expect(wrapper.classList.contains('tn-checkbox--error')).toBe(false);
+      expect(wrapper.classList.contains('tn-checkbox--indeterminate')).toBe(false);
+    });
+  });
+
+  describe('error display', () => {
+    it('should not show error by default', () => {
+      expect(getError()).toBeNull();
+    });
+
+    it('should show error message', () => {
+      host.error.set('You must accept');
+      fixture.detectChanges();
+
+      const error = getError();
+      expect(error).toBeTruthy();
+      expect(error?.textContent?.trim()).toBe('You must accept');
+    });
+
+    it('should have alert role for accessibility', () => {
+      host.error.set('Error');
+      fixture.detectChanges();
+
+      expect(getError()?.getAttribute('role')).toBe('alert');
+    });
+
+    it('should set aria-invalid on the input when error is present', () => {
+      host.error.set('Error');
+      fixture.detectChanges();
+
+      expect(getCheckbox().getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('should not set aria-invalid when no error', () => {
+      expect(getCheckbox().getAttribute('aria-invalid')).toBeNull();
+    });
+  });
+
+  describe('ControlValueAccessor', () => {
+    it('should update checked state via form control', () => {
+      host.control.setValue(true);
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('should handle null writeValue gracefully', () => {
+      host.control.setValue(null);
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).checked).toBe(false);
+    });
+
+    it('should handle undefined writeValue gracefully', () => {
+      host.control.setValue(undefined as unknown as boolean);
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).checked).toBe(false);
+    });
+
+    it('should disable via form control', () => {
+      host.control.disable();
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).disabled).toBe(true);
+      expect(getWrapper().classList.contains('tn-checkbox--disabled')).toBe(true);
+    });
+
+    it('should re-enable via form control', () => {
+      host.control.disable();
+      fixture.detectChanges();
+      host.control.enable();
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('should update form control on click', () => {
+      clickLabel();
+      expect(host.control.value).toBe(true);
+
+      clickLabel();
+      expect(host.control.value).toBe(false);
+    });
+  });
+
+  describe('input attributes', () => {
+    it('should set required attribute', () => {
+      host.required.set(true);
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).required).toBe(true);
+    });
+
+    it('should set indeterminate property', () => {
+      host.indeterminate.set(true);
+      fixture.detectChanges();
+
+      expect((getCheckbox() as HTMLInputElement).indeterminate).toBe(true);
+    });
+
+    it('should set data-testid attribute', () => {
+      expect(getCheckbox().getAttribute('data-testid')).toBe('main');
+    });
+  });
+
+  describe('content projection', () => {
+    it('should update form control when projected-label checkbox is clicked', () => {
+      clickLabel('projected');
+      expect(host.projectedControl.value).toBe(true);
+    });
+
+    it('should render link inside projected label', () => {
+      const link = getLabelText('projected')?.querySelector('a');
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute('href')).toBe('/terms');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.ts
@@ -1,9 +1,26 @@
 import { FocusMonitor, A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import type { ElementRef, AfterViewInit, OnDestroy} from '@angular/core';
-import { Component, viewChild, inject, input, output, computed, signal, forwardRef } from '@angular/core';
+import { Component, viewChild, inject, input, output, computed, signal, forwardRef, contentChildren, Directive } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+/**
+ * Directive to mark content for projection into the checkbox label area.
+ * Use when the label needs rich content (links, icons, etc.) instead of plain text.
+ *
+ * @example
+ * ```html
+ * <tn-checkbox formControlName="terms">
+ *   <span tnCheckboxLabel>I agree to the <a href="/terms">Terms</a></span>
+ * </tn-checkbox>
+ * ```
+ */
+@Directive({
+  selector: '[tnCheckboxLabel]',
+  standalone: true,
+})
+export class TnCheckboxLabelDirective {}
 
 @Component({
   selector: 'tn-checkbox',
@@ -32,6 +49,9 @@ export class TnCheckboxComponent implements AfterViewInit, OnDestroy, ControlVal
   checked = input<boolean>(false);
 
   change = output<boolean>();
+
+  private labelContent = contentChildren(TnCheckboxLabelDirective);
+  protected hasProjectedLabel = computed(() => this.labelContent().length > 0);
 
   id = `tn-checkbox-${Math.random().toString(36).substr(2, 9)}`;
 

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.ts
@@ -57,6 +57,7 @@ export class TnCheckboxComponent implements AfterViewInit, OnDestroy, ControlVal
 
   // Internal state for CVA
   private internalChecked = signal<boolean>(false);
+  private cvaControlled = signal(false);
 
   // CVA disabled state management
   private formDisabled = signal<boolean>(false);
@@ -83,11 +84,14 @@ export class TnCheckboxComponent implements AfterViewInit, OnDestroy, ControlVal
     }
   }
 
-  // Computed for effective checked state (input or CVA-controlled)
-  effectiveChecked = computed(() => this.internalChecked() || this.checked());
+  // CVA takes precedence once a form control has written a value
+  effectiveChecked = computed(() =>
+    this.cvaControlled() ? this.internalChecked() : this.checked()
+  );
 
   // ControlValueAccessor implementation
   writeValue(value: boolean): void {
+    this.cvaControlled.set(true);
     this.internalChecked.set(value !== null && value !== undefined ? value : false);
   }
 

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.harness.spec.ts
@@ -1,0 +1,286 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnCheckboxComponent, TnCheckboxLabelDirective } from './checkbox.component';
+import { TnCheckboxHarness } from './checkbox.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnCheckboxComponent, TnCheckboxLabelDirective, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-checkbox
+      testId="test-checkbox"
+      [label]="label()"
+      [disabled]="disabled()"
+      [required]="required()"
+      [indeterminate]="indeterminate()"
+      [error]="error()"
+      [hideLabel]="hideLabel()"
+      [formControl]="control"
+      (change)="lastChange = $event" />
+
+    <tn-checkbox
+      label="Second checkbox"
+      testId="second-checkbox"
+      [formControl]="secondControl" />
+
+    <tn-checkbox testId="terms-checkbox" [formControl]="termsControl">
+      <span tnCheckboxLabel>I agree to the <a href="/terms">Terms</a></span>
+    </tn-checkbox>
+  `
+})
+class TestHostComponent {
+  label = signal('Accept terms');
+  disabled = signal(false);
+  required = signal(false);
+  indeterminate = signal(false);
+  hideLabel = signal(false);
+  error = signal<string | null>(null);
+  control = new FormControl(false);
+  secondControl = new FormControl(false);
+  termsControl = new FormControl(false);
+  lastChange: boolean | null = null;
+}
+
+describe('TnCheckboxHarness', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness', async () => {
+    const checkbox = await loader.getHarness(TnCheckboxHarness);
+    expect(checkbox).toBeTruthy();
+  });
+
+  describe('with() filter', () => {
+    it('should filter by exact label text', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ label: 'Accept terms' })
+      );
+      expect(checkbox).toBeTruthy();
+    });
+
+    it('should filter by label regex', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ label: /accept/i })
+      );
+      expect(checkbox).toBeTruthy();
+    });
+
+    it('should filter by testId', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'second-checkbox' })
+      );
+      expect(await checkbox.getLabelText()).toBe('Second checkbox');
+    });
+  });
+
+  describe('getLabelText', () => {
+    it('should return the label text', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.getLabelText()).toBe('Accept terms');
+    });
+
+    it('should return projected label content', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'terms-checkbox' })
+      );
+      const text = await checkbox.getLabelText();
+      expect(text).toContain('I agree to the');
+      expect(text).toContain('Terms');
+    });
+
+    it('should reflect updated label', async () => {
+      hostComponent.label.set('New label');
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.getLabelText()).toBe('New label');
+    });
+  });
+
+  describe('isChecked / check / uncheck / toggle', () => {
+    it('should be unchecked initially', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isChecked()).toBe(false);
+    });
+
+    it('should check the checkbox', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.check();
+      expect(await checkbox.isChecked()).toBe(true);
+    });
+
+    it('should uncheck the checkbox', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.check();
+      await checkbox.uncheck();
+      expect(await checkbox.isChecked()).toBe(false);
+    });
+
+    it('should toggle the checkbox', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.toggle();
+      expect(await checkbox.isChecked()).toBe(true);
+      await checkbox.toggle();
+      expect(await checkbox.isChecked()).toBe(false);
+    });
+
+    it('should be a no-op when checking an already checked checkbox', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.check();
+      await checkbox.check();
+      expect(await checkbox.isChecked()).toBe(true);
+    });
+
+    it('should be a no-op when unchecking an already unchecked checkbox', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.uncheck();
+      expect(await checkbox.isChecked()).toBe(false);
+    });
+
+    it('should update form control value', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      await checkbox.check();
+      expect(hostComponent.control.value).toBe(true);
+
+      await checkbox.uncheck();
+      expect(hostComponent.control.value).toBe(false);
+    });
+
+  });
+
+  describe('isDisabled', () => {
+    it('should return false when enabled', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isDisabled()).toBe(false);
+    });
+
+    it('should return true when disabled via input', async () => {
+      hostComponent.disabled.set(true);
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isDisabled()).toBe(true);
+    });
+
+    it('should return true when disabled via form control', async () => {
+      hostComponent.control.disable();
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('isRequired', () => {
+    it('should return false by default', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isRequired()).toBe(false);
+    });
+
+    it('should return true when required', async () => {
+      hostComponent.required.set(true);
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isRequired()).toBe(true);
+    });
+  });
+
+  describe('isIndeterminate', () => {
+    it('should return false by default', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isIndeterminate()).toBe(false);
+    });
+
+    it('should return true when indeterminate', async () => {
+      hostComponent.indeterminate.set(true);
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.isIndeterminate()).toBe(true);
+    });
+  });
+
+  describe('getTestId', () => {
+    it('should return the test ID', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ label: 'Accept terms' })
+      );
+      expect(await checkbox.getTestId()).toBe('test-checkbox');
+    });
+  });
+
+  describe('getErrorText', () => {
+    it('should return null when no error', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.getErrorText()).toBeNull();
+    });
+
+    it('should return error message when error is set', async () => {
+      hostComponent.error.set('You must accept the terms');
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'test-checkbox' })
+      );
+      expect(await checkbox.getErrorText()).toBe('You must accept the terms');
+    });
+  });
+
+  describe('content projection', () => {
+    it('should render projected label content with tnCheckboxLabel', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'terms-checkbox' })
+      );
+      const text = await checkbox.getLabelText();
+      expect(text).toContain('Terms');
+    });
+
+    it('should update form control when checkbox with projected label is toggled', async () => {
+      const checkbox = await loader.getHarness(
+        TnCheckboxHarness.with({ testId: 'terms-checkbox' })
+      );
+      await checkbox.check();
+      expect(hostComponent.termsControl.value).toBe(true);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.harness.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.harness.ts
@@ -1,0 +1,230 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with tn-checkbox in tests.
+ * Provides methods for checking, unchecking, and querying checkbox state.
+ *
+ * @example
+ * ```typescript
+ * // Find and check a checkbox
+ * const checkbox = await loader.getHarness(TnCheckboxHarness.with({ label: 'Accept terms' }));
+ * await checkbox.check();
+ * expect(await checkbox.isChecked()).toBe(true);
+ *
+ * // Toggle a checkbox
+ * await checkbox.toggle();
+ * expect(await checkbox.isChecked()).toBe(false);
+ *
+ * // Find by testId
+ * const terms = await loader.getHarness(TnCheckboxHarness.with({ testId: 'terms-checkbox' }));
+ * ```
+ */
+export class TnCheckboxHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnCheckboxComponent` instance.
+   */
+  static hostSelector = 'tn-checkbox';
+
+  private _input = this.locatorFor('.tn-checkbox__input');
+  private _label = this.locatorFor('.tn-checkbox__label');
+  private _text = this.locatorForOptional('.tn-checkbox__text');
+  private _error = this.locatorForOptional('.tn-checkbox__error');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a checkbox
+   * with specific attributes.
+   *
+   * @param options Options for filtering which checkbox instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find by label text
+   * const checkbox = await loader.getHarness(TnCheckboxHarness.with({ label: 'Accept' }));
+   *
+   * // Find by label regex
+   * const checkbox = await loader.getHarness(TnCheckboxHarness.with({ label: /terms/i }));
+   *
+   * // Find by testId
+   * const checkbox = await loader.getHarness(TnCheckboxHarness.with({ testId: 'my-checkbox' }));
+   * ```
+   */
+  static with(options: CheckboxHarnessFilters = {}) {
+    return new HarnessPredicate(TnCheckboxHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabelText(), label)
+      )
+      .addOption('testId', options.testId, async (harness, testId) => {
+        return (await harness.getTestId()) === testId;
+      });
+  }
+
+  /**
+   * Gets the checkbox label text content.
+   *
+   * @returns Promise resolving to the label text.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.getLabelText()).toBe('Accept terms');
+   * ```
+   */
+  async getLabelText(): Promise<string> {
+    const text = await this._text();
+    return text ? (await text.text()).trim() : '';
+  }
+
+  /**
+   * Checks whether the checkbox is currently checked.
+   *
+   * @returns Promise resolving to true if the checkbox is checked.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.isChecked()).toBe(false);
+   * ```
+   */
+  async isChecked(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('checked')) ?? false;
+  }
+
+  /**
+   * Checks whether the checkbox is disabled.
+   *
+   * @returns Promise resolving to true if the checkbox is disabled.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.isDisabled()).toBe(false);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Checks whether the checkbox is required.
+   *
+   * @returns Promise resolving to true if the checkbox is required.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.isRequired()).toBe(true);
+   * ```
+   */
+  async isRequired(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('required')) ?? false;
+  }
+
+  /**
+   * Checks whether the checkbox is in the indeterminate state.
+   *
+   * @returns Promise resolving to true if the checkbox is indeterminate.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.isIndeterminate()).toBe(false);
+   * ```
+   */
+  async isIndeterminate(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('indeterminate')) ?? false;
+  }
+
+  /**
+   * Gets the test ID attribute value.
+   *
+   * @returns Promise resolving to the test ID string, or null.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.getTestId()).toBe('terms-checkbox');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const input = await this._input();
+    return input.getAttribute('data-testid');
+  }
+
+  /**
+   * Gets the error message text, if any.
+   *
+   * @returns Promise resolving to the error message, or null if none.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * expect(await checkbox.getErrorText()).toBe('You must accept the terms');
+   * ```
+   */
+  async getErrorText(): Promise<string | null> {
+    const error = await this._error();
+    return error ? (await error.text()).trim() : null;
+  }
+
+  /**
+   * Checks the checkbox. No-op if already checked.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * await checkbox.check();
+   * expect(await checkbox.isChecked()).toBe(true);
+   * ```
+   */
+  async check(): Promise<void> {
+    if (!(await this.isChecked())) {
+      await this.toggle();
+    }
+  }
+
+  /**
+   * Unchecks the checkbox. No-op if already unchecked.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * await checkbox.uncheck();
+   * expect(await checkbox.isChecked()).toBe(false);
+   * ```
+   */
+  async uncheck(): Promise<void> {
+    if (await this.isChecked()) {
+      await this.toggle();
+    }
+  }
+
+  /**
+   * Toggles the checkbox checked state by clicking the label.
+   *
+   * @example
+   * ```typescript
+   * const checkbox = await loader.getHarness(TnCheckboxHarness);
+   * await checkbox.toggle();
+   * ```
+   */
+  async toggle(): Promise<void> {
+    const label = await this._label();
+    await label.click();
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnCheckboxHarness` instances.
+ */
+export interface CheckboxHarnessFilters extends BaseHarnessFilters {
+  /** Filters by label text. Supports string or regex matching. */
+  label?: string | RegExp;
+  /** Filters by data-testid attribute. */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './lib/chip/chip.component';
 export * from './lib/card';
 export * from './lib/expansion-panel/expansion-panel.component';
 export * from './lib/checkbox/checkbox.component';
+export * from './lib/checkbox/checkbox.harness';
 export * from './lib/radio/radio.component';
 export * from './lib/slide-toggle/slide-toggle.component';
 export * from './lib/tabs/tabs.component';

--- a/projects/truenas-ui/src/stories/checkbox.stories.ts
+++ b/projects/truenas-ui/src/stories/checkbox.stories.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
-import { TnCheckboxComponent } from '../lib/checkbox/checkbox.component';
+import { TnCheckboxComponent, TnCheckboxLabelDirective } from '../lib/checkbox/checkbox.component';
 
 const meta: Meta<TnCheckboxComponent> = {
   title: 'Components/Checkbox',
@@ -199,6 +199,42 @@ export const Interactive: Story = {
       imports: [FormsModule, CommonModule]
     }
   })
+};
+
+export const RichLabel: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
+        <tn-checkbox label="I agree to the Terms of Service">
+          <span tnCheckboxLabel>
+            I have read and agree to the
+            <a href="https://example.com/terms" target="_blank"
+              style="color: var(--tn-primary); text-decoration: underline;">
+              Terms of Service
+            </a>
+          </span>
+        </tn-checkbox>
+
+        <tn-checkbox label="Privacy policy">
+          <span tnCheckboxLabel>
+            I accept the
+            <a href="https://example.com/privacy" target="_blank"
+              style="color: var(--tn-primary); text-decoration: underline;">
+              Privacy Policy
+            </a>
+            and
+            <a href="https://example.com/cookies" target="_blank"
+              style="color: var(--tn-primary); text-decoration: underline;">
+              Cookie Policy
+            </a>
+          </span>
+        </tn-checkbox>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [TnCheckboxLabelDirective],
+    },
+  }),
 };
 
 export const Group: Story = {


### PR DESCRIPTION
Add TnCheckboxLabelDirective for projecting HTML into the checkbox label area. When [tnCheckboxLabel] content is present, it renders instead of the plain text label. Useful for labels with links, icons, or other rich content (e.g., Terms of Service checkboxes).

Backwards compatible — existing label input usage is unchanged.