### PR TITLE
fix(calendar): use stable track keys for month view cells

### DIFF
--- a/projects/truenas-ui/src/lib/calendar/month-view.component.html
+++ b/projects/truenas-ui/src/lib/calendar/month-view.component.html
@@ -14,7 +14,7 @@
   <!-- Table body with calendar cells -->
   <tbody class="tn-calendar-body">
     <!-- Calendar rows -->
-    @for (row of calendarRows(); track trackByRow($index, row); let rowIndex = $index) {
+    @for (row of calendarRows(); track trackByRow($index); let rowIndex = $index) {
       <tr role="row">
         @for (cell of row; track trackByDate($index, cell); let colIndex = $index) {
           <td

--- a/projects/truenas-ui/src/lib/calendar/month-view.component.ts
+++ b/projects/truenas-ui/src/lib/calendar/month-view.component.ts
@@ -187,11 +187,12 @@ export class TnMonthViewComponent {
   }
 
   trackByDate(index: number, cell: CalendarCell): string {
-    return cell.date.toISOString();
+    if (cell.value === 0) { return `empty-${index}`; }
+    return `${cell.date.getFullYear()}-${cell.date.getMonth()}-${cell.date.getDate()}`;
   }
 
-  trackByRow(index: number, row: CalendarCell[]): string {
-    return row.map(cell => cell.date.toISOString()).join(',');
+  trackByRow(index: number): number {
+    return index;
   }
 
   onCellClicked(cell: CalendarCell): void {


### PR DESCRIPTION
Empty cells (padding before/after month days) all used `new Date()` which produced identical ISO strings when created in the same millisecond, triggering Angular's NG0955 duplicate key warning.

Use position-based keys for empty cells and date-component keys (year-month-day) for day cells. Use index for row tracking.