### PR TITLE
fix(dialog): enable automatic content scrolling without explicit height

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -483,9 +483,29 @@ textarea.tn-input-directive {
   border-radius: 8px;
   background: var(--tn-bg1, #ffffff);
   color: var(--tn-fg1, #000000);
+  overflow: hidden; /* enforce max-height boundary */
   box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2),
               0 24px 38px 3px rgba(0, 0, 0, 0.14),
               0 9px 46px 8px rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Propagate the flex / height constraint from .tn-dialog-panel through
+ * the two CDK-generated wrapper elements so tn-dialog-shell can size
+ * itself correctly and .tn-dialog__content can scroll.
+ */
+.tn-dialog-panel > .cdk-dialog-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.tn-dialog-panel > .cdk-dialog-container > :first-child {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* Shell component wrapper */
@@ -589,15 +609,6 @@ tn-dialog-shell {
 /* Dialog backdrop */
 .cdk-dialog-backdrop {
   background: rgba(0, 0, 0, 0.5);
-}
-
-/* Container positioning */
-.cdk-dialog-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  box-sizing: border-box;
 }
 
 /* Fullscreen dialog support */

--- a/projects/truenas-ui/src/lib/dialog/dialog.scss
+++ b/projects/truenas-ui/src/lib/dialog/dialog.scss
@@ -10,9 +10,34 @@
   border-radius: 8px;
   background: var(--bg1, #ffffff);
   color: var(--fg1, #000000);
+  overflow: hidden; /* enforce max-height boundary */
   box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2),
               0 24px 38px 3px rgba(0, 0, 0, 0.14),
               0 9px 46px 8px rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Propagate the flex / height constraint from .tn-dialog-panel through
+ * the two CDK-generated wrapper elements so tn-dialog-shell can size
+ * itself correctly and .tn-dialog__content can scroll.
+ *
+ *   .tn-dialog-panel  (flex column, max-height 90vh)
+ *     > cdk-dialog-container
+ *       > <user-component>
+ *         > tn-dialog-shell
+ */
+.tn-dialog-panel > .cdk-dialog-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.tn-dialog-panel > .cdk-dialog-container > :first-child {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* Shell component wrapper */
@@ -137,15 +162,6 @@ tn-dialog-shell {
   background: rgba(0, 0, 0, 0.5);
 }
 
-/* Container positioning */
-.cdk-dialog-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  padding: 20px;
-  box-sizing: border-box;
-}
 
 /* Fullscreen mode styles */
 .tn-dialog--fullscreen {

--- a/projects/truenas-ui/src/lib/dialog/dialog.scss
+++ b/projects/truenas-ui/src/lib/dialog/dialog.scss
@@ -162,7 +162,6 @@ tn-dialog-shell {
   background: rgba(0, 0, 0, 0.5);
 }
 
-
 /* Fullscreen mode styles */
 .tn-dialog--fullscreen {
   border-radius: 0 !important;

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -221,7 +221,6 @@ export class MyPageComponent {
   openMyDialog() {
     const dialogRef = this.ixDialog.open(MyCustomDialogComponent, {
       width: '500px',
-      height: '400px',
       data: { initialValue: 'Hello' } // Optional data to pass
     });
 
@@ -284,9 +283,8 @@ When opening dialogs, you can configure:
 \`\`\`typescript
 this.ixDialog.open(MyDialogComponent, {
   width: '600px',           // Dialog width
-  height: '500px',          // Dialog height  
-  maxWidth: '90vw',         // Maximum width
-  maxHeight: '90vh',        // Maximum height
+  maxWidth: '90vw',         // Maximum width (default: 90vw)
+  maxHeight: '90vh',        // Maximum height (default: 90vh)
   disableClose: true,       // Prevent ESC/backdrop close
   data: { userId: 123 },    // Data to pass to dialog
   panelClass: ['custom-dialog'] // Additional CSS classes

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -99,8 +99,7 @@ class DialogDemoComponent {
 
   openSystemDialog() {
     const dialogRef = this.ixDialog.open(SystemSettingsDialogComponent, {
-      width: '700px',
-      height: '600px'
+      width: '700px'
     });
 
     dialogRef.closed.subscribe((result) => {

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -483,9 +483,29 @@ textarea.tn-input-directive {
   border-radius: 8px;
   background: var(--tn-bg1, #ffffff);
   color: var(--tn-fg1, #000000);
+  overflow: hidden; /* enforce max-height boundary */
   box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2),
               0 24px 38px 3px rgba(0, 0, 0, 0.14),
               0 9px 46px 8px rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Propagate the flex / height constraint from .tn-dialog-panel through
+ * the two CDK-generated wrapper elements so tn-dialog-shell can size
+ * itself correctly and .tn-dialog__content can scroll.
+ */
+.tn-dialog-panel > .cdk-dialog-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.tn-dialog-panel > .cdk-dialog-container > :first-child {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* Shell component wrapper */
@@ -589,15 +609,6 @@ tn-dialog-shell {
 /* Dialog backdrop */
 .cdk-dialog-backdrop {
   background: rgba(0, 0, 0, 0.5);
-}
-
-/* Container positioning */
-.cdk-dialog-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  box-sizing: border-box;
 }
 
 /* Fullscreen dialog support */


### PR DESCRIPTION
The .cdk-dialog-container rule had min-height: 100vh, which forced the inner container to always be at least viewport height — preventing content from ever overflowing and scrolling. Removed that rule (CDK handles centering via cdk-global-overlay-wrapper) and added flex propagation rules so the max-height: 90vh constraint on .tn-dialog-panel reaches .tn-dialog__content through the intermediate CDK wrapper elements.

Consumers no longer need to set an explicit height for dialogs with tall content — the content area scrolls automatically while the header and action buttons remain fixed.