### PR TITLE
NAS-141244 / 27.0.0-BETA.1 / fix(autocomplete): truncated large lists

### DIFF
--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -13,6 +13,7 @@
     [attr.aria-expanded]="isOpen()"
     [attr.aria-autocomplete]="'list'"
     [attr.aria-controls]="isOpen() ? uid + '-dropdown' : null"
+    [attr.aria-owns]="isOpen() ? uid + '-dropdown' : null"
     [attr.aria-activedescendant]="highlightedIndex() >= 0 ? uid + '-option-' + highlightedIndex() : null"
     (input)="onInput($event)"
     (focus)="onFocus()"

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -18,33 +18,37 @@
     (focus)="onFocus()"
     (blur)="onBlur()"
     (keydown)="onKeydown($event)" />
+</div>
 
-  @if (isOpen()) {
-    <div
-      class="tn-autocomplete__dropdown"
-      role="listbox"
-      [attr.id]="uid + '-dropdown'">
+<!-- Dropdown panel — portaled via CDK Overlay so it escapes parent
+     overflow/clipping. Attach/detach (driven by open()/close()) controls
+     visibility; the input keeps DOM focus throughout. -->
+<ng-template #dropdownTemplate>
+  <div
+    class="tn-autocomplete__dropdown"
+    role="listbox"
+    [style.--tn-autocomplete-panel-max-height]="panelMaxHeightValue()"
+    [attr.id]="uid + '-dropdown'">
 
-      @if (hasResults()) {
-        @for (option of filteredOptions(); track $index) {
-          <div
-            class="tn-autocomplete__option"
-            role="option"
-            tabindex="-1"
-            [class.highlighted]="highlightedIndex() === $index"
-            [attr.id]="uid + '-option-' + $index"
-            [attr.aria-selected]="highlightedIndex() === $index"
-            (mousedown)="$event.preventDefault()"
-            (click)="onOptionClick(option)"
-            (keydown.enter)="onOptionClick(option)">
-            {{ displayWith()(option) }}
-          </div>
-        }
-      } @else {
-        <div class="tn-autocomplete__no-results">
-          {{ noResultsText() }}
+    @if (hasResults()) {
+      @for (option of filteredOptions(); track $index) {
+        <div
+          class="tn-autocomplete__option"
+          role="option"
+          tabindex="-1"
+          [class.highlighted]="highlightedIndex() === $index"
+          [attr.id]="uid + '-option-' + $index"
+          [attr.aria-selected]="highlightedIndex() === $index"
+          (mousedown)="$event.preventDefault()"
+          (click)="onOptionClick(option)"
+          (keydown.enter)="onOptionClick(option)">
+          {{ displayWith()(option) }}
         </div>
       }
-    </div>
-  }
-</div>
+    } @else {
+      <div class="tn-autocomplete__no-results">
+        {{ noResultsText() }}
+      </div>
+    }
+  </div>
+</ng-template>

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -42,17 +42,17 @@
 }
 
 .tn-autocomplete__dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  margin-top: 0.25rem;
+  // No position / top / left here on purpose: the panel is rendered inside a
+  // CDK overlay pane that handles positioning (offset, width-match, viewport
+  // flip). Adding `position: absolute` collapses the pane and the panel never
+  // becomes visible.
   background-color: var(--tn-bg2, #f5f5f5);
   border: 1px solid var(--tn-lines, #d1d5db);
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  max-height: 200px;
+  // Default mirrors the `panelMaxHeight` input default; the bound custom
+  // property overrides it when a caller sets the input.
+  max-height: var(--tn-autocomplete-panel-max-height, 320px);
   overflow-y: auto;
   padding: 0.25rem 0;
 }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -1,3 +1,4 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
@@ -50,18 +51,22 @@ class TestHostComponent {
 describe('TnAutocompleteComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
+  let overlayContainer: OverlayContainer;
+  let overlayEl: HTMLElement;
 
   const getInput = (): HTMLInputElement =>
     fixture.nativeElement.querySelector('.tn-autocomplete__input');
 
+  // The dropdown panel is portaled into the CDK overlay container (on
+  // document.body), not the component host, so all panel queries go there.
   const getDropdown = (): HTMLElement | null =>
-    fixture.nativeElement.querySelector('.tn-autocomplete__dropdown');
+    overlayEl.querySelector('.tn-autocomplete__dropdown');
 
   const getOptions = (): HTMLElement[] =>
-    Array.from(fixture.nativeElement.querySelectorAll('.tn-autocomplete__option'));
+    Array.from(overlayEl.querySelectorAll('.tn-autocomplete__option'));
 
   const getHighlighted = (): HTMLElement | null =>
-    fixture.nativeElement.querySelector('.tn-autocomplete__option.highlighted');
+    overlayEl.querySelector('.tn-autocomplete__option.highlighted');
 
   const typeInInput = (value: string) => {
     const input = getInput();
@@ -87,7 +92,14 @@ describe('TnAutocompleteComponent', () => {
 
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayEl = overlayContainer.getContainerElement();
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // Dispose any overlay left attached so panels don't leak between specs.
+    overlayContainer.ngOnDestroy();
   });
 
   describe('dropdown visibility', () => {
@@ -141,7 +153,7 @@ describe('TnAutocompleteComponent', () => {
 
     it('should show no-results message when nothing matches', () => {
       typeInInput('xyz');
-      const noResults = fixture.nativeElement.querySelector('.tn-autocomplete__no-results');
+      const noResults = overlayEl.querySelector('.tn-autocomplete__no-results');
       expect(noResults).toBeTruthy();
       expect(noResults.textContent?.trim()).toBe('No results found');
     });

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -1,8 +1,10 @@
+import { Overlay, type OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
 import {
   Component,
   ElementRef,
+  ViewContainerRef,
   computed,
-  effect,
   forwardRef,
   inject,
   input,
@@ -10,8 +12,10 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import type { OnDestroy, TemplateRef } from '@angular/core';
 import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import type { Subscription } from 'rxjs';
 import { TnTestIdDirective } from '../test-id';
 
 let nextId = 0;
@@ -30,8 +34,10 @@ let nextId = 0;
   templateUrl: './autocomplete.component.html',
   styleUrl: './autocomplete.component.scss',
 })
-export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor {
+export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor, OnDestroy {
   private readonly elementRef = inject(ElementRef);
+  private readonly overlay = inject(Overlay);
+  private readonly viewContainerRef = inject(ViewContainerRef);
 
   /** Unique instance ID for ARIA linkage */
   protected readonly uid = `tn-autocomplete-${nextId++}`;
@@ -57,8 +63,22 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** Text shown when no options match the search */
   noResultsText = input<string>('No results found');
 
-  /** Maximum number of options to render */
-  maxResults = input<number>(100);
+  /**
+   * Maximum number of options to render.
+   *
+   * Defaults to `Infinity` so browsing the open dropdown without a search term
+   * never silently truncates a long list. Pass an explicit cap if you want to
+   * limit how many filtered results are rendered at once.
+   */
+  maxResults = input<number>(Infinity);
+
+  /**
+   * Max height of the dropdown panel before it scrolls. Accepts a number
+   * (interpreted as `px`) or any CSS length string (e.g. `'320px'`,
+   * `'min(320px, 40vh)'`). Surfaced as the `--tn-autocomplete-panel-max-height`
+   * custom property so it can also be themed in CSS.
+   */
+  panelMaxHeight = input<string | number>('320px');
 
   /** Test ID attribute */
   testId = input<string>('');
@@ -68,6 +88,15 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
   /** Reference to the input element */
   inputEl = viewChild<ElementRef<HTMLInputElement>>('inputEl');
+
+  /** Template for the dropdown panel, portaled into a CDK overlay on open. */
+  private dropdownTemplate = viewChild.required<TemplateRef<unknown>>('dropdownTemplate');
+
+  /** Normalized panel max-height as a CSS length string. */
+  protected panelMaxHeightValue = computed(() => {
+    const value = this.panelMaxHeight();
+    return typeof value === 'number' ? `${value}px` : value;
+  });
 
   /** Current search term typed by the user */
   protected searchTerm = signal('');
@@ -113,26 +142,15 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   private onChange = (_value: T | null) => {};
   private onTouched = () => {};
 
-  constructor() {
-    // Click-outside detection
-    effect(() => {
-      if (this.isOpen()) {
-        const listener = (event: Event) => {
-          if (!this.elementRef.nativeElement.contains(event.target as Node)) {
-            this.close();
-          }
-        };
+  /** Live overlay holding the dropdown panel, or undefined when closed. */
+  private overlayRef?: OverlayRef;
+  /** Subscriptions tied to the current overlay; torn down on close. */
+  private overlaySubs: Subscription[] = [];
 
-        setTimeout(() => {
-          document.addEventListener('click', listener);
-        }, 0);
-
-        return () => {
-          document.removeEventListener('click', listener);
-        };
-      }
-      return undefined;
-    });
+  ngOnDestroy(): void {
+    // If the component is destroyed while the dropdown is open (e.g. router
+    // navigates away), close() never runs — clean up the overlay directly.
+    this.detachOverlay();
   }
 
   // ── ControlValueAccessor ──
@@ -166,13 +184,17 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     this.highlightedIndex.set(-1);
 
     if (!this.isOpen()) {
-      this.isOpen.set(true);
+      this.open();
+    } else {
+      // Filtering changes the panel's height; nudge CDK to re-evaluate the
+      // anchored position so it stays attached to the input.
+      this.overlayRef?.updatePosition();
     }
   }
 
   onFocus(): void {
     if (!this.isDisabled()) {
-      this.isOpen.set(true);
+      this.open();
     }
   }
 
@@ -213,7 +235,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       case 'ArrowDown':
         event.preventDefault();
         if (!this.isOpen()) {
-          this.isOpen.set(true);
+          this.open();
         } else {
           this.highlightedIndex.update((i) =>
             i < options.length - 1 ? i + 1 : 0
@@ -257,17 +279,79 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     this.close();
   }
 
+  private open(): void {
+    if (this.isDisabled() || this.isOpen()) {
+      return;
+    }
+    this.isOpen.set(true);
+    this.attachOverlay();
+  }
+
   private close(): void {
     this.isOpen.set(false);
     this.highlightedIndex.set(-1);
+    this.detachOverlay();
+  }
+
+  /**
+   * Attach the dropdown panel as a CDK overlay anchored to the input.
+   *
+   * Why an overlay (vs. an inline absolutely-positioned panel): the panel is
+   * appended to the overlay container on `document.body`, so it can never be
+   * clipped by an ancestor's `overflow: hidden`/`auto` (e.g. a surrounding
+   * card). CDK also flips the panel above the input near the viewport edge and
+   * matches its width to the input. Mirrors TnSelectComponent's approach.
+   */
+  private attachOverlay(): void {
+    const anchor = this.inputEl()?.nativeElement;
+    if (!anchor) {
+      return;
+    }
+
+    const positionStrategy = this.overlay
+      .position()
+      .flexibleConnectedTo(anchor)
+      .withPositions([
+        { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
+        { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -4 },
+      ]);
+
+    this.overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      hasBackdrop: false,
+      width: anchor.offsetWidth,
+    });
+
+    this.overlayRef.attach(new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef));
+
+    // Non-intercepting click-outside: the pointer event still reaches whatever
+    // the user clicked; we just notice and close. Ignore targets inside the
+    // host (the input itself) so we don't fight the focus/typing handlers.
+    this.overlaySubs.push(
+      this.overlayRef.outsidePointerEvents().subscribe((event: MouseEvent) => {
+        const target = event.target as Node | null;
+        if (target && this.elementRef.nativeElement.contains(target)) {
+          return;
+        }
+        this.close();
+      })
+    );
+  }
+
+  private detachOverlay(): void {
+    this.overlaySubs.forEach((sub) => sub.unsubscribe());
+    this.overlaySubs = [];
+    this.overlayRef?.dispose();
+    this.overlayRef = undefined;
   }
 
   private scrollToHighlighted(): void {
     const idx = this.highlightedIndex();
-    const dropdown = this.elementRef.nativeElement.querySelector(
-      '.tn-autocomplete__dropdown'
-    );
-    const options = dropdown?.querySelectorAll('.tn-autocomplete__option');
+    // The panel lives in the CDK overlay (outside the host), so scope the query
+    // to the overlay element rather than the host element.
+    const overlayEl = this.overlayRef?.overlayElement;
+    const options = overlayEl?.querySelectorAll<HTMLElement>('.tn-autocomplete__option');
     if (options?.[idx]?.scrollIntoView) {
       options[idx].scrollIntoView({ block: 'nearest' });
     }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.harness.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.harness.ts
@@ -119,8 +119,11 @@ export class TnAutocompleteHarness extends ComponentHarness {
    * ```
    */
   async isOpen(): Promise<boolean> {
-    const dropdown = await this.locatorForOptional('.tn-autocomplete__dropdown')();
-    return dropdown !== null;
+    // The dropdown panel is rendered in a CDK overlay (outside the host), so we
+    // read the open state from the `.open` class the input carries while the
+    // panel is attached rather than looking for the panel in the host subtree.
+    const input = await this._input();
+    return input.hasClass('open');
   }
 
   /**
@@ -154,7 +157,9 @@ export class TnAutocompleteHarness extends ComponentHarness {
    * ```
    */
   async getOptions(): Promise<string[]> {
-    const options = await this.locatorForAll('.tn-autocomplete__option')();
+    // Options render inside a CDK overlay (outside the host element), so search
+    // the document root rather than the harness-local subtree.
+    const options = await this.documentRootLocatorFactory().locatorForAll('.tn-autocomplete__option')();
     const labels: string[] = [];
     for (const option of options) {
       labels.push((await option.text()).trim());
@@ -184,7 +189,9 @@ export class TnAutocompleteHarness extends ComponentHarness {
     const input = await this._input();
     await input.focus();
 
-    const options = await this.locatorForAll('.tn-autocomplete__option')();
+    // Options render inside a CDK overlay (outside the host element), so search
+    // the document root rather than the harness-local subtree.
+    const options = await this.documentRootLocatorFactory().locatorForAll('.tn-autocomplete__option')();
     for (const option of options) {
       const text = (await option.text()).trim();
       const matches = filter instanceof RegExp ? filter.test(text) : text === filter;

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   border-radius: 8px;
   transition: box-shadow 0.3s ease;
+  overflow: hidden;
 
   &--elevation-none {
     box-shadow: none;

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -4,7 +4,10 @@
   flex-direction: column;
   border-radius: 8px;
   transition: box-shadow 0.3s ease;
-  overflow: hidden;
+  // `clip` (not `hidden`) still enforces border-radius clipping of visual
+  // overflow, but doesn't create a scroll container — so absolutely-positioned
+  // descendants and CDK-overlay anchors aren't trapped inside the card.
+  overflow: clip;
 
   &--elevation-none {
     box-shadow: none;

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -4,10 +4,6 @@
   flex-direction: column;
   border-radius: 8px;
   transition: box-shadow 0.3s ease;
-  // `clip` (not `hidden`) still enforces border-radius clipping of visual
-  // overflow, but doesn't create a scroll container — so absolutely-positioned
-  // descendants and CDK-overlay anchors aren't trapped inside the card.
-  overflow: clip;
 
   &--elevation-none {
     box-shadow: none;

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -36,6 +36,11 @@ const simpleOptions = [
   'Mango', 'Nectarine', 'Orange', 'Papaya', 'Quince',
 ];
 
+const manyOptions = Array.from(
+  { length: 150 },
+  (_, i) => `Option ${String(i + 1).padStart(3, '0')}`
+);
+
 const meta: Meta<TnAutocompleteComponent<unknown>> = {
   title: 'Components/Autocomplete',
   component: TnAutocompleteComponent,
@@ -246,6 +251,32 @@ export const MaxResults: Story = {
       imports: [TnFormFieldComponent],
     },
   }),
+};
+
+export const LongList: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      options: manyOptions,
+    },
+    template: `
+      <tn-form-field
+        label="Item (150 options)"
+        hint="Open without typing — every option renders and the panel scrolls">
+        <tn-autocomplete
+          [options]="options"
+          [placeholder]="placeholder"
+          (optionSelected)="optionSelected($event)">
+        </tn-autocomplete>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  args: {
+    placeholder: 'Type or scroll through 150 options...',
+  },
 };
 
 export const ComponentHarness: Story = {

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -67,7 +67,12 @@ const meta: Meta<TnAutocompleteComponent<unknown>> = {
     },
     maxResults: {
       control: 'number',
-      description: 'Maximum number of options to render',
+      description: 'Maximum number of options to render (defaults to Infinity)',
+    },
+    panelMaxHeight: {
+      control: 'text',
+      description:
+        'Max height of the dropdown panel before it scrolls (number = px, or any CSS length)',
     },
     optionSelected: { action: 'optionSelected' },
   },


### PR DESCRIPTION
fix an issue where very long autocomplete lists (i.e. the countries dropdown on the TNC UI) clipped off their containing component and didn't show all options.

| <img width="482" height="403" alt="image" src="https://github.com/user-attachments/assets/11843a5d-7366-480b-ac8a-499891d246dd" /> |
| :---: |
| example of the dropdown functioning on the TNC UI |
