### PR TITLE
NAS-141242 / 27.0.0-BETA.1 / chore: add /review-branch slash command

### DIFF
--- a/.claude/commands/review-branch.md
+++ b/.claude/commands/review-branch.md
@@ -1,0 +1,3 @@
+Review the current branch and provide comprehensive feedback on the changes compared to main.
+
+{{file:.claude/review-prompt.md}}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ yarn-error.log
 *.sublime-workspace
 /.claude/*
 !/.claude/review-prompt.md
+!/.claude/commands
+/.claude/commands/*
+!/.claude/commands/review-branch.md
 
 # Visual Studio Code
 .vscode/*


### PR DESCRIPTION
Adds a review-branch command that reviews the current branch against main using the existing .claude/review-prompt.md. Un-ignores .claude/commands/review-branch.md in .gitignore so it is tracked.