### PR TITLE
feat(form-field): add subscriptSizing input and remove default margin…

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -15,19 +15,21 @@
   </div>
 
   <!-- Hint or Error Message -->
-  <div class="tn-form-field-subscript">
-    @if (showError()) {
-      <div
-        class="tn-form-field-error"
-        role="alert"
-        aria-live="polite">
-        {{ errorMessage() }}
-      </div>
-    }
-    @if (showHint()) {
-      <div class="tn-form-field-hint">
-        {{ hint() }}
-      </div>
-    }
-  </div>
+  @if (showSubscript()) {
+    <div class="tn-form-field-subscript" [class.tn-form-field-subscript-dynamic]="subscriptSizing() === 'dynamic'">
+      @if (showError()) {
+        <div
+          class="tn-form-field-error"
+          role="alert"
+          aria-live="polite">
+          {{ errorMessage() }}
+        </div>
+      }
+      @if (showHint()) {
+        <div class="tn-form-field-hint">
+          {{ hint() }}
+        </div>
+      }
+    </div>
+  }
 </div>

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -1,7 +1,6 @@
 .tn-form-field {
   display: block;
   width: 100%;
-  margin-bottom: 1rem;
   font-family: var(--tn-font-family-body, 'Inter'), sans-serif;
 }
 
@@ -59,6 +58,10 @@
   margin-top: 0.25rem;
   font-size: 0.75rem;
   line-height: 1.4;
+
+  &-dynamic {
+    min-height: 0;
+  }
 }
 
 .tn-form-field-error {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -3,6 +3,8 @@ import type { AfterContentInit } from '@angular/core';
 import { Component, input, computed, signal, contentChild } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
+export type SubscriptSizing = 'fixed' | 'dynamic';
+
 @Component({
   selector: 'tn-form-field',
   standalone: true,
@@ -15,6 +17,7 @@ export class TnFormFieldComponent implements AfterContentInit {
   hint = input<string>('');
   required = input<boolean>(false);
   testId = input<string>('');
+  subscriptSizing = input<SubscriptSizing>('dynamic');
 
   control = contentChild(NgControl);
 
@@ -72,5 +75,9 @@ export class TnFormFieldComponent implements AfterContentInit {
 
   showHint = computed(() => {
     return !!this.hint() && !this.showError();
+  });
+
+  protected showSubscript = computed(() => {
+    return this.subscriptSizing() === 'fixed' || this.showError() || this.showHint();
   });
 }

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -30,6 +30,14 @@ import { TnInputComponent } from '../input/input.component';
     <tn-form-field label="Custom" testId="custom-field">
       <tn-input [formControl]="customControl" />
     </tn-form-field>
+
+    <tn-form-field label="Fixed" testId="fixed-field" subscriptSizing="fixed">
+      <tn-input [formControl]="fixedControl" />
+    </tn-form-field>
+
+    <tn-form-field label="Dynamic" testId="dynamic-field" subscriptSizing="dynamic" hint="A dynamic hint">
+      <tn-input [formControl]="dynamicControl" />
+    </tn-form-field>
   `
 })
 class TestHostComponent {
@@ -37,6 +45,8 @@ class TestHostComponent {
   emailControl = new FormControl('', [Validators.required, Validators.email]);
   optionalControl = new FormControl('');
   customControl = new FormControl('', customValidator());
+  fixedControl = new FormControl('');
+  dynamicControl = new FormControl('', Validators.required);
 }
 
 function customValidator(): ValidatorFn {
@@ -93,7 +103,7 @@ describe('TnFormFieldHarness', () => {
 
     it('should find all form fields', async () => {
       const fields = await loader.getAllHarnesses(TnFormFieldHarness);
-      expect(fields.length).toBe(4);
+      expect(fields.length).toBe(6);
     });
   });
 
@@ -237,6 +247,47 @@ describe('TnFormFieldHarness', () => {
         TnFormFieldHarness.with({ label: 'Name' })
       );
       expect(await field.getTestId()).toBe('name-field');
+    });
+  });
+
+  describe('subscriptSizing', () => {
+    it('should default to dynamic mode with no subscript when empty', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Optional' })
+      );
+      expect(await field.hasSubscript()).toBe(false);
+      expect(await field.getSubscriptSizing()).toBe('dynamic');
+    });
+
+    it('should always render subscript in fixed mode', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'fixed-field' })
+      );
+      expect(await field.hasSubscript()).toBe(true);
+      expect(await field.getSubscriptSizing()).toBe('fixed');
+    });
+
+    it('should render subscript in dynamic mode when hint is present', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'dynamic-field' })
+      );
+      expect(await field.hasSubscript()).toBe(true);
+      expect(await field.getSubscriptSizing()).toBe('dynamic');
+      expect(await field.getHint()).toBe('A dynamic hint');
+    });
+
+    it('should show error in dynamic mode', async () => {
+      const host = fixture.componentInstance;
+      host.dynamicControl.markAsTouched();
+      host.dynamicControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'dynamic-field' })
+      );
+      expect(await field.hasSubscript()).toBe(true);
+      expect(await field.hasError()).toBe(true);
+      expect(await field.getErrorMessage()).toBe('This field is required');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -162,6 +162,42 @@ export class TnFormFieldHarness extends ComponentHarness {
     const root = await this.locatorFor('.tn-form-field')();
     return root.getAttribute('data-testid');
   }
+
+  /**
+   * Checks whether the subscript wrapper is currently rendered.
+   *
+   * @returns Promise resolving to true if the subscript area is present in the DOM.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Name' }));
+   * expect(await field.hasSubscript()).toBe(false);
+   * ```
+   */
+  async hasSubscript(): Promise<boolean> {
+    const subscript = await this.locatorForOptional('.tn-form-field-subscript')();
+    return subscript !== null;
+  }
+
+  /**
+   * Gets the current subscript sizing mode.
+   *
+   * @returns Promise resolving to `'fixed'` or `'dynamic'`.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Name' }));
+   * expect(await field.getSubscriptSizing()).toBe('dynamic');
+   * ```
+   */
+  async getSubscriptSizing(): Promise<string> {
+    const subscript = await this.locatorForOptional('.tn-form-field-subscript')();
+    if (!subscript) {
+      return 'dynamic';
+    }
+    const isDynamic = await subscript.hasClass('tn-form-field-subscript-dynamic');
+    return isDynamic ? 'dynamic' : 'fixed';
+  }
 }
 
 /**

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -65,6 +65,11 @@ When used with Angular reactive forms, the form field automatically:
       control: 'text',
       description: 'Test ID for automated testing',
     },
+    subscriptSizing: {
+      control: 'radio',
+      options: ['fixed', 'dynamic'],
+      description: 'Controls whether the subscript area reserves space when empty. "fixed" always reserves space (prevents layout shift), "dynamic" collapses when empty.',
+    },
   },
 };
 
@@ -85,7 +90,8 @@ export const BasicInput: Story = {
         [label]="label"
         [hint]="hint"
         [required]="required"
-        [testId]="testId">
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
         <tn-input
           inputType="text"
           placeholder="Enter your name">
@@ -112,7 +118,8 @@ export const RequiredField: Story = {
         [label]="label"
         [hint]="hint"
         [required]="required"
-        [testId]="testId">
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
         <tn-input
           inputType="email"
           placeholder="Enter your email address">
@@ -195,7 +202,8 @@ export const WithSelect: Story = {
         [label]="label"
         [hint]="hint"
         [required]="required"
-        [testId]="testId">
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
         <tn-select
           [options]="options"
           placeholder="Choose a size">
@@ -222,7 +230,8 @@ export const WithCheckbox: Story = {
         [label]="label"
         [hint]="hint"
         [required]="required"
-        [testId]="testId">
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
         <tn-checkbox
           label="I agree to the terms and conditions">
         </tn-checkbox>
@@ -248,7 +257,8 @@ export const WithRadioGroup: Story = {
         [label]="label"
         [hint]="hint"
         [required]="required"
-        [testId]="testId">
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
         <div style="display: flex; flex-direction: column; gap: 0.5rem;">
           <tn-radio
             name="priority"
@@ -386,6 +396,40 @@ export const MultipleFields: Story = {
     },
   }),
   args: {},
+};
+
+export const SubscriptSizing: Story = {
+  render: () => ({
+    props: {
+      fixedControl: new FormControl('', Validators.required),
+      dynamicControl: new FormControl('', Validators.required),
+    },
+    template: `
+      <div style="display: flex; gap: 2rem; max-width: 800px;">
+        <div style="flex: 1; display: flex; flex-direction: column; gap: 1rem;">
+          <h4 style="margin: 0; color: var(--tn-fg1);">Fixed (reserves space)</h4>
+          <tn-form-field label="Name" subscriptSizing="fixed" [required]="true">
+            <tn-input [formControl]="fixedControl" placeholder="Enter name" />
+          </tn-form-field>
+          <tn-form-field label="No Validation" subscriptSizing="fixed">
+            <tn-input placeholder="Notice space below" />
+          </tn-form-field>
+        </div>
+        <div style="flex: 1; display: flex; flex-direction: column; gap: 1rem;">
+          <h4 style="margin: 0; color: var(--tn-fg1);">Dynamic (collapses when empty)</h4>
+          <tn-form-field label="Name" subscriptSizing="dynamic" [required]="true">
+            <tn-input [formControl]="dynamicControl" placeholder="Enter name" />
+          </tn-form-field>
+          <tn-form-field label="No Validation" subscriptSizing="dynamic">
+            <tn-input placeholder="No extra space below" />
+          </tn-form-field>
+        </div>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [TnInputComponent, ReactiveFormsModule],
+    },
+  }),
 };
 
 export const ComponentHarness: Story = {


### PR DESCRIPTION
The subscript area previously always reserved space in the DOM, causing exaggerated spacing between form elements. Add a subscriptSizing input ('fixed' | 'dynamic') so consumers can control this behavior. Dynamic mode (the new default) collapses the subscript when empty. Fixed mode preserves the original space-reserving behavior for layout-shift prevention.

Also removes the hardcoded margin-bottom: 1rem so parent containers can control inter-element spacing via flex/grid gap.