### PR TITLE
fix(form-field): display custom validator error message strings

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -57,8 +57,13 @@ export class TnFormFieldComponent implements AfterContentInit {
     if (errors['min']) {return `Minimum value is ${errors['min'].min}`;}
     if (errors['max']) {return `Maximum value is ${errors['max'].max}`;}
 
-    // Return custom error message if available
-    return Object.keys(errors)[0] || 'Invalid input';
+    // Return custom error message if the value is a string, otherwise use the key
+    const firstKey = Object.keys(errors)[0];
+    if (firstKey) {
+      const value = errors[firstKey];
+      return typeof value === 'string' ? value : firstKey;
+    }
+    return 'Invalid input';
   }
 
   showError = computed(() => {

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -3,6 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
+import type { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TnFormFieldComponent } from './form-field.component';
 import { TnFormFieldHarness } from './form-field.harness';
@@ -25,12 +26,27 @@ import { TnInputComponent } from '../input/input.component';
     <tn-form-field label="Optional" testId="optional-field">
       <tn-input [formControl]="optionalControl" />
     </tn-form-field>
+
+    <tn-form-field label="Custom" testId="custom-field">
+      <tn-input [formControl]="customControl" />
+    </tn-form-field>
   `
 })
 class TestHostComponent {
   nameControl = new FormControl('', Validators.required);
   emailControl = new FormControl('', [Validators.required, Validators.email]);
   optionalControl = new FormControl('');
+  customControl = new FormControl('', customValidator());
+}
+
+function customValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value as string;
+    if (value && !/\d/.test(value)) {
+      return { customPolicy: 'Must contain at least one number' };
+    }
+    return null;
+  };
 }
 
 describe('TnFormFieldHarness', () => {
@@ -77,7 +93,7 @@ describe('TnFormFieldHarness', () => {
 
     it('should find all form fields', async () => {
       const fields = await loader.getAllHarnesses(TnFormFieldHarness);
-      expect(fields.length).toBe(3);
+      expect(fields.length).toBe(4);
     });
   });
 
@@ -198,6 +214,20 @@ describe('TnFormFieldHarness', () => {
         TnFormFieldHarness.with({ label: 'Name' })
       );
       expect(await field.hasError()).toBe(false);
+    });
+
+    it('should display custom validator error message string', async () => {
+      const host = fixture.componentInstance;
+      host.customControl.setValue('abc');
+      host.customControl.markAsTouched();
+      host.customControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Custom' })
+      );
+      expect(await field.hasError()).toBe(true);
+      expect(await field.getErrorMessage()).toBe('Must contain at least one number');
     });
   });
 


### PR DESCRIPTION
When a custom validator returns { key: 'human readable message' }, getErrorMessage() was returning the key name instead of the message string. Now checks if the error value is a string and uses it.