### PR TITLE
NAS-141320 / 27.0.0-BETA.1 / feat: tn-button anchor support, tn-menu selected + projected items

### DIFF
--- a/projects/truenas-ui/.storybook/preview.ts
+++ b/projects/truenas-ui/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import { Preview, Decorator, applicationConfig } from '@storybook/angular';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { APP_INITIALIZER } from '@angular/core';
@@ -100,6 +101,7 @@ export const decorators: Decorator[] = [
     providers: [
       provideAnimationsAsync(),
       provideHttpClient(),
+      provideRouter([]),
       Dialog,
       TnThemeService,
       TnIconRegistryService,

--- a/projects/truenas-ui/package.json
+++ b/projects/truenas-ui/package.json
@@ -19,6 +19,7 @@
     "@angular/cdk": "^21.0.0",
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
+    "@angular/router": "^21.0.0",
     "@mdi/angular-material": "^7.2.96",
     "@mdi/js": "^7.4.47"
   },

--- a/projects/truenas-ui/src/lib/button/button.component.html
+++ b/projects/truenas-ui/src/lib/button/button.component.html
@@ -1,10 +1,47 @@
-<button
-  type="button"
-  [ngClass]="classes()"
-  [ngStyle]="{ 'background-color': backgroundColor() }"
-  [disabled]="disabled()"
-  [tnTestId]="testId()"
-  (click)="onClick.emit($event)"
->
-  {{ label() }}
-</button>
+@if (isRouterLink()) {
+  <a
+    [ngClass]="classes()"
+    [ngStyle]="{ 'background-color': backgroundColor() }"
+    [routerLink]="disabled() ? null : routerLink()"
+    [queryParams]="queryParams()"
+    [fragment]="fragment()"
+    [target]="target()"
+    [rel]="rel()"
+    [attr.aria-disabled]="disabled() ? 'true' : null"
+    [attr.aria-label]="ariaLabel()"
+    [attr.tabindex]="disabled() ? -1 : null"
+    [class.is-disabled]="disabled()"
+    [tnTestId]="testId()"
+    (click)="handleAnchorClick($event)"
+  >
+    {{ label() }}
+  </a>
+} @else if (isAnchor()) {
+  <a
+    [ngClass]="classes()"
+    [ngStyle]="{ 'background-color': backgroundColor() }"
+    [attr.href]="disabled() ? null : href()"
+    [target]="target()"
+    [rel]="rel()"
+    [attr.aria-disabled]="disabled() ? 'true' : null"
+    [attr.aria-label]="ariaLabel()"
+    [attr.tabindex]="disabled() ? -1 : null"
+    [class.is-disabled]="disabled()"
+    [tnTestId]="testId()"
+    (click)="handleAnchorClick($event)"
+  >
+    {{ label() }}
+  </a>
+} @else {
+  <button
+    type="button"
+    [ngClass]="classes()"
+    [ngStyle]="{ 'background-color': backgroundColor() }"
+    [disabled]="disabled()"
+    [attr.aria-label]="ariaLabel()"
+    [tnTestId]="testId()"
+    (click)="onClick.emit($event)"
+  >
+    {{ label() }}
+  </button>
+}

--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -12,11 +12,17 @@
   line-height: 1;
   font-family: 'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
-  &:disabled {
+  &:disabled,
+  &.is-disabled {
     opacity: 0.5;
     cursor: not-allowed;
     pointer-events: none;
   }
+}
+
+a.storybook-button {
+  text-decoration: none;
+  text-align: center;
 }
 .button-primary {
   background-color: var(--tn-primary);

--- a/projects/truenas-ui/src/lib/button/button.component.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.spec.ts
@@ -1,5 +1,6 @@
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { TnButtonComponent } from './button.component';
 
 describe('TnButtonComponent', () => {
@@ -8,7 +9,8 @@ describe('TnButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TnButtonComponent]
+      imports: [TnButtonComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TnButtonComponent);
@@ -118,6 +120,67 @@ describe('TnButtonComponent', () => {
       button.click();
 
       expect(clickSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('href mode', () => {
+    it('should render an <a> when href is set', () => {
+      fixture.componentRef.setInput('href', 'https://truenas.com');
+      fixture.detectChanges();
+      const anchor = fixture.nativeElement.querySelector('a');
+      const button = fixture.nativeElement.querySelector('button');
+      expect(anchor).toBeTruthy();
+      expect(button).toBeNull();
+      expect(anchor.getAttribute('href')).toBe('https://truenas.com');
+    });
+
+    it('should drop href and expose aria-disabled when disabled', () => {
+      fixture.componentRef.setInput('href', 'https://truenas.com');
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      const anchor = fixture.nativeElement.querySelector('a');
+      expect(anchor.hasAttribute('href')).toBe(false);
+      expect(anchor.getAttribute('aria-disabled')).toBe('true');
+      expect(anchor.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should not emit onClick when disabled anchor is clicked', () => {
+      fixture.componentRef.setInput('href', 'https://truenas.com');
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      const clickSpy = jest.fn();
+      component.onClick.subscribe(clickSpy);
+      const anchor = fixture.nativeElement.querySelector('a');
+      anchor.click();
+      expect(clickSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit onClick when enabled anchor is clicked', () => {
+      fixture.componentRef.setInput('href', 'https://truenas.com');
+      fixture.detectChanges();
+      const clickSpy = jest.fn();
+      component.onClick.subscribe(clickSpy);
+      const anchor = fixture.nativeElement.querySelector('a');
+      anchor.click();
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('routerLink mode', () => {
+    it('should render an <a> with href derived from routerLink', () => {
+      fixture.componentRef.setInput('routerLink', ['/audit', 'settings']);
+      fixture.detectChanges();
+      const anchor = fixture.nativeElement.querySelector('a');
+      expect(anchor).toBeTruthy();
+      expect(anchor.getAttribute('href')).toBe('/audit/settings');
+    });
+
+    it('should prefer routerLink over href', () => {
+      fixture.componentRef.setInput('href', 'https://example.com');
+      fixture.componentRef.setInput('routerLink', '/audit');
+      fixture.detectChanges();
+      const anchor = fixture.nativeElement.querySelector('a');
+      expect(anchor.getAttribute('href')).toBe('/audit');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/button/button.component.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, input, output, computed } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { TnTestIdDirective } from '../test-id';
 
 @Component({
   selector: 'tn-button',
   standalone: true,
-  imports: [CommonModule, TnTestIdDirective],
+  imports: [CommonModule, RouterLink, TnTestIdDirective],
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
 })
@@ -19,12 +20,35 @@ export class TnButtonComponent {
   label = input<string>('Button');
   disabled = input<boolean>(false);
   /**
-   * Test-id applied to the rendered `<button>` element. Rendered under whichever attribute
+   * Test-id applied to the rendered element. Rendered under whichever attribute
    * name is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
   testId = input<string | undefined>(undefined);
 
+  /**
+   * Renders the button as an `<a>` with a plain `href` attribute.
+   * Mutually exclusive with `routerLink` — if both are provided, `routerLink` wins.
+   */
+  href = input<string | undefined>(undefined);
+  /**
+   * Renders the button as an `<a>` driven by Angular Router. Accepts the same
+   * shapes as `[routerLink]` (`string | any[]`).
+   */
+  routerLink = input<string | unknown[] | undefined>(undefined);
+  queryParams = input<Record<string, unknown> | undefined>(undefined);
+  fragment = input<string | undefined>(undefined);
+  target = input<string | undefined>(undefined);
+  rel = input<string | undefined>(undefined);
+  /**
+   * Accessible label for the rendered element. Mirrors `aria-label`; useful when
+   * the visible label alone is insufficient (e.g. icon-only links).
+   */
+  ariaLabel = input<string | undefined>(undefined);
+
   onClick = output<MouseEvent>();
+
+  isAnchor = computed(() => this.routerLink() !== undefined || this.href() !== undefined);
+  isRouterLink = computed(() => this.routerLink() !== undefined);
 
   classes = computed(() => {
     // Support both primary boolean and color string approaches
@@ -52,4 +76,13 @@ export class TnButtonComponent {
 
     return ['storybook-button', `storybook-button--${this.size}`, mode];
   });
+
+  handleAnchorClick(event: MouseEvent): void {
+    if (this.disabled()) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    this.onClick.emit(event);
+  }
 }

--- a/projects/truenas-ui/src/lib/button/button.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.spec.ts
@@ -3,6 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { TnButtonComponent } from './button.component';
 import { TnButtonHarness } from './button.harness';
 
@@ -20,6 +21,29 @@ class TestHostComponent {
   handleClick(_event: MouseEvent): void {
     this.clickCount++;
   }
+}
+
+@Component({
+  selector: 'tn-link-host',
+  standalone: true,
+  imports: [TnButtonComponent],
+  template: `<tn-button [label]="label()" [href]="href()" [disabled]="disabled()" />`
+})
+class LinkHostComponent {
+  label = signal('Audit Settings');
+  href = signal<string | undefined>('https://truenas.com/docs');
+  disabled = signal(false);
+}
+
+@Component({
+  selector: 'tn-router-host',
+  standalone: true,
+  imports: [TnButtonComponent],
+  template: `<tn-button [label]="label()" [routerLink]="routerLink()" />`
+})
+class RouterHostComponent {
+  label = signal('Audit');
+  routerLink = signal<string | unknown[] | undefined>(['/audit', 'settings']);
 }
 
 describe('TnButtonHarness', () => {
@@ -137,6 +161,82 @@ describe('TnButtonHarness', () => {
       hostComponent.label.set('Save');
 
       expect(await loader.hasHarness(TnButtonHarness.with({ label: 'NonExistent' }))).toBe(false);
+    });
+  });
+});
+
+describe('TnButtonHarness — anchor variants', () => {
+  describe('href mode', () => {
+    let hostComponent: LinkHostComponent;
+    let fixture: ComponentFixture<LinkHostComponent>;
+    let loader: HarnessLoader;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [LinkHostComponent]
+      }).compileComponents();
+      fixture = TestBed.createComponent(LinkHostComponent);
+      hostComponent = fixture.componentInstance;
+      loader = TestbedHarnessEnvironment.loader(fixture);
+    });
+
+    it('resolves harness against an <a> host element', async () => {
+      const harness = await loader.getHarness(TnButtonHarness);
+      expect(harness).toBeTruthy();
+    });
+
+    it('reads the label from the anchor', async () => {
+      const harness = await loader.getHarness(TnButtonHarness.with({ label: 'Audit Settings' }));
+      expect(await harness.getLabel()).toBe('Audit Settings');
+    });
+
+    it('returns the href via getHref', async () => {
+      const harness = await loader.getHarness(TnButtonHarness);
+      expect(await harness.getHref()).toBe('https://truenas.com/docs');
+    });
+
+    it('reports disabled when aria-disabled is set', async () => {
+      hostComponent.disabled.set(true);
+      const harness = await loader.getHarness(TnButtonHarness);
+      expect(await harness.isDisabled()).toBe(true);
+      expect(await harness.getHref()).toBeNull();
+    });
+  });
+
+  describe('routerLink mode', () => {
+    let fixture: ComponentFixture<RouterHostComponent>;
+    let loader: HarnessLoader;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [RouterHostComponent],
+        providers: [provideRouter([])]
+      }).compileComponents();
+      fixture = TestBed.createComponent(RouterHostComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+    });
+
+    it('resolves harness and returns the resolved URL', async () => {
+      const harness = await loader.getHarness(TnButtonHarness);
+      expect(await harness.getHref()).toBe('/audit/settings');
+    });
+  });
+
+  describe('button mode (regression)', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let loader: HarnessLoader;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TestHostComponent]
+      }).compileComponents();
+      fixture = TestBed.createComponent(TestHostComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+    });
+
+    it('returns null from getHref for button-mode renders', async () => {
+      const harness = await loader.getHarness(TnButtonHarness);
+      expect(await harness.getHref()).toBeNull();
     });
   });
 });

--- a/projects/truenas-ui/src/lib/button/button.harness.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.ts
@@ -25,7 +25,7 @@ export class TnButtonHarness extends ComponentHarness {
    */
   static hostSelector = 'tn-button';
 
-  private _button = this.locatorFor('button');
+  private _button = this.locatorFor('button, a');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button
@@ -80,7 +80,31 @@ export class TnButtonHarness extends ComponentHarness {
    */
   async isDisabled(): Promise<boolean> {
     const button = await this._button();
+    const tagName = (await button.getProperty<string>('tagName')).toLowerCase();
+    if (tagName === 'a') {
+      return (await button.getAttribute('aria-disabled')) === 'true';
+    }
     return (await button.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Gets the resolved URL of the rendered element. Returns the `href` for
+   * anchor-mode renders (both plain `href` and `routerLink`) and `null` for
+   * button-mode renders.
+   *
+   * @example
+   * ```typescript
+   * const link = await loader.getHarness(TnButtonHarness.with({ label: 'Audit Settings' }));
+   * expect(await link.getHref()).toContain('/audit/settings');
+   * ```
+   */
+  async getHref(): Promise<string | null> {
+    const button = await this._button();
+    const tagName = (await button.getProperty<string>('tagName')).toLowerCase();
+    if (tagName !== 'a') {
+      return null;
+    }
+    return button.getAttribute('href');
   }
 
   /**

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -76,6 +76,7 @@
 .tn-card__content {
   flex: 1;
   min-height: 0;
+  font-size: 0.875rem;
 }
 
 .tn-card__header {

--- a/projects/truenas-ui/src/lib/menu/index.ts
+++ b/projects/truenas-ui/src/lib/menu/index.ts
@@ -1,4 +1,5 @@
 export * from './menu.component';
+export * from './menu-item.component';
 export * from './menu-trigger.directive';
 export * from './menu.harness';
 export * from './menu-testing';

--- a/projects/truenas-ui/src/lib/menu/menu-item.component.html
+++ b/projects/truenas-ui/src/lib/menu/menu-item.component.html
@@ -1,0 +1,24 @@
+<button
+  class="tn-menu-item"
+  type="button"
+  role="menuitem"
+  [tnTestId]="resolvedTestId()"
+  [disabled]="disabled()"
+  [class.disabled]="disabled()"
+  [class.tn-menu-item--selected]="selected()"
+  [attr.aria-current]="selected() ? 'true' : null"
+  [attr.tabindex]="disabled() ? -1 : 0"
+  (click)="handleClick($event)"
+>
+  @if (label() !== undefined) {
+    @if (icon()) {
+      <tn-icon size="sm" class="tn-menu-item-icon" [name]="icon()!" [library]="iconLibrary()" />
+    }
+    <span class="tn-menu-item-label">{{ label() }}</span>
+    @if (shortcut()) {
+      <span class="tn-menu-item-shortcut">{{ shortcut() }}</span>
+    }
+  } @else {
+    <ng-content />
+  }
+</button>

--- a/projects/truenas-ui/src/lib/menu/menu-item.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-item.component.ts
@@ -1,0 +1,65 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, input, output } from '@angular/core';
+import { TnIconComponent } from '../icon/icon.component';
+import { TnTestIdDirective } from '../test-id';
+
+/**
+ * Projection-based menu item for use inside `<tn-menu>`.
+ *
+ * Two authoring modes:
+ * 1. **Convenience** — set `label` (and optionally `icon`/`shortcut`); the
+ *    default icon + label + shortcut layout renders.
+ * 2. **Custom content** — omit `label`; project arbitrary content via
+ *    `<ng-content>` (badges, two-line layouts, etc.).
+ *
+ * Existing `<tn-menu [items]="...">` consumers don't need this component;
+ * the items-array API continues to work unchanged. Items-array entries and
+ * projected `<tn-menu-item>` children render together inside one `<tn-menu>`.
+ *
+ * Subscribe to either the projected item's own `itemClick` output (preferred,
+ * per-item handlers) or the parent menu's `menuItemClick` (uniform handler).
+ * Trigger-driven menus close automatically on projected-item click.
+ *
+ * **Note on keyboard navigation:** projected items render as `role="menuitem"`
+ * buttons but do not participate in `CdkMenu` arrow-key navigation (CdkMenuItem
+ * requires its parent `CdkMenu` in the same injector tree, which projection
+ * breaks). For menus that depend on arrow-key navigation between options, use
+ * the `items` input form. Tab/Shift+Tab and Enter/Space activation still work.
+ *
+ * @example
+ * ```html
+ * <tn-menu>
+ *   <tn-menu-item label="JSON" [selected]="format === 'json'"
+ *                 (itemClick)="setFormat('json')" />
+ *   <tn-menu-item label="CSV"  [selected]="format === 'csv'"
+ *                 (itemClick)="setFormat('csv')" />
+ * </tn-menu>
+ * ```
+ */
+@Component({
+  selector: 'tn-menu-item',
+  standalone: true,
+  imports: [CommonModule, TnIconComponent, TnTestIdDirective],
+  templateUrl: './menu-item.component.html',
+})
+export class TnMenuItemComponent {
+  id = input<string | undefined>(undefined);
+  label = input<string | undefined>(undefined);
+  icon = input<string | undefined>(undefined);
+  iconLibrary = input<'material' | 'mdi' | 'custom' | 'lucide' | undefined>(undefined);
+  shortcut = input<string | undefined>(undefined);
+  disabled = input<boolean>(false);
+  selected = input<boolean>(false);
+  testId = input<string | undefined>(undefined);
+
+  itemClick = output<MouseEvent>();
+
+  resolvedTestId = computed(() => this.testId() ?? (this.id() ? `menu-item-${this.id()}` : undefined));
+
+  handleClick(event: MouseEvent): void {
+    if (this.disabled()) {
+      return;
+    }
+    this.itemClick.emit(event);
+  }
+}

--- a/projects/truenas-ui/src/lib/menu/menu.component.html
+++ b/projects/truenas-ui/src/lib/menu/menu.component.html
@@ -1,4 +1,4 @@
-<!-- Context menu content slot -->
+<!-- Context menu content slot: anything that isn't a projected <tn-menu-item> -->
 @if (contextMenu()) {
   <div class="tn-menu-context-content" (contextmenu)="onContextMenu($event)">
     <ng-content />
@@ -23,6 +23,8 @@
               [tnTestId]="item.testId ?? 'menu-item-' + item.id"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
+              [class.tn-menu-item--selected]="item.selected"
+              [attr.aria-current]="item.selected ? 'true' : null"
               (click)="onMenuItemClick(item)"
             >
               @if (item.icon) {
@@ -42,6 +44,8 @@
               [cdkMenuTriggerFor]="nestedMenu"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
+              [class.tn-menu-item--selected]="item.selected"
+              [attr.aria-current]="item.selected ? 'true' : null"
             >
               @if (item.icon) {
                 <tn-icon size="sm" class="tn-menu-item-icon" [name]="item.icon" [library]="item.iconLibrary" />
@@ -70,6 +74,8 @@
                         [tnTestId]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
+                        [class.tn-menu-item--selected]="nestedItem.selected"
+                        [attr.aria-current]="nestedItem.selected ? 'true' : null"
                         (click)="onMenuItemClick(nestedItem)"
                       >
                         @if (nestedItem.icon) {
@@ -89,6 +95,8 @@
                         [cdkMenuTriggerFor]="deepNestedMenu"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
+                        [class.tn-menu-item--selected]="nestedItem.selected"
+                        [attr.aria-current]="nestedItem.selected ? 'true' : null"
                       >
                         @if (nestedItem.icon) {
                           <tn-icon size="sm" class="tn-menu-item-icon" [name]="nestedItem.icon" [library]="nestedItem.iconLibrary" />
@@ -116,6 +124,8 @@
                                 [tnTestId]="deepNestedItem.testId ?? 'menu-item-' + deepNestedItem.id"
                                 [disabled]="deepNestedItem.disabled"
                                 [class.disabled]="deepNestedItem.disabled"
+                                [class.tn-menu-item--selected]="deepNestedItem.selected"
+                                [attr.aria-current]="deepNestedItem.selected ? 'true' : null"
                                 (click)="onMenuItemClick(deepNestedItem)"
                               >
                                 @if (deepNestedItem.icon) {
@@ -144,6 +154,8 @@
   <!-- Regular menu template -->
   <ng-template #menuTemplate>
     <div class="tn-menu" cdkMenu tnMenuActivateHover>
+      <!-- Projected <tn-menu-item> children render here, mixed with the items() array below. -->
+      <ng-content select="tn-menu-item, .tn-menu-separator" />
       @for (item of items(); track trackByItemId($index, item)) {
         @if (item.separator) {
           <div
@@ -159,6 +171,8 @@
               [tnTestId]="item.testId ?? 'menu-item-' + item.id"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
+              [class.tn-menu-item--selected]="item.selected"
+              [attr.aria-current]="item.selected ? 'true' : null"
               (click)="onMenuItemClick(item)"
             >
               @if (item.icon) {
@@ -178,6 +192,8 @@
               [cdkMenuTriggerFor]="nestedMenu"
               [disabled]="item.disabled"
               [class.disabled]="item.disabled"
+              [class.tn-menu-item--selected]="item.selected"
+              [attr.aria-current]="item.selected ? 'true' : null"
             >
               @if (item.icon) {
                 <tn-icon size="sm" class="tn-menu-item-icon" [name]="item.icon" [library]="item.iconLibrary" />
@@ -206,6 +222,8 @@
                         [tnTestId]="nestedItem.testId ?? 'menu-item-' + nestedItem.id"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
+                        [class.tn-menu-item--selected]="nestedItem.selected"
+                        [attr.aria-current]="nestedItem.selected ? 'true' : null"
                         (click)="onMenuItemClick(nestedItem)"
                       >
                         @if (nestedItem.icon) {
@@ -225,6 +243,8 @@
                         [cdkMenuTriggerFor]="deepNestedMenu"
                         [disabled]="nestedItem.disabled"
                         [class.disabled]="nestedItem.disabled"
+                        [class.tn-menu-item--selected]="nestedItem.selected"
+                        [attr.aria-current]="nestedItem.selected ? 'true' : null"
                       >
                         @if (nestedItem.icon) {
                           <tn-icon size="sm" class="tn-menu-item-icon" [name]="nestedItem.icon" [library]="nestedItem.iconLibrary" />
@@ -252,6 +272,8 @@
                                 [tnTestId]="deepNestedItem.testId ?? 'menu-item-' + deepNestedItem.id"
                                 [disabled]="deepNestedItem.disabled"
                                 [class.disabled]="deepNestedItem.disabled"
+                                [class.tn-menu-item--selected]="deepNestedItem.selected"
+                                [attr.aria-current]="deepNestedItem.selected ? 'true' : null"
                                 (click)="onMenuItemClick(deepNestedItem)"
                               >
                                 @if (deepNestedItem.icon) {

--- a/projects/truenas-ui/src/lib/menu/menu.component.scss
+++ b/projects/truenas-ui/src/lib/menu/menu.component.scss
@@ -88,6 +88,12 @@
     background: var(--tn-alt-bg2, #e8f4fd);
   }
 
+  &.tn-menu-item--selected {
+    background: var(--tn-alt-bg2, #e8f4fd);
+    font-weight: 600;
+    color: var(--tn-primary, #007bff);
+  }
+
   &.disabled {
     opacity: 0.5;
     cursor: not-allowed;

--- a/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
@@ -1,6 +1,7 @@
-import { Component, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { TnMenuItemComponent } from './menu-item.component';
 import { TnMenuTriggerDirective } from './menu-trigger.directive';
 import type { TnMenuItem } from './menu.component';
 import { TnMenuComponent } from './menu.component';
@@ -403,4 +404,203 @@ describe('tn-menu as context menu', () => {
     expect(getMenuPanel()).toBeFalsy();
     expect(host.closed).toBe(true);
   }));
+});
+
+// ===========================================================================
+// Selected state (TnMenuItem.selected)
+// ===========================================================================
+/* eslint-disable @angular-eslint/component-max-inline-declarations */
+@Component({
+  standalone: true,
+  imports: [TnMenuComponent, TnMenuTriggerDirective],
+  template: `
+    <button class="trigger" [tnMenuTriggerFor]="menu">Open</button>
+    <tn-menu #menu [items]="items" />
+  `,
+})
+class SelectedItemsHostComponent {
+  items: TnMenuItem[] = [
+    { id: 'csv', label: 'CSV' },
+    { id: 'json', label: 'JSON', selected: true },
+    { id: 'yaml', label: 'YAML' },
+  ];
+  trigger = viewChild.required(TnMenuTriggerDirective);
+}
+
+describe('tn-menu selected items', () => {
+  let fixture: ComponentFixture<SelectedItemsHostComponent>;
+  let host: SelectedItemsHostComponent;
+  let triggerButton: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectedItemsHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectedItemsHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    triggerButton = fixture.nativeElement.querySelector('.trigger');
+  });
+
+  afterEach(() => host.trigger().closeMenu());
+
+  it('applies the tn-menu-item--selected class to the selected item only', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const selected = document.querySelectorAll('.tn-menu-item--selected');
+    expect(selected.length).toBe(1);
+    expect(selected[0].textContent?.trim()).toBe('JSON');
+  });
+
+  it('applies aria-current="true" on the selected item', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const currentItems = Array.from(getMenuItems()).filter(
+      (el) => el.getAttribute('aria-current') === 'true',
+    );
+    expect(currentItems.length).toBe(1);
+    expect(currentItems[0].textContent).toContain('JSON');
+  });
+
+  it('does not set aria-current on unselected items', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const items = getMenuItems();
+    const withoutCurrent = items.filter((el) => !el.hasAttribute('aria-current'));
+    expect(withoutCurrent.length).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Projected <tn-menu-item> items
+// ===========================================================================
+@Component({
+  standalone: true,
+  imports: [TnMenuComponent, TnMenuItemComponent, TnMenuTriggerDirective],
+  template: `
+    <button class="trigger" [tnMenuTriggerFor]="menu">Open</button>
+    <tn-menu #menu (menuItemClick)="menuClicked = true">
+      <tn-menu-item
+        id="csv"
+        label="CSV"
+        [selected]="format() === 'csv'"
+        (itemClick)="setFormat('csv')"
+      />
+      <tn-menu-item
+        id="json"
+        label="JSON"
+        [selected]="format() === 'json'"
+        (itemClick)="setFormat('json')"
+      />
+      <tn-menu-item id="disabled-item" label="Disabled" [disabled]="true" />
+      <tn-menu-item id="custom">
+        <span class="custom-content">Custom <strong>Badge</strong></span>
+      </tn-menu-item>
+    </tn-menu>
+  `,
+})
+class ProjectedItemsHostComponent {
+  format = signal<'csv' | 'json'>('json');
+  menuClicked = false;
+
+  setFormat(value: 'csv' | 'json'): void {
+    this.format.set(value);
+  }
+
+  trigger = viewChild.required(TnMenuTriggerDirective);
+}
+
+describe('tn-menu with projected <tn-menu-item>', () => {
+  let fixture: ComponentFixture<ProjectedItemsHostComponent>;
+  let host: ProjectedItemsHostComponent;
+  let triggerButton: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectedItemsHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectedItemsHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    triggerButton = fixture.nativeElement.querySelector('.trigger');
+  });
+
+  afterEach(() => host.trigger().closeMenu());
+
+  it('renders projected items in the overlay', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const labels = getMenuItems().map((el) => el.textContent?.trim());
+    expect(labels).toEqual(expect.arrayContaining(['CSV', 'JSON', 'Disabled']));
+  });
+
+  it('renders custom content when label is omitted', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const custom = document.querySelector('.custom-content');
+    expect(custom).toBeTruthy();
+    expect(custom?.textContent?.trim()).toBe('Custom Badge');
+  });
+
+  it('marks the selected projected item with aria-current and modifier class', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const selectedEl = document.querySelector('.tn-menu-item--selected');
+    expect(selectedEl?.getAttribute('aria-current')).toBe('true');
+    expect(selectedEl?.textContent).toContain('JSON');
+  });
+
+  it('emits per-item itemClick and updates the selection', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const csvItem = getMenuItems().find((el) => el.textContent?.includes('CSV'))!;
+    csvItem.click();
+    fixture.detectChanges();
+
+    expect(host.format()).toBe('csv');
+  });
+
+  it('closes the trigger overlay after projected-item click (via menuItemClick re-emit)', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+    expect(getMenuPanel()).toBeTruthy();
+
+    const jsonItem = getMenuItems().find((el) => el.textContent?.trim() === 'JSON')!;
+    jsonItem.click();
+    fixture.detectChanges();
+
+    expect(getMenuPanel()).toBeFalsy();
+    expect(host.menuClicked).toBe(true);
+  });
+
+  it('does not emit itemClick when a disabled projected item is clicked', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const initialFormat = host.format();
+    const disabledItem = getMenuItems().find((el) => el.textContent?.includes('Disabled'))!;
+    disabledItem.click();
+    fixture.detectChanges();
+
+    expect(host.format()).toBe(initialFormat);
+  });
+
+  it('renders default data-testid based on id input', () => {
+    triggerButton.click();
+    fixture.detectChanges();
+
+    const ids = getMenuItems().map((el) => el.getAttribute('data-testid'));
+    expect(ids).toEqual(
+      expect.arrayContaining(['menu-item-csv', 'menu-item-json', 'menu-item-disabled-item']),
+    );
+  });
 });

--- a/projects/truenas-ui/src/lib/menu/menu.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.ts
@@ -3,9 +3,10 @@ import { Overlay, type OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import type { AfterContentInit, TemplateRef } from '@angular/core';
-import { Component, Directive, ElementRef, input, output, viewChild, computed, inject, ViewContainerRef } from '@angular/core';
+import { Component, Directive, ElementRef, contentChildren, effect, input, output, viewChild, computed, inject, ViewContainerRef } from '@angular/core';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective } from '../test-id';
+import { TnMenuItemComponent } from './menu-item.component';
 
 /**
  * Activates CDK menu hover-to-open behavior for menus opened via custom overlays.
@@ -47,6 +48,12 @@ export interface TnMenuItem {
   action?: () => void;
   children?: TnMenuItem[];
   shortcut?: string;
+  /**
+   * Marks this item as the currently-chosen option (e.g. the active sort key
+   * or export format). Applies the `tn-menu-item--selected` class and an
+   * `aria-current="true"` attribute. Visually distinct from focus/hover.
+   */
+  selected?: boolean;
 }
 
 @Component({
@@ -83,6 +90,27 @@ export class TnMenuComponent {
         this.closeContextMenu();
       }
     }
+  }
+
+  private contentItems = contentChildren(TnMenuItemComponent);
+
+  constructor() {
+    // Forward projected `<tn-menu-item>` clicks to `menuItemClick` so trigger-
+    // driven menus close uniformly. The synthetic emission mirrors the input
+    // shape; consumers wanting per-item behavior should bind to the projected
+    // item's own `itemClick` output.
+    effect((onCleanup) => {
+      const items = this.contentItems();
+      const subs = items.map((item) =>
+        item.itemClick.subscribe(() => {
+          this.menuItemClick.emit({ id: item.id() ?? '', label: item.label() ?? '' });
+          if (this.contextOverlayRef) {
+            this.closeContextMenu();
+          }
+        }),
+      );
+      onCleanup(() => subs.forEach((s) => s.unsubscribe()));
+    });
   }
 
   hasChildren = computed(() => (item: TnMenuItem): boolean => {

--- a/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
@@ -98,4 +98,35 @@ describe('TnMenuHarness', () => {
     expect(await menu.isItemDisabled({ label: 'Edit' })).toBe(false);
     expect(await menu.isItemDisabled({ label: 'Locked' })).toBe(true);
   });
+
+  it('reports isItemSelected for items marked selected', async () => {
+    hostComponent.items = [
+      { id: 'csv', label: 'CSV' },
+      { id: 'json', label: 'JSON', selected: true },
+    ];
+    fixture.detectChanges();
+    openMenu();
+
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(await menu.isItemSelected({ label: 'JSON' })).toBe(true);
+    expect(await menu.isItemSelected({ label: 'CSV' })).toBe(false);
+  });
+
+  it('returns the label of the currently-selected item', async () => {
+    hostComponent.items = [
+      { id: 'csv', label: 'CSV' },
+      { id: 'json', label: 'JSON', selected: true },
+    ];
+    fixture.detectChanges();
+    openMenu();
+
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(await menu.getSelectedItemLabel()).toBe('JSON');
+  });
+
+  it('returns null from getSelectedItemLabel when no item is selected', async () => {
+    openMenu();
+    const menu = await rootLoader.getHarness(TnMenuHarness);
+    expect(await menu.getSelectedItemLabel()).toBeNull();
+  });
 });

--- a/projects/truenas-ui/src/lib/menu/menu.harness.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.harness.ts
@@ -8,12 +8,20 @@ import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
 class TnMenuItemHarness extends ComponentHarness {
   static hostSelector = '.tn-menu-item';
 
-  private _label = this.locatorFor('.tn-menu-item-label');
+  private _label = this.locatorForOptional('.tn-menu-item-label');
 
-  /** Gets the label text of this menu item. */
+  /**
+   * Gets the label text of this menu item. Reads `.tn-menu-item-label` when
+   * present (the default layout), otherwise falls back to the host text so
+   * fully-projected `<tn-menu-item>` content still resolves a label.
+   */
   async getLabel(): Promise<string> {
     const label = await this._label();
-    return (await label.text()).trim();
+    if (label) {
+      return (await label.text()).trim();
+    }
+    const host = await this.host();
+    return (await host.text()).trim();
   }
 
   /** Checks whether this menu item is disabled via the native `disabled` attribute. */
@@ -21,6 +29,12 @@ class TnMenuItemHarness extends ComponentHarness {
     const host = await this.host();
     const disabled = await host.getProperty<boolean>('disabled');
     return !!disabled;
+  }
+
+  /** Checks whether this menu item is marked as the currently-selected option. */
+  async isSelected(): Promise<boolean> {
+    const host = await this.host();
+    return (await host.getAttribute('aria-current')) === 'true';
   }
 
   /** Clicks this menu item. */
@@ -164,6 +178,44 @@ export class TnMenuHarness extends ComponentHarness {
    */
   async getItemCount(): Promise<number> {
     return (await this._items()).length;
+  }
+
+  /**
+   * Checks whether a menu item is marked as the currently-selected option
+   * (i.e. has `aria-current="true"`).
+   *
+   * @example
+   * ```typescript
+   * const menu = await rootLoader.getHarness(TnMenuHarness);
+   * expect(await menu.isItemSelected({ label: 'JSON' })).toBe(true);
+   * ```
+   */
+  async isItemSelected(filter: { label: string | RegExp }): Promise<boolean> {
+    const items = await this._items();
+    for (const item of items) {
+      const text = await item.getLabel();
+      const matches = filter.label instanceof RegExp
+        ? filter.label.test(text)
+        : text === filter.label;
+      if (matches) {
+        return item.isSelected();
+      }
+    }
+    throw new Error(`Could not find menu item with label "${String(filter.label)}"`);
+  }
+
+  /**
+   * Gets the label of the currently-selected item, or `null` when no item is
+   * marked as selected.
+   */
+  async getSelectedItemLabel(): Promise<string | null> {
+    const items = await this._items();
+    for (const item of items) {
+      if (await item.isSelected()) {
+        return item.getLabel();
+      }
+    }
+    return null;
   }
 }
 

--- a/projects/truenas-ui/src/stories/button.stories.ts
+++ b/projects/truenas-ui/src/stories/button.stories.ts
@@ -26,6 +26,17 @@ const meta: Meta<TnButtonComponent> = {
     primary: {
       control: 'boolean',
     },
+    href: {
+      control: 'text',
+      description: 'When set, renders as <a> with this href',
+    },
+    routerLink: {
+      control: 'text',
+      description: 'When set, renders as <a routerLink>. Takes precedence over href.',
+    },
+    target: {
+      control: 'text',
+    },
     onClick: { action: "clicked" },
   },
 };
@@ -121,6 +132,57 @@ export const OutlineWarn: Story = {
 
     await expect(outlineWarnButton.classList.contains('button-outline-warn')).toBe(true);
     await userEvent.click(outlineWarnButton);
+  },
+};
+
+export const AsLink: Story = {
+  args: {
+    color: 'primary',
+    variant: 'outline',
+    label: 'Audit Settings',
+    href: 'https://www.truenas.com/docs/',
+    target: '_blank',
+    rel: 'noopener',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /Audit Settings/i });
+
+    await expect(link.tagName.toLowerCase()).toBe('a');
+    await expect(link.getAttribute('href')).toBe('https://www.truenas.com/docs/');
+  },
+};
+
+export const AsRouterLink: Story = {
+  args: {
+    color: 'primary',
+    variant: 'filled',
+    label: 'Open audit page',
+    routerLink: '/audit/settings',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /Open audit page/i });
+
+    await expect(link.tagName.toLowerCase()).toBe('a');
+    await expect(link.getAttribute('href')).toBe('/audit/settings');
+  },
+};
+
+export const DisabledLink: Story = {
+  args: {
+    color: 'primary',
+    variant: 'outline',
+    label: 'Audit Settings (disabled)',
+    href: 'https://www.truenas.com/docs/',
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /Audit Settings/i });
+
+    await expect(link.getAttribute('aria-disabled')).toBe('true');
+    await expect(link.hasAttribute('href')).toBe(false);
   },
 };
 

--- a/projects/truenas-ui/src/stories/menu.stories.ts
+++ b/projects/truenas-ui/src/stories/menu.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, userEvent, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
+import { TnMenuItemComponent } from '../lib/menu/menu-item.component';
 import { TnMenuTriggerDirective } from '../lib/menu/menu-trigger.directive';
 import type { TnMenuItem } from '../lib/menu/menu.component';
 import { TnMenuComponent } from '../lib/menu/menu.component';
@@ -383,6 +384,100 @@ export const ContextMenu: Story = {
     docs: {
       description: {
         story: 'Context menu mode allows the menu to be triggered by right-clicking anywhere within the component area. The menu will appear at the exact cursor position.',
+      },
+    },
+  },
+};
+
+export const WithSelectedItem: Story = {
+  args: {
+    items: [
+      { id: 'csv', label: 'CSV' },
+      { id: 'json', label: 'JSON', selected: true },
+      { id: 'yaml', label: 'YAML' },
+    ],
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tn-button [tnMenuTriggerFor]="menu">Export Format</tn-button>
+      <tn-menu #menu [items]="items" (menuItemClick)="menuItemClick($event)"></tn-menu>
+    `,
+    moduleMetadata: {
+      imports: [TnMenuTriggerDirective, TnButtonComponent],
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Set `selected: true` on a `TnMenuItem` to mark the currently-chosen option. The selected item gets the `tn-menu-item--selected` class and `aria-current="true"`, mirroring the `mat-menu` `[class.selected]` pattern (e.g. format/sort pickers).',
+      },
+    },
+  },
+};
+
+export const TemplatedItems: Story = {
+  render: () => ({
+    props: {
+      format: 'json',
+      setFormat(this: { format: string }, value: string) {
+        this.format = value;
+      },
+    },
+    template: `
+      <tn-button [tnMenuTriggerFor]="menu">Export as {{ format | uppercase }}</tn-button>
+      <tn-menu #menu>
+        <tn-menu-item id="csv"  label="CSV"  [selected]="format === 'csv'"  (itemClick)="setFormat('csv')" />
+        <tn-menu-item id="json" label="JSON" [selected]="format === 'json'" (itemClick)="setFormat('json')" />
+        <tn-menu-item id="yaml" label="YAML" [selected]="format === 'yaml'" (itemClick)="setFormat('yaml')" />
+      </tn-menu>
+    `,
+    moduleMetadata: {
+      imports: [TnMenuTriggerDirective, TnButtonComponent, TnMenuItemComponent],
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Authoring with projected `<tn-menu-item>` children instead of the `items` array. Useful when each item needs its own click handler or arbitrary layout. Mix-and-match with `items` is supported.',
+      },
+    },
+  },
+};
+
+export const TemplatedItemsCustomLayout: Story = {
+  render: () => ({
+    template: `
+      <tn-button [tnMenuTriggerFor]="menu">Notifications</tn-button>
+      <tn-menu #menu>
+        <tn-menu-item id="inbox">
+          <span style="display:flex;align-items:center;gap:12px;width:100%;">
+            <span style="flex:1;">Inbox</span>
+            <span style="background:var(--tn-primary,#007bff);color:white;border-radius:10px;padding:2px 8px;font-size:12px;font-weight:600;">12</span>
+          </span>
+        </tn-menu-item>
+        <tn-menu-item id="archived">
+          <span style="display:flex;align-items:center;gap:12px;width:100%;">
+            <span style="flex:1;">Archived</span>
+            <span style="background:var(--tn-bg2,#eee);color:var(--tn-fg2,#666);border-radius:10px;padding:2px 8px;font-size:12px;font-weight:600;">3</span>
+          </span>
+        </tn-menu-item>
+        <tn-menu-item id="drafts">
+          <span style="display:flex;flex-direction:column;align-items:flex-start;">
+            <strong>Drafts</strong>
+            <small style="opacity:0.7;">Auto-saved 2 minutes ago</small>
+          </span>
+        </tn-menu-item>
+      </tn-menu>
+    `,
+    moduleMetadata: {
+      imports: [TnMenuTriggerDirective, TnButtonComponent, TnMenuItemComponent],
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Omit the `label` input on `<tn-menu-item>` to project arbitrary content (badges, two-line layouts, etc.).',
       },
     },
   },


### PR DESCRIPTION
Unblocks two webui migrations from Material:

- tn-button now renders as <a> when routerLink or href is set, with proper disabled-anchor semantics (drops href, sets aria-disabled, intercepts clicks). Harness keeps one host selector and adds getHref(). Replaces <a mat-button>/MatAnchor usage.

- tn-menu gains a selected flag on TnMenuItem (renders aria-current and a tn-menu-item--selected modifier class, distinct from the keyboard-focus aria-selected style), and a projection-based <tn-menu-item> authoring mode for arbitrary per-item content. Existing items-array API is unchanged. Replaces the mat-menu [class.selected] pattern used in format/sort pickers.

- tn-card content font-size set to 0.875rem (14px) to match the prior Material card-content sizing.

@angular/router added to peerDependencies (RouterLink import).