### PR TITLE
fix(button-toggle): invoke value signal instead of passing signal reference

### DIFF
--- a/projects/truenas-ui/src/lib/button-toggle/button-toggle-group.component.ts
+++ b/projects/truenas-ui/src/lib/button-toggle/button-toggle-group.component.ts
@@ -103,7 +103,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
 
   private handleSingleSelection(clickedToggle: TnButtonToggleComponent): void {
     // In radio mode, clicking the same toggle deselects it
-    if (this.selectedValue() === clickedToggle.value) {
+    if (this.selectedValue() === clickedToggle.value()) {
       this.selectedValue.set(null);
       clickedToggle._markForUncheck();
     } else {
@@ -115,7 +115,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
         }
       });
 
-      this.selectedValue.set(clickedToggle.value);
+      this.selectedValue.set(clickedToggle.value());
       clickedToggle._markForCheck();
     }
 
@@ -124,7 +124,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
 
   private handleMultipleSelection(clickedToggle: TnButtonToggleComponent): void {
     const currentValues = [...this.selectedValues()];
-    const index = currentValues.indexOf(clickedToggle.value);
+    const index = currentValues.indexOf(clickedToggle.value());
 
     if (index > -1) {
       // Remove from selection
@@ -132,7 +132,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
       clickedToggle._markForUncheck();
     } else {
       // Add to selection
-      currentValues.push(clickedToggle.value);
+      currentValues.push(clickedToggle.value());
       clickedToggle._markForCheck();
     }
 
@@ -145,7 +145,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
     const value = this.selectedValue();
 
     toggles.forEach(toggle => {
-      if (toggle.value === value) {
+      if (toggle.value() === value) {
         toggle._markForCheck();
       } else {
         toggle._markForUncheck();
@@ -158,7 +158,7 @@ export class TnButtonToggleGroupComponent implements ControlValueAccessor {
     const values = this.selectedValues();
 
     toggles.forEach(toggle => {
-      if (values.includes(toggle.value)) {
+      if (values.includes(toggle.value())) {
         toggle._markForCheck();
       } else {
         toggle._markForUncheck();

--- a/projects/truenas-ui/src/lib/button-toggle/button-toggle.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/button-toggle/button-toggle.harness.spec.ts
@@ -1,7 +1,8 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TnButtonToggleGroupComponent } from './button-toggle-group.component';
 import { TnButtonToggleComponent } from './button-toggle.component';
 import { TnButtonToggleHarness, TnButtonToggleGroupHarness } from './button-toggle.harness';
@@ -172,5 +173,103 @@ describe('TnButtonToggleGroupHarness', () => {
       expect(checked).not.toBeNull();
       expect(await checked!.getLabelText()).toContain('Bold');
     });
+  });
+});
+
+// --- ControlValueAccessor integration tests ---
+
+@Component({
+  selector: 'tn-button-toggle-cva-test',
+  standalone: true,
+  imports: [TnButtonToggleComponent, TnButtonToggleGroupComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-button-toggle-group [formControl]="control">
+      <tn-button-toggle value="bold">Bold</tn-button-toggle>
+      <tn-button-toggle value="italic">Italic</tn-button-toggle>
+      <tn-button-toggle value="underline">Underline</tn-button-toggle>
+    </tn-button-toggle-group>
+
+    <tn-button-toggle-group [formControl]="multiControl" [multiple]="true">
+      <tn-button-toggle value="a">A</tn-button-toggle>
+      <tn-button-toggle value="b">B</tn-button-toggle>
+      <tn-button-toggle value="c">C</tn-button-toggle>
+    </tn-button-toggle-group>
+  `,
+})
+class ButtonToggleCvaTestComponent {
+  control = new FormControl<string | null>(null);
+  multiControl = new FormControl<string[]>([]);
+}
+
+describe('TnButtonToggleGroup — ControlValueAccessor', () => {
+  let fixture: ComponentFixture<ButtonToggleCvaTestComponent>;
+  let component: ButtonToggleCvaTestComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ButtonToggleCvaTestComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonToggleCvaTestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should propagate the primitive value to FormControl on click', async () => {
+    const bold = await loader.getHarness(TnButtonToggleHarness.with({ label: 'Bold' }));
+    await bold.check();
+    fixture.detectChanges();
+
+    expect(component.control.value).toBe('bold');
+  });
+
+  it('should update the checked toggle when FormControl value changes programmatically', async () => {
+    component.control.setValue('italic');
+    fixture.detectChanges();
+
+    const group = await loader.getHarness(TnButtonToggleGroupHarness);
+    const checked = await group.getCheckedToggle();
+    expect(checked).not.toBeNull();
+    expect(await checked!.getLabelText()).toContain('Italic');
+  });
+
+  it('should set FormControl to null when the selected toggle is deselected', async () => {
+    const bold = await loader.getHarness(TnButtonToggleHarness.with({ label: 'Bold' }));
+    await bold.check();
+    fixture.detectChanges();
+    expect(component.control.value).toBe('bold');
+
+    // Click again to deselect in radio mode
+    await bold.toggle();
+    fixture.detectChanges();
+    expect(component.control.value).toBeNull();
+  });
+
+  it('should replace the previous value when a different toggle is clicked', async () => {
+    const bold = await loader.getHarness(TnButtonToggleHarness.with({ label: 'Bold' }));
+    const italic = await loader.getHarness(TnButtonToggleHarness.with({ label: 'Italic' }));
+
+    await bold.check();
+    fixture.detectChanges();
+    expect(component.control.value).toBe('bold');
+
+    await italic.check();
+    fixture.detectChanges();
+    expect(component.control.value).toBe('italic');
+  });
+
+  it('should propagate an array of primitive values in multiple mode', async () => {
+    const groups = await loader.getAllHarnesses(TnButtonToggleGroupHarness);
+    const multiGroup = groups[1];
+    const toggles = await multiGroup.getToggles();
+
+    await toggles[0].check(); // A
+    await toggles[2].check(); // C
+    fixture.detectChanges();
+
+    expect(component.multiControl.value).toEqual(['a', 'c']);
   });
 });


### PR DESCRIPTION
TnButtonToggleGroupComponent was using `clickedToggle.value` (the InputSignal function) instead of `clickedToggle.value()` (the resolved value). This caused FormControls bound via formControlName to receive the signal function as their value rather than the actual toggle value.