### PR TITLE
ci: allow optional ticket/version prefix in commit titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,19 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
-        uses: amannn/action-semantic-pull-request@v5
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env (not interpolated into the script) to avoid shell injection.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Conventional Commit title, optionally prefixed with "<anything> / " segments
+          # (e.g. "NAS-141240 / 27.0.0-BETA.1 / feat(form-field): ..."). The prefix is
+          # optional so plain "feat(scope): ..." titles still pass. Keep this pattern in
+          # sync with parserOpts.headerPattern in .releaserc.json.
+          pattern='^(.+ / )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title OK: $PR_TITLE"
+          else
+            echo "::error::PR title must follow Conventional Commits, optionally prefixed with '<ticket> / <version> / '."
+            echo "::error::Examples: 'feat(form-field): add tooltip' or 'NAS-141240 / 27.0.0-BETA.1 / feat(form-field): add tooltip'."
+            echo "::error::Got: $PR_TITLE"
+            exit 1
+          fi

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,10 +9,20 @@
         { "type": "perf", "release": "patch" },
         { "type": "refactor", "release": "patch" },
         { "breaking": true, "release": "minor" }
-      ]
+      ],
+      "parserOpts": {
+        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!?: (.+)$",
+        "headerCorrespondence": ["type", "scope", "subject"],
+        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!: (.+)$"
+      }
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits",
+      "parserOpts": {
+        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!?: (.+)$",
+        "headerCorrespondence": ["type", "scope", "subject"],
+        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!: (.+)$"
+      },
       "presetConfig": {
         "types": [
           { "type": "feat", "section": "Features" },


### PR DESCRIPTION
Conventional Commit titles may now be prefixed with one or more "<segment> / " parts (e.g. "NAS-141240 / 27.0.0-BETA.1 / feat(...)") while still being parsed for releases. Plain "feat(scope): ..." titles keep working since the prefix is optional.

- .releaserc.json: add parserOpts (headerPattern, headerCorrespondence, breakingHeaderPattern) to commit-analyzer and release-notes-generator so semantic-release reads the conventional type after the prefix.
- pr-title.yml: replace amannn/action-semantic-pull-request (which only accepts the type at the start) with a regex check mirroring the same optional-prefix pattern.