### PR TITLE
feat(slide-toggle): add TnSlideToggleHarness for testing

### DIFF
--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.spec.ts
@@ -1,0 +1,148 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnSlideToggleComponent } from './slide-toggle.component';
+import { TnSlideToggleHarness } from './slide-toggle.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSlideToggleComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-slide-toggle
+      label="Notifications"
+      testId="test-toggle"
+      [formControl]="control" />
+
+    <tn-slide-toggle
+      label="Disabled toggle"
+      testId="disabled-toggle"
+      [disabled]="true"
+      [checked]="true" />
+  `
+})
+class TestHostComponent {
+  control = new FormControl(false);
+}
+
+describe('TnSlideToggleHarness', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness', async () => {
+    const toggle = await loader.getHarness(TnSlideToggleHarness);
+    expect(toggle).toBeTruthy();
+  });
+
+  describe('with() filter', () => {
+    it('should filter by label', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      expect(await toggle.getLabelText()).toBe('Notifications');
+    });
+
+    it('should filter by label regex', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: /notif/i })
+      );
+      expect(toggle).toBeTruthy();
+    });
+
+    it('should filter by testId', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ testId: 'disabled-toggle' })
+      );
+      expect(await toggle.getLabelText()).toBe('Disabled toggle');
+    });
+
+    it('should find all toggles', async () => {
+      const toggles = await loader.getAllHarnesses(TnSlideToggleHarness);
+      expect(toggles.length).toBe(2);
+    });
+  });
+
+  describe('isChecked / toggle / check / uncheck', () => {
+    it('should be unchecked initially', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should toggle on', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      await toggle.toggle();
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should toggle off', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      await toggle.toggle();
+      await toggle.toggle();
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should check (no-op if already checked)', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      await toggle.check();
+      await toggle.check();
+      expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should uncheck (no-op if already unchecked)', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      await toggle.uncheck();
+      expect(await toggle.isChecked()).toBe(false);
+    });
+
+    it('should update form control value', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      await toggle.check();
+      expect(hostComponent.control.value).toBe(true);
+      await toggle.uncheck();
+      expect(hostComponent.control.value).toBe(false);
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('should return false for enabled toggle', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Notifications' })
+      );
+      expect(await toggle.isDisabled()).toBe(false);
+    });
+
+    it('should return true for disabled toggle', async () => {
+      const toggle = await loader.getHarness(
+        TnSlideToggleHarness.with({ label: 'Disabled toggle' })
+      );
+      expect(await toggle.isDisabled()).toBe(true);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.ts
@@ -1,0 +1,126 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with `tn-slide-toggle` in tests.
+ *
+ * @example
+ * ```typescript
+ * const toggle = await loader.getHarness(
+ *   TnSlideToggleHarness.with({ label: 'Enable notifications' })
+ * );
+ * await toggle.toggle();
+ * expect(await toggle.isChecked()).toBe(true);
+ * ```
+ */
+export class TnSlideToggleHarness extends ComponentHarness {
+  static hostSelector = 'tn-slide-toggle';
+
+  private _input = this.locatorFor('.tn-slide-toggle__input');
+  private _label = this.locatorForOptional('.tn-slide-toggle__label-text');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a slide toggle
+   * with specific attributes.
+   */
+  static with(options: SlideToggleHarnessFilters = {}) {
+    return new HarnessPredicate(TnSlideToggleHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabelText(), label)
+      )
+      .addOption('testId', options.testId, async (harness, testId) => {
+        return (await harness.getTestId()) === testId;
+      });
+  }
+
+  /**
+   * Gets the label text of the slide toggle.
+   *
+   * @example
+   * ```typescript
+   * expect(await toggle.getLabelText()).toBe('Enable notifications');
+   * ```
+   */
+  async getLabelText(): Promise<string> {
+    const label = await this._label();
+    return label ? (await label.text()).trim() : '';
+  }
+
+  /**
+   * Checks whether the slide toggle is currently checked.
+   *
+   * @example
+   * ```typescript
+   * expect(await toggle.isChecked()).toBe(false);
+   * ```
+   */
+  async isChecked(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('checked')) ?? false;
+  }
+
+  /**
+   * Checks whether the slide toggle is disabled.
+   */
+  async isDisabled(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Checks whether the slide toggle is required.
+   */
+  async isRequired(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('required')) ?? false;
+  }
+
+  /**
+   * Gets the test ID attribute value.
+   */
+  async getTestId(): Promise<string | null> {
+    const root = await this.locatorFor('.tn-slide-toggle')();
+    return root.getAttribute('data-testid');
+  }
+
+  /**
+   * Toggles the slide toggle by clicking the input element.
+   *
+   * @example
+   * ```typescript
+   * await toggle.toggle();
+   * ```
+   */
+  async toggle(): Promise<void> {
+    const input = await this._input();
+    await input.click();
+  }
+
+  /**
+   * Checks the slide toggle. No-op if already checked.
+   */
+  async check(): Promise<void> {
+    if (!(await this.isChecked())) {
+      await this.toggle();
+    }
+  }
+
+  /**
+   * Unchecks the slide toggle. No-op if already unchecked.
+   */
+  async uncheck(): Promise<void> {
+    if (await this.isChecked()) {
+      await this.toggle();
+    }
+  }
+}
+
+/**
+ * Filters for finding `TnSlideToggleHarness` instances.
+ */
+export interface SlideToggleHarnessFilters extends BaseHarnessFilters {
+  /** Filters by label text. Supports string or regex matching. */
+  label?: string | RegExp;
+  /** Filters by data-testid attribute. */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -25,6 +25,7 @@ export * from './lib/checkbox/checkbox.component';
 export * from './lib/checkbox/checkbox.harness';
 export * from './lib/radio/radio.component';
 export * from './lib/slide-toggle/slide-toggle.component';
+export * from './lib/slide-toggle/slide-toggle.harness';
 export * from './lib/tabs/tabs.component';
 export * from './lib/tabs/tabs.harness';
 export * from './lib/tab/tab.component';

--- a/projects/truenas-ui/src/stories/slide-toggle.stories.ts
+++ b/projects/truenas-ui/src/stories/slide-toggle.stories.ts
@@ -1,8 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
 import { TnSlideToggleComponent } from '../lib/slide-toggle/slide-toggle.component';
+
+const harnessDoc = loadHarnessDoc('slide-toggle');
 
 const meta: Meta<TnSlideToggleComponent> = {
   title: 'Components/Slide Toggle',
@@ -362,4 +365,22 @@ export const ColorComparison: Story = {
     `,
   }),
   args: {},
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
 };


### PR DESCRIPTION
- TnSlideToggleHarness: find by label (string/regex) or testId, toggle/check/uncheck, query checked/disabled/required state
- 13 unit tests covering all harness methods
- Storybook ComponentHarness story with auto-generated docs
- Exported from public API