### PR TITLE
NAS-141315 / 27.0.0-BETA.1 / test(table-pager): lock in per-option page-size test ids

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -52,32 +52,18 @@ if [ -n "$COMPONENT_FILES" ]; then
 fi
 
 echo ""
-echo "🔎 Linting (same command CI runs) to catch lint errors before they reach CI..."
-yarn lint
+echo "🔎 Linting + testing staged files (lint-staged)..."
+# Runs eslint --fix and jest --findRelatedTests on staged files only, so commits
+# stay fast and only touch what changed. eslint auto-fixes (e.g. import order)
+# are re-staged automatically; unfixable lint errors or failing related tests
+# abort the commit. Full lint/test/build still run in CI.
+yarn lint-staged
 
 if [ $? -ne 0 ]; then
   echo ""
-  echo "❌ Error: Lint failed. Run 'yarn lint:fix' to auto-fix, then re-stage and commit."
+  echo "❌ Error: lint-staged failed. Fix the reported lint errors / failing tests, then re-stage and commit."
   echo ""
   exit 1
 fi
 
-echo "✅ Lint passed"
-echo ""
-
-echo "🧪 Running tests to prevent regressions..."
-yarn test --passWithNoTests
-
-if [ $? -ne 0 ]; then
-  echo ""
-  echo "❌ Error: Tests are failing. Please fix failing tests before committing."
-  echo ""
-  exit 1
-fi
-
-echo "✅ All tests passed"
-echo ""
-
-# Build as a compile-time safety check. `dist/` is gitignored and never
-# committed, so we don't stage it (a bare `git add dist/` would fail the hook).
-yarn build
+echo "✅ Staged files passed lint + related tests"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -52,6 +52,19 @@ if [ -n "$COMPONENT_FILES" ]; then
 fi
 
 echo ""
+echo "🔎 Linting (same command CI runs) to catch lint errors before they reach CI..."
+yarn lint
+
+if [ $? -ne 0 ]; then
+  echo ""
+  echo "❌ Error: Lint failed. Run 'yarn lint:fix' to auto-fix, then re-stage and commit."
+  echo ""
+  exit 1
+fi
+
+echo "✅ Lint passed"
+echo ""
+
 echo "🧪 Running tests to prevent regressions..."
 yarn test --passWithNoTests
 
@@ -65,5 +78,6 @@ fi
 echo "✅ All tests passed"
 echo ""
 
+# Build as a compile-time safety check. `dist/` is gitignored and never
+# committed, so we don't stage it (a bare `git add dist/` would fail the hook).
 yarn build
-git add dist/

--- a/package.json
+++ b/package.json
@@ -42,6 +42,18 @@
     "reinstall": "rm -rf ./node_modules && yarn install",
     "prepare": "husky"
   },
+  "lint-staged": {
+    "projects/truenas-ui/src/**/*.ts": [
+      "eslint --fix",
+      "jest --config ./projects/truenas-ui/jest.config.ts --bail --coverage=false --passWithNoTests --findRelatedTests"
+    ],
+    "projects/truenas-ui/src/**/*.html": [
+      "eslint --fix"
+    ],
+    "scripts/**/*.ts": [
+      "eslint --fix"
+    ]
+  },
   "private": true,
   "peerDependencies": {
     "rxjs": "^7.5.0",
@@ -114,6 +126,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
+    "lint-staged": "^17.0.7",
     "lucide": "^0.545.0",
     "ng-packagr": "^21.1.0",
     "rxjs": "^7.8.2",

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
@@ -3,9 +3,9 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
-import { TnSelectHarness } from '../select/select.harness';
 import type { TnTableDataProvider, TnTablePagination } from './table-pager.component';
 import { TnTablePagerComponent } from './table-pager.component';
+import { TnSelectHarness } from '../select/select.harness';
 
 describe('TnTablePagerComponent', () => {
   let fixture: ComponentFixture<TnTablePagerComponent>;

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
@@ -1,7 +1,9 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
+import { TnSelectHarness } from '../select/select.harness';
 import type { TnTableDataProvider, TnTablePagination } from './table-pager.component';
 import { TnTablePagerComponent } from './table-pager.component';
 
@@ -245,6 +247,32 @@ describe('TnTablePagerComponent', () => {
     ])('should expose a stable test id on the %s navigation button', (testId) => {
       const host = fixture.nativeElement as HTMLElement;
       expect(host.querySelector(`[data-testid="${testId}"]`)).toBeTruthy();
+    });
+
+    it.each([
+      [10, 'option-page-size-10'],
+      [20, 'option-page-size-20'],
+      [50, 'option-page-size-50'],
+      [100, 'option-page-size-100'],
+    ])('exposes a stable test id on the %i page-size option', async (_value, testId) => {
+      const loader = TestbedHarnessEnvironment.loader(fixture);
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+
+      // The dropdown options are rendered in a CDK overlay, outside the host element.
+      expect(document.querySelector(`[data-testid="${testId}"]`)).toBeTruthy();
+    });
+
+    it('scopes page-size option test ids with the pager testId base', async () => {
+      fixture.componentRef.setInput('testId', 'storage');
+      fixture.detectChanges();
+
+      const loader = TestbedHarnessEnvironment.loader(fixture);
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+
+      expect(document.querySelector('[data-testid="option-storage-page-size-10"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="option-page-size-10"]')).toBeNull();
     });
 
     it('scopes child test ids with the pager testId base so multiple pagers do not collide', () => {

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
@@ -280,13 +280,25 @@ describe('TnTablePagerComponent', () => {
       fixture.detectChanges();
       const host = fixture.nativeElement as HTMLElement;
 
-      // host carries the base verbatim (via hostDirectives); children are scoped under it
+      // host carries the base verbatim (written imperatively by the pager); children are scoped under it
       expect(host.getAttribute('data-testid')).toBe('storage');
       expect(host.querySelector('[data-testid="select-storage-page-size"]')).toBeTruthy();
       expect(host.querySelector('[data-testid="button-storage-first-page"]')).toBeTruthy();
       expect(host.querySelector('[data-testid="button-storage-last-page"]')).toBeTruthy();
       // the unscoped id is gone once a base is set
       expect(host.querySelector('[data-testid="select-page-size"]')).toBeNull();
+    });
+
+    it('removes the host test-id attribute when the base is cleared', () => {
+      const host = fixture.nativeElement as HTMLElement;
+
+      fixture.componentRef.setInput('testId', 'storage');
+      fixture.detectChanges();
+      expect(host.getAttribute('data-testid')).toBe('storage');
+
+      fixture.componentRef.setInput('testId', undefined);
+      fixture.detectChanges();
+      expect(host.hasAttribute('data-testid')).toBe(false);
     });
   });
 

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -2,7 +2,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   InjectionToken,
+  Renderer2,
   type Signal,
   computed,
   effect,
@@ -18,7 +20,7 @@ import { FormsModule } from '@angular/forms';
 import type { Observable, Subscription } from 'rxjs';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnSelectComponent, type TnSelectOption } from '../select/select.component';
-import { TnTestIdDirective, scopeTestId } from '../test-id';
+import { TN_TEST_ATTR, composeTestId, scopeTestId, type TnTestIdValue } from '../test-id';
 
 /**
  * Default labels rendered inside `tn-table-pager`. Consumers can override any
@@ -134,7 +136,7 @@ export interface TnTableDataProvider {
 @Component({
   selector: 'tn-table-pager',
   standalone: true,
-  imports: [FormsModule, TnIconButtonComponent, TnSelectComponent, TnTestIdDirective],
+  imports: [FormsModule, TnIconButtonComponent, TnSelectComponent],
   templateUrl: './table-pager.component.html',
   styleUrls: ['./table-pager.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -143,17 +145,26 @@ export interface TnTableDataProvider {
     'role': 'navigation',
     '[attr.aria-label]': 'resolvedTablePaginationLabel()',
   },
-  hostDirectives: [{ directive: TnTestIdDirective, inputs: ['tnTestId: testId'] }],
 })
 export class TnTablePagerComponent {
   private destroyRef = inject(DestroyRef);
+  private renderer = inject(Renderer2);
+  private hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private testAttrName = inject(TN_TEST_ATTR);
 
-  // The pager's `testId` (applied to the host via hostDirectives) also scopes
-  // each child control, so multiple pagers on one page don't collide on
-  // `select-page-size` / `button-first-page`. With a base of `storage` the
-  // children become `select-storage-page-size`, `button-storage-first-page`,
-  // etc.; with no base they stay `select-page-size` / `button-first-page`.
-  private readonly testIdDirective = inject(TnTestIdDirective);
+  /**
+   * Semantic base applied to the host (via the `tnTestId` host directive) and
+   * used to scope each child control, so multiple pagers on one page don't
+   * collide on `select-page-size` / `button-first-page`. With a base of
+   * `storage` the children become `select-storage-page-size`,
+   * `button-storage-first-page`, etc.; with no base they stay
+   * `select-page-size` / `button-first-page`.
+   *
+   * The page-size dropdown also scopes each option by its value, so individual
+   * sizes are addressable: `option-page-size-10` / `-20` / `-50` / `-100` (or
+   * `option-storage-page-size-10` under a base).
+   */
+  testId = input<TnTestIdValue>(undefined);
 
   /**
    * Build a child control's test-id base by joining the pager's `testId` with
@@ -162,7 +173,7 @@ export class TnTablePagerComponent {
    * `TnTestIdValue` testId.
    */
   protected childTestId(suffix: string): string {
-    return scopeTestId(this.testIdDirective.testId(), suffix)
+    return scopeTestId(this.testId(), suffix)
       .filter((part): part is string | number => part !== null && part !== undefined && part !== '')
       .join('-');
   }
@@ -288,6 +299,20 @@ export class TnTablePagerComponent {
   constructor() {
     const provided = inject(TN_TABLE_PAGER_LABELS);
     this.defaultLabels = isSignal(provided) ? provided : signal(provided).asReadonly();
+
+    // Write the pager's own test-id to the host. We replicate `TnTestIdDirective`
+    // inline rather than applying it via `hostDirectives`: the pager also needs
+    // to read this base back (see `childTestId`), and injecting a host directive
+    // to read its input signal is unreliable in the AOT-linked package build.
+    effect(() => {
+      const composed = composeTestId(undefined, this.testId());
+      const element = this.hostRef.nativeElement;
+      if (composed) {
+        this.renderer.setAttribute(element, this.testAttrName, composed);
+      } else {
+        this.renderer.removeAttribute(element, this.testAttrName);
+      }
+    });
 
     // Re-bind when the dataProvider reference changes (including swap to a
     // different instance or clearing back to undefined). `untracked` keeps the

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -20,7 +20,7 @@ import { FormsModule } from '@angular/forms';
 import type { Observable, Subscription } from 'rxjs';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnSelectComponent, type TnSelectOption } from '../select/select.component';
-import { TN_TEST_ATTR, composeTestId, scopeTestId, type TnTestIdValue } from '../test-id';
+import { TN_TEST_ATTR, composeTestId, scopeTestId, writeTestId, type TnTestIdValue } from '../test-id';
 
 /**
  * Default labels rendered inside `tn-table-pager`. Consumers can override any
@@ -300,18 +300,14 @@ export class TnTablePagerComponent {
     const provided = inject(TN_TABLE_PAGER_LABELS);
     this.defaultLabels = isSignal(provided) ? provided : signal(provided).asReadonly();
 
-    // Write the pager's own test-id to the host. We replicate `TnTestIdDirective`
-    // inline rather than applying it via `hostDirectives`: the pager also needs
+    // Write the pager's own test-id to the host. We write it imperatively rather
+    // than applying `TnTestIdDirective` via `hostDirectives`: the pager also needs
     // to read this base back (see `childTestId`), and injecting a host directive
-    // to read its input signal is unreliable in the AOT-linked package build.
+    // to read its input signal is unreliable in the AOT-linked package build. The
+    // set/remove semantics are shared with the directive via `writeTestId`.
     effect(() => {
       const composed = composeTestId(undefined, this.testId());
-      const element = this.hostRef.nativeElement;
-      if (composed) {
-        this.renderer.setAttribute(element, this.testAttrName, composed);
-      } else {
-        this.renderer.removeAttribute(element, this.testAttrName);
-      }
+      writeTestId(this.renderer, this.hostRef.nativeElement, this.testAttrName, composed);
     });
 
     // Re-bind when the dataProvider reference changes (including swap to a

--- a/projects/truenas-ui/src/lib/test-id/index.ts
+++ b/projects/truenas-ui/src/lib/test-id/index.ts
@@ -1,3 +1,4 @@
 export * from './compose-test-id';
 export * from './test-attr.token';
 export * from './test-id.directive';
+export * from './write-test-id';

--- a/projects/truenas-ui/src/lib/test-id/test-id.directive.spec.ts
+++ b/projects/truenas-ui/src/lib/test-id/test-id.directive.spec.ts
@@ -6,7 +6,6 @@ import { TnTestIdDirective } from './test-id.directive';
 @Component({
   standalone: true,
   imports: [TnTestIdDirective],
-  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <!-- eslint-disable-next-line tn-local/require-tn-testid-type -- exercises verbatim (no tnTestIdType) directive behavior -->
     <button [tnTestId]="value">click</button>
@@ -100,7 +99,6 @@ describe('TnTestIdDirective', () => {
     @Component({
       standalone: true,
       imports: [TnTestIdDirective],
-      // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <!-- eslint-disable-next-line tn-local/require-tn-testid-type -- exercises verbatim (no tnTestIdType) directive behavior -->
     <button [tnTestId]="value">click</button>

--- a/projects/truenas-ui/src/lib/test-id/test-id.directive.ts
+++ b/projects/truenas-ui/src/lib/test-id/test-id.directive.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { composeTestId, type TnTestIdValue } from './compose-test-id';
 import { TN_TEST_ATTR } from './test-attr.token';
+import { writeTestId } from './write-test-id';
 
 /**
  * Writes a composed `testId` value to whichever attribute name is configured via
@@ -54,12 +55,7 @@ export class TnTestIdDirective {
   constructor() {
     effect(() => {
       const composed = composeTestId(this.tnTestIdType(), this.testId());
-      const element = this.host.nativeElement;
-      if (composed) {
-        this.renderer.setAttribute(element, this.attrName, composed);
-      } else {
-        this.renderer.removeAttribute(element, this.attrName);
-      }
+      writeTestId(this.renderer, this.host.nativeElement, this.attrName, composed);
     });
   }
 }

--- a/projects/truenas-ui/src/lib/test-id/write-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/write-test-id.ts
@@ -1,0 +1,24 @@
+import type { Renderer2 } from '@angular/core';
+
+/**
+ * Apply a composed test-id string to `element`'s `attrName`, removing the
+ * attribute entirely when `composed` is empty (avoids `attr=""`).
+ *
+ * Shared by {@link TnTestIdDirective} and by components that must write the
+ * attribute imperatively because they also read their base back — notably
+ * `tn-table-pager`, where injecting a host directive to read its input signal
+ * is unreliable in the AOT-linked package build. Centralizing the set/remove
+ * branch keeps those write semantics in one place so they can't drift.
+ */
+export function writeTestId(
+  renderer: Renderer2,
+  element: Element,
+  attrName: string,
+  composed: string,
+): void {
+  if (composed) {
+    renderer.setAttribute(element, attrName, composed);
+  } else {
+    renderer.removeAttribute(element, attrName);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8066,7 +8066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
+"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
@@ -9286,6 +9286,16 @@ __metadata:
     slice-ansi: "npm:^7.1.0"
     string-width: "npm:^8.0.0"
   checksum: 10c0/3842920829a62f3e041ce39199050c42706c3c9c756a4efc8b86d464e102d1fa031d8b1b9b2e3bb36e1017c763558275472d031bdc884c1eff22a2f20e4f6b0a
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "cli-truncate@npm:5.2.0"
+  dependencies:
+    slice-ansi: "npm:^8.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10c0/0d4ec94702ca85b64522ac93633837fb5ea7db17b79b1322a60f6045e6ae2b8cd7bd4c1d19ac7d1f9e10e3bbda1112e172e439b68c02b785ee00da8d6a5c5471
   languageName: node
   linkType: hard
 
@@ -11536,6 +11546,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
+  languageName: node
+  linkType: hard
+
 "events-universal@npm:^1.0.0":
   version: 1.0.1
   resolution: "events-universal@npm:1.0.1"
@@ -12433,6 +12450,13 @@ __metadata:
   version: 1.4.0
   resolution: "get-east-asian-width@npm:1.4.0"
   checksum: 10c0/4e481d418e5a32061c36fbb90d1b225a254cc5b2df5f0b25da215dcd335a3c111f0c2023ffda43140727a9cafb62dac41d022da82c08f31083ee89f714ee3b83
+  languageName: node
+  linkType: hard
+
+"get-east-asian-width@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 10c0/7e72e9550fd49ca5b246f9af6bb2afc129c96412845ff6556b3274fd44817a381702ca17028efe9866b261a3d44254cbf21e6c90cf05b4b61675630af776d431
   languageName: node
   linkType: hard
 
@@ -13555,7 +13579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^5.0.0":
+"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
   version: 5.1.0
   resolution: "is-fullwidth-code-point@npm:5.1.0"
   dependencies:
@@ -15621,6 +15645,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lint-staged@npm:^17.0.7":
+  version: 17.0.7
+  resolution: "lint-staged@npm:17.0.7"
+  dependencies:
+    listr2: "npm:^10.2.1"
+    picomatch: "npm:^4.0.4"
+    string-argv: "npm:^0.3.2"
+    tinyexec: "npm:^1.2.4"
+    yaml: "npm:^2.9.0"
+  dependenciesMeta:
+    yaml:
+      optional: true
+  bin:
+    lint-staged: bin/lint-staged.js
+  checksum: 10c0/c4e7100becb327d817999a231b8d345e6be389c555d9cd8d668797d2670832ad15c4e5085b61895e3fbf937f0fbd6be5c78ca76a4599ed332227f37270ebe8eb
+  languageName: node
+  linkType: hard
+
 "listr2@npm:9.0.5":
   version: 9.0.5
   resolution: "listr2@npm:9.0.5"
@@ -15632,6 +15674,19 @@ __metadata:
     rfdc: "npm:^1.4.1"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10c0/46448d1ba0addc9d71aeafd05bb8e86ded9641ccad930ac302c2bd2ad71580375604743e18586fcb8f11906edf98e8e17fca75ba0759947bf275d381f68e311d
+  languageName: node
+  linkType: hard
+
+"listr2@npm:^10.2.1":
+  version: 10.2.1
+  resolution: "listr2@npm:10.2.1"
+  dependencies:
+    cli-truncate: "npm:^5.2.0"
+    eventemitter3: "npm:^5.0.4"
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^10.0.0"
+  checksum: 10c0/a381a7aaef2e8625e6e882835ef446d14306c8fa371b56c4499cf23ece86f84922008af11962bfba5411b51589e02d280bea2b820451a2efad89ebf78bbe68a4
   languageName: node
   linkType: hard
 
@@ -18149,6 +18204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
 "pify@npm:^3.0.0":
   version: 3.0.0
   resolution: "pify@npm:3.0.0"
@@ -19964,6 +20026,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slice-ansi@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "slice-ansi@npm:8.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10c0/0ce4aa91febb7cea4a00c2c27bb820fa53b6d2862ce0f80f7120134719f7914fc416b0ed966cf35250a3169e152916392f35917a2d7cad0fcc5d8b841010fa9a
+  languageName: node
+  linkType: hard
+
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -20359,6 +20431,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-argv@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "string-argv@npm:0.3.2"
+  checksum: 10c0/75c02a83759ad1722e040b86823909d9a2fc75d15dd71ec4b537c3560746e33b5f5a07f7332d1e3f88319909f82190843aa2f0a0d8c8d591ec08e93d5b8dec82
+  languageName: node
+  linkType: hard
+
 "string-length@npm:^4.0.1, string-length@npm:^4.0.2":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
@@ -20418,6 +20497,16 @@ __metadata:
     get-east-asian-width: "npm:^1.3.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/749b5d0dab2532b4b6b801064230f4da850f57b3891287023117ab63a464ad79dd208f42f793458f48f3ad121fe2e1f01dd525ff27ead957ed9f205e27406593
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.2.0":
+  version: 8.2.1
+  resolution: "string-width@npm:8.2.1"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
   languageName: node
   linkType: hard
 
@@ -20972,6 +21061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyexec@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "tinyexec@npm:1.2.4"
+  checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:0.2.15, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -21165,6 +21261,7 @@ __metadata:
     karma-coverage: "npm:~2.2.0"
     karma-jasmine: "npm:~5.1.0"
     karma-jasmine-html-reporter: "npm:~2.0.0"
+    lint-staged: "npm:^17.0.7"
     lucide: "npm:^0.545.0"
     ng-packagr: "npm:^21.1.0"
     rxjs: "npm:^7.8.2"
@@ -22551,6 +22648,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "wrap-ansi@npm:10.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    string-width: "npm:^8.2.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/6b163457630fe6d1c72aeed283a7410b2cc7487312df8b0ce96df3fbd64a2a7c948856ea97c25148c848627587c5c7945be474d8e723ab6011bb0756a53a9e89
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
@@ -22756,6 +22864,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The select already derives a test id per option from its primitive value, so the pager's page-size dropdown options are addressable as `option-page-size-10` / `-20` / `-50` / `-100` (scoped to `option-storage-page-size-10` under a pager testId base). Add tests asserting each option's id and the scoped variant, and document the option ids on the `testId` input.