### PR TITLE
feat(theme): add --tn-fg3/fg4 vars and color palette story

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -14,6 +14,8 @@
   --tn-bg3: #333333;
   --tn-fg1: #ffffff;
   --tn-fg2: rgba(255,255,255,0.85);
+  --tn-fg3: rgba(255,255,255,0.55);
+  --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
   --tn-alt-fg1: rgba(194,194,194,0.5);
@@ -71,6 +73,8 @@
   --tn-bg3: #333333;
   --tn-fg1: #e0e0e0;
   --tn-fg2: rgba(255,255,255,0.85);
+  --tn-fg3: rgba(255,255,255,0.55);
+  --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
   --tn-alt-fg1: rgba(194,194,194,0.5);
@@ -105,6 +109,8 @@
   --tn-bg3: #e8e8e8;
   --tn-fg1: #585858;
   --tn-fg2: #666666;
+  --tn-fg3: #888888;
+  --tn-fg4: #909090;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;
@@ -140,6 +146,8 @@
   --tn-bg3: #343746;
   --tn-fg1: #efefef;
   --tn-fg2: #cacac5;
+  --tn-fg3: #9a9a95;
+  --tn-fg4: #7a7a75;
   --tn-alt-bg1: #3a3d4a;
   --tn-alt-bg2: #44475a;
   --tn-alt-fg1: #f8f8f2;
@@ -175,6 +183,8 @@
   --tn-bg3: #454d5e;
   --tn-fg1: #eceff4;
   --tn-fg2: #e5e9f0;
+  --tn-fg3: #a0a8b4;
+  --tn-fg4: #7b8394;
   --tn-alt-bg1: #434c5e;
   --tn-alt-bg2: #4c566a;
   --tn-alt-fg1: #d8dee9;
@@ -209,6 +219,8 @@
   --tn-bg3: #e8e8e8;
   --tn-fg1: #3f3f3f;
   --tn-fg2: #666666;
+  --tn-fg3: #888888;
+  --tn-fg4: #909090;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;
@@ -246,6 +258,8 @@
   --tn-bg3: #0a4050;
   --tn-fg1: #586e75;
   --tn-fg2: #7f99a2;
+  --tn-fg3: #4a5e65;
+  --tn-fg4: #3a4d53;
   --tn-alt-bg1: #0e4853;
   --tn-alt-bg2: #155a68;
   --tn-alt-fg1: #839496;
@@ -282,6 +296,8 @@
   --tn-bg3: #3d4a55;
   --tn-fg1: #aaaaaa;
   --tn-fg2: #cccccc;
+  --tn-fg3: #888888;
+  --tn-fg4: #666666;
   --tn-alt-bg1: #3d4a55;
   --tn-alt-bg2: #4a5762;
   --tn-alt-fg1: #c1c1c1;
@@ -315,6 +331,8 @@
   --tn-bg3: #d0d0d0;
   --tn-fg1: #222222;
   --tn-fg2: #333333;
+  --tn-fg3: #666666;
+  --tn-fg4: #777777;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -133,12 +133,15 @@ Each theme defines the following CSS custom properties:
 ### Background Colors
 - `--tn-bg1`: Main background color
 - `--tn-bg2`: Secondary background color (cards, panels)
-- `--tn-alt-bg1`: Alternative background 1
-- `--tn-alt-bg2`: Alternative background 2
+- `--tn-bg3`: Tertiary background color (elevated surfaces, popovers)
+- `--tn-alt-bg1`: Alternative background 1 (hover, selected states)
+- `--tn-alt-bg2`: Alternative background 2 (skeleton loaders, subtle separators)
 
 ### Text Colors
-- `--tn-fg1`: Primary text color
-- `--tn-fg2`: Secondary text color
+- `--tn-fg1`: Primary text color (headings, body)
+- `--tn-fg2`: Secondary text color (labels, descriptions)
+- `--tn-fg3`: Muted text (placeholders, timestamps, hints)
+- `--tn-fg4`: Very subdued text (disabled states, decorative)
 - `--tn-alt-fg1`: Alternative text color 1
 - `--tn-alt-fg2`: Alternative text color 2
 

--- a/projects/truenas-ui/src/stories/color-palette.stories.ts
+++ b/projects/truenas-ui/src/stories/color-palette.stories.ts
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+const meta: Meta = {
+  title: 'API/Color Palette',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Visual reference for all `--tn-*` CSS color variables. Switch themes in the Storybook toolbar to see how each variable adapts.',
+      },
+    },
+    controls: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const fgVars = ['--tn-fg1', '--tn-fg2', '--tn-fg3', '--tn-fg4', '--tn-alt-fg1', '--tn-alt-fg2'];
+const bgVars = ['--tn-bg1', '--tn-bg2', '--tn-bg3', '--tn-alt-bg1', '--tn-alt-bg2'];
+const uiVars = ['--tn-primary', '--tn-primary-txt', '--tn-accent', '--tn-topbar', '--tn-topbar-txt', '--tn-lines'];
+const statusVars = ['--tn-red', '--tn-green', '--tn-yellow', '--tn-orange', '--tn-blue', '--tn-cyan', '--tn-magenta', '--tn-violet'];
+
+function swatchRow(varName: string, type: 'bg' | 'fg'): string {
+  if (type === 'bg') {
+    return `
+      <div style="display:flex; align-items:center; gap:12px; padding:8px 0;">
+        <div style="width:48px; height:48px; border-radius:8px; border:1px solid var(--tn-lines); background:var(${varName});"></div>
+        <div>
+          <div style="font-weight:600; font-size:14px; color:var(--tn-fg1);">${varName}</div>
+          <div style="font-size:12px; color:var(--tn-fg3);">Background</div>
+        </div>
+      </div>`;
+  }
+  return `
+    <div style="display:flex; align-items:center; gap:12px; padding:8px 0;">
+      <div style="width:48px; height:48px; border-radius:8px; border:1px solid var(--tn-lines); background:var(--tn-bg2); display:flex; align-items:center; justify-content:center;">
+        <span style="font-size:18px; font-weight:700; color:var(${varName});">Aa</span>
+      </div>
+      <div>
+        <div style="font-weight:600; font-size:14px; color:var(--tn-fg1);">${varName}</div>
+        <div style="font-size:12px; color:var(--tn-fg3);">Text</div>
+      </div>
+    </div>`;
+}
+
+function section(title: string, vars: string[], type: 'bg' | 'fg'): string {
+  return `
+    <div style="margin-bottom:32px;">
+      <h3 style="font-size:16px; font-weight:700; color:var(--tn-fg1); margin-bottom:12px; border-bottom:1px solid var(--tn-lines); padding-bottom:8px;">${title}</h3>
+      <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:4px;">
+        ${vars.map(v => swatchRow(v, type)).join('')}
+      </div>
+    </div>`;
+}
+
+function comboGrid(): string {
+  const headers = bgVars.map(bg => `<th style="padding:8px; font-size:11px; color:var(--tn-fg3); font-weight:600;">${bg.replace('--tn-', '')}</th>`).join('');
+  const rows = fgVars.map(fg => {
+    const cells = bgVars.map(bg => `
+      <td style="padding:4px;">
+        <div style="background:var(${bg}); border-radius:6px; padding:8px; text-align:center; border:1px solid var(--tn-lines);">
+          <span style="color:var(${fg}); font-size:13px; font-weight:600;">Aa</span>
+        </div>
+      </td>`).join('');
+    return `<tr>
+      <td style="padding:8px; font-size:11px; color:var(--tn-fg3); font-weight:600;">${fg.replace('--tn-', '')}</td>
+      ${cells}
+    </tr>`;
+  }).join('');
+
+  return `
+    <div style="margin-bottom:32px;">
+      <h3 style="font-size:16px; font-weight:700; color:var(--tn-fg1); margin-bottom:12px; border-bottom:1px solid var(--tn-lines); padding-bottom:8px;">Foreground × Background Combinations</h3>
+      <div style="overflow-x:auto;">
+        <table style="border-collapse:collapse; width:100%;">
+          <thead><tr><th></th>${headers}</tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`;
+}
+
+export const Backgrounds: Story = {
+  render: () => ({
+    template: section('Background Variables', bgVars, 'bg'),
+  }),
+};
+
+export const Foregrounds: Story = {
+  render: () => ({
+    template: section('Foreground Variables', fgVars, 'fg'),
+  }),
+};
+
+export const UIColors: Story = {
+  name: 'UI Colors',
+  render: () => ({
+    template: section('UI & Chrome', uiVars, 'bg'),
+  }),
+};
+
+export const StatusColors: Story = {
+  render: () => ({
+    template: section('Status Colors', statusVars, 'bg'),
+  }),
+};
+
+export const Combinations: Story = {
+  name: 'FG × BG Matrix',
+  render: () => ({
+    template: comboGrid(),
+  }),
+};

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -14,6 +14,8 @@
   --tn-bg3: #333333;
   --tn-fg1: #ffffff;
   --tn-fg2: rgba(255,255,255,0.85);
+  --tn-fg3: rgba(255,255,255,0.55);
+  --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
   --tn-alt-fg1: rgba(194,194,194,0.5);
@@ -71,6 +73,8 @@
   --tn-bg3: #333333;
   --tn-fg1: #e0e0e0;
   --tn-fg2: rgba(255,255,255,0.85);
+  --tn-fg3: rgba(255,255,255,0.55);
+  --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
   --tn-alt-fg1: rgba(194,194,194,0.5);
@@ -105,6 +109,8 @@
   --tn-bg3: #e8e8e8;
   --tn-fg1: #585858;
   --tn-fg2: #666666;
+  --tn-fg3: #888888;
+  --tn-fg4: #909090;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;
@@ -140,6 +146,8 @@
   --tn-bg3: #343746;
   --tn-fg1: #efefef;
   --tn-fg2: #cacac5;
+  --tn-fg3: #9a9a95;
+  --tn-fg4: #7a7a75;
   --tn-alt-bg1: #3a3d4a;
   --tn-alt-bg2: #44475a;
   --tn-alt-fg1: #f8f8f2;
@@ -175,6 +183,8 @@
   --tn-bg3: #454d5e;
   --tn-fg1: #eceff4;
   --tn-fg2: #e5e9f0;
+  --tn-fg3: #a0a8b4;
+  --tn-fg4: #7b8394;
   --tn-alt-bg1: #434c5e;
   --tn-alt-bg2: #4c566a;
   --tn-alt-fg1: #d8dee9;
@@ -209,6 +219,8 @@
   --tn-bg3: #e8e8e8;
   --tn-fg1: #3f3f3f;
   --tn-fg2: #666666;
+  --tn-fg3: #888888;
+  --tn-fg4: #909090;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;
@@ -246,6 +258,8 @@
   --tn-bg3: #0a4050;
   --tn-fg1: #586e75;
   --tn-fg2: #7f99a2;
+  --tn-fg3: #4a5e65;
+  --tn-fg4: #3a4d53;
   --tn-alt-bg1: #0e4853;
   --tn-alt-bg2: #155a68;
   --tn-alt-fg1: #839496;
@@ -282,6 +296,8 @@
   --tn-bg3: #3d4a55;
   --tn-fg1: #aaaaaa;
   --tn-fg2: #cccccc;
+  --tn-fg3: #888888;
+  --tn-fg4: #666666;
   --tn-alt-bg1: #3d4a55;
   --tn-alt-bg2: #4a5762;
   --tn-alt-fg1: #c1c1c1;
@@ -315,6 +331,8 @@
   --tn-bg3: #d0d0d0;
   --tn-fg1: #222222;
   --tn-fg2: #333333;
+  --tn-fg3: #666666;
+  --tn-fg4: #777777;
   --tn-alt-bg1: #f0f0f0;
   --tn-alt-bg2: #e8e8e8;
   --tn-alt-fg1: #181a26;


### PR DESCRIPTION
Add --tn-fg3 (muted) and --tn-fg4 (very subdued) foreground variables to all 8 themes plus root defaults. These fill the gap between fg2 and alt-fg1 for placeholders, timestamps, hints, and disabled states.

Add Color Palette story under API/ with:
- Background swatches
- Foreground swatches
- UI & Chrome colors
- Status colors
- FG × BG combination matrix

Update theming docs to describe the new variables.