### PR TITLE
NAS-141322 / 27.0.0-BETA.1 / feat(form-field): customizable validation messages

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,7 +1,13 @@
 
 import type { AfterContentInit } from '@angular/core';
-import { Component, input, computed, signal, contentChild } from '@angular/core';
+import { Component, input, computed, signal, contentChild, inject } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import {
+  TN_FORM_FIELD_ERRORS,
+  activeErrorKey,
+  defaultErrorMessage,
+} from './form-field.errors';
+import type { TnFormFieldErrorMessages } from './form-field.errors';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 import { TnTooltipDirective } from '../tooltip/tooltip.directive';
@@ -28,7 +34,17 @@ export class TnFormFieldComponent implements AfterContentInit {
   /** Placement of the tooltip relative to its help icon. */
   tooltipPosition = input<TooltipPosition>('above');
 
+  /**
+   * Per-field overrides for validation messages, keyed by error key. Values may
+   * be a string or a function that receives the error's detail value. Takes
+   * precedence over the app-wide {@link TN_FORM_FIELD_ERRORS} resolver and the
+   * built-in defaults.
+   */
+  errorMessages = input<TnFormFieldErrorMessages>({});
+
   control = contentChild(NgControl);
+
+  private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
 
   protected hasError = signal<boolean>(false);
   protected errorMessage = signal<string>('');
@@ -59,23 +75,30 @@ export class TnFormFieldComponent implements AfterContentInit {
     if (!control?.errors) {return '';}
 
     const errors = control.errors;
+    const key = activeErrorKey(errors);
+    if (!key) {return 'Invalid input';}
 
-    // Return the first error message found
-    if (errors['required']) {return 'This field is required';}
-    if (errors['email']) {return 'Please enter a valid email address';}
-    if (errors['minlength']) {return `Minimum length is ${errors['minlength'].requiredLength}`;}
-    if (errors['maxlength']) {return `Maximum length is ${errors['maxlength'].requiredLength}`;}
-    if (errors['pattern']) {return 'Please enter a valid format';}
-    if (errors['min']) {return `Minimum value is ${errors['min'].min}`;}
-    if (errors['max']) {return `Maximum value is ${errors['max'].max}`;}
+    const value = errors[key];
 
-    // Return custom error message if the value is a string, otherwise use the key
-    const firstKey = Object.keys(errors)[0];
-    if (firstKey) {
-      const value = errors[firstKey];
-      return typeof value === 'string' ? value : firstKey;
+    // 1. Per-field override (string or factory).
+    const override = this.errorMessages()[key];
+    if (override != null) {
+      return typeof override === 'function' ? override(value) : override;
     }
-    return 'Invalid input';
+
+    // 2. App-wide resolver (e.g. wired to a translation service).
+    const resolved = this.errorResolver?.(key, value, control.control ?? null);
+    if (resolved != null) {return resolved;}
+
+    // 3. Built-in default messages for standard validators.
+    const builtIn = defaultErrorMessage(key, errors);
+    if (builtIn != null) {return builtIn;}
+
+    // 4. A custom validator that returned its own message string.
+    if (typeof value === 'string') {return value;}
+
+    // 5. Last resort: the raw error key.
+    return key;
   }
 
   showError = computed(() => {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,6 +1,6 @@
 
 import type { AfterContentInit } from '@angular/core';
-import { Component, input, computed, signal, contentChild, inject, DestroyRef } from '@angular/core';
+import { Component, input, computed, signal, contentChild, inject, isDevMode, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 import type { ValidationErrors } from '@angular/forms';
@@ -16,6 +16,13 @@ import { TnTooltipDirective } from '../tooltip/tooltip.directive';
 import type { TooltipPosition } from '../tooltip/tooltip.directive';
 
 export type SubscriptSizing = 'fixed' | 'dynamic';
+
+/** Snapshot of the projected control's validation state. */
+interface ControlStateSnapshot {
+  invalid: boolean;
+  interacted: boolean;
+  errors: ValidationErrors | null;
+}
 
 @Component({
   selector: 'tn-form-field',
@@ -60,7 +67,7 @@ export class TnFormFieldComponent implements AfterContentInit {
    * stream because `NgControl` itself is not signal-based; downstream `computed`s
    * read this so the derived state stays reactive.
    */
-  private controlState = signal<{ invalid: boolean; interacted: boolean; errors: ValidationErrors | null }>({
+  private controlState = signal<ControlStateSnapshot>({
     invalid: false,
     interacted: false,
     errors: null,
@@ -114,14 +121,22 @@ export class TnFormFieldComponent implements AfterContentInit {
 
     const value = errors[key];
 
-    // 1. Per-field override (string or factory).
+    // 1. Per-field override (string or factory). A throwing factory must not
+    //    break change detection, so fall through to the next layer instead.
     const override = this.errorMessages()[key];
     if (override != null) {
-      return typeof override === 'function' ? override(value) : override;
+      const message = this.runGuarded(
+        () => (typeof override === 'function' ? override(value) : override),
+        `errorMessages["${key}"]`
+      );
+      if (message != null) {return message;}
     }
 
     // 2. App-wide resolver (e.g. wired to a translation service).
-    const resolved = this.errorResolver?.(key, value, this.control()?.control ?? null);
+    const resolved = this.runGuarded(
+      () => this.errorResolver?.(key, value, this.control()?.control ?? null),
+      'TN_FORM_FIELD_ERRORS resolver'
+    );
     if (resolved != null) {return resolved;}
 
     // 3. Built-in default messages for standard validators.
@@ -133,6 +148,22 @@ export class TnFormFieldComponent implements AfterContentInit {
 
     // 5. Last resort: the raw error key.
     return key;
+  }
+
+  /**
+   * Runs a caller-supplied message provider, swallowing any throw so a buggy
+   * override or resolver cannot break change detection. Logs in dev mode and
+   * returns null so resolution falls through to the next layer.
+   */
+  private runGuarded(provider: () => string | null | undefined, context: string): string | null {
+    try {
+      return provider() ?? null;
+    } catch (error) {
+      if (isDevMode()) {
+        console.error(`[tn-form-field] ${context} threw while resolving a validation message`, error);
+      }
+      return null;
+    }
   }
 
   showError = computed(() => {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -2,6 +2,7 @@
 import type { AfterContentInit } from '@angular/core';
 import { Component, input, computed, signal, contentChild, inject } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import type { ValidationErrors } from '@angular/forms';
 import {
   TN_FORM_FIELD_ERRORS,
   activeErrorKey,
@@ -46,35 +47,58 @@ export class TnFormFieldComponent implements AfterContentInit {
 
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
 
-  protected hasError = signal<boolean>(false);
-  protected errorMessage = signal<string>('');
+  /**
+   * Snapshot of the relevant control state. Updated from the control's status
+   * stream because `NgControl` itself is not signal-based; downstream `computed`s
+   * read this so the derived state stays reactive.
+   */
+  private controlState = signal<{ invalid: boolean; interacted: boolean; errors: ValidationErrors | null }>({
+    invalid: false,
+    interacted: false,
+    errors: null,
+  });
+
+  protected hasError = computed(() => {
+    const state = this.controlState();
+    return state.invalid && state.interacted;
+  });
+
+  protected errorMessage = computed(() => {
+    const { errors } = this.controlState();
+    return errors ? this.resolveErrorMessage(errors) : '';
+  });
 
   ngAfterContentInit(): void {
     const control = this.control();
     if (control) {
       // Listen for control status changes
       control.statusChanges?.subscribe(() => {
-        this.updateErrorState();
+        this.syncControlState();
       });
 
       // Initial error state check
-      this.updateErrorState();
+      this.syncControlState();
     }
   }
 
-  private updateErrorState(): void {
+  private syncControlState(): void {
     const control = this.control();
     if (control) {
-      this.hasError.set(!!(control.invalid && (control.dirty || control.touched)));
-      this.errorMessage.set(this.getErrorMessage());
+      this.controlState.set({
+        invalid: !!control.invalid,
+        interacted: !!(control.dirty || control.touched),
+        errors: control.errors ?? null,
+      });
     }
   }
 
-  private getErrorMessage(): string {
-    const control = this.control();
-    if (!control?.errors) {return '';}
-
-    const errors = control.errors;
+  /**
+   * Resolves a user-facing message for the active error. Reads the
+   * `errorMessages` input (and the injected resolver), so it is reactive: the
+   * displayed message updates when either the control errors or the overrides
+   * change — e.g. a runtime locale switch.
+   */
+  private resolveErrorMessage(errors: ValidationErrors): string {
     const key = activeErrorKey(errors);
     if (!key) {return 'Invalid input';}
 
@@ -87,7 +111,7 @@ export class TnFormFieldComponent implements AfterContentInit {
     }
 
     // 2. App-wide resolver (e.g. wired to a translation service).
-    const resolved = this.errorResolver?.(key, value, control.control ?? null);
+    const resolved = this.errorResolver?.(key, value, this.control()?.control ?? null);
     if (resolved != null) {return resolved;}
 
     // 3. Built-in default messages for standard validators.

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -86,7 +86,11 @@ export class TnFormFieldComponent implements AfterContentInit {
   ngAfterContentInit(): void {
     const control = this.control();
     if (control) {
-      // Listen for control status changes
+      // Listen for control status changes.
+      // NOTE: `statusChanges` does not emit on touched/pristine-only transitions
+      // (e.g. `markAsTouched()` / `markAllAsTouched()` on blur or submit), so an
+      // error may not surface until the next value/status change. Reacting to
+      // those via `control.control?.events` is tracked as a follow-up.
       control.statusChanges
         ?.pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
@@ -157,7 +161,11 @@ export class TnFormFieldComponent implements AfterContentInit {
    */
   private runGuarded(provider: () => string | null | undefined, context: string): string | null {
     try {
-      return provider() ?? null;
+      // Treat a blank message as "no answer" so it falls through to the next
+      // layer instead of hiding the error — e.g. a translation service that
+      // returns '' for a missing key.
+      const message = provider();
+      return message != null && message.trim() !== '' ? message : null;
     } catch (error) {
       if (isDevMode()) {
         console.error(`[tn-form-field] ${context} threw while resolving a validation message`, error);

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,6 +1,7 @@
 
 import type { AfterContentInit } from '@angular/core';
-import { Component, input, computed, signal, contentChild, inject } from '@angular/core';
+import { Component, input, computed, signal, contentChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 import type { ValidationErrors } from '@angular/forms';
 import {
@@ -45,6 +46,13 @@ export class TnFormFieldComponent implements AfterContentInit {
 
   control = contentChild(NgControl);
 
+  private destroyRef = inject(DestroyRef);
+
+  /**
+   * App-wide message resolver, captured once at construction. Unlike the
+   * `errorMessages` input it is not reactive — swapping the provided function at
+   * runtime will not be picked up by an already-created field.
+   */
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
 
   /**
@@ -72,9 +80,11 @@ export class TnFormFieldComponent implements AfterContentInit {
     const control = this.control();
     if (control) {
       // Listen for control status changes
-      control.statusChanges?.subscribe(() => {
-        this.syncControlState();
-      });
+      control.statusChanges
+        ?.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => {
+          this.syncControlState();
+        });
 
       // Initial error state check
       this.syncControlState();
@@ -115,7 +125,7 @@ export class TnFormFieldComponent implements AfterContentInit {
     if (resolved != null) {return resolved;}
 
     // 3. Built-in default messages for standard validators.
-    const builtIn = defaultErrorMessage(key, errors);
+    const builtIn = defaultErrorMessage(key, value);
     if (builtIn != null) {return builtIn;}
 
     // 4. A custom validator that returned its own message string.

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
@@ -1,0 +1,52 @@
+import { activeErrorKey, defaultErrorMessage } from './form-field.errors';
+
+describe('activeErrorKey', () => {
+  it('returns null when there are no errors', () => {
+    expect(activeErrorKey({})).toBeNull();
+  });
+
+  it('returns the single present key', () => {
+    expect(activeErrorKey({ required: true })).toBe('required');
+  });
+
+  it('prefers built-in keys in priority order over later ones', () => {
+    // required outranks minlength even if minlength is listed first.
+    expect(activeErrorKey({ minlength: { requiredLength: 4 }, required: true })).toBe('required');
+    expect(activeErrorKey({ pattern: true, email: true })).toBe('email');
+    expect(activeErrorKey({ max: { max: 10 }, min: { min: 1 } })).toBe('min');
+  });
+
+  it('falls back to the first key for custom-only errors', () => {
+    expect(activeErrorKey({ customPolicy: 'nope', anotherRule: true })).toBe('customPolicy');
+  });
+
+  it('prefers a built-in key over a custom one regardless of order', () => {
+    expect(activeErrorKey({ customPolicy: 'nope', required: true })).toBe('required');
+  });
+});
+
+describe('defaultErrorMessage', () => {
+  it('returns fixed strings for required, email and pattern', () => {
+    expect(defaultErrorMessage('required', { required: true })).toBe('This field is required');
+    expect(defaultErrorMessage('email', { email: true })).toBe('Please enter a valid email address');
+    expect(defaultErrorMessage('pattern', { pattern: true })).toBe('Please enter a valid format');
+  });
+
+  it('interpolates length and value metadata', () => {
+    expect(defaultErrorMessage('minlength', { minlength: { requiredLength: 8 } })).toBe('Minimum length is 8');
+    expect(defaultErrorMessage('maxlength', { maxlength: { requiredLength: 20 } })).toBe('Maximum length is 20');
+    expect(defaultErrorMessage('min', { min: { min: 1 } })).toBe('Minimum value is 1');
+    expect(defaultErrorMessage('max', { max: { max: 10 } })).toBe('Maximum value is 10');
+  });
+
+  it('returns null for unknown keys', () => {
+    expect(defaultErrorMessage('customPolicy', { customPolicy: 'x' })).toBeNull();
+  });
+
+  it('does not crash on malformed error detail shapes', () => {
+    // A custom validator could set a non-object value for a built-in key.
+    expect(() => defaultErrorMessage('minlength', { minlength: true as unknown as object })).not.toThrow();
+    expect(defaultErrorMessage('minlength', { minlength: true as unknown as object })).toBe('Minimum length is');
+    expect(defaultErrorMessage('min', { min: null as unknown as object })).toBe('Minimum value is');
+  });
+});

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
@@ -43,10 +43,17 @@ describe('defaultErrorMessage', () => {
     expect(defaultErrorMessage('customPolicy', 'x')).toBeNull();
   });
 
-  it('does not crash on malformed error detail shapes', () => {
+  it('handles the requiredLength: 0 edge case', () => {
+    expect(defaultErrorMessage('minlength', { requiredLength: 0 })).toBe('Minimum length is 0');
+    expect(defaultErrorMessage('min', { min: 0 })).toBe('Minimum value is 0');
+  });
+
+  it('falls back to a complete sentence on malformed error detail shapes', () => {
     // A custom validator could set a non-object value for a built-in key.
     expect(() => defaultErrorMessage('minlength', true)).not.toThrow();
-    expect(defaultErrorMessage('minlength', true)).toBe('Minimum length is');
-    expect(defaultErrorMessage('min', null)).toBe('Minimum value is');
+    expect(defaultErrorMessage('minlength', true)).toBe('Value is too short');
+    expect(defaultErrorMessage('maxlength', true)).toBe('Value is too long');
+    expect(defaultErrorMessage('min', null)).toBe('Value is too small');
+    expect(defaultErrorMessage('max', undefined)).toBe('Value is too large');
   });
 });

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
@@ -27,26 +27,26 @@ describe('activeErrorKey', () => {
 
 describe('defaultErrorMessage', () => {
   it('returns fixed strings for required, email and pattern', () => {
-    expect(defaultErrorMessage('required', { required: true })).toBe('This field is required');
-    expect(defaultErrorMessage('email', { email: true })).toBe('Please enter a valid email address');
-    expect(defaultErrorMessage('pattern', { pattern: true })).toBe('Please enter a valid format');
+    expect(defaultErrorMessage('required', true)).toBe('This field is required');
+    expect(defaultErrorMessage('email', true)).toBe('Please enter a valid email address');
+    expect(defaultErrorMessage('pattern', true)).toBe('Please enter a valid format');
   });
 
   it('interpolates length and value metadata', () => {
-    expect(defaultErrorMessage('minlength', { minlength: { requiredLength: 8 } })).toBe('Minimum length is 8');
-    expect(defaultErrorMessage('maxlength', { maxlength: { requiredLength: 20 } })).toBe('Maximum length is 20');
-    expect(defaultErrorMessage('min', { min: { min: 1 } })).toBe('Minimum value is 1');
-    expect(defaultErrorMessage('max', { max: { max: 10 } })).toBe('Maximum value is 10');
+    expect(defaultErrorMessage('minlength', { requiredLength: 8 })).toBe('Minimum length is 8');
+    expect(defaultErrorMessage('maxlength', { requiredLength: 20 })).toBe('Maximum length is 20');
+    expect(defaultErrorMessage('min', { min: 1 })).toBe('Minimum value is 1');
+    expect(defaultErrorMessage('max', { max: 10 })).toBe('Maximum value is 10');
   });
 
   it('returns null for unknown keys', () => {
-    expect(defaultErrorMessage('customPolicy', { customPolicy: 'x' })).toBeNull();
+    expect(defaultErrorMessage('customPolicy', 'x')).toBeNull();
   });
 
   it('does not crash on malformed error detail shapes', () => {
     // A custom validator could set a non-object value for a built-in key.
-    expect(() => defaultErrorMessage('minlength', { minlength: true as unknown as object })).not.toThrow();
-    expect(defaultErrorMessage('minlength', { minlength: true as unknown as object })).toBe('Minimum length is');
-    expect(defaultErrorMessage('min', { min: null as unknown as object })).toBe('Minimum value is');
+    expect(() => defaultErrorMessage('minlength', true)).not.toThrow();
+    expect(defaultErrorMessage('minlength', true)).toBe('Minimum length is');
+    expect(defaultErrorMessage('min', null)).toBe('Minimum value is');
   });
 });

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -73,42 +73,54 @@ export const TN_FORM_FIELD_ERRORS = new InjectionToken<TnFormFieldErrorResolver>
  * resolver supplies a message. English-only by design — override the others for
  * localization.
  *
+ * @param errorKey   The active validation error key.
+ * @param errorValue The detail Angular stored for that key (e.g.
+ *                   `{ requiredLength: 8 }` for `minlength`). Tolerates malformed
+ *                   shapes so a bad validator can't crash rendering.
  * @internal
  */
 export function defaultErrorMessage(
   errorKey: string,
-  errors: ValidationErrors
+  errorValue: unknown
 ): string | null {
+  const detail = (errorValue ?? {}) as Record<string, unknown>;
   switch (errorKey) {
     case 'required':
       return 'This field is required';
     case 'email':
       return 'Please enter a valid email address';
     case 'minlength':
-      return `Minimum length is ${errors['minlength']?.requiredLength ?? ''}`.trim();
+      return `Minimum length is ${detail['requiredLength'] ?? ''}`.trim();
     case 'maxlength':
-      return `Maximum length is ${errors['maxlength']?.requiredLength ?? ''}`.trim();
+      return `Maximum length is ${detail['requiredLength'] ?? ''}`.trim();
     case 'pattern':
       return 'Please enter a valid format';
     case 'min':
-      return `Minimum value is ${errors['min']?.min ?? ''}`.trim();
+      return `Minimum value is ${detail['min'] ?? ''}`.trim();
     case 'max':
-      return `Maximum value is ${errors['max']?.max ?? ''}`.trim();
+      return `Maximum value is ${detail['max'] ?? ''}`.trim();
     default:
       return null;
   }
 }
 
 /**
+ * Order in which built-in validator errors are surfaced when a control reports
+ * more than one at once.
+ */
+const BUILT_IN_ERROR_PRIORITY = [
+  'required', 'email', 'minlength', 'maxlength', 'pattern', 'min', 'max',
+] as const;
+
+/**
  * Picks which error to display when a control has more than one. Built-in keys
- * are preferred in a stable priority order; any remaining custom key falls back
- * to insertion order.
+ * are preferred in {@link BUILT_IN_ERROR_PRIORITY} order; any remaining custom
+ * key falls back to insertion order.
  *
  * @internal
  */
 export function activeErrorKey(errors: ValidationErrors): string | null {
-  const priority = ['required', 'email', 'minlength', 'maxlength', 'pattern', 'min', 'max'];
-  for (const key of priority) {
+  for (const key of BUILT_IN_ERROR_PRIORITY) {
     if (errors[key] != null) {
       return key;
     }

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -90,15 +90,23 @@ export function defaultErrorMessage(
     case 'email':
       return 'Please enter a valid email address';
     case 'minlength':
-      return `Minimum length is ${detail['requiredLength'] ?? ''}`.trim();
+      return detail['requiredLength'] == null
+        ? 'Value is too short'
+        : `Minimum length is ${detail['requiredLength']}`;
     case 'maxlength':
-      return `Maximum length is ${detail['requiredLength'] ?? ''}`.trim();
+      return detail['requiredLength'] == null
+        ? 'Value is too long'
+        : `Maximum length is ${detail['requiredLength']}`;
     case 'pattern':
       return 'Please enter a valid format';
     case 'min':
-      return `Minimum value is ${detail['min'] ?? ''}`.trim();
+      return detail['min'] == null
+        ? 'Value is too small'
+        : `Minimum value is ${detail['min']}`;
     case 'max':
-      return `Maximum value is ${detail['max'] ?? ''}`.trim();
+      return detail['max'] == null
+        ? 'Value is too large'
+        : `Maximum value is ${detail['max']}`;
     default:
       return null;
   }

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -25,7 +25,7 @@ export type TnFormFieldErrorMessage =
  * }">
  * ```
  */
-export type TnFormFieldErrorMessages = Record<string, TnFormFieldErrorMessage>;
+export type TnFormFieldErrorMessages = Partial<Record<string, TnFormFieldErrorMessage>>;
 
 /**
  * App-wide resolver for validation messages. Register one with the
@@ -85,15 +85,15 @@ export function defaultErrorMessage(
     case 'email':
       return 'Please enter a valid email address';
     case 'minlength':
-      return `Minimum length is ${errors['minlength'].requiredLength}`;
+      return `Minimum length is ${errors['minlength']?.requiredLength ?? ''}`.trim();
     case 'maxlength':
-      return `Maximum length is ${errors['maxlength'].requiredLength}`;
+      return `Maximum length is ${errors['maxlength']?.requiredLength ?? ''}`.trim();
     case 'pattern':
       return 'Please enter a valid format';
     case 'min':
-      return `Minimum value is ${errors['min'].min}`;
+      return `Minimum value is ${errors['min']?.min ?? ''}`.trim();
     case 'max':
-      return `Maximum value is ${errors['max'].max}`;
+      return `Maximum value is ${errors['max']?.max ?? ''}`.trim();
     default:
       return null;
   }

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -1,0 +1,117 @@
+import { InjectionToken } from '@angular/core';
+import type { AbstractControl, ValidationErrors } from '@angular/forms';
+
+/**
+ * A user-friendly message for a single validation error, or a function that
+ * builds one from the error's detail value.
+ *
+ * The function form receives the error value Angular stored for that key, which
+ * lets you interpolate validator metadata, e.g.
+ * `minlength: (e) => \`At least ${e.requiredLength} characters\``.
+ */
+export type TnFormFieldErrorMessage =
+  | string
+  | ((errorValue: unknown) => string);
+
+/**
+ * A per-field map of validation error key -> message (or message factory).
+ *
+ * @example
+ * ```html
+ * <tn-form-field [errorMessages]="{
+ *   required: 'Please enter a name',
+ *   pattern: 'Letters only',
+ *   minlength: messageFn
+ * }">
+ * ```
+ */
+export type TnFormFieldErrorMessages = Record<string, TnFormFieldErrorMessage>;
+
+/**
+ * App-wide resolver for validation messages. Register one with the
+ * {@link TN_FORM_FIELD_ERRORS} token to centralize wording and i18n.
+ *
+ * Return a string to provide a message, or `null`/`undefined` to defer to the
+ * next layer (built-in defaults, then the raw error key).
+ *
+ * @param errorKey   The active validation error key (e.g. `'required'`).
+ * @param errorValue The value Angular stored for that key.
+ * @param control    The control that failed validation, if available.
+ */
+export type TnFormFieldErrorResolver = (
+  errorKey: string,
+  errorValue: unknown,
+  control: AbstractControl | null
+) => string | null | undefined;
+
+/**
+ * Injection token for an app-wide {@link TnFormFieldErrorResolver}.
+ *
+ * Because the library ships no localized strings, this is the recommended hook
+ * for wiring a translation service so every `tn-form-field` resolves messages
+ * consistently. Per-field `errorMessages` still take precedence over it.
+ *
+ * @example
+ * ```ts
+ * providers: [
+ *   {
+ *     provide: TN_FORM_FIELD_ERRORS,
+ *     useFactory: (translate: TranslateService): TnFormFieldErrorResolver =>
+ *       (key, value) => translate.instant(`errors.${key}`, value as object),
+ *     deps: [TranslateService],
+ *   },
+ * ];
+ * ```
+ */
+export const TN_FORM_FIELD_ERRORS = new InjectionToken<TnFormFieldErrorResolver>(
+  'TN_FORM_FIELD_ERRORS'
+);
+
+/**
+ * Built-in fallback messages for Angular's standard validators. Used only when
+ * neither a per-field `errorMessages` entry nor a {@link TN_FORM_FIELD_ERRORS}
+ * resolver supplies a message. English-only by design — override the others for
+ * localization.
+ *
+ * @internal
+ */
+export function defaultErrorMessage(
+  errorKey: string,
+  errors: ValidationErrors
+): string | null {
+  switch (errorKey) {
+    case 'required':
+      return 'This field is required';
+    case 'email':
+      return 'Please enter a valid email address';
+    case 'minlength':
+      return `Minimum length is ${errors['minlength'].requiredLength}`;
+    case 'maxlength':
+      return `Maximum length is ${errors['maxlength'].requiredLength}`;
+    case 'pattern':
+      return 'Please enter a valid format';
+    case 'min':
+      return `Minimum value is ${errors['min'].min}`;
+    case 'max':
+      return `Maximum value is ${errors['max'].max}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Picks which error to display when a control has more than one. Built-in keys
+ * are preferred in a stable priority order; any remaining custom key falls back
+ * to insertion order.
+ *
+ * @internal
+ */
+export function activeErrorKey(errors: ValidationErrors): string | null {
+  const priority = ['required', 'email', 'minlength', 'maxlength', 'pattern', 'min', 'max'];
+  for (const key of priority) {
+    if (errors[key] != null) {
+      return key;
+    }
+  }
+  return Object.keys(errors)[0] ?? null;
+}

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -9,6 +9,7 @@ import { TnFormFieldComponent } from './form-field.component';
 import { TN_FORM_FIELD_ERRORS } from './form-field.errors';
 import type { TnFormFieldErrorMessages, TnFormFieldErrorResolver } from './form-field.errors';
 import { TnFormFieldHarness } from './form-field.harness';
+import { TnIconTesting } from '../icon/icon-testing';
 import { TnInputComponent } from '../input/input.component';
 
 @Component({
@@ -68,6 +69,7 @@ describe('TnFormFieldHarness', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
+      providers: [TnIconTesting.jest.providers()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -318,19 +320,19 @@ describe('TnFormFieldHarness', () => {
   imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
-    <tn-form-field label="Name" testId="name-field" [errorMessages]="stringMessages">
+    <tn-form-field label="Name" testId="name" [errorMessages]="stringMessages">
       <tn-input [formControl]="nameControl" />
     </tn-form-field>
 
-    <tn-form-field label="Password" testId="password-field" [errorMessages]="fnMessages">
+    <tn-form-field label="Password" testId="password" [errorMessages]="fnMessages">
       <tn-input [formControl]="passwordControl" />
     </tn-form-field>
 
-    <tn-form-field label="Unrelated" testId="unrelated-field" [errorMessages]="unrelatedMessages">
+    <tn-form-field label="Unrelated" testId="unrelated" [errorMessages]="unrelatedMessages">
       <tn-input [formControl]="unrelatedControl" />
     </tn-form-field>
 
-    <tn-form-field label="Throwing" testId="throwing-field" [errorMessages]="throwingMessages">
+    <tn-form-field label="Throwing" testId="throwing" [errorMessages]="throwingMessages">
       <tn-input [formControl]="throwingControl" />
     </tn-form-field>
   `
@@ -368,6 +370,7 @@ describe('TnFormField per-field errorMessages', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ErrorMessagesHostComponent],
+      providers: [TnIconTesting.jest.providers()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ErrorMessagesHostComponent);
@@ -382,7 +385,7 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'name-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-name' })
     );
     expect(await field.getErrorMessage()).toBe('Please enter a name');
   });
@@ -395,7 +398,7 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'password-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-password' })
     );
     expect(await field.getErrorMessage()).toBe('Needs 8 characters');
   });
@@ -407,7 +410,7 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'unrelated-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-unrelated' })
     );
     expect(await field.hasError()).toBe(true);
     expect(await field.getErrorMessage()).toBe('This field is required');
@@ -420,7 +423,7 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'name-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-name' })
     );
     expect(await field.getErrorMessage()).toBe('Please enter a name');
 
@@ -439,12 +442,27 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'throwing-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-throwing' })
     );
     expect(await field.hasError()).toBe(true);
     expect(await field.getErrorMessage()).toBe('This field is required');
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  it('should fall through to the built-in default when an override resolves to a blank string', async () => {
+    const host = fixture.componentInstance;
+    // e.g. a translation service returning '' for a missing key.
+    host.stringMessages = { required: '   ' };
+    host.nameControl.markAsTouched();
+    host.nameControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'form-field-name' })
+    );
+    expect(await field.hasError()).toBe(true);
+    expect(await field.getErrorMessage()).toBe('This field is required');
   });
 });
 
@@ -454,11 +472,11 @@ describe('TnFormField per-field errorMessages', () => {
   imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
-    <tn-form-field label="Resolved" testId="resolved-field">
+    <tn-form-field label="Resolved" testId="resolved">
       <tn-input [formControl]="resolvedControl" />
     </tn-form-field>
 
-    <tn-form-field label="Overridden" testId="overridden-field" [errorMessages]="overrides">
+    <tn-form-field label="Overridden" testId="overridden" [errorMessages]="overrides">
       <tn-input [formControl]="overriddenControl" />
     </tn-form-field>
   `
@@ -482,7 +500,10 @@ describe('TnFormField global error resolver', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ResolverHostComponent],
-      providers: [{ provide: TN_FORM_FIELD_ERRORS, useValue: resolver }],
+      providers: [
+        TnIconTesting.jest.providers(),
+        { provide: TN_FORM_FIELD_ERRORS, useValue: resolver },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ResolverHostComponent);
@@ -497,7 +518,7 @@ describe('TnFormField global error resolver', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'resolved-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-resolved' })
     );
     expect(await field.getErrorMessage()).toBe('Resolved from token');
   });
@@ -509,7 +530,7 @@ describe('TnFormField global error resolver', () => {
     fixture.detectChanges();
 
     const field = await loader.getHarness(
-      TnFormFieldHarness.with({ testId: 'overridden-field' })
+      TnFormFieldHarness.with({ testId: 'form-field-overridden' })
     );
     expect(await field.getErrorMessage()).toBe('Field-level wins');
   });

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -329,12 +329,17 @@ describe('TnFormFieldHarness', () => {
     <tn-form-field label="Unrelated" testId="unrelated-field" [errorMessages]="unrelatedMessages">
       <tn-input [formControl]="unrelatedControl" />
     </tn-form-field>
+
+    <tn-form-field label="Throwing" testId="throwing-field" [errorMessages]="throwingMessages">
+      <tn-input [formControl]="throwingControl" />
+    </tn-form-field>
   `
 })
 class ErrorMessagesHostComponent {
   nameControl = new FormControl('', Validators.required);
   passwordControl = new FormControl('', Validators.minLength(8));
   unrelatedControl = new FormControl('', Validators.required);
+  throwingControl = new FormControl('', Validators.required);
 
   stringMessages: TnFormFieldErrorMessages = {
     required: 'Please enter a name',
@@ -347,6 +352,12 @@ class ErrorMessagesHostComponent {
 
   unrelatedMessages: TnFormFieldErrorMessages = {
     somethingElse: 'Never shown',
+  };
+
+  throwingMessages: TnFormFieldErrorMessages = {
+    required: () => {
+      throw new Error('boom');
+    },
   };
 }
 
@@ -418,6 +429,22 @@ describe('TnFormField per-field errorMessages', () => {
     fixture.detectChanges();
 
     expect(await field.getErrorMessage()).toBe('Updated message');
+  });
+
+  it('should fall through to the built-in default when an override factory throws', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const host = fixture.componentInstance;
+    host.throwingControl.markAsTouched();
+    host.throwingControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'throwing-field' })
+    );
+    expect(await field.hasError()).toBe(true);
+    expect(await field.getErrorMessage()).toBe('This field is required');
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -325,11 +325,16 @@ describe('TnFormFieldHarness', () => {
     <tn-form-field label="Password" testId="password-field" [errorMessages]="fnMessages">
       <tn-input [formControl]="passwordControl" />
     </tn-form-field>
+
+    <tn-form-field label="Unrelated" testId="unrelated-field" [errorMessages]="unrelatedMessages">
+      <tn-input [formControl]="unrelatedControl" />
+    </tn-form-field>
   `
 })
 class ErrorMessagesHostComponent {
   nameControl = new FormControl('', Validators.required);
   passwordControl = new FormControl('', Validators.minLength(8));
+  unrelatedControl = new FormControl('', Validators.required);
 
   stringMessages: TnFormFieldErrorMessages = {
     required: 'Please enter a name',
@@ -338,6 +343,10 @@ class ErrorMessagesHostComponent {
   fnMessages: TnFormFieldErrorMessages = {
     minlength: (err) =>
       `Needs ${(err as { requiredLength: number }).requiredLength} characters`,
+  };
+
+  unrelatedMessages: TnFormFieldErrorMessages = {
+    somethingElse: 'Never shown',
   };
 }
 
@@ -378,6 +387,37 @@ describe('TnFormField per-field errorMessages', () => {
       TnFormFieldHarness.with({ testId: 'password-field' })
     );
     expect(await field.getErrorMessage()).toBe('Needs 8 characters');
+  });
+
+  it('should fall back to the built-in default when errorMessages has no matching key', async () => {
+    const host = fixture.componentInstance;
+    host.unrelatedControl.markAsTouched();
+    host.unrelatedControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'unrelated-field' })
+    );
+    expect(await field.hasError()).toBe(true);
+    expect(await field.getErrorMessage()).toBe('This field is required');
+  });
+
+  it('should re-resolve the message when errorMessages changes while the error is shown', async () => {
+    const host = fixture.componentInstance;
+    host.nameControl.markAsTouched();
+    host.nameControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'name-field' })
+    );
+    expect(await field.getErrorMessage()).toBe('Please enter a name');
+
+    // Change only the overrides (e.g. a locale switch) — no control status change.
+    host.stringMessages = { required: 'Updated message' };
+    fixture.detectChanges();
+
+    expect(await field.getErrorMessage()).toBe('Updated message');
   });
 });
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -6,6 +6,8 @@ import type { ComponentFixture } from '@angular/core/testing';
 import type { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TnFormFieldComponent } from './form-field.component';
+import { TN_FORM_FIELD_ERRORS } from './form-field.errors';
+import type { TnFormFieldErrorMessages, TnFormFieldErrorResolver } from './form-field.errors';
 import { TnFormFieldHarness } from './form-field.harness';
 import { TnInputComponent } from '../input/input.component';
 
@@ -307,5 +309,141 @@ describe('TnFormFieldHarness', () => {
       expect(await field.hasError()).toBe(true);
       expect(await field.getErrorMessage()).toBe('This field is required');
     });
+  });
+});
+
+@Component({
+  selector: 'tn-error-messages-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-field label="Name" testId="name-field" [errorMessages]="stringMessages">
+      <tn-input [formControl]="nameControl" />
+    </tn-form-field>
+
+    <tn-form-field label="Password" testId="password-field" [errorMessages]="fnMessages">
+      <tn-input [formControl]="passwordControl" />
+    </tn-form-field>
+  `
+})
+class ErrorMessagesHostComponent {
+  nameControl = new FormControl('', Validators.required);
+  passwordControl = new FormControl('', Validators.minLength(8));
+
+  stringMessages: TnFormFieldErrorMessages = {
+    required: 'Please enter a name',
+  };
+
+  fnMessages: TnFormFieldErrorMessages = {
+    minlength: (err) =>
+      `Needs ${(err as { requiredLength: number }).requiredLength} characters`,
+  };
+}
+
+describe('TnFormField per-field errorMessages', () => {
+  let fixture: ComponentFixture<ErrorMessagesHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ErrorMessagesHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ErrorMessagesHostComponent);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should use a per-field string override instead of the built-in default', async () => {
+    const host = fixture.componentInstance;
+    host.nameControl.markAsTouched();
+    host.nameControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'name-field' })
+    );
+    expect(await field.getErrorMessage()).toBe('Please enter a name');
+  });
+
+  it('should use a per-field function override with interpolated error detail', async () => {
+    const host = fixture.componentInstance;
+    host.passwordControl.setValue('short');
+    host.passwordControl.markAsTouched();
+    host.passwordControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'password-field' })
+    );
+    expect(await field.getErrorMessage()).toBe('Needs 8 characters');
+  });
+});
+
+@Component({
+  selector: 'tn-resolver-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-field label="Resolved" testId="resolved-field">
+      <tn-input [formControl]="resolvedControl" />
+    </tn-form-field>
+
+    <tn-form-field label="Overridden" testId="overridden-field" [errorMessages]="overrides">
+      <tn-input [formControl]="overriddenControl" />
+    </tn-form-field>
+  `
+})
+class ResolverHostComponent {
+  resolvedControl = new FormControl('', Validators.required);
+  overriddenControl = new FormControl('', Validators.required);
+
+  overrides: TnFormFieldErrorMessages = {
+    required: 'Field-level wins',
+  };
+}
+
+describe('TnFormField global error resolver', () => {
+  let fixture: ComponentFixture<ResolverHostComponent>;
+  let loader: HarnessLoader;
+
+  const resolver: TnFormFieldErrorResolver = (key) =>
+    key === 'required' ? 'Resolved from token' : null;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResolverHostComponent],
+      providers: [{ provide: TN_FORM_FIELD_ERRORS, useValue: resolver }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResolverHostComponent);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should use the resolver message instead of the built-in default', async () => {
+    const host = fixture.componentInstance;
+    host.resolvedControl.markAsTouched();
+    host.resolvedControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'resolved-field' })
+    );
+    expect(await field.getErrorMessage()).toBe('Resolved from token');
+  });
+
+  it('should let a per-field override take precedence over the resolver', async () => {
+    const host = fixture.componentInstance;
+    host.overriddenControl.markAsTouched();
+    host.overriddenControl.updateValueAndValidity();
+    fixture.detectChanges();
+
+    const field = await loader.getHarness(
+      TnFormFieldHarness.with({ testId: 'overridden-field' })
+    );
+    expect(await field.getErrorMessage()).toBe('Field-level wins');
   });
 });

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -37,7 +37,12 @@ export * from './lib/tab-panel/tab-panel.harness';
 export * from './lib/menu';
 export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
-export * from './lib/form-field/form-field.errors';
+export { TN_FORM_FIELD_ERRORS } from './lib/form-field/form-field.errors';
+export type {
+  TnFormFieldErrorMessage,
+  TnFormFieldErrorMessages,
+  TnFormFieldErrorResolver,
+} from './lib/form-field/form-field.errors';
 export * from './lib/form-field/form-field.harness';
 export * from './lib/select/select.component';
 export * from './lib/select/select.harness';

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -37,6 +37,7 @@ export * from './lib/tab-panel/tab-panel.harness';
 export * from './lib/menu';
 export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
+export * from './lib/form-field/form-field.errors';
 export * from './lib/form-field/form-field.harness';
 export * from './lib/select/select.component';
 export * from './lib/select/select.harness';

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -83,6 +83,10 @@ When used with Angular reactive forms, the form field automatically:
       options: ['above', 'below', 'left', 'right', 'before', 'after'],
       description: 'Placement of the tooltip relative to its help icon.',
     },
+    errorMessages: {
+      control: 'object',
+      description: 'Per-field overrides for validation messages, keyed by error key. Values are a string or a function receiving the error detail. Takes precedence over the app-wide TN_FORM_FIELD_ERRORS resolver and the built-in defaults.',
+    },
   },
 };
 
@@ -202,6 +206,57 @@ export const WithValidation: Story = {
     required: true,
     testId: 'validation-field',
   },
+};
+
+export const CustomErrorMessages: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Override validation messages per field with the `errorMessages` map. ' +
+          'Values may be a string or a function that receives the error detail ' +
+          '(used here for `minlength`). For app-wide wording or i18n, provide a ' +
+          '`TN_FORM_FIELD_ERRORS` resolver instead; per-field entries still win.',
+      },
+    },
+  },
+  render: () => ({
+    props: {
+      usernameControl: new FormControl('', [
+        Validators.required,
+        Validators.minLength(4),
+      ]),
+      errorMessages: {
+        required: 'Pick a username',
+        minlength: (err: { requiredLength: number }) =>
+          `Use at least ${err.requiredLength} characters`,
+      },
+      markAsTouched(this: { usernameControl: FormControl }) {
+        this.usernameControl.markAsTouched();
+        this.usernameControl.updateValueAndValidity();
+      },
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 400px;">
+        <tn-form-field
+          label="Username"
+          [required]="true"
+          [errorMessages]="errorMessages">
+          <tn-input placeholder="Type a short value, then blur" [formControl]="usernameControl" />
+        </tn-form-field>
+
+        <button
+          type="button"
+          (click)="markAsTouched()"
+          style="width: fit-content; padding: 0.5rem 1rem; background: var(--tn-primary); color: white; border: none; border-radius: 0.25rem; cursor: pointer;">
+          Trigger Validation
+        </button>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [TnInputComponent, ReactiveFormsModule],
+    },
+  }),
 };
 
 export const WithSelect: Story = {

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -214,23 +214,31 @@ export const CustomErrorMessages: Story = {
       description: {
         story:
           'Override validation messages per field with the `errorMessages` map. ' +
-          'Values may be a string or a function that receives the error detail ' +
-          '(used here for `minlength`). For app-wide wording or i18n, provide a ' +
-          '`TN_FORM_FIELD_ERRORS` resolver instead; per-field entries still win.',
+          'Edit the `errorMessages` control to see overrides apply — keys that do ' +
+          'not match the active error (e.g. removing `required`) fall back to the ' +
+          'built-in default. Values may also be functions that receive the error ' +
+          'detail (e.g. `minlength: (e) => "At least " + e.requiredLength`); for ' +
+          'app-wide wording or i18n, provide a `TN_FORM_FIELD_ERRORS` resolver ' +
+          'instead, which per-field entries still win over.',
       },
     },
   },
-  render: () => ({
+  args: {
+    label: 'Username',
+    required: true,
+    testId: 'username-field',
+    errorMessages: {
+      required: 'Pick a username',
+      minlength: 'Use at least 4 characters',
+    },
+  },
+  render: (args) => ({
     props: {
+      ...args,
       usernameControl: new FormControl('', [
         Validators.required,
         Validators.minLength(4),
       ]),
-      errorMessages: {
-        required: 'Pick a username',
-        minlength: (err: { requiredLength: number }) =>
-          `Use at least ${err.requiredLength} characters`,
-      },
       markAsTouched(this: { usernameControl: FormControl }) {
         this.usernameControl.markAsTouched();
         this.usernameControl.updateValueAndValidity();
@@ -239,10 +247,11 @@ export const CustomErrorMessages: Story = {
     template: `
       <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 400px;">
         <tn-form-field
-          label="Username"
-          [required]="true"
+          [label]="label"
+          [required]="required"
+          [testId]="testId"
           [errorMessages]="errorMessages">
-          <tn-input placeholder="Type a short value, then blur" [formControl]="usernameControl" />
+          <tn-input placeholder="Type 1-3 chars, then click Trigger" [formControl]="usernameControl" />
         </tn-form-field>
 
         <button
@@ -251,10 +260,18 @@ export const CustomErrorMessages: Story = {
           style="width: fit-content; padding: 0.5rem 1rem; background: var(--tn-primary); color: white; border: none; border-radius: 0.25rem; cursor: pointer;">
           Trigger Validation
         </button>
+
+        <div style="font-size: 1rem; color: var(--tn-fg2);">
+          <strong>Form State:</strong><br>
+          Valid: {{ usernameControl.valid }}<br>
+          Touched: {{ usernameControl.touched }}<br>
+          Value: "{{ usernameControl.value }}"<br>
+          Errors: {{ usernameControl.errors | json }}
+        </div>
       </div>
     `,
     moduleMetadata: {
-      imports: [TnInputComponent, ReactiveFormsModule],
+      imports: [TnInputComponent, ReactiveFormsModule, CommonModule],
     },
   }),
 };


### PR DESCRIPTION
Resolve a control's validation message through a layered precedence so custom validators can show user-friendly text:

  per-field errorMessages -> TN_FORM_FIELD_ERRORS resolver
    -> built-in defaults -> validator-returned string -> raw key

- Add `errorMessages` input: a map of error key -> string | (err) => string, letting each field reword (and interpolate) any validator's message.
- Add the TN_FORM_FIELD_ERRORS injection token for an app-wide resolver, the recommended hook for wiring a translation service.
- Extract message logic (defaults, active-key priority) into form-field.errors.ts and export the token/types from public-api.