### PR TITLE
NAS-141240 / 27.0.0-BETA.1 / feat(form-field): add optional tooltip with help icon next to label

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -3,10 +3,7 @@
   @if (label() || tooltip()) {
     <div class="tn-form-field-label-row">
       @if (label()) {
-        <label
-          class="tn-form-field-label"
-          [class.required]="required()"
-          [attr.aria-describedby]="tooltip() ? tooltipId : null">
+        <label class="tn-form-field-label" [class.required]="required()">
           {{ label() }}
           @if (required()) {
             <span class="required-asterisk" aria-label="required">*</span>
@@ -17,7 +14,6 @@
         <button
           type="button"
           class="tn-form-field-tooltip"
-          [id]="tooltipId"
           [attr.aria-label]="tooltip()"
           [tnTooltip]="tooltip()"
           [tnTooltipPosition]="tooltipPosition()">

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -1,12 +1,26 @@
 <div class="tn-form-field" [tnTestId]="testId()">
   <!-- Label -->
-  @if (label()) {
-    <label class="tn-form-field-label" [class.required]="required()">
-      {{ label() }}
-      @if (required()) {
-        <span class="required-asterisk" aria-label="required">*</span>
+  @if (label() || tooltip()) {
+    <div class="tn-form-field-label-row">
+      @if (label()) {
+        <label class="tn-form-field-label" [class.required]="required()">
+          {{ label() }}
+          @if (required()) {
+            <span class="required-asterisk" aria-label="required">*</span>
+          }
+        </label>
       }
-    </label>
+      @if (tooltip()) {
+        <button
+          type="button"
+          class="tn-form-field-tooltip"
+          [attr.aria-label]="tooltip()"
+          [tnTooltip]="tooltip()"
+          [tnTooltipPosition]="tooltipPosition()">
+          <tn-icon name="help-circle" library="mdi" size="sm" />
+        </button>
+      }
+    </div>
   }
 
   <!-- Form Control Content -->

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -3,7 +3,10 @@
   @if (label() || tooltip()) {
     <div class="tn-form-field-label-row">
       @if (label()) {
-        <label class="tn-form-field-label" [class.required]="required()">
+        <label
+          class="tn-form-field-label"
+          [class.required]="required()"
+          [attr.aria-describedby]="tooltip() ? tooltipId : null">
           {{ label() }}
           @if (required()) {
             <span class="required-asterisk" aria-label="required">*</span>
@@ -14,6 +17,7 @@
         <button
           type="button"
           class="tn-form-field-tooltip"
+          [id]="tooltipId"
           [attr.aria-label]="tooltip()"
           [tnTooltip]="tooltip()"
           [tnTooltipPosition]="tooltipPosition()">

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -4,9 +4,15 @@
   font-family: var(--tn-font-family-body, 'Inter'), sans-serif;
 }
 
+.tn-form-field-label-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+}
+
 .tn-form-field-label {
   display: block;
-  margin-bottom: 0.5rem;
   font-size: 1rem;
   font-weight: 500;
   color: var(--tn-fg1, #333);
@@ -17,6 +23,23 @@
       color: var(--tn-error, #dc3545);
       margin-left: 0.25rem;
     }
+  }
+}
+
+.tn-form-field-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--tn-fg2, #6c757d);
+  cursor: help;
+  line-height: 0;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--tn-primary, #007bff);
   }
 }
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -41,6 +41,12 @@
   &:focus-visible {
     color: var(--tn-primary, #007bff);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--tn-primary, #007bff);
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
 }
 
 .tn-form-field-wrapper {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -28,10 +28,6 @@ export class TnFormFieldComponent implements AfterContentInit {
   /** Placement of the tooltip relative to its help icon. */
   tooltipPosition = input<TooltipPosition>('above');
 
-  private static nextId = 0;
-  /** Stable id for the tooltip trigger so the label can describe the relationship. */
-  protected tooltipId = `tn-form-field-tooltip-${TnFormFieldComponent.nextId++}`;
-
   control = contentChild(NgControl);
 
   protected hasError = signal<boolean>(false);

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -2,14 +2,17 @@
 import type { AfterContentInit } from '@angular/core';
 import { Component, input, computed, signal, contentChild } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective } from '../test-id';
+import { TnTooltipDirective } from '../tooltip/tooltip.directive';
+import type { TooltipPosition } from '../tooltip/tooltip.directive';
 
 export type SubscriptSizing = 'fixed' | 'dynamic';
 
 @Component({
   selector: 'tn-form-field',
   standalone: true,
-  imports: [TnTestIdDirective],
+  imports: [TnTestIdDirective, TnIconComponent, TnTooltipDirective],
   templateUrl: './form-field.component.html',
   styleUrls: ['./form-field.component.scss']
 })
@@ -19,6 +22,11 @@ export class TnFormFieldComponent implements AfterContentInit {
   required = input<boolean>(false);
   testId = input<string>('');
   subscriptSizing = input<SubscriptSizing>('dynamic');
+
+  /** Optional tooltip shown via a help icon next to the label. */
+  tooltip = input<string>('');
+  /** Placement of the tooltip relative to its help icon. */
+  tooltipPosition = input<TooltipPosition>('above');
 
   control = contentChild(NgControl);
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -28,6 +28,10 @@ export class TnFormFieldComponent implements AfterContentInit {
   /** Placement of the tooltip relative to its help icon. */
   tooltipPosition = input<TooltipPosition>('above');
 
+  private static nextId = 0;
+  /** Stable id for the tooltip trigger so the label can describe the relationship. */
+  protected tooltipId = `tn-form-field-tooltip-${TnFormFieldComponent.nextId++}`;
+
   control = contentChild(NgControl);
 
   protected hasError = signal<boolean>(false);

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -15,7 +15,7 @@ import { TnInputComponent } from '../input/input.component';
   imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
-    <tn-form-field label="Name" testId="name-field" [required]="true">
+    <tn-form-field label="Name" testId="name-field" tooltip="Your full legal name" [required]="true">
       <tn-input [formControl]="nameControl" />
     </tn-form-field>
 
@@ -138,6 +138,24 @@ describe('TnFormFieldHarness', () => {
         TnFormFieldHarness.with({ label: 'Optional' })
       );
       expect(await field.isRequired()).toBe(false);
+    });
+  });
+
+  describe('tooltip', () => {
+    it('should report a tooltip when provided', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'name-field' })
+      );
+      expect(await field.hasTooltip()).toBe(true);
+      expect(await field.getTooltip()).toBe('Your full legal name');
+    });
+
+    it('should report no tooltip when absent', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ label: 'Email' })
+      );
+      expect(await field.hasTooltip()).toBe(false);
+      expect(await field.getTooltip()).toBeNull();
     });
   });
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -33,6 +33,7 @@ export class TnFormFieldHarness extends ComponentHarness {
   private _label = this.locatorForOptional('.tn-form-field-label');
   private _error = this.locatorForOptional('.tn-form-field-error');
   private _hint = this.locatorForOptional('.tn-form-field-hint');
+  private _tooltip = this.locatorForOptional('.tn-form-field-tooltip');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a form field
@@ -128,6 +129,38 @@ export class TnFormFieldHarness extends ComponentHarness {
   async getHint(): Promise<string | null> {
     const hint = await this._hint();
     return hint ? (await hint.text()).trim() : null;
+  }
+
+  /**
+   * Checks whether the form field has a tooltip help icon.
+   *
+   * @returns Promise resolving to true if the tooltip trigger is present.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Purpose' }));
+   * expect(await field.hasTooltip()).toBe(true);
+   * ```
+   */
+  async hasTooltip(): Promise<boolean> {
+    const tooltip = await this._tooltip();
+    return tooltip !== null;
+  }
+
+  /**
+   * Gets the tooltip message (read from the trigger's accessible label).
+   *
+   * @returns Promise resolving to the tooltip text, or null if no tooltip.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Purpose' }));
+   * expect(await field.getTooltip()).toBe('What this share is used for');
+   * ```
+   */
+  async getTooltip(): Promise<string | null> {
+    const tooltip = await this._tooltip();
+    return tooltip ? tooltip.getAttribute('aria-label') : null;
   }
 
   /**

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -4,10 +4,13 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnCheckboxComponent } from '../lib/checkbox/checkbox.component';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
 import { TnInputComponent } from '../lib/input/input.component';
 import { TnRadioComponent } from '../lib/radio/radio.component';
 import type { TnSelectOption } from '../lib/select/select.component';
 import { TnSelectComponent } from '../lib/select/select.component';
+
+tnIconMarker('help-circle', 'mdi');
 
 const harnessDoc = loadHarnessDoc('form-field');
 
@@ -69,6 +72,15 @@ When used with Angular reactive forms, the form field automatically:
       control: 'radio',
       options: ['fixed', 'dynamic'],
       description: 'Controls whether the subscript area reserves space when empty. "fixed" always reserves space (prevents layout shift), "dynamic" collapses when empty.',
+    },
+    tooltip: {
+      control: 'text',
+      description: 'Optional tooltip shown via a help icon next to the label.',
+    },
+    tooltipPosition: {
+      control: 'radio',
+      options: ['above', 'below', 'left', 'right', 'before', 'after'],
+      description: 'Placement of the tooltip relative to its help icon.',
     },
   },
 };
@@ -219,6 +231,40 @@ export const WithSelect: Story = {
     hint: 'Select the appropriate size for your needs',
     required: false,
     testId: 'size-field',
+  },
+};
+
+export const WithTooltip: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      options: selectOptions,
+    },
+    template: `
+      <tn-form-field
+        [label]="label"
+        [hint]="hint"
+        [required]="required"
+        [testId]="testId"
+        [tooltip]="tooltip"
+        [tooltipPosition]="tooltipPosition"
+        [subscriptSizing]="subscriptSizing">
+        <tn-select
+          [options]="options"
+          placeholder="Multi-Protocol Share">
+        </tn-select>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnSelectComponent],
+    },
+  }),
+  args: {
+    label: 'Purpose',
+    required: true,
+    tooltip: 'Describes how this share will be accessed and what it is used for.',
+    tooltipPosition: "below",
+    testId: 'purpose-field',
   },
 };
 


### PR DESCRIPTION
Adds `tooltip` and `tooltipPosition` inputs to tn-form-field. When a tooltip is set, a keyboard-focusable help-circle icon renders next to the label and surfaces the message via tnTooltip. Includes harness helpers (hasTooltip/getTooltip), tests, a story, and argTypes.

<img width="394" height="111" alt="image" src="https://github.com/user-attachments/assets/5c9d13b2-e930-46cb-9374-e51d9c5b14ca" />
