### PR TITLE
NAS-141314 / 27.0.0-BETA.1 / fix(test-id): accept TnTestIdValue across components and add icon test-id support

### DIFF
--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -16,7 +16,7 @@ import type { OnDestroy, TemplateRef } from '@angular/core';
 import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { Subscription } from 'rxjs';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 let nextId = 0;
 
@@ -81,7 +81,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   panelMaxHeight = input<string | number>('320px');
 
   /** Test ID attribute */
-  testId = input<string>('');
+  testId = input<TnTestIdValue>(undefined);
 
   /** Emits when an option is selected */
   optionSelected = output<T>();

--- a/projects/truenas-ui/src/lib/date-range-input/date-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-input.component.ts
@@ -11,7 +11,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { TnCalendarComponent } from '../calendar/calendar.component';
 import { TnInputDirective } from '../input/input.directive';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 @Component({
   selector: 'tn-date-input',
@@ -43,7 +43,7 @@ export class TnDateInputComponent implements ControlValueAccessor, OnInit, OnDes
    * Test-id applied to the date-input container. Rendered under whichever attribute name
    * is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
 
   private formDisabled = signal<boolean>(false);
   isDisabled = computed(() => this.disabled() || this.formDisabled());

--- a/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.ts
@@ -9,7 +9,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { TnCalendarComponent } from '../calendar/calendar.component';
 import { TnInputDirective } from '../input/input.directive';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 export interface DateRange {
   start: Date | null;
@@ -40,7 +40,7 @@ export class TnDateRangeInputComponent implements ControlValueAccessor, OnInit, 
    * Test-id applied to the date-range-input container. Rendered under whichever attribute name
    * is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
 
   private formDisabled = signal<boolean>(false);
   isDisabled = computed(() => this.disabled() || this.formDisabled());

--- a/projects/truenas-ui/src/lib/date-range-input/time-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/time-input.component.ts
@@ -4,6 +4,7 @@ import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR, FormsModule } from '@angular/forms';
 import type { TnSelectOption } from '../select/select.component';
 import { TnSelectComponent } from '../select/select.component';
+import type { TnTestIdValue } from '../test-id';
 
 @Component({
   selector: 'tn-time-input',
@@ -27,7 +28,7 @@ export class TnTimeInputComponent implements ControlValueAccessor {
   format = input<'12h' | '24h'>('12h');
   granularity = input<'15m' | '30m' | '1h'>('15m');
   placeholder = input<string>('Pick a time');
-  testId = input<string>('');
+  testId = input<TnTestIdValue>(undefined);
 
   private formDisabled = signal<boolean>(false);
   isDisabled = computed(() => this.disabled() || this.formDisabled());

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.html
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.html
@@ -5,13 +5,13 @@
       type="button"
       class="tn-dialog__fullscreen"
       tnTestIdType="button"
-      [tnTestId]="[testId(), 'fullscreen']"
+      [tnTestId]="fullscreenTestId()"
       [attr.aria-label]="isFullscreen() ? 'Exit fullscreen' : 'Enter fullscreen'"
       (click)="toggleFullscreen()">
       <span class="tn-dialog__fullscreen-icon" aria-hidden="true">{{ isFullscreen() ? '⤓' : '⤢' }}</span>
     </button>
   }
-  <button type="button" class="tn-dialog__close" aria-label="Close dialog" tnTestIdType="button" [tnTestId]="[testId(), 'close']" (click)="close()">
+  <button type="button" class="tn-dialog__close" aria-label="Close dialog" tnTestIdType="button" [tnTestId]="closeTestId()" (click)="close()">
     <span class="tn-dialog__close-icon" aria-hidden="true">✕</span>
   </button>
 </header>

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -2,7 +2,7 @@ import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { DOCUMENT } from '@angular/common';
 import { Component, ElementRef, computed, effect, input, signal, inject } from '@angular/core';
 import type { OnInit} from '@angular/core';
-import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { TnTestIdDirective, scopeTestId, type TnTestIdValue } from '../test-id';
 
 let nextUniqueId = 0;
 
@@ -26,16 +26,10 @@ export class TnDialogShellComponent implements OnInit {
    */
   testId = input<TnTestIdValue>(undefined);
 
-  /** Base segments (a single token or array), flattened so a per-button suffix can be appended. */
-  private testIdSegments = computed(() => {
-    const base = this.testId();
-    return Array.isArray(base) ? base : [base];
-  });
-
   /** Scoped test-id segments for the close button (`button-[<base>-]close`). */
-  protected closeTestId = computed(() => [...this.testIdSegments(), 'close']);
+  protected closeTestId = computed(() => scopeTestId(this.testId(), 'close'));
   /** Scoped test-id segments for the fullscreen button (`button-[<base>-]fullscreen`). */
-  protected fullscreenTestId = computed(() => [...this.testIdSegments(), 'fullscreen']);
+  protected fullscreenTestId = computed(() => scopeTestId(this.testId(), 'fullscreen'));
 
   /** Stable id for the title heading, referenced by the dialog's aria-labelledby. */
   readonly titleId = `tn-dialog-title-${nextUniqueId++}`;

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -1,8 +1,8 @@
 import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { DOCUMENT } from '@angular/common';
-import { Component, ElementRef, effect, input, signal, inject } from '@angular/core';
+import { Component, ElementRef, computed, effect, input, signal, inject } from '@angular/core';
 import type { OnInit} from '@angular/core';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 let nextUniqueId = 0;
 
@@ -24,7 +24,18 @@ export class TnDialogShellComponent implements OnInit {
    * or `button-<testId>-close` / `-fullscreen` when a base is provided (useful
    * when more than one dialog can be open).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
+
+  /** Base segments (a single token or array), flattened so a per-button suffix can be appended. */
+  private testIdSegments = computed(() => {
+    const base = this.testId();
+    return Array.isArray(base) ? base : [base];
+  });
+
+  /** Scoped test-id segments for the close button (`button-[<base>-]close`). */
+  protected closeTestId = computed(() => [...this.testIdSegments(), 'close']);
+  /** Scoped test-id segments for the fullscreen button (`button-[<base>-]fullscreen`). */
+  protected fullscreenTestId = computed(() => [...this.testIdSegments(), 'fullscreen']);
 
   /** Stable id for the title heading, referenced by the dialog's aria-labelledby. */
   readonly titleId = `tn-dialog-title-${nextUniqueId++}`;

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -12,7 +12,7 @@ import type { CreateFolderEvent, FilePickerCallbacks, FilePickerError, FilePicke
 import { TnIconComponent } from '../icon/icon.component';
 import { TnInputDirective } from '../input/input.directive';
 import { StripMntPrefixPipe } from '../pipes/strip-mnt-prefix/strip-mnt-prefix.pipe';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 @Component({
   selector: 'tn-file-picker',
@@ -54,7 +54,7 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
    * Test-id applied to the file-picker container. Rendered under whichever attribute name
    * is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
   startPath = input<string>('/mnt');
   rootPath = input<string | undefined>(undefined);
   fileExtensions = input<string[] | undefined>(undefined);

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -20,7 +20,7 @@ export class TnFormFieldComponent implements AfterContentInit {
   label = input<string>('');
   hint = input<string>('');
   required = input<boolean>(false);
-  testId = input<TnTestIdValue>('');
+  testId = input<TnTestIdValue>(undefined);
   subscriptSizing = input<SubscriptSizing>('dynamic');
 
   /** Optional tooltip shown via a help icon next to the label. */

--- a/projects/truenas-ui/src/lib/icon/icon.component.html
+++ b/projects/truenas-ui/src/lib/icon/icon.component.html
@@ -1,6 +1,8 @@
 <div
   class="tn-icon"
   role="img"
+  tnTestIdType="icon"
+  [tnTestId]="testId()"
   [attr.aria-label]="effectiveAriaLabel()"
   [attr.title]="tooltip()">
   

--- a/projects/truenas-ui/src/lib/icon/icon.component.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.ts
@@ -1,6 +1,7 @@
 import type { ElementRef } from '@angular/core';
 import { Component, input, computed, effect, signal, ChangeDetectionStrategy, ViewEncapsulation, inject, viewChild, isDevMode } from '@angular/core';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 import { TnIconRegistryService } from './icon-registry.service';
 
 export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -16,6 +17,7 @@ export interface IconResult {
 @Component({
   selector: 'tn-icon',
   standalone: true,
+  imports: [TnTestIdDirective],
   templateUrl: './icon.component.html',
   styleUrl: './icon.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,6 +44,15 @@ export class TnIconComponent {
   tooltip = input<string | undefined>(undefined);
   ariaLabel = input<string | undefined>(undefined);
   library = input<IconLibraryType | undefined>(undefined);
+
+  /**
+   * Semantic test-id base for the icon. The library prepends the element type
+   * (`icon`) and renders the result under whichever attribute name is configured
+   * via `TN_TEST_ATTR` (default `data-testid`) — e.g. `testId="close"` →
+   * `icon-close`. Accepts an array of segments to scope the id (e.g.
+   * `['tooltip', header()]`). Unset emits no attribute.
+   */
+  testId = input<TnTestIdValue>(undefined);
 
   /**
    * When true, the icon will expand to fill its container (100% width and height)

--- a/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.spec.ts
@@ -20,6 +20,7 @@ import { TnIconHarness } from './icon.harness';
     [color]="color()"
     [fullSize]="fullSize()"
     [customSize]="customSize()"
+    [testId]="testId()"
     (click)="onIconClick()"
   />`
 })
@@ -31,6 +32,7 @@ class TestHostComponent {
   color = signal<string | undefined>(undefined);
   fullSize = signal(false);
   customSize = signal<string | undefined>(undefined);
+  testId = signal<string | string[] | undefined>(undefined);
   clickCount = 0;
 
   onIconClick(): void {
@@ -88,6 +90,37 @@ describe('TnIconHarness', () => {
       fixture.detectChanges();
 
       expect(await icon.getName()).toBe('star');
+    });
+  });
+
+  describe('getTestId', () => {
+    it('should return null when testId is not set', async () => {
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getTestId()).toBeNull();
+    });
+
+    it('should compose the icon element-type prefix', async () => {
+      hostComponent.testId.set('close');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getTestId()).toBe('icon-close');
+    });
+
+    it('should scope a composed id from array segments', async () => {
+      hostComponent.testId.set(['tooltip', 'My Header']);
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness);
+      expect(await icon.getTestId()).toBe('icon-tooltip-my-header');
+    });
+
+    it('should filter icons by testId', async () => {
+      hostComponent.testId.set('close');
+      fixture.detectChanges();
+
+      const icon = await loader.getHarness(TnIconHarness.with({ testId: 'icon-close' }));
+      expect(icon).toBeTruthy();
     });
   });
 

--- a/projects/truenas-ui/src/lib/icon/icon.harness.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.harness.ts
@@ -79,8 +79,13 @@ export class TnIconHarness extends ComponentHarness {
       })
       .addOption('customSize', options.customSize, async (harness, customSize) => {
         return (await harness.getCustomSize()) === customSize;
+      })
+      .addOption('testId', options.testId, async (harness, testId) => {
+        return (await harness.getTestId()) === testId;
       });
   }
+
+  private root = this.locatorFor('.tn-icon');
 
   /**
    * Gets the icon name.
@@ -217,6 +222,22 @@ export class TnIconHarness extends ComponentHarness {
     const host = await this.host();
     return host.click();
   }
+
+  /**
+   * Gets the composed test-id attribute value (e.g. `icon-close`).
+   *
+   * @returns Promise resolving to the test-id string, or null when unset.
+   *
+   * @example
+   * ```typescript
+   * const icon = await loader.getHarness(TnIconHarness);
+   * expect(await icon.getTestId()).toBe('icon-close');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const root = await this.root();
+    return (await root.getAttribute('data-testid')) ?? (await root.getAttribute('data-test'));
+  }
 }
 
 /**
@@ -233,4 +254,6 @@ export interface IconHarnessFilters extends BaseHarnessFilters {
   fullSize?: boolean;
   /** Filters by custom size value. */
   customSize?: string;
+  /** Filters by composed test-id value (e.g. `icon-close`). */
+  testId?: string;
 }

--- a/projects/truenas-ui/src/lib/menu/menu-item.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-item.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import type { TemplateRef } from '@angular/core';
 import { Component, computed, input, output, viewChild } from '@angular/core';
+import type { TnTestIdValue } from '../test-id';
 
 /**
  * Projection-based menu item for use inside `<tn-menu>`.
@@ -62,7 +63,12 @@ export class TnMenuItemComponent {
   shortcut = input<string | undefined>(undefined);
   disabled = input<boolean>(false);
   selected = input<boolean>(false);
-  testId = input<string | undefined>(undefined);
+  /**
+   * Semantic test-id base. Accepts a single token or an array of segments
+   * (e.g. `['format', format]`) to scope dynamic/repeated items. The owning
+   * `<tn-menu-panel>` prepends the `button` element type.
+   */
+  testId = input<TnTestIdValue>(undefined);
 
   itemClick = output<MouseEvent>();
 

--- a/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
@@ -2,7 +2,7 @@ import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, forwardRef, inject, input } from '@angular/core';
 import { TnIconComponent } from '../icon/icon.component';
-import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { TnTestIdDirective, scopeTestId, type TnTestIdValue } from '../test-id';
 import { TnMenuActivateHoverDirective } from './menu-activate-hover.directive';
 import type { TnMenuItemComponent } from './menu-item.component';
 import type { TnMenuItem } from './menu.component';
@@ -83,8 +83,7 @@ export class TnMenuPanelComponent {
    * child items share the root base. With no menu base this is `button-${item.id}`.
    */
   protected resolvedItemTestId(item: TnMenuItem): TnTestIdValue {
-    const base = this.menu.testId();
-    return item.testId ?? [...(Array.isArray(base) ? base : [base]), item.id];
+    return item.testId ?? scopeTestId(this.menu.testId(), item.id);
   }
 
   protected onItemClick(item: TnMenuItem): void {

--- a/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
@@ -83,7 +83,8 @@ export class TnMenuPanelComponent {
    * child items share the root base. With no menu base this is `button-${item.id}`.
    */
   protected resolvedItemTestId(item: TnMenuItem): TnTestIdValue {
-    return item.testId ?? [this.menu.testId(), item.id];
+    const base = this.menu.testId();
+    return item.testId ?? [...(Array.isArray(base) ? base : [base]), item.id];
   }
 
   protected onItemClick(item: TnMenuItem): void {

--- a/projects/truenas-ui/src/lib/menu/menu.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.ts
@@ -3,6 +3,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import type { OnDestroy, TemplateRef } from '@angular/core';
 import { Component, contentChildren, input, output, viewChild, computed, inject, ViewContainerRef } from '@angular/core';
 import type { Subscription } from 'rxjs';
+import type { TnTestIdValue } from '../test-id';
 import { TnMenuItemComponent } from './menu-item.component';
 import { TnMenuPanelComponent } from './menu-panel.component';
 
@@ -14,7 +15,7 @@ export { TnMenuActivateHoverDirective } from './menu-activate-hover.directive';
 export interface TnMenuItem {
   id: string;
   label: string;
-  testId?: string;
+  testId?: TnTestIdValue;
   icon?: string;
   iconLibrary?: 'material' | 'mdi' | 'custom' | 'lucide';
   disabled?: boolean;
@@ -50,7 +51,7 @@ export class TnMenuComponent implements OnDestroy {
    * composed with the same `button-` prefix (idempotently, so an already
    * `button-`-prefixed value is not doubled).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
 
   menuItemClick = output<TnMenuItem>();
   menuOpen = output<void>();

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -7,7 +7,7 @@ import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { Subscription } from 'rxjs';
 import { TnCheckboxComponent } from '../checkbox/checkbox.component';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, composeTestId, type TnTestIdValue } from '../test-id';
 
 export interface TnSelectOption<T = unknown> {
   value: T;
@@ -54,7 +54,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    */
   noOptionsLabel = input<string>('No options available');
   disabled = input<boolean>(false);
-  testId = input<string>('');
+  testId = input<TnTestIdValue>(undefined);
   multiple = input<boolean>(false);
 
   /**
@@ -109,7 +109,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * specific instances; otherwise falls back to a per-instance counter so two
    * `<tn-select>`s on the same page never collide on `aria-controls`/group ids.
    */
-  protected idNamespace = computed(() => this.testId() || this.instanceId);
+  protected idNamespace = computed(() => composeTestId(undefined, this.testId()) || this.instanceId);
 
   // Computed disabled state (combines input and form state)
   isDisabled = computed(() => this.disabled() || this.formDisabled());
@@ -178,7 +178,8 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     } else {
       key = option.label;
     }
-    return [this.testId(), key];
+    const base = this.testId();
+    return [...(Array.isArray(base) ? base : [base]), key];
   }
 
   private onChange = (_value: T | T[] | null) => {};

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -7,7 +7,7 @@ import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { Subscription } from 'rxjs';
 import { TnCheckboxComponent } from '../checkbox/checkbox.component';
-import { TnTestIdDirective, composeTestId, type TnTestIdValue } from '../test-id';
+import { TnTestIdDirective, composeTestId, scopeTestId, type TnTestIdValue } from '../test-id';
 
 export interface TnSelectOption<T = unknown> {
   value: T;
@@ -178,8 +178,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     } else {
       key = option.label;
     }
-    const base = this.testId();
-    return [...(Array.isArray(base) ? base : [base]), key];
+    return scopeTestId(this.testId(), key);
   }
 
   private onChange = (_value: T | T[] | null) => {};

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -11,7 +11,7 @@ import { take } from 'rxjs';
 import type { Observable } from 'rxjs';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 /**
  * Directive to mark an element as a side-panel footer action.
@@ -86,7 +86,7 @@ export class TnSidePanelComponent implements OnDestroy {
    * Test-id applied to the panel's root overlay element. Rendered under whichever attribute
    * name is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
-  testId = input<string | undefined>(undefined);
+  testId = input<TnTestIdValue>(undefined);
   /**
    * Test-id applied to the panel's close (×) button.
    */

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -18,7 +18,7 @@ import { FormsModule } from '@angular/forms';
 import type { Observable, Subscription } from 'rxjs';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnSelectComponent, type TnSelectOption } from '../select/select.component';
-import { TnTestIdDirective } from '../test-id';
+import { TnTestIdDirective, scopeTestId } from '../test-id';
 
 /**
  * Default labels rendered inside `tn-table-pager`. Consumers can override any
@@ -162,10 +162,9 @@ export class TnTablePagerComponent {
    * `TnTestIdValue` testId.
    */
   protected childTestId(suffix: string): string {
-    const base = this.testIdDirective.testId();
-    const parts = (Array.isArray(base) ? base : [base])
-      .filter((part): part is string | number => part !== null && part !== undefined && part !== '');
-    return [...parts, suffix].join('-');
+    return scopeTestId(this.testIdDirective.testId(), suffix)
+      .filter((part): part is string | number => part !== null && part !== undefined && part !== '')
+      .join('-');
   }
 
   /**

--- a/projects/truenas-ui/src/lib/test-id/compose-test-id.spec.ts
+++ b/projects/truenas-ui/src/lib/test-id/compose-test-id.spec.ts
@@ -1,4 +1,4 @@
-import { composeTestId, kebabTestSegment } from './compose-test-id';
+import { composeTestId, kebabTestSegment, scopeTestId } from './compose-test-id';
 
 describe('kebabTestSegment', () => {
   it.each([
@@ -12,6 +12,29 @@ describe('kebabTestSegment', () => {
     [42, '42'],
   ])('normalizes %p to %p', (input, expected) => {
     expect(kebabTestSegment(input)).toBe(expected);
+  });
+});
+
+describe('scopeTestId', () => {
+  it('flattens a single-token base and appends the suffix', () => {
+    expect(scopeTestId('actions', 'edit')).toEqual(['actions', 'edit']);
+  });
+
+  it('flattens an array base and appends the suffix', () => {
+    expect(scopeTestId(['menu', 'main'], 'edit')).toEqual(['menu', 'main', 'edit']);
+  });
+
+  it('preserves a falsy base (composeTestId applies the drop/scoping rules)', () => {
+    expect(scopeTestId(undefined, 'close')).toEqual([undefined, 'close']);
+    expect(composeTestId('button', scopeTestId(undefined, 'close'))).toBe('button-close');
+  });
+
+  it('appends multiple suffix segments', () => {
+    expect(scopeTestId('base', 'a', 'b')).toEqual(['base', 'a', 'b']);
+  });
+
+  it('round-trips through composeTestId to a scoped id', () => {
+    expect(composeTestId('option', scopeTestId('username', 'Jane Doe'))).toBe('option-username-jane-doe');
   });
 });
 

--- a/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
@@ -28,6 +28,31 @@ export function kebabTestSegment(part: string | number): string {
 }
 
 /**
+ * Scope a test-id base with one or more trailing suffix segments.
+ *
+ * Normalizes the base — a single token or an array of segments — into a flat
+ * segment array and appends the suffixes, producing a value that is itself a
+ * valid {@link TnTestIdValue}. This is the canonical "derive a per-child id from
+ * a parent base" operation, e.g. a dialog's close button (`[base, 'close']`) or
+ * a select's per-option id (`[base, option.label]`). Centralizing it keeps the
+ * `string | array` flattening contract in one place rather than re-implemented
+ * at each call site.
+ *
+ * Falsy segments are preserved here (not filtered) so `composeTestId` can apply
+ * its own drop/scoping rules — `scopeTestId(undefined, 'close')` yields
+ * `[undefined, 'close']`, which `composeTestId('button', …)` renders as the
+ * unscoped `button-close`.
+ *
+ * @example
+ * scopeTestId('actions', 'edit')        // ['actions', 'edit']
+ * scopeTestId(['menu', 'main'], 'edit') // ['menu', 'main', 'edit']
+ * scopeTestId(undefined, 'close')       // [undefined, 'close']
+ */
+export function scopeTestId(base: TnTestIdValue, ...suffix: (string | number | null | undefined)[]): (string | number | null | undefined)[] {
+  return [...(Array.isArray(base) ? base : [base]), ...suffix];
+}
+
+/**
  * Compose the canonical test-id string: `${type}-${...segments}`.
  *
  * - `type` is the element-type prefix the component declares (e.g. `'button'`,


### PR DESCRIPTION
Standardize the `testId` input on autocomplete, date-input, date-range-input, time-input, dialog-shell, file-picker, form-field, menu, menu-item, select, and side-panel to accept `TnTestIdValue` (a single token or array of segments, defaulting to `undefined`) instead of a plain string. This lets callers scope ids with multiple segments and avoids emitting empty attributes.

- dialog-shell: flatten the base into per-button computed segments (`closeTestId`/`fullscreenTestId`) so array bases compose correctly.
- menu-panel/select: handle array bases when composing item/option ids.
- select: route the id namespace through `composeTestId`.
- icon: add a `testId` input rendered via `TnTestIdDirective` with the `icon` element-type prefix, plus `getTestId()` harness method, filter, and tests.