### PR TITLE
fix(input): remove default placeholder text

### DIFF
--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -25,7 +25,7 @@ export class TnInputComponent implements AfterViewInit, ControlValueAccessor {
   inputEl = viewChild.required<ElementRef<HTMLInputElement | HTMLTextAreaElement>>('inputEl');
 
   inputType = input<InputType>(InputType.PlainText);
-  placeholder = input<string>('Enter your name');
+  placeholder = input<string>('');
   testId = input<string | undefined>(undefined);
   disabled = input<boolean>(false);
   multiline = input<boolean>(false);

--- a/projects/truenas-ui/src/lib/input/input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.harness.spec.ts
@@ -30,7 +30,7 @@ import type { IconLibraryType } from '../icon/icon.component';
 })
 class TestHostComponent {
   inputType = signal<InputType>(InputType.PlainText);
-  placeholder = signal('Enter your name');
+  placeholder = signal('Enter your name here');
   disabled = signal(false);
   multiline = signal(false);
   rows = signal(3);
@@ -110,7 +110,7 @@ describe('TnInputHarness', () => {
   describe('getPlaceholder', () => {
     it('should return the placeholder text', async () => {
       const input = await loader.getHarness(TnInputHarness);
-      expect(await input.getPlaceholder()).toBe('Enter your name');
+      expect(await input.getPlaceholder()).toBe('Enter your name here');
     });
 
     it('should reflect updated placeholder', async () => {


### PR DESCRIPTION
The tn-input component had a default placeholder of 'Enter your name' which showed on every input that didn't explicitly set a placeholder. Changed the default to an empty string.