### PR TITLE
feat(table): add width input to tnColumnDef

### DIFF
--- a/projects/truenas-ui/src/lib/table-column/table-column.directive.ts
+++ b/projects/truenas-ui/src/lib/table-column/table-column.directive.ts
@@ -24,6 +24,7 @@ export class TnCellDefDirective {
 export class TnTableColumnDirective {
   name = input.required<string>({ alias: 'tnColumnDef' });
   sortable = input<boolean>(false);
+  width = input<string | undefined>(undefined);
 
   headerTemplate = contentChild(TnHeaderCellDefDirective, {
     read: TemplateRef,

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -27,6 +27,7 @@
             class="tn-table__header-cell"
             [class.tn-table__header-cell--sortable]="getColumnDef(column)?.sortable()"
             [class.tn-table__header-cell--sorted]="isSorted(column)"
+            [style.width]="getColumnDef(column)?.width()"
             [attr.aria-sort]="
               isSorted(column)
                 ? sortDirection() === 'asc' ? 'ascending' : 'descending'
@@ -93,6 +94,7 @@
           } @else {
             <td
               class="tn-table__cell"
+              [style.width]="getColumnDef(column)?.width()"
               [attr.data-column]="column">
               @if (getColumnDef(column)?.cellTemplate(); as tmpl) {
                 <ng-container

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -343,6 +343,37 @@ export const TableWithFiltering: Story = {
   }),
 };
 
+export const ColumnWidths: Story = {
+  render: () => ({
+    props: {
+      tableData: sampleData,
+      tableColumns: ['id', 'name', 'email', 'actions'],
+    },
+    template: `
+      <tn-table
+        [dataSource]="tableData"
+        [displayedColumns]="tableColumns">
+        <ng-container tnColumnDef="id" width="60px">
+          <ng-template tnHeaderCellDef>ID</ng-template>
+          <ng-template let-user tnCellDef>{{ user.id }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="actions" width="48px">
+          <ng-template tnHeaderCellDef></ng-template>
+          <ng-template let-user tnCellDef>⋮</ng-template>
+        </ng-container>
+      </tn-table>
+    `,
+  }),
+};
+
 export const EmptyTable: Story = {
   render: () => ({
     props: {


### PR DESCRIPTION
Consumers can now set column width via the directive: <ng-container tnColumnDef="actions" width="48px">

The width is applied to both <th> and <td> via [style.width]. Includes a ColumnWidths story demonstrating narrow ID and actions columns alongside flexible content columns.