### PR TITLE
fix(icon-button): preserve custom color on hover

### DIFF
--- a/projects/truenas-ui/src/lib/icon-button/icon-button.component.scss
+++ b/projects/truenas-ui/src/lib/icon-button/icon-button.component.scss
@@ -24,6 +24,15 @@
     background-color: var(--tn-bg3, #e5e7eb);
   }
 
+  // When an explicit color is set, don't override it on hover
+  &.tn-icon-button--custom-color {
+    &:hover:not(:disabled),
+    &:active:not(:disabled) {
+      background-color: rgba(255, 255, 255, 0.1);
+      color: inherit;
+    }
+  }
+
   &:focus-visible {
     outline: 2px solid var(--tn-primary, #2563eb);
     outline-offset: 2px;

--- a/projects/truenas-ui/src/lib/icon-button/icon-button.component.ts
+++ b/projects/truenas-ui/src/lib/icon-button/icon-button.component.ts
@@ -25,7 +25,9 @@ export class TnIconButtonComponent {
   onClick = output<MouseEvent>();
 
   classes = computed(() => {
-    return ['tn-icon-button'];
+    const result = ['tn-icon-button'];
+    if (this.color()) {result.push('tn-icon-button--custom-color');}
+    return result;
   });
 
   effectiveAriaLabel = computed(() => {


### PR DESCRIPTION
When an explicit color input is set, the hover state was overriding it with --tn-fg1, making the icon invisible on colored backgrounds (e.g., white icons on a blue header). Now uses a subtle white overlay for hover and preserves the custom color via color:inherit.