### PR TITLE
fix(tree): replace deprecated ChangeDetectionStrategy.Default with OnPush in TnTree

### DIFF
--- a/projects/truenas-ui/src/lib/tree/tree.component.ts
+++ b/projects/truenas-ui/src/lib/tree/tree.component.ts
@@ -119,7 +119,7 @@ export class TnTreeFlatDataSource<T, F> extends DataSource<F> {
     'role': 'tree'
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.Default,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TnTreeComponent<T, K = T> extends CdkTree<T, K> {
   constructor() {


### PR DESCRIPTION
ChangeDetectionStrategy.Default is deprecated in Angular 21 and causes build failures in consuming applications.