### PR TITLE
feat(empty): add iconSize input for custom icon sizing

### DIFF
--- a/projects/truenas-ui/src/lib/empty/empty.component.html
+++ b/projects/truenas-ui/src/lib/empty/empty.component.html
@@ -4,7 +4,8 @@
       aria-hidden="true"
       [name]="icon()!"
       [library]="iconLibrary()"
-      [size]="iconSize()"
+      [size]="iconSizePreset()"
+      [customSize]="iconSize()"
     />
   </div>
 }

--- a/projects/truenas-ui/src/lib/empty/empty.component.spec.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.component.spec.ts
@@ -19,6 +19,7 @@ import { TnIconHarness } from '../icon/icon.harness';
     [description]="description()"
     [icon]="icon()"
     [iconLibrary]="iconLibrary()"
+    [iconSize]="iconSize()"
     [actionText]="actionText()"
     [bordered]="bordered()"
     [size]="size()"
@@ -31,6 +32,7 @@ class TestHostComponent {
   description = signal<string | undefined>(undefined);
   icon = signal<string | undefined>(undefined);
   iconLibrary = signal('mdi');
+  iconSize = signal<string | undefined>(undefined);
   actionText = signal<string | undefined>(undefined);
   bordered = signal(false);
   size = signal<TnEmptySize>('compact');
@@ -165,6 +167,23 @@ describe('TnEmptyComponent', () => {
 
       const hasIcon = await loader.hasHarness(TnIconHarness.with({ size: 'xl' }));
       expect(hasIcon).toBe(true);
+    });
+
+    it('should apply a custom icon size when iconSize is set', async () => {
+      hostComponent.icon.set('inbox');
+      hostComponent.iconSize.set('48px');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getCustomSize()).toBe('48px');
+    });
+
+    it('should not set a custom icon size when iconSize is unset', async () => {
+      hostComponent.icon.set('inbox');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getCustomSize()).toBeNull();
     });
   });
 

--- a/projects/truenas-ui/src/lib/empty/empty.component.ts
+++ b/projects/truenas-ui/src/lib/empty/empty.component.ts
@@ -23,6 +23,12 @@ export class TnEmptyComponent {
   description = input<string>();
   icon = input<string>();
   iconLibrary = input<IconLibraryType>('mdi');
+  /**
+   * Overrides the icon size derived from `size`. Accepts any valid CSS size value
+   * (e.g. `'48px'`, `'3rem'`). Use this when the variant presets are too small for an
+   * empty-state illustration. When unset, the icon falls back to the `size`-based preset.
+   */
+  iconSize = input<string>();
   actionText = input<string>();
   bordered = input<boolean>(false);
   size = input<TnEmptySize>('compact');
@@ -31,7 +37,7 @@ export class TnEmptyComponent {
 
   protected hasAction = computed(() => !!this.actionText());
 
-  iconSize = computed(() => {
+  protected iconSizePreset = computed(() => {
     return this.size() === 'compact' ? 'lg' : 'xl';
   });
 }

--- a/projects/truenas-ui/src/stories/empty.stories.ts
+++ b/projects/truenas-ui/src/stories/empty.stories.ts
@@ -42,6 +42,10 @@ const meta: Meta<TnEmptyComponent> = {
       options: ['mdi', 'material', 'lucide'],
       description: 'Icon library (defaults to mdi)',
     },
+    iconSize: {
+      control: 'text',
+      description: 'Optional CSS size override for the icon (e.g. "48px"). Falls back to the size-based preset when unset.',
+    },
     actionText: {
       control: 'text',
       description: 'Optional CTA button label. Renders a primary outline button when set.',
@@ -136,6 +140,15 @@ export const BorderedCompact: Story = {
     icon: 'tag',
     title: 'No tags found',
     bordered: true,
+  },
+};
+
+export const LargeIcon: Story = {
+  args: {
+    icon: 'inbox',
+    title: 'No messages',
+    description: 'The icon size is overridden via the iconSize input.',
+    iconSize: '64px',
   },
 };
 


### PR DESCRIPTION
The empty-state icon previously derived its size from the general icon scale (lg/xl = 24/32px), which is too small for empty-state illustrations. Add an optional `iconSize` input that accepts any CSS size value and overrides the size-variant preset, leaving the existing defaults (and tn-table's inline empty state) unchanged.