### PR TITLE
NAS-141311 / 27.0.0-BETA.1 / fix(card): make header/footer dividers visible in dark mode

### DIFF
--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -85,10 +85,6 @@
   justify-content: space-between;
   gap: 16px;
   border-bottom: 1px solid var(--tn-lines, #e5e7eb);
-
-  .tn-card:not(.tn-card--bordered) & {
-    border-bottom-color: rgba(0, 0, 0, 0.1);
-  }
 }
 
 .tn-card__header-left {
@@ -180,10 +176,6 @@
 
   .tn-card--padding-large & {
     padding: 24px 32px;
-  }
-
-  .tn-card:not(.tn-card--bordered) & {
-    border-top-color: rgba(0, 0, 0, 0.1);
   }
 }
 


### PR DESCRIPTION
Non-bordered cards overrode the divider color with hardcoded rgba(0, 0, 0, 0.1), which is invisible against dark card backgrounds. Removed the overrides so dividers fall back to the theme-aware var(--tn-lines), keeping them visible across all themes.