### PR TITLE
feat(form-field): add TnFormFieldHarness for testing

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -1,0 +1,212 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TnFormFieldComponent } from './form-field.component';
+import { TnFormFieldHarness } from './form-field.harness';
+import { TnInputComponent } from '../input/input.component';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-field label="Name" testId="name-field" [required]="true">
+      <tn-input [formControl]="nameControl" />
+    </tn-form-field>
+
+    <tn-form-field label="Email" testId="email-field" hint="We'll never share your email">
+      <tn-input [formControl]="emailControl" />
+    </tn-form-field>
+
+    <tn-form-field label="Optional" testId="optional-field">
+      <tn-input [formControl]="optionalControl" />
+    </tn-form-field>
+  `
+})
+class TestHostComponent {
+  nameControl = new FormControl('', Validators.required);
+  emailControl = new FormControl('', [Validators.required, Validators.email]);
+  optionalControl = new FormControl('');
+}
+
+describe('TnFormFieldHarness', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness', async () => {
+    const field = await loader.getHarness(TnFormFieldHarness);
+    expect(field).toBeTruthy();
+  });
+
+  describe('with() filter', () => {
+    it('should filter by exact label text', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(field).toBeTruthy();
+      expect(await field.getLabel()).toBe('Name');
+    });
+
+    it('should filter by label regex', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: /email/i })
+      );
+      expect(await field.getLabel()).toBe('Email');
+    });
+
+    it('should filter by testId', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'email-field' })
+      );
+      expect(await field.getLabel()).toBe('Email');
+    });
+
+    it('should find all form fields', async () => {
+      const fields = await loader.getAllHarnesses(TnFormFieldHarness);
+      expect(fields.length).toBe(3);
+    });
+  });
+
+  describe('getLabel', () => {
+    it('should return the label text', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'name-field' })
+      );
+      expect(await field.getLabel()).toBe('Name');
+    });
+
+    it('should strip required asterisk from label text', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'name-field' })
+      );
+      const label = await field.getLabel();
+      expect(label).not.toContain('*');
+      expect(label).toBe('Name');
+    });
+  });
+
+  describe('isRequired', () => {
+    it('should return true for required fields', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.isRequired()).toBe(true);
+    });
+
+    it('should return false for optional fields', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Optional' })
+      );
+      expect(await field.isRequired()).toBe(false);
+    });
+  });
+
+  describe('getHint', () => {
+    it('should return hint text when visible', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Email' })
+      );
+      expect(await field.getHint()).toBe("We'll never share your email");
+    });
+
+    it('should return null when no hint', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.getHint()).toBeNull();
+    });
+  });
+
+  describe('error state', () => {
+    it('should not show error on pristine control', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.hasError()).toBe(false);
+      expect(await field.getErrorMessage()).toBeNull();
+    });
+
+    it('should show error after control is touched', async () => {
+      const host = fixture.componentInstance;
+      host.nameControl.markAsTouched();
+      host.nameControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.hasError()).toBe(true);
+      expect(await field.getErrorMessage()).toBe('This field is required');
+    });
+
+    it('should show email error for invalid email', async () => {
+      const host = fixture.componentInstance;
+      host.emailControl.setValue('not-an-email');
+      host.emailControl.markAsTouched();
+      host.emailControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Email' })
+      );
+      expect(await field.hasError()).toBe(true);
+      expect(await field.getErrorMessage()).toBe('Please enter a valid email address');
+    });
+
+    it('should hide hint when error is showing', async () => {
+      const host = fixture.componentInstance;
+      host.emailControl.markAsTouched();
+      host.emailControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Email' })
+      );
+      expect(await field.hasError()).toBe(true);
+      expect(await field.getHint()).toBeNull();
+    });
+
+    it('should clear error when value becomes valid', async () => {
+      const host = fixture.componentInstance;
+      host.nameControl.markAsTouched();
+      host.nameControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      let field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.hasError()).toBe(true);
+
+      host.nameControl.setValue('John');
+      fixture.detectChanges();
+
+      field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.hasError()).toBe(false);
+    });
+  });
+
+  describe('getTestId', () => {
+    it('should return the data-testid value', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Name' })
+      );
+      expect(await field.getTestId()).toBe('name-field');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -1,0 +1,175 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with `tn-form-field` in tests.
+ * Provides methods for querying label, hint, error state, and accessing
+ * the projected form control.
+ *
+ * @example
+ * ```typescript
+ * // Find a form field by label
+ * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Email' }));
+ * expect(await field.getLabel()).toBe('Email');
+ *
+ * // Check for validation errors
+ * expect(await field.hasError()).toBe(true);
+ * expect(await field.getErrorMessage()).toBe('This field is required');
+ *
+ * // Check hint text
+ * const hinted = await loader.getHarness(TnFormFieldHarness.with({ label: 'Port' }));
+ * expect(await hinted.getHint()).toBe('Default port is 443');
+ *
+ * // Find by testId
+ * const field = await loader.getHarness(TnFormFieldHarness.with({ testId: 'email-field' }));
+ * ```
+ */
+export class TnFormFieldHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnFormFieldComponent` instance.
+   */
+  static hostSelector = 'tn-form-field';
+
+  private _label = this.locatorForOptional('.tn-form-field-label');
+  private _error = this.locatorForOptional('.tn-form-field-error');
+  private _hint = this.locatorForOptional('.tn-form-field-hint');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a form field
+   * with specific attributes.
+   *
+   * @param options Options for filtering which form field instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find by label text
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Name' }));
+   *
+   * // Find by label regex
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: /email/i }));
+   *
+   * // Find by testId
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ testId: 'name-field' }));
+   * ```
+   */
+  static with(options: FormFieldHarnessFilters = {}) {
+    return new HarnessPredicate(TnFormFieldHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabel(), label)
+      )
+      .addOption('testId', options.testId, async (harness, testId) => {
+        return (await harness.getTestId()) === testId;
+      });
+  }
+
+  /**
+   * Gets the form field label text.
+   *
+   * @returns Promise resolving to the label text, or empty string if no label.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Name' }));
+   * expect(await field.getLabel()).toBe('Name');
+   * ```
+   */
+  async getLabel(): Promise<string> {
+    const label = await this._label();
+    if (!label) { return ''; }
+    const text = await label.text();
+    // Strip the required asterisk from the label text
+    return text.replace(/\s*\*\s*$/, '').trim();
+  }
+
+  /**
+   * Gets the error message text, if visible.
+   *
+   * @returns Promise resolving to the error message, or null if no error is shown.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Email' }));
+   * expect(await field.getErrorMessage()).toBe('Please enter a valid email address');
+   * ```
+   */
+  async getErrorMessage(): Promise<string | null> {
+    const error = await this._error();
+    return error ? (await error.text()).trim() : null;
+  }
+
+  /**
+   * Checks whether the form field is currently showing an error.
+   *
+   * @returns Promise resolving to true if an error message is visible.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Email' }));
+   * expect(await field.hasError()).toBe(true);
+   * ```
+   */
+  async hasError(): Promise<boolean> {
+    const error = await this._error();
+    return error !== null;
+  }
+
+  /**
+   * Gets the hint text, if visible.
+   *
+   * @returns Promise resolving to the hint text, or null if no hint is shown.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Port' }));
+   * expect(await field.getHint()).toBe('Default port is 443');
+   * ```
+   */
+  async getHint(): Promise<string | null> {
+    const hint = await this._hint();
+    return hint ? (await hint.text()).trim() : null;
+  }
+
+  /**
+   * Checks whether the form field is marked as required.
+   *
+   * @returns Promise resolving to true if the required asterisk is present.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Name' }));
+   * expect(await field.isRequired()).toBe(true);
+   * ```
+   */
+  async isRequired(): Promise<boolean> {
+    const label = await this._label();
+    if (!label) { return false; }
+    return label.hasClass('required');
+  }
+
+  /**
+   * Gets the test ID attribute value.
+   *
+   * @returns Promise resolving to the data-testid string, or null.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness);
+   * expect(await field.getTestId()).toBe('email-field');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const root = await this.locatorFor('.tn-form-field')();
+    return root.getAttribute('data-testid');
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnFormFieldHarness` instances.
+ */
+export interface FormFieldHarnessFilters extends BaseHarnessFilters {
+  /** Filters by label text. Supports string or regex matching. */
+  label?: string | RegExp;
+  /** Filters by data-testid attribute. */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -34,6 +34,7 @@ export * from './lib/tab-panel/tab-panel.harness';
 export * from './lib/menu';
 export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
+export * from './lib/form-field/form-field.harness';
 export * from './lib/select/select.component';
 export * from './lib/select/select.harness';
 export * from './lib/icon/icon.component';

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnCheckboxComponent } from '../lib/checkbox/checkbox.component';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
 import { TnInputComponent } from '../lib/input/input.component';
 import { TnRadioComponent } from '../lib/radio/radio.component';
 import type { TnSelectOption } from '../lib/select/select.component';
 import { TnSelectComponent } from '../lib/select/select.component';
+
+const harnessDoc = loadHarnessDoc('form-field');
 
 const meta: Meta<TnFormFieldComponent> = {
   title: 'Components/Form Field',
@@ -383,4 +386,22 @@ export const MultipleFields: Story = {
     },
   }),
   args: {},
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
 };


### PR DESCRIPTION
Adds a component test harness for tn-form-field that supports:
- Finding form fields by label text or testId
- Querying error messages, hint text, and required state
- 17 unit tests covering all harness methods
- Storybook ComponentHarness story with auto-generated docs