### PR TITLE
fix(menu): restore item-button styling in items-array API

### DIFF
--- a/projects/truenas-ui/src/lib/menu/menu-item-renderer.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-item-renderer.component.ts
@@ -40,6 +40,14 @@ import { TnMenuComponent } from './menu.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './menu-item-renderer.component.html',
+  // Shares `<tn-menu>`'s stylesheet so the buttons this component renders
+  // (the items-array API) are styled identically to the projected
+  // `<tn-menu-item>` entries that `<tn-menu>` renders itself. Because this is
+  // a separate component, Angular's emulated encapsulation scopes styles per
+  // component — without its own copy of these rules, `.tn-menu-item` here
+  // wouldn't match the selectors scoped to `<tn-menu>` and the buttons would
+  // fall back to default browser styling.
+  styleUrls: ['./menu.component.scss'],
 })
 export class TnMenuItemRendererComponent {
   item = input.required<TnMenuItem>();


### PR DESCRIPTION
The menu refactor (PR #94) extracted item rendering into TnMenuItemRendererComponent, a separate component with its own emulated view encapsulation. The .tn-menu-item rules live only in menu.component.scss, scoped to TnMenuComponent, so the renderer's buttons carried the wrong _ngcontent attribute and fell back to default browser styling. Only the [items]-array API was affected; projected <tn-menu-item> children render inside <tn-menu> and stayed styled.

Share menu.component.scss with the renderer so its buttons (and nested submenu containers) are scoped and styled identically.