### PR TITLE
fix: move testid to label in `tn-checkbox`

### DIFF
--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="classes()">
-  <label class="tn-checkbox__label" [for]="id">
+  <label class="tn-checkbox__label" [for]="id" [tnTestId]="testId()">
     <input
       #checkboxEl
       type="checkbox"
@@ -9,7 +9,6 @@
       [disabled]="isDisabled()"
       [required]="required()"
       [indeterminate]="indeterminate()"
-      [tnTestId]="testId()"
       [attr.aria-label]="hasProjectedLabel() ? label() : null"
       [attr.aria-describedby]="error() ? id + '-error' : null"
       [attr.aria-invalid]="error() ? 'true' : null"

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.spec.ts
@@ -44,9 +44,12 @@ describe('TnCheckboxComponent', () => {
     fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
 
   const getWrapper = (testId = 'main'): HTMLElement => {
-    const input = getCheckbox(testId);
-    return input.closest('.tn-checkbox') as HTMLElement;
+    const label = getCheckbox(testId);
+    return label.closest('.tn-checkbox') as HTMLElement;
   };
+
+  const getInput = (testId = 'main'): HTMLInputElement =>
+    getWrapper(testId).querySelector('.tn-checkbox__input') as HTMLInputElement;
 
   const getLabelText = (testId = 'main'): HTMLElement | null =>
     getWrapper(testId).querySelector('.tn-checkbox__text');
@@ -148,11 +151,11 @@ describe('TnCheckboxComponent', () => {
       host.error.set('Error');
       fixture.detectChanges();
 
-      expect(getCheckbox().getAttribute('aria-invalid')).toBe('true');
+      expect(getInput().getAttribute('aria-invalid')).toBe('true');
     });
 
     it('should not set aria-invalid when no error', () => {
-      expect(getCheckbox().getAttribute('aria-invalid')).toBeNull();
+      expect(getInput().getAttribute('aria-invalid')).toBeNull();
     });
   });
 
@@ -161,28 +164,28 @@ describe('TnCheckboxComponent', () => {
       host.control.setValue(true);
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).checked).toBe(true);
+      expect(getInput().checked).toBe(true);
     });
 
     it('should handle null writeValue gracefully', () => {
       host.control.setValue(null);
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).checked).toBe(false);
+      expect(getInput().checked).toBe(false);
     });
 
     it('should handle undefined writeValue gracefully', () => {
       host.control.setValue(undefined as unknown as boolean);
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).checked).toBe(false);
+      expect(getInput().checked).toBe(false);
     });
 
     it('should disable via form control', () => {
       host.control.disable();
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).disabled).toBe(true);
+      expect(getInput().disabled).toBe(true);
       expect(getWrapper().classList.contains('tn-checkbox--disabled')).toBe(true);
     });
 
@@ -192,7 +195,7 @@ describe('TnCheckboxComponent', () => {
       host.control.enable();
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).disabled).toBe(false);
+      expect(getInput().disabled).toBe(false);
     });
 
     it('should update form control on click', () => {
@@ -209,14 +212,14 @@ describe('TnCheckboxComponent', () => {
       host.required.set(true);
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).required).toBe(true);
+      expect(getInput().required).toBe(true);
     });
 
     it('should set indeterminate property', () => {
       host.indeterminate.set(true);
       fixture.detectChanges();
 
-      expect((getCheckbox() as HTMLInputElement).indeterminate).toBe(true);
+      expect(getInput().indeterminate).toBe(true);
     });
 
     it('should set data-testid attribute', () => {

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.harness.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.harness.ts
@@ -152,8 +152,8 @@ export class TnCheckboxHarness extends ComponentHarness {
    * ```
    */
   async getTestId(): Promise<string | null> {
-    const input = await this._input();
-    return (await input.getAttribute('data-testid')) ?? (await input.getAttribute('data-test'));
+    const label = await this._label();
+    return (await label.getAttribute('data-testid')) ?? (await label.getAttribute('data-test'));
   }
 
   /**

--- a/projects/truenas-ui/src/lib/radio/radio.component.html
+++ b/projects/truenas-ui/src/lib/radio/radio.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="classes()">
-  <label class="tn-radio__label" [for]="id">
+  <label class="tn-radio__label" [for]="id" [tnTestId]="testId()">
     <input
       #radioEl
       type="radio"
@@ -10,7 +10,6 @@
       [checked]="checked"
       [disabled]="isDisabled()"
       [required]="required()"
-      [tnTestId]="testId()"
       [attr.aria-describedby]="error() ? id + '-error' : null"
       [attr.aria-invalid]="error() ? 'true' : null"
       (change)="onRadioChange($event)"

--- a/projects/truenas-ui/src/lib/radio/radio.harness.ts
+++ b/projects/truenas-ui/src/lib/radio/radio.harness.ts
@@ -115,8 +115,8 @@ export class TnRadioHarness extends ComponentHarness {
    * ```
    */
   async getTestId(): Promise<string | null> {
-    const input = await this._input();
-    return (await input.getAttribute('data-testid')) ?? (await input.getAttribute('data-test'));
+    const label = await this._label();
+    return (await label.getAttribute('data-testid')) ?? (await label.getAttribute('data-test'));
   }
 
   /**

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.html
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="classes()">
-  <label class="tn-slide-toggle__label" [for]="id">
+  <label class="tn-slide-toggle__label" [for]="id" [tnTestId]="testId()">
 
     <!-- Label before toggle -->
     @if (label() && labelPosition() === 'before') {
@@ -24,7 +24,6 @@
         [checked]="effectiveChecked()"
         [disabled]="isDisabled()"
         [required]="required()"
-        [tnTestId]="testId()"
         [attr.aria-label]="effectiveAriaLabel()"
         [attr.aria-labelledby]="ariaLabelledby()"
         (change)="onToggleChange($event)"

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.harness.ts
@@ -17,6 +17,7 @@ export class TnSlideToggleHarness extends ComponentHarness {
   static hostSelector = 'tn-slide-toggle';
 
   private _input = this.locatorFor('.tn-slide-toggle__input');
+  private _labelEl = this.locatorFor('.tn-slide-toggle__label');
   private _label = this.locatorForOptional('.tn-slide-toggle__label-text');
 
   /**
@@ -79,8 +80,8 @@ export class TnSlideToggleHarness extends ComponentHarness {
    * Gets the test ID attribute value.
    */
   async getTestId(): Promise<string | null> {
-    const input = await this._input();
-    return (await input.getAttribute('data-testid')) ?? (await input.getAttribute('data-test'));
+    const label = await this._labelEl();
+    return (await label.getAttribute('data-testid')) ?? (await label.getAttribute('data-test'));
   }
 
   /**


### PR DESCRIPTION
move the testid to the `label` element for the `tn-checkbox` component. selenium was incapable of clicking the checkbox, since the testid was on the `input` element itself which had size 0.

see [TNC-1845](https://ixsystemsinc.atlassian.net/browse/TNC-1845) for this problem affecting TNC's automated tests.