### PR TITLE
fix(theme): add --tn-bg3 hover surface variable to all themes

### DIFF
--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -11,6 +11,7 @@
   --tn-accent: #545454;
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
+  --tn-bg3: #333333;
   --tn-fg1: #ffffff;
   --tn-fg2: rgba(255,255,255,0.85);
   --tn-alt-bg1: #383838;
@@ -67,6 +68,7 @@
   --tn-accent: var(--tn-yellow);
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
+  --tn-bg3: #333333;
   --tn-fg1: #e0e0e0;
   --tn-fg2: rgba(255,255,255,0.85);
   --tn-alt-bg1: #383838;
@@ -100,6 +102,7 @@
   --tn-accent: #DED142;
   --tn-bg1: #f2f2f2;
   --tn-bg2: #ffffff;
+  --tn-bg3: #e8e8e8;
   --tn-fg1: #585858;
   --tn-fg2: #666666;
   --tn-alt-bg1: #f0f0f0;
@@ -134,6 +137,7 @@
   --tn-accent: #bd93f9;
   --tn-bg1: #181a26;
   --tn-bg2: #282a36;
+  --tn-bg3: #343746;
   --tn-fg1: #efefef;
   --tn-fg2: #cacac5;
   --tn-alt-bg1: #3a3d4a;
@@ -168,6 +172,7 @@
   --tn-accent: #5e81aC;
   --tn-bg1: #2e3440;
   --tn-bg2: #3b4252;
+  --tn-bg3: #454d5e;
   --tn-fg1: #eceff4;
   --tn-fg2: #e5e9f0;
   --tn-alt-bg1: #434c5e;
@@ -201,6 +206,7 @@
   --tn-accent: #f0cb00;
   --tn-bg1: #F2F2F2;
   --tn-bg2: #FAFAFA;
+  --tn-bg3: #e8e8e8;
   --tn-fg1: #3f3f3f;
   --tn-fg2: #666666;
   --tn-alt-bg1: #f0f0f0;
@@ -237,6 +243,7 @@
   --tn-accent: var(--tn-cyan);
   --tn-bg1: #002b36;
   --tn-bg2: #073642;
+  --tn-bg3: #0a4050;
   --tn-fg1: #586e75;
   --tn-fg2: #7f99a2;
   --tn-alt-bg1: #0e4853;
@@ -272,6 +279,7 @@
   --tn-accent: var(--tn-violet);
   --tn-bg1: #212a35;
   --tn-bg2: #303d48;
+  --tn-bg3: #3d4a55;
   --tn-fg1: #aaaaaa;
   --tn-fg2: #cccccc;
   --tn-alt-bg1: #3d4a55;
@@ -304,6 +312,7 @@
   --tn-accent: var(--tn-magenta);
   --tn-bg1: #dddddd;
   --tn-bg2: #ffffff;
+  --tn-bg3: #d0d0d0;
   --tn-fg1: #222222;
   --tn-fg2: #333333;
   --tn-alt-bg1: #f0f0f0;


### PR DESCRIPTION
Dark themes were falling back to a light gray (#f3f4f6) for icon button hover backgrounds, making white icons nearly invisible. Define --tn-bg3 per theme so hover states use appropriate surface colors.