### PR TITLE
fix(storybook): disable router initial navigation

### DIFF
--- a/projects/truenas-ui/.storybook/preview.ts
+++ b/projects/truenas-ui/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import { Preview, Decorator, applicationConfig } from '@storybook/angular';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideHttpClient } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withDisabledInitialNavigation } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { APP_INITIALIZER } from '@angular/core';
@@ -101,7 +101,7 @@ export const decorators: Decorator[] = [
     providers: [
       provideAnimationsAsync(),
       provideHttpClient(),
-      provideRouter([]),
+      provideRouter([], withDisabledInitialNavigation()),
       Dialog,
       TnThemeService,
       TnIconRegistryService,


### PR DESCRIPTION
provideRouter([]) triggered an initial navigation that tried to match the Storybook iframe URL (iframe.html) against an empty route table, throwing NG04002. The router is only needed so tn-button's RouterLink resolves; withDisabledInitialNavigation() keeps it available while skipping the startup navigation that caused the error.