### PR TITLE
feat(card): support content projection in card header

### DIFF
--- a/projects/truenas-ui/src/lib/card/card-header.directive.ts
+++ b/projects/truenas-ui/src/lib/card/card-header.directive.ts
@@ -1,0 +1,7 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[tn-card-header]',
+  standalone: true,
+})
+export class TnCardHeaderDirective {}

--- a/projects/truenas-ui/src/lib/card/card-header.directive.ts
+++ b/projects/truenas-ui/src/lib/card/card-header.directive.ts
@@ -1,7 +1,7 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: '[tn-card-header]',
+  selector: '[tnCardHeader]',
   standalone: true,
 })
 export class TnCardHeaderDirective {}

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -3,7 +3,8 @@
   @if (hasHeader()) {
     <div class="tn-card__header">
       <div class="tn-card__header-left">
-        @if (title()) {
+        <ng-content select="[tn-card-header]" />
+        @if (!projectedHeader() && title()) {
           <h3
             class="tn-card__title"
             [class.tn-card__title--link]="titleLink()"

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -3,7 +3,7 @@
   @if (hasHeader()) {
     <div class="tn-card__header">
       <div class="tn-card__header-left">
-        <ng-content select="[tn-card-header]" />
+        <ng-content select="[tnCardHeader]" />
         @if (!projectedHeader() && title()) {
           <h3
             class="tn-card__title"

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, input, computed, inject, contentChild } from '@angular/core';
 import { mdiDotsVertical } from '@mdi/js';
+import { TnCardHeaderDirective } from './card-header.directive';
 import type {
   TnCardAction,
   TnCardControl,
@@ -15,7 +16,6 @@ import { TnMenuTriggerDirective } from '../menu/menu-trigger.directive';
 import type { TnMenuItem } from '../menu/menu.component';
 import { TnMenuComponent } from '../menu/menu.component';
 import { TnSlideToggleComponent } from '../slide-toggle/slide-toggle.component';
-import { TnCardHeaderDirective } from './card-header.directive';
 
 @Component({
   selector: 'tn-card',

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, input, computed, inject } from '@angular/core';
+import { Component, input, computed, inject, contentChild } from '@angular/core';
 import { mdiDotsVertical } from '@mdi/js';
 import type {
   TnCardAction,
@@ -15,6 +15,7 @@ import { TnMenuTriggerDirective } from '../menu/menu-trigger.directive';
 import type { TnMenuItem } from '../menu/menu.component';
 import { TnMenuComponent } from '../menu/menu.component';
 import { TnSlideToggleComponent } from '../slide-toggle/slide-toggle.component';
+import { TnCardHeaderDirective } from './card-header.directive';
 
 @Component({
   selector: 'tn-card',
@@ -30,6 +31,8 @@ export class TnCardComponent {
     // Register MDI icons used by this component
     this.registerMdiIcons();
   }
+
+  projectedHeader = contentChild(TnCardHeaderDirective);
 
   title = input<string | undefined>(undefined);
   titleLink = input<string | undefined>(undefined); // Makes title navigable
@@ -82,7 +85,7 @@ export class TnCardComponent {
   });
 
   hasHeader = computed(() => {
-    return !!(this.title() || this.headerStatus() || this.headerControl() || this.headerMenu());
+    return !!(this.projectedHeader() || this.title() || this.headerStatus() || this.headerControl() || this.headerMenu());
   });
 
   hasFooter = computed(() => {

--- a/projects/truenas-ui/src/lib/card/index.ts
+++ b/projects/truenas-ui/src/lib/card/index.ts
@@ -1,2 +1,3 @@
 export * from './card.component';
+export * from './card-header.directive';
 export * from './card.interfaces';

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, within } from 'storybook/test';
-import { TnCardComponent } from '../lib/card/card.component';
 import { TnCardHeaderDirective } from '../lib/card/card-header.directive';
+import { TnCardComponent } from '../lib/card/card.component';
 
 const meta: Meta<TnCardComponent> = {
   title: 'Components/Card',
@@ -438,13 +438,13 @@ export const WithProjectedHeader: Story = {
         [padContent]="padContent"
         [bordered]="bordered"
         [background]="background">
-        <div tn-card-header style="display: flex; align-items: center; gap: 12px;">
+        <div tnCardHeader style="display: flex; align-items: center; gap: 12px;">
           <span style="width: 8px; height: 8px; border-radius: 50%; background: #10b981;"></span>
           <h3 style="margin: 0; font-size: 1.125rem; font-weight: 600;">Custom Header Content</h3>
           <span style="font-size: 0.75rem; color: #6b7280;">— with icon and subtitle</span>
         </div>
         <p>This card uses projected header content instead of a simple title string.</p>
-        <p>You can put any content in the header using the <code>tn-card-header</code> attribute.</p>
+        <p>You can put any content in the header using the <code>tnCardHeader</code> attribute.</p>
       </tn-card>
     `,
   }),

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, within } from 'storybook/test';
 import { TnCardComponent } from '../lib/card/card.component';
+import { TnCardHeaderDirective } from '../lib/card/card-header.directive';
 
 const meta: Meta<TnCardComponent> = {
   title: 'Components/Card',
@@ -416,6 +417,42 @@ export const WithFooterLink: Story = {
       </tn-card>
     `,
   }),
+};
+
+export const WithProjectedHeader: Story = {
+  args: {
+    elevation: 'medium',
+    padding: 'medium',
+    padContent: true,
+    bordered: true,
+  },
+  render: (args) => ({
+    props: args,
+    moduleMetadata: {
+      imports: [TnCardHeaderDirective],
+    },
+    template: `
+      <tn-card
+        [elevation]="elevation"
+        [padding]="padding"
+        [padContent]="padContent"
+        [bordered]="bordered"
+        [background]="background">
+        <div tn-card-header style="display: flex; align-items: center; gap: 12px;">
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: #10b981;"></span>
+          <h3 style="margin: 0; font-size: 1.125rem; font-weight: 600;">Custom Header Content</h3>
+          <span style="font-size: 0.75rem; color: #6b7280;">— with icon and subtitle</span>
+        </div>
+        <p>This card uses projected header content instead of a simple title string.</p>
+        <p>You can put any content in the header using the <code>tn-card-header</code> attribute.</p>
+      </tn-card>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = canvas.getByText('Custom Header Content');
+    await expect(header).toBeInTheDocument();
+  },
 };
 
 export const CompleteExample: Story = {


### PR DESCRIPTION
Add [tn-card-header] directive for projecting custom content into the card header area. The title text input remains as a simple fallback when projected content is not provided.