### PR TITLE
feat(menu): forward data-testid on menu items

### DIFF
--- a/projects/truenas-ui/src/lib/menu/menu.component.html
+++ b/projects/truenas-ui/src/lib/menu/menu.component.html
@@ -20,6 +20,7 @@
               cdkMenuItem
               class="tn-menu-item"
               type="button"
+              [attr.data-testid]="item.testId ?? 'menu-item-' + item.id"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
               (click)="onMenuItemClick(item)"
@@ -37,6 +38,7 @@
               cdkMenuItem
               class="tn-menu-item tn-menu-item--nested"
               type="button"
+              [attr.data-testid]="item.testId ?? 'menu-item-' + item.id"
               [cdkMenuTriggerFor]="nestedMenu"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
@@ -65,6 +67,7 @@
                         cdkMenuItem
                         class="tn-menu-item"
                         type="button"
+                        [attr.data-testid]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
                         (click)="onMenuItemClick(nestedItem)"
@@ -82,6 +85,7 @@
                         cdkMenuItem
                         class="tn-menu-item tn-menu-item--nested"
                         type="button"
+                        [attr.data-testid]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [cdkMenuTriggerFor]="deepNestedMenu"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
@@ -109,6 +113,7 @@
                                 cdkMenuItem
                                 class="tn-menu-item"
                                 type="button"
+                                [attr.data-testid]="deepNestedItem.testId ?? 'menu-item-' + deepNestedItem.id"
                                 [disabled]="deepNestedItem.disabled"
                                 [class.disabled]="deepNestedItem.disabled"
                                 (click)="onMenuItemClick(deepNestedItem)"
@@ -151,6 +156,7 @@
               cdkMenuItem
               class="tn-menu-item"
               type="button"
+              [attr.data-testid]="item.testId ?? 'menu-item-' + item.id"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
               (click)="onMenuItemClick(item)"
@@ -168,6 +174,7 @@
               cdkMenuItem
               class="tn-menu-item tn-menu-item--nested"
               type="button"
+              [attr.data-testid]="item.testId ?? 'menu-item-' + item.id"
               [cdkMenuTriggerFor]="nestedMenu"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
@@ -196,6 +203,7 @@
                         cdkMenuItem
                         class="tn-menu-item"
                         type="button"
+                        [attr.data-testid]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
                         (click)="onMenuItemClick(nestedItem)"
@@ -213,6 +221,7 @@
                         cdkMenuItem
                         class="tn-menu-item tn-menu-item--nested"
                         type="button"
+                        [attr.data-testid]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [cdkMenuTriggerFor]="deepNestedMenu"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
@@ -240,6 +249,7 @@
                                 cdkMenuItem
                                 class="tn-menu-item"
                                 type="button"
+                                [attr.data-testid]="deepNestedItem.testId ?? 'menu-item-' + deepNestedItem.id"
                                 [disabled]="deepNestedItem.disabled"
                                 [class.disabled]="deepNestedItem.disabled"
                                 (click)="onMenuItemClick(deepNestedItem)"

--- a/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
@@ -205,6 +205,55 @@ describe('tn-menu with trigger', () => {
     expect(disabledItems.length).toBe(1);
   });
 
+  // -- data-testid forwarding --------------------------------------------
+
+  it('should render default data-testid as "menu-item-<id>" for each item', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const ids = getMenuItems().map(el => el.getAttribute('data-testid'));
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'menu-item-cut',
+        'menu-item-copy',
+        'menu-item-disabled',
+        'menu-item-more',
+      ]),
+    );
+  });
+
+  it('should use the item.testId override when provided', () => {
+    host.items = [
+      { id: 'cut', label: 'Cut', testId: 'custom-cut' },
+      { id: 'copy', label: 'Copy' },
+    ];
+    fixture.detectChanges();
+
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const ids = getMenuItems().map(el => el.getAttribute('data-testid'));
+    expect(ids).toContain('custom-cut');
+    expect(ids).toContain('menu-item-copy');
+    expect(ids).not.toContain('menu-item-cut');
+  });
+
+  it('should render data-testid on nested child items', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const moreButton = getMenuItems().find(
+      el => el.textContent?.includes('More'),
+    )!;
+    moreButton.click();
+    fixture.detectChanges();
+
+    const ids = getMenuItems().map(el => el.getAttribute('data-testid'));
+    expect(ids).toEqual(
+      expect.arrayContaining(['menu-item-child-1', 'menu-item-child-2']),
+    );
+  });
+
   // -- Selection ----------------------------------------------------------
 
   it('should emit selected item and close menu on leaf item click', () => {

--- a/projects/truenas-ui/src/lib/menu/menu.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.ts
@@ -38,6 +38,7 @@ export class TnMenuActivateHoverDirective implements AfterContentInit {
 export interface TnMenuItem {
   id: string;
   label: string;
+  testId?: string;
   icon?: string;
   iconLibrary?: 'material' | 'mdi' | 'custom' | 'lucide';
   disabled?: boolean;


### PR DESCRIPTION
Render `data-testid="menu-item-<id>"` by default on every menu-item button, with an optional `testId` field on `TnMenuItem` that overrides the default when callers need a custom value. Applies to all nesting levels in both the regular and context menu templates.