### PR TITLE
NAS-141326 / 27.0.0-BETA.1 / fix(dialog): emit role-first test ids for close/fullscreen buttons

### DIFF
--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -2,7 +2,7 @@ import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { DOCUMENT } from '@angular/common';
 import { Component, ElementRef, computed, effect, input, signal, inject } from '@angular/core';
 import type { OnInit} from '@angular/core';
-import { TnTestIdDirective, scopeTestId, type TnTestIdValue } from '../test-id';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 let nextUniqueId = 0;
 
@@ -21,15 +21,34 @@ export class TnDialogShellComponent implements OnInit {
   /**
    * Optional semantic base that scopes the shell's chrome buttons. The close
    * and fullscreen buttons emit `button-close` / `button-fullscreen` by default,
-   * or `button-<testId>-close` / `-fullscreen` when a base is provided (useful
-   * when more than one dialog can be open).
+   * or `button-close-<testId>` / `button-fullscreen-<testId>` when a base is
+   * provided (useful when more than one dialog can be open).
    */
   testId = input<TnTestIdValue>(undefined);
 
-  /** Scoped test-id segments for the close button (`button-[<base>-]close`). */
-  protected closeTestId = computed(() => scopeTestId(this.testId(), 'close'));
-  /** Scoped test-id segments for the fullscreen button (`button-[<base>-]fullscreen`). */
-  protected fullscreenTestId = computed(() => scopeTestId(this.testId(), 'fullscreen'));
+  /**
+   * The `testId` base normalized to a flat segment array. Nothing is dropped
+   * here — `composeTestId` (via the `[tnTestId]` directive) filters falsy
+   * segments, so an unset base collapses to the bare role (`button-close`).
+   */
+  private readonly baseSegments = computed<(string | number | null | undefined)[]>(() => {
+    const base = this.testId();
+    return Array.isArray(base) ? base : [base];
+  });
+
+  /**
+   * Role-first test-id segments for the close button: `button-close[-<base>]`.
+   *
+   * The close and fullscreen buttons are fixed dialog chrome, not content
+   * children, so the role leads rather than the base (content children are
+   * base-first via `scopeTestId`). This keeps every dialog's close button under
+   * a shared `button-close-*` prefix — it matches webui's established
+   * close-button ids and lets automation target "all close buttons" with one
+   * selector.
+   */
+  protected closeTestId = computed(() => ['close', ...this.baseSegments()]);
+  /** Role-first test-id segments for the fullscreen button: `button-fullscreen[-<base>]`. */
+  protected fullscreenTestId = computed(() => ['fullscreen', ...this.baseSegments()]);
 
   /** Stable id for the title heading, referenced by the dialog's aria-labelledby. */
   readonly titleId = `tn-dialog-title-${nextUniqueId++}`;

--- a/projects/truenas-ui/src/lib/dialog/dialog.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog.harness.spec.ts
@@ -18,6 +18,7 @@ import { TnButtonComponent } from '../button/button.component';
   template: `
     <tn-dialog-shell
       [title]="data?.title ?? 'Test Dialog'"
+      [testId]="data?.testId"
       [showFullscreenButton]="data?.showFullscreen ?? false">
       <p>{{ data?.content ?? 'Dialog content' }}</p>
       <div tnDialogAction>
@@ -214,6 +215,44 @@ describe('TnDialogHarness', () => {
 
       const fullscreenIcon = document.querySelector('.tn-dialog__fullscreen-icon');
       expect(fullscreenIcon?.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  describe('chrome button test ids', () => {
+    it('scopes the close button role-first as button-close-<testId>', () => {
+      tnDialog.open(TestDialogComponent, {
+        data: { title: 'Feedback', testId: 'feedback-dialog' },
+      });
+      fixture.detectChanges();
+
+      // role leads, base trails — every dialog's close shares the button-close-* prefix
+      expect(document.querySelector('[data-testid="button-close-feedback-dialog"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="button-feedback-dialog-close"]')).toBeFalsy();
+    });
+
+    it('scopes the fullscreen button role-first as button-fullscreen-<testId>', () => {
+      tnDialog.open(TestDialogComponent, {
+        data: { title: 'Feedback', testId: 'feedback-dialog', showFullscreen: true },
+      });
+      fixture.detectChanges();
+
+      expect(document.querySelector('[data-testid="button-fullscreen-feedback-dialog"]')).toBeTruthy();
+    });
+
+    it('falls back to the bare role when no testId is set', () => {
+      tnDialog.open(TestDialogComponent, { data: { title: 'No base' } });
+      fixture.detectChanges();
+
+      expect(document.querySelector('[data-testid="button-close"]')).toBeTruthy();
+    });
+
+    it('flattens an array testId without nesting', () => {
+      tnDialog.open(TestDialogComponent, {
+        data: { title: 'Array base', testId: ['feedback', 'dialog'] },
+      });
+      fixture.detectChanges();
+
+      expect(document.querySelector('[data-testid="button-close-feedback-dialog"]')).toBeTruthy();
     });
   });
 

--- a/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
@@ -33,20 +33,24 @@ export function kebabTestSegment(part: string | number): string {
  * Normalizes the base — a single token or an array of segments — into a flat
  * segment array and appends the suffixes, producing a value that is itself a
  * valid {@link TnTestIdValue}. This is the canonical "derive a per-child id from
- * a parent base" operation, e.g. a dialog's close button (`[base, 'close']`) or
- * a select's per-option id (`[base, option.label]`). Centralizing it keeps the
- * `string | array` flattening contract in one place rather than re-implemented
- * at each call site.
+ * a parent base" operation, e.g. a select's per-option id
+ * (`[base, option.label]`) or a menu item's id (`[base, item.id]`). Centralizing
+ * it keeps the `string | array` flattening contract in one place rather than
+ * re-implemented at each call site.
+ *
+ * Note this is *base-first*: the suffix trails the base. Fixed chrome whose role
+ * should lead (e.g. `tn-dialog-shell`'s `button-close-<base>`) prepends the role
+ * manually instead of calling this.
  *
  * Falsy segments are preserved here (not filtered) so `composeTestId` can apply
- * its own drop/scoping rules — `scopeTestId(undefined, 'close')` yields
- * `[undefined, 'close']`, which `composeTestId('button', …)` renders as the
- * unscoped `button-close`.
+ * its own drop/scoping rules — `scopeTestId(undefined, 'edit')` yields
+ * `[undefined, 'edit']`, which `composeTestId('menu-item', …)` renders as the
+ * unscoped `menu-item-edit`.
  *
  * @example
  * scopeTestId('actions', 'edit')        // ['actions', 'edit']
  * scopeTestId(['menu', 'main'], 'edit') // ['menu', 'main', 'edit']
- * scopeTestId(undefined, 'close')       // [undefined, 'close']
+ * scopeTestId(undefined, 'edit')        // [undefined, 'edit']
  */
 export function scopeTestId(base: TnTestIdValue, ...suffix: (string | number | null | undefined)[]): (string | number | null | undefined)[] {
   return [...(Array.isArray(base) ? base : [base]), ...suffix];


### PR DESCRIPTION
The dialog shell scoped its chrome buttons base-first (`button-<base>-close`), but webui's established convention puts the role first (`button-close-<base>`). Prepend the role so every dialog's close button shares a `button-close-*` prefix — preserving migrated webui test ids byte-for-byte and letting automation target all close buttons with a single selector.

Prepend explicitly rather than reversing `scopeTestId`'s args: that helper flattens the base but not the suffix, so a reversed call would nest an array `testId`. `scopeTestId` stays base-first for content children (menu/select/table-pager); its doc no longer cites the dialog close button as the canonical example.

The unscoped default (`button-close` / `button-fullscreen`) is unchanged.