### PR TITLE
feat(date-picker): add selectDate and selectRange to harnesses

### DIFF
--- a/projects/truenas-ui/src/lib/date-range-input/date-harness-helpers.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-harness-helpers.ts
@@ -1,4 +1,4 @@
-import type { TestElement } from '@angular/cdk/testing';
+import type { LocatorFactory, TestElement } from '@angular/cdk/testing';
 
 /**
  * Formats a Date into zero-padded month, day, and year strings.
@@ -43,4 +43,85 @@ export async function setInputValue(
     await el.sendKeys(value);
   }
   await el.blur();
+}
+
+const MONTHS = [
+  'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+  'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC',
+];
+
+/**
+ * Navigates the calendar overlay to the target month/year, then clicks the day cell.
+ * Assumes the calendar popup is already open.
+ *
+ * @param rootLocator The document root locator factory (for finding overlay elements).
+ * @param date The target date to select.
+ */
+export async function selectCalendarDate(
+  rootLocator: LocatorFactory,
+  date: Date
+): Promise<void> {
+  await navigateCalendarTo(rootLocator, date);
+
+  const dayStr = date.getDate().toString();
+  const cells = await rootLocator.locatorForAll(
+    '.tn-calendar-body-cell:not([disabled])'
+  )();
+
+  for (const cell of cells) {
+    if ((await cell.text()).trim() === dayStr) {
+      await cell.click();
+      return;
+    }
+  }
+
+  throw new Error(
+    `Could not find enabled calendar cell for day ${dayStr}`
+  );
+}
+
+/**
+ * Navigates the calendar to show the month/year of the target date by
+ * clicking previous/next buttons as needed.
+ */
+async function navigateCalendarTo(
+  rootLocator: LocatorFactory,
+  date: Date
+): Promise<void> {
+  const targetLabel = `${MONTHS[date.getMonth()]} ${date.getFullYear()}`;
+
+  // Safety limit to prevent infinite loops
+  for (let i = 0; i < 120; i++) {
+    const periodButton = await rootLocator.locatorFor(
+      '.tn-calendar-period-button'
+    )();
+    const currentLabel = (await periodButton.text()).trim();
+
+    if (currentLabel === targetLabel) {
+      return;
+    }
+
+    const currentDate = parseCalendarLabel(currentLabel);
+    const targetTime = date.getFullYear() * 12 + date.getMonth();
+    const currentTime = currentDate.year * 12 + currentDate.month;
+
+    const navSelector = targetTime > currentTime
+      ? '.tn-calendar-next-button'
+      : '.tn-calendar-previous-button';
+
+    const navButton = await rootLocator.locatorFor(navSelector)();
+    await navButton.click();
+  }
+
+  throw new Error(`Could not navigate calendar to ${targetLabel}`);
+}
+
+function parseCalendarLabel(label: string): {
+  year: number;
+  month: number;
+} {
+  const parts = label.split(' ');
+  const monthIndex = MONTHS.indexOf(parts[0]);
+  const year = parseInt(parts[1], 10);
+  return { year, month: monthIndex >= 0 ? monthIndex : 0 };
 }

--- a/projects/truenas-ui/src/lib/date-range-input/date-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-input.harness.spec.ts
@@ -81,4 +81,14 @@ describe('TnDateInputHarness', () => {
     await harness.openCalendar();
     expect(await harness.isCalendarOpen()).toBe(true);
   });
+
+  it('should select a date via the calendar popup', async () => {
+    const harness = await loader.getHarness(TnDateInputHarness);
+    await harness.selectDate(new Date(2026, 3, 15));
+
+    expect(component.control.value?.getFullYear()).toBe(2026);
+    expect(component.control.value?.getMonth()).toBe(3);
+    expect(component.control.value?.getDate()).toBe(15);
+    expect(await harness.getDisplayText()).toBe('04/15/2026');
+  });
 });

--- a/projects/truenas-ui/src/lib/date-range-input/date-input.harness.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-input.harness.ts
@@ -1,6 +1,6 @@
 import type { BaseHarnessFilters } from '@angular/cdk/testing';
 import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
-import { formatDateParts, getInputValue, setInputValue } from './date-harness-helpers';
+import { formatDateParts, getInputValue, selectCalendarDate, setInputValue } from './date-harness-helpers';
 
 /**
  * Harness for interacting with `tn-date-input` in tests.
@@ -100,6 +100,26 @@ export class TnDateInputHarness extends ComponentHarness {
   async isCalendarOpen(): Promise<boolean> {
     const overlay = await this.documentRootLocatorFactory().locatorForOptional('.tn-datepicker-overlay')();
     return overlay !== null;
+  }
+
+  /**
+   * Selects a date via the calendar popup. Opens the calendar if not already
+   * open, navigates to the target month, and clicks the day cell.
+   *
+   * @param date The date to select.
+   *
+   * @example
+   * ```typescript
+   * const dateInput = await loader.getHarness(TnDateInputHarness);
+   * await dateInput.selectDate(new Date(2026, 3, 15));
+   * expect(await dateInput.getDisplayText()).toBe('04/15/2026');
+   * ```
+   */
+  async selectDate(date: Date): Promise<void> {
+    if (!(await this.isCalendarOpen())) {
+      await this.openCalendar();
+    }
+    await selectCalendarDate(this.documentRootLocatorFactory(), date);
   }
 }
 

--- a/projects/truenas-ui/src/lib/date-range-input/date-range-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-range-input.harness.spec.ts
@@ -93,4 +93,15 @@ describe('TnDateRangeInputHarness', () => {
     await harness.openCalendar();
     expect(await harness.isCalendarOpen()).toBe(true);
   });
+
+  it('should select a date range via the calendar popup', async () => {
+    const harness = await loader.getHarness(TnDateRangeInputHarness);
+    await harness.selectRange({
+      start: new Date(2026, 3, 1),
+      end: new Date(2026, 3, 20),
+    });
+
+    expect(await harness.getStartText()).toBe('04/01/2026');
+    expect(await harness.getEndText()).toBe('04/20/2026');
+  });
 });

--- a/projects/truenas-ui/src/lib/date-range-input/date-range-input.harness.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-range-input.harness.ts
@@ -1,6 +1,6 @@
 import type { BaseHarnessFilters } from '@angular/cdk/testing';
 import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
-import { formatDateParts, getInputValue, setInputValue } from './date-harness-helpers';
+import { formatDateParts, getInputValue, selectCalendarDate, setInputValue } from './date-harness-helpers';
 
 /**
  * Harness for interacting with `tn-date-range-input` in tests.
@@ -128,6 +128,32 @@ export class TnDateRangeInputHarness extends ComponentHarness {
   async isCalendarOpen(): Promise<boolean> {
     const overlay = await this.documentRootLocatorFactory().locatorForOptional('.tn-datepicker-overlay')();
     return overlay !== null;
+  }
+
+  /**
+   * Selects a date range via the calendar popup. Opens the calendar if not
+   * already open, navigates to each target month, and clicks the day cells.
+   *
+   * @param range An object with `start` and `end` dates.
+   *
+   * @example
+   * ```typescript
+   * const rangeInput = await loader.getHarness(TnDateRangeInputHarness);
+   * await rangeInput.selectRange({
+   *   start: new Date(2026, 0, 1),
+   *   end: new Date(2026, 0, 31),
+   * });
+   * expect(await rangeInput.getStartText()).toBe('01/01/2026');
+   * expect(await rangeInput.getEndText()).toBe('01/31/2026');
+   * ```
+   */
+  async selectRange(range: { start: Date; end: Date }): Promise<void> {
+    if (!(await this.isCalendarOpen())) {
+      await this.openCalendar();
+    }
+    const rootLocator = this.documentRootLocatorFactory();
+    await selectCalendarDate(rootLocator, range.start);
+    await selectCalendarDate(rootLocator, range.end);
   }
 }
 


### PR DESCRIPTION
Add calendar-interaction methods that open the popup, navigate to the target month, and click the day cell:

- TnDateInputHarness.selectDate(date) — single date selection
- TnDateRangeInputHarness.selectRange({ start, end }) — range selection

Shared navigation and cell-clicking logic lives in date-harness-helpers.