### PR TITLE
feat(menu): add TnMenuHarness and TnMenuTesting for test support

### DIFF
--- a/projects/truenas-ui/src/lib/menu/index.ts
+++ b/projects/truenas-ui/src/lib/menu/index.ts
@@ -1,2 +1,4 @@
 export * from './menu.component';
 export * from './menu-trigger.directive';
+export * from './menu.harness';
+export * from './menu-testing';

--- a/projects/truenas-ui/src/lib/menu/menu-testing.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-testing.ts
@@ -1,0 +1,32 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import type { ComponentFixture } from '@angular/core/testing';
+
+/**
+ * Test utilities for TnMenu.
+ *
+ * Provides a document-root `HarnessLoader` that can find menus rendered
+ * in CDK overlays. Use this alongside `TnDialogTesting.rootLoader()` if
+ * your tests also open dialogs.
+ *
+ * @example
+ * ```typescript
+ * import { TnMenuTesting, TnMenuHarness } from '@truenas/ui-components';
+ *
+ * const rootLoader = TnMenuTesting.rootLoader(spectator.fixture);
+ *
+ * // Open the menu trigger, then query the overlay
+ * spectator.click('[tnMenuTriggerFor]');
+ * const menu = await rootLoader.getHarness(TnMenuHarness);
+ * await menu.clickItem({ label: 'Edit' });
+ * ```
+ */
+export class TnMenuTesting {
+  /**
+   * Creates a `HarnessLoader` that searches the entire document,
+   * including CDK overlays where menus are rendered.
+   */
+  static rootLoader(fixture: ComponentFixture<unknown>): HarnessLoader {
+    return TestbedHarnessEnvironment.documentRootLoader(fixture);
+  }
+}

--- a/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
@@ -1,0 +1,101 @@
+import { OverlayModule } from '@angular/cdk/overlay';
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnMenuTesting } from './menu-testing';
+import { TnMenuTriggerDirective } from './menu-trigger.directive';
+import type { TnMenuItem } from './menu.component';
+import { TnMenuComponent } from './menu.component';
+import { TnMenuHarness } from './menu.harness';
+import { TnIconTesting } from '../icon/icon-testing';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnMenuComponent, TnMenuTriggerDirective, OverlayModule],
+  template: `
+    <button data-testid="trigger" [tnMenuTriggerFor]="menu">Open</button>
+    <tn-menu #menu [items]="items" />
+  `
+})
+class TestHostComponent {
+  menuRef = viewChild<TnMenuComponent>('menu');
+  items: TnMenuItem[] = [
+    { id: 'edit', label: 'Edit', action: jest.fn() },
+    { id: 'delete', label: 'Delete', action: jest.fn() },
+    { id: 'disabled-item', label: 'Locked', disabled: true, action: jest.fn() },
+  ];
+}
+
+describe('TnMenuHarness', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let rootLoader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+    rootLoader = TnMenuTesting.rootLoader(fixture);
+  });
+
+  function openMenu() {
+    const trigger = fixture.nativeElement.querySelector('[data-testid="trigger"]') as HTMLElement;
+    trigger.click();
+    fixture.detectChanges();
+  }
+
+  it('should find menu after opening', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(menu).toBeTruthy();
+  });
+
+  it('should get item labels', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    const labels = await menu.getItemLabels();
+    expect(labels).toEqual(['Edit', 'Delete', 'Locked']);
+  });
+
+  it('should get item count', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(await menu.getItemCount()).toBe(3);
+  });
+
+  it('should click a menu item by label', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    await menu.clickItem({ label: 'Edit' });
+    expect(hostComponent.items[0].action).toHaveBeenCalled();
+  });
+
+  it('should click a menu item by regex', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    await menu.clickItem({ label: /del/i });
+    expect(hostComponent.items[1].action).toHaveBeenCalled();
+  });
+
+  it('should throw when clicking non-existent item', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    await expect(menu.clickItem({ label: 'NonExistent' })).rejects.toThrow(
+      'Could not find menu item matching label "NonExistent"'
+    );
+  });
+
+  it('should check if item is disabled', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(await menu.isItemDisabled({ label: 'Edit' })).toBe(false);
+    expect(await menu.isItemDisabled({ label: 'Locked' })).toBe(true);
+  });
+});

--- a/projects/truenas-ui/src/lib/menu/menu.harness.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.harness.ts
@@ -1,0 +1,173 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for a single menu item (`button.tn-menu-item`).
+ * @internal Used by TnMenuHarness to interact with individual items.
+ */
+class TnMenuItemHarness extends ComponentHarness {
+  static hostSelector = '.tn-menu-item';
+
+  private _label = this.locatorFor('.tn-menu-item-label');
+
+  /** Gets the label text of this menu item. */
+  async getLabel(): Promise<string> {
+    const label = await this._label();
+    return (await label.text()).trim();
+  }
+
+  /** Checks whether this menu item is disabled via the native `disabled` attribute. */
+  async isDisabled(): Promise<boolean> {
+    const host = await this.host();
+    const disabled = await host.getProperty<boolean>('disabled');
+    return !!disabled;
+  }
+
+  /** Clicks this menu item. */
+  async click(): Promise<void> {
+    const host = await this.host();
+    await host.click();
+  }
+}
+
+/**
+ * Harness for interacting with `tn-menu` in tests.
+ *
+ * Menus render in a CDK overlay **outside** the component tree, so a regular
+ * `TestbedHarnessEnvironment.loader(fixture)` won't find them. Use
+ * `TnMenuTesting.rootLoader(fixture)` instead — it searches the entire document.
+ *
+ * ## Test Setup
+ *
+ * ```typescript
+ * import {
+ *   TnMenuHarness,
+ *   TnMenuTesting,
+ *   TnIconButtonHarness,
+ * } from '@truenas/ui-components';
+ *
+ * let loader: HarnessLoader;   // for components
+ * let rootLoader: HarnessLoader; // for overlays (menus, dialogs)
+ *
+ * beforeEach(() => {
+ *   spectator = createComponent();
+ *   loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+ *   rootLoader = TnMenuTesting.rootLoader(spectator.fixture);
+ * });
+ * ```
+ *
+ * ## Opening a Menu
+ *
+ * Click the trigger element to open the menu before querying it:
+ *
+ * ```typescript
+ * // Via harness (if trigger is a tn-icon-button)
+ * const trigger = await loader.getHarness(
+ *   TnIconButtonHarness.with({ name: 'more_vert' })
+ * );
+ * await trigger.click();
+ *
+ * // Or via DOM
+ * spectator.click('[tnMenuTriggerFor]');
+ * ```
+ *
+ * ## Querying and Clicking Items
+ *
+ * ```typescript
+ * const menu = await rootLoader.getHarness(TnMenuHarness);
+ * expect(await menu.getItemLabels()).toEqual(['Edit', 'Delete']);
+ * await menu.clickItem({ label: 'Edit' });
+ * await menu.clickItem({ label: /del/i }); // regex match
+ * expect(await menu.isItemDisabled({ label: 'Delete' })).toBe(false);
+ * ```
+ */
+export class TnMenuHarness extends ComponentHarness {
+  static hostSelector = '.tn-menu';
+
+  private _items = this.locatorForAll(TnMenuItemHarness);
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a menu.
+   */
+  static with(options: MenuHarnessFilters = {}) {
+    return new HarnessPredicate(TnMenuHarness, options);
+  }
+
+  /**
+   * Gets the labels of all menu items.
+   *
+   * @example
+   * ```typescript
+   * const menu = await rootLoader.getHarness(TnMenuHarness);
+   * expect(await menu.getItemLabels()).toEqual(['Edit', 'Delete']);
+   * ```
+   */
+  async getItemLabels(): Promise<string[]> {
+    const items = await this._items();
+    return Promise.all(items.map(item => item.getLabel()));
+  }
+
+  /**
+   * Clicks a menu item by its label text.
+   *
+   * @param filter Object with `label` to match (string or RegExp).
+   *
+   * @example
+   * ```typescript
+   * const menu = await rootLoader.getHarness(TnMenuHarness);
+   * await menu.clickItem({ label: 'Delete' });
+   * ```
+   */
+  async clickItem(filter: { label: string | RegExp }): Promise<void> {
+    const items = await this._items();
+    for (const item of items) {
+      const text = await item.getLabel();
+      const matches = filter.label instanceof RegExp
+        ? filter.label.test(text)
+        : text === filter.label;
+      if (matches) {
+        await item.click();
+        return;
+      }
+    }
+    throw new Error(`Could not find menu item matching label "${String(filter.label)}"`);
+  }
+
+  /**
+   * Checks if a menu item is disabled.
+   *
+   * @param filter Object with `label` to match (string or RegExp).
+   * @returns Promise resolving to true if the item is disabled.
+   *
+   * @example
+   * ```typescript
+   * const menu = await rootLoader.getHarness(TnMenuHarness);
+   * expect(await menu.isItemDisabled({ label: 'Delete' })).toBe(true);
+   * ```
+   */
+  async isItemDisabled(filter: { label: string | RegExp }): Promise<boolean> {
+    const items = await this._items();
+    for (const item of items) {
+      const text = await item.getLabel();
+      const matches = filter.label instanceof RegExp
+        ? filter.label.test(text)
+        : text === filter.label;
+      if (matches) {
+        return item.isDisabled();
+      }
+    }
+    throw new Error(`Could not find menu item with label "${String(filter.label)}"`);
+  }
+
+  /**
+   * Gets the number of menu items (excluding separators).
+   */
+  async getItemCount(): Promise<number> {
+    return (await this._items()).length;
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter `TnMenuHarness` instances.
+ */
+export interface MenuHarnessFilters extends BaseHarnessFilters {}

--- a/projects/truenas-ui/src/stories/menu.stories.ts
+++ b/projects/truenas-ui/src/stories/menu.stories.ts
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, userEvent, within } from 'storybook/test';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
 import { TnMenuTriggerDirective } from '../lib/menu/menu-trigger.directive';
 import type { TnMenuItem } from '../lib/menu/menu.component';
 import { TnMenuComponent } from '../lib/menu/menu.component';
+
+const harnessDoc = loadHarnessDoc('menu');
 
 const meta: Meta<TnMenuComponent> = {
   title: 'Components/Menu',
@@ -383,5 +386,23 @@ export const ContextMenu: Story = {
       },
     },
   },
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
 };
 


### PR DESCRIPTION
- TnMenuHarness: find menus in CDK overlay, get item labels, click items by label (string or regex), check disabled state
- TnMenuItemHarness: internal sub-harness for individual menu items
- TnMenuTesting.rootLoader(): creates document-root loader for finding menus rendered in CDK overlays
- 7 unit tests covering find, labels, click, regex, disabled, error
- Exported from menu/index.ts