### PR TITLE
NAS-141325 / 27.0.0-BETA.1 / feat(tooltip): render tn-tooltip content as HTML

### DIFF
--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.html
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.html
@@ -2,6 +2,6 @@
   class="tn-tooltip"
   role="tooltip"
   [id]="id()"
-  [attr.aria-hidden]="false">
-  {{ message() }}
+  [attr.aria-hidden]="false"
+  [innerHTML]="message()">
 </div>

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { TnTooltipComponent } from './tooltip.component';
+
+function createTooltip(message: string) {
+  const fixture = TestBed.createComponent(TnTooltipComponent);
+  fixture.componentRef.setInput('message', message);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('TnTooltipComponent HTML rendering', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TnTooltipComponent] });
+  });
+
+  it('renders HTML markup in the message', () => {
+    const fixture = createTooltip('<b>Online</b> &mdash; <i>healthy</i>');
+    const tooltip = fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+
+    expect(tooltip.querySelector('b')?.textContent).toBe('Online');
+    expect(tooltip.querySelector('i')?.textContent).toBe('healthy');
+  });
+
+  it('renders <br> line breaks', () => {
+    const fixture = createTooltip('Line 1<br>Line 2');
+    const tooltip = fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+
+    expect(tooltip.querySelector('br')).toBeTruthy();
+  });
+
+  it('strips <script> tags via Angular sanitization', () => {
+    const fixture = createTooltip("Safe <script>alert('xss')</script> text");
+    const tooltip = fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+
+    expect(tooltip.querySelector('script')).toBeNull();
+    expect(tooltip.innerHTML).not.toContain('<script');
+    expect(tooltip.textContent).toContain('Safe');
+  });
+
+  it('strips inline event handlers via Angular sanitization', () => {
+    const fixture = createTooltip('<img src="x" onerror="alert(1)">');
+    const tooltip = fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+
+    expect(tooltip.querySelector('img')?.getAttribute('onerror')).toBeNull();
+  });
+
+  it('renders plain text safely', () => {
+    const fixture = createTooltip('Just plain text');
+    const tooltip = fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+
+    expect(tooltip.textContent?.trim()).toBe('Just plain text');
+  });
+});

--- a/projects/truenas-ui/src/stories/tooltip.stories.ts
+++ b/projects/truenas-ui/src/stories/tooltip.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
   argTypes: {
     tnTooltip: {
       control: 'text',
-      description: 'Tooltip message text. For multi-line tooltips in this control, press Enter to create line breaks (typing \\n won\'t work in Storybook UI). See the MultiLine story for code examples.'
+      description: 'Tooltip content. Rendered as HTML, so markup like <b> or <br> is supported (sanitized by Angular; <script> and event handlers are stripped). Plain newlines still produce line breaks via white-space: pre-line. For multi-line tooltips in this control, press Enter to create line breaks (typing \\n won\'t work in Storybook UI). See the MultiLine and HtmlContent stories for code examples.'
     },
     tnTooltipPosition: {
       control: { type: 'select' },
@@ -199,6 +199,56 @@ export const OnDifferentElements: Story = {
       ],
     },
   }),
+};
+
+export const HtmlContent: Story = {
+  render: () => ({
+    template: `
+      <div style="padding: 50px; display: flex; flex-direction: column; gap: 20px; align-items: center;">
+        <tn-button
+          label="Bold and emphasis"
+          tnTooltip="<b>Online</b> &mdash; all disks <i>healthy</i>">
+        </tn-button>
+
+        <tn-button
+          label="Line breaks via <br>"
+          tnTooltip="Capacity: 2.5 TB<br>Used: 1.8 TB<br>Health: Online">
+        </tn-button>
+
+        <tn-button
+          label="List markup"
+          tnTooltip="Status:<ul style='margin:4px 0 0;padding-left:18px;'><li>Pool: tank</li><li>State: ONLINE</li></ul>">
+        </tn-button>
+
+        <tn-button
+          label="Sanitized (script stripped)"
+          tnTooltip="Safe text <script>alert('xss')</script> after">
+        </tn-button>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [
+        TnButtonComponent,
+        TnTooltipDirective,
+        TnTooltipComponent
+      ],
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Tooltip content is rendered as HTML, so you can pass markup such as \`<b>\`, \`<br>\`, or lists.
+
+\`\`\`html
+<button tnTooltip="Capacity: 2.5 TB<br>Used: 1.8 TB<br>Health: <b>Online</b>">Hover me</button>
+\`\`\`
+
+Content is sanitized by Angular's built-in DOM sanitizer: \`<script>\` tags, inline event handlers, and other unsafe constructs are stripped automatically. Plain newline characters continue to render as line breaks via \`white-space: pre-line\`.
+        `,
+      },
+    },
+  },
 };
 
 export const MultiLine: Story = {


### PR DESCRIPTION
Bind the tooltip message via [innerHTML] so markup such as <b> and <br> is rendered. Content is sanitized by Angular's built-in DOM sanitizer, so <script> tags and inline event handlers are stripped automatically. white-space: pre-line is retained, so existing \n callers still get line breaks.