### PR TITLE
NAS-141334 / 27.0.0-BETA.1 / feat(input): add Size input type with human-readable data sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/vinyl": "~2.0.12",
     "cheerio": "~1.0.0",
     "fast-glob": "^3.3.3",
+    "filesize": "~11.0.17",
     "svg-sprite": "~2.0.4",
     "tslib": "^2.3.0",
     "tsx": "~4.19.1",

--- a/projects/truenas-ui/ng-package.json
+++ b/projects/truenas-ui/ng-package.json
@@ -14,6 +14,7 @@
     "@mdi/svg",
     "@material-design-icons/svg",
     "cheerio",
+    "filesize",
     "svg-sprite",
     "vinyl",
     "tsx",

--- a/projects/truenas-ui/package.json
+++ b/projects/truenas-ui/package.json
@@ -29,6 +29,7 @@
     "@types/svg-sprite": "~0.0.39",
     "@types/vinyl": "~2.0.12",
     "cheerio": "~1.0.0",
+    "filesize": "~11.0.17",
     "svg-sprite": "~2.0.4",
     "tslib": "^2.3.0",
     "tsx": "~4.19.1",

--- a/projects/truenas-ui/src/lib/enums/input-type.enum.ts
+++ b/projects/truenas-ui/src/lib/enums/input-type.enum.ts
@@ -3,4 +3,11 @@ export enum InputType {
   Number = 'number',
   Password = 'password',
   PlainText = 'text',
+  /**
+   * Data-size field: the form model holds a raw byte count (a number), while the
+   * field displays/accepts a human-readable string (e.g. `2 GiB`, `500M`, `2 TB`).
+   * See `tn-input`'s `sizeStandard` / `sizeDefaultUnit` inputs to tune formatting
+   * and bare-number parsing.
+   */
+  Size = 'size',
 }

--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -4,6 +4,7 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TnInputComponent } from './input.component';
+import { parseSize } from './size-conversion';
 import { InputType } from '../enums/input-type.enum';
 import { TnIconTesting } from '../icon/icon-testing';
 
@@ -281,6 +282,142 @@ describe('TnInputComponent', () => {
       expect(input.value).toBe('1234');
       // Caret stays right after '1', not jumped to the end.
       expect(input.selectionStart).toBe(1);
+    });
+
+    it('should not render a textarea even when multiline is set', () => {
+      fixture.componentRef.setInput('multiline', true);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('textarea')).toBeNull();
+      expect(fixture.nativeElement.querySelector('input')).toBeTruthy();
+    });
+  });
+
+  describe('size type', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('inputType', InputType.Size);
+      fixture.detectChanges();
+    });
+
+    it('should render a text input (accepts unit letters) with no numeric inputmode', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      expect(input.type).toBe('text');
+      expect(input.hasAttribute('inputmode')).toBe(false);
+    });
+
+    it('should display a byte-count model as a human-readable string', () => {
+      component.writeValue(2 * 1024 ** 3);
+      expect(component['value']).toBe('2 GiB');
+    });
+
+    it('should display empty string for null/undefined', () => {
+      component.writeValue(null);
+      expect(component['value']).toBe('');
+      component.writeValue(undefined);
+      expect(component['value']).toBe('');
+    });
+
+    it('should emit a byte count as the user types', () => {
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = '2 GiB';
+      input.dispatchEvent(new Event('input'));
+
+      expect(changeSpy).toHaveBeenCalledWith(2 * 1024 ** 3);
+    });
+
+    it('should keep the raw text in the field while typing', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = '2 gi';
+      input.dispatchEvent(new Event('input'));
+
+      expect(component['value']).toBe('2 gi');
+    });
+
+    it('should emit null for unparseable input (not 0)', () => {
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = 'abc';
+      input.dispatchEvent(new Event('input'));
+
+      expect(changeSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should assume the configured default unit for a bare number', () => {
+      fixture.componentRef.setInput('sizeDefaultUnit', 'KiB');
+      fixture.detectChanges();
+
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = '200';
+      input.dispatchEvent(new Event('input'));
+
+      expect(changeSpy).toHaveBeenCalledWith(200 * 1024);
+    });
+
+    it('should canonicalize the display on blur', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = '2048 KiB';
+      input.dispatchEvent(new Event('input'));
+      input.dispatchEvent(new Event('blur'));
+
+      expect(component['value']).toBe('2 MiB');
+    });
+
+    it('should re-sync the model to the canonicalized display on blur (lossy rounding)', () => {
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = fixture.nativeElement.querySelector('input');
+      // 1.755 GiB does not round-trip through a 2-decimal display.
+      input.value = '1.755 GiB';
+      input.dispatchEvent(new Event('input'));
+      input.dispatchEvent(new Event('blur'));
+
+      const display = component['value'];
+      const model = changeSpy.mock.calls.at(-1)![0];
+      // The invariant that matters: re-parsing what the user sees yields the model.
+      expect(parseSize(display, 'MiB', 'iec')).toBe(model);
+      // ...and the display is itself the canonical render of that model (stable).
+      expect(display).toBe(component['value']);
+    });
+
+    it('should not emit on blur when a pre-filled value is unchanged (no spurious dirty)', () => {
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+      // Pre-populate from the model (as a consumer form would), then tab in/out
+      // with no edit. The canonical form equals the displayed text, so the control
+      // must stay pristine — no onChange.
+      component.writeValue(200 * 1024 ** 4);
+
+      const input = fixture.nativeElement.querySelector('input');
+      input.dispatchEvent(new Event('blur'));
+
+      expect(changeSpy).not.toHaveBeenCalled();
+      expect(component['value']).toBe('200 TiB');
+    });
+
+    it('should leave unparseable text untouched on blur', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = 'not a size';
+      input.dispatchEvent(new Event('input'));
+      input.dispatchEvent(new Event('blur'));
+
+      expect(component['value']).toBe('not a size');
+    });
+
+    it('should use the SI standard when configured', () => {
+      fixture.componentRef.setInput('sizeStandard', 'si');
+      fixture.detectChanges();
+
+      component.writeValue(2_000_000_000);
+      expect(component['value']).toBe('2 GB');
     });
 
     it('should not render a textarea even when multiline is set', () => {
@@ -595,5 +732,74 @@ describe('TnInputComponent number type with consumer validators', () => {
 
     expect(hostComponent.control.valid).toBe(false);
     expect(hostComponent.control.errors).toEqual({ max: { max: 50, actual: 60 } });
+  });
+});
+
+
+@Component({
+  selector: 'tn-test-size-cva-host',
+  standalone: true,
+  imports: [TnInputComponent, ReactiveFormsModule],
+  template: `<tn-input [inputType]="sizeType" [formControl]="control" />`
+})
+class TestSizeCvaHostComponent {
+  sizeType = InputType.Size;
+  // The form model holds a byte count; the field shows a human-readable string.
+  control = new FormControl<number | null>(null);
+}
+
+
+describe('TnInputComponent size type with FormControl', () => {
+  let fixture: ComponentFixture<TestSizeCvaHostComponent>;
+  let hostComponent: TestSizeCvaHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestSizeCvaHostComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestSizeCvaHostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should put a byte count in the form model when the user types a size', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '2 GiB';
+    input.dispatchEvent(new Event('input'));
+
+    expect(hostComponent.control.value).toBe(2 * 1024 ** 3);
+    expect(typeof hostComponent.control.value).toBe('number');
+  });
+
+  it('should display a byte-count model as a human-readable string', () => {
+    hostComponent.control.setValue(200 * 1024 ** 4);
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    expect(input.value).toBe('200 TiB');
+  });
+
+  it('should set the form model to null when the field is cleared', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '2 GiB';
+    input.dispatchEvent(new Event('input'));
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+
+    expect(hostComponent.control.value).toBeNull();
+  });
+
+  it('should keep the form model in lockstep with the canonicalized display on blur', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '1.755 GiB';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+    // Flush the [value] binding so the DOM reflects the canonicalized display.
+    fixture.detectChanges();
+
+    // What the user sees parses back to exactly what's stored — no divergence.
+    expect(parseSize(input.value, 'MiB', 'iec')).toBe(hostComponent.control.value);
   });
 });

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -7,6 +7,7 @@ import { InputType } from '../enums/input-type.enum';
 import type { IconLibraryType } from '../icon/icon.component';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { formatSize, parseSize, type SizeStandard } from './size-conversion';
 
 // Module-level counter for deterministic, unique instance ids (matches the
 // tn-autocomplete convention). Deterministic ids are SSR/hydration-safe and
@@ -58,6 +59,27 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
    */
   allowDecimals = input<boolean>(true);
 
+  /**
+   * Unit standard for the `Size` input type — `iec` (base-2, `KiB`/`MiB`) or
+   * `si` (base-10, `kB`/`MB`). Drives both the formatted display and how bare
+   * numbers are scaled when parsing. Ignored unless `inputType` is `Size`.
+   */
+  sizeStandard = input<SizeStandard>('iec');
+
+  /**
+   * Unit assumed when a user types a bare number (no unit) into a `Size` field —
+   * e.g. with the default `MiB`, typing `200` yields 200 MiB. Accepts IEC
+   * (`KiB`), short (`KB`), or human (`K`) spellings. Ignored unless `inputType`
+   * is `Size`.
+   */
+  sizeDefaultUnit = input<string>('MiB');
+
+  /**
+   * Decimal places used when formatting a `Size` field's value for display
+   * (e.g. `1.5 GiB`). Ignored unless `inputType` is `Size`.
+   */
+  sizeRound = input<number>(2);
+
   // Icon inputs
   prefixIcon = input<string | undefined>(undefined);
   prefixIconLibrary = input<IconLibraryType | undefined>(undefined);
@@ -72,17 +94,19 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
 
   // Numeric mode state
   isNumeric = computed(() => this.inputType() === InputType.Number);
+  /** True when the field is in data-size mode (human-readable string ⇄ byte-count model). */
+  isSize = computed(() => this.inputType() === InputType.Size);
   /** True when the field only accepts whole numbers (i.e. `allowDecimals` is false). */
   integerOnly = computed(() => !this.allowDecimals());
-  /** The `type` attribute actually rendered. Number mode uses a text input + inputmode to avoid the native type="number" footguns. */
-  resolvedType = computed(() => (this.isNumeric() ? InputType.PlainText : this.inputType()));
-  /** `inputmode` hint: numeric keypad for integers, decimal keypad otherwise. Null (omitted) when not in number mode. */
+  /** The `type` attribute actually rendered. Number and size modes use a text input: number avoids the native type="number" footguns, size must accept unit letters. */
+  resolvedType = computed(() => (this.isNumeric() || this.isSize() ? InputType.PlainText : this.inputType()));
+  /** `inputmode` hint: numeric keypad for integers, decimal keypad otherwise. Null (omitted) outside number mode — size fields accept unit letters, so they keep the full keyboard. */
   numericInputMode = computed<'numeric' | 'decimal' | null>(() => {
     if (!this.isNumeric()) {return null;}
     return this.integerOnly() ? 'numeric' : 'decimal';
   });
-  /** Number mode is always single-line; it wins over `multiline` if both are set. */
-  showTextarea = computed(() => this.multiline() && !this.isNumeric());
+  /** Number and size modes are always single-line; they win over `multiline` if both are set. */
+  showTextarea = computed(() => this.multiline() && !this.isNumeric() && !this.isSize());
 
   // Unique per instance: a hard-coded id produced duplicate ids when multiple
   // tn-inputs share a page (invalid HTML, and it breaks any future label `for=`,
@@ -121,6 +145,12 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   // Accepts undefined as well as the declared types: Angular may hand writeValue an
   // undefined model at init, and it maps to the empty display like null.
   writeValue(value: string | number | null | undefined): void {
+    if (this.isSize()) {
+      // The model is a byte count; show it as a human-readable string. Empty/null
+      // stays blank, and a non-numeric model maps to blank (formatSize returns '').
+      this.value = formatSize(value, this.sizeStandard(), this.sizeRound());
+      return;
+    }
     // Display the model verbatim via String(); do NOT sanitize here. Sanitizing a
     // canonical number string would corrupt fractions in integer mode (3.5 -> "35"),
     // silently diverging the display from the form model.
@@ -146,6 +176,14 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   protected onValueChange(event: Event): void {
     const target = event.target as HTMLInputElement | HTMLTextAreaElement;
 
+    if (this.isSize()) {
+      // Keep the raw text in the field as the user types (unit letters and all);
+      // emit the parsed byte count, mapping invalid/partial input to null (never 0).
+      this.value = target.value;
+      this.onChange(parseSize(this.value, this.sizeDefaultUnit(), this.sizeStandard()));
+      return;
+    }
+
     if (this.isNumeric()) {
       const el = target as HTMLInputElement;
       const sanitized = this.sanitizeNumeric(el.value);
@@ -170,6 +208,26 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   }
 
   protected onBlur(): void {
+    if (this.isSize() && this.value !== '') {
+      // Canonicalize the display on blur: "2048 KiB" -> "2 MiB", "200tib" -> "200 TiB".
+      // Leave unparseable text in place so the consumer's validators can flag it.
+      const bytes = parseSize(this.value, this.sizeDefaultUnit(), this.sizeStandard());
+      if (bytes !== null) {
+        const canonical = formatSize(bytes, this.sizeStandard(), this.sizeRound());
+        // Only rewrite + re-emit when the canonical form actually differs from what
+        // the user left in the field. This both:
+        //  (a) skips a no-op onChange that would mark an untouched, pre-filled
+        //      control dirty (falsely tripping "unsaved changes" guards), and
+        //  (b) still re-syncs the model when rounding is lossy — e.g. an edited
+        //      "1.755 GiB" canonicalizes to a different string, so it emits the
+        //      byte count parsed back from the rounded display, keeping
+        //      parseSize(display) === model.
+        if (canonical !== this.value) {
+          this.value = canonical;
+          this.onChange(parseSize(canonical, this.sizeDefaultUnit(), this.sizeStandard()));
+        }
+      }
+    }
     this.onTouched();
   }
 

--- a/projects/truenas-ui/src/lib/input/input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.harness.spec.ts
@@ -254,6 +254,36 @@ describe('TnInputHarness', () => {
     });
   });
 
+  describe('size type', () => {
+    beforeEach(() => {
+      hostComponent.inputType.set(InputType.Size);
+      fixture.detectChanges();
+    });
+
+    it('should read the displayed value as a byte count', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      await input.setValue('2 GiB');
+      expect(await input.getByteValue()).toBe(2 * 1024 ** 3);
+    });
+
+    it('should read an empty value as null', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      expect(await input.getByteValue()).toBeNull();
+    });
+
+    it('should honor a custom default unit for a bare number', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      await input.setValue('200');
+      expect(await input.getByteValue('iec', 'KiB')).toBe(200 * 1024);
+    });
+
+    it('should read SI-standard values when told', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      await input.setValue('2 GB');
+      expect(await input.getByteValue('si')).toBe(2_000_000_000);
+    });
+  });
+
   describe('aria-label', () => {
     it('should return null when unset', async () => {
       const input = await loader.getHarness(TnInputHarness);

--- a/projects/truenas-ui/src/lib/input/input.harness.ts
+++ b/projects/truenas-ui/src/lib/input/input.harness.ts
@@ -1,5 +1,6 @@
 import type { BaseHarnessFilters } from '@angular/cdk/testing';
 import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { parseSize, type SizeStandard } from './size-conversion';
 import { TnIconHarness } from '../icon/icon.harness';
 
 /**
@@ -98,6 +99,23 @@ export class TnInputHarness extends ComponentHarness {
     const integerMode = (await this.getInputMode()) === 'numeric';
     const parsed = integerMode ? parseInt(raw, 10) : parseFloat(raw);
     return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * Gets the displayed value of a `Size`-type input parsed into a byte count,
+   * mirroring what the control emits to the form model.
+   *
+   * The harness reads only the DOM, so it can't see the component's configured
+   * `sizeStandard`/`sizeDefaultUnit` — pass them here to match the field under
+   * test. Defaults to IEC base-2 with a `MiB` default unit (the component
+   * defaults). Empty/invalid input resolves to `null`.
+   *
+   * @param standard Unit standard the field uses (defaults to `'iec'`).
+   * @param defaultUnit Unit assumed for bare numbers (defaults to `'MiB'`).
+   * @returns Promise resolving to the byte count, or null.
+   */
+  async getByteValue(standard: SizeStandard = 'iec', defaultUnit = 'MiB'): Promise<number | null> {
+    return parseSize(await this.getValue(), defaultUnit, standard);
   }
 
   /**

--- a/projects/truenas-ui/src/lib/input/size-conversion.spec.ts
+++ b/projects/truenas-ui/src/lib/input/size-conversion.spec.ts
@@ -1,0 +1,85 @@
+import { formatSize, parseSize } from './size-conversion';
+
+describe('size-conversion', () => {
+  describe('formatSize', () => {
+    it('formats bytes as IEC units by default', () => {
+      expect(formatSize(2 * 1024 ** 3)).toBe('2 GiB');
+      expect(formatSize(1536)).toBe('1.5 KiB');
+      expect(formatSize(512)).toBe('512 B');
+      expect(formatSize(200 * 1024 ** 4)).toBe('200 TiB');
+    });
+
+    it('formats bytes as SI units when requested', () => {
+      expect(formatSize(2_000_000_000, 'si')).toBe('2 GB');
+      expect(formatSize(1500, 'si')).toBe('1.5 kB');
+    });
+
+    it('honors the round parameter', () => {
+      expect(formatSize(1_500_000, 'iec', 0)).toBe('1 MiB');
+      expect(formatSize(1_500_000, 'iec', 2)).toBe('1.43 MiB');
+    });
+
+    it('returns an empty string for null/undefined/empty/non-numeric', () => {
+      expect(formatSize(null)).toBe('');
+      expect(formatSize(undefined)).toBe('');
+      expect(formatSize('')).toBe('');
+      expect(formatSize('abc')).toBe('');
+    });
+
+    it('formats zero as "0 B"', () => {
+      expect(formatSize(0)).toBe('0 B');
+    });
+  });
+
+  describe('parseSize', () => {
+    it('parses IEC unit spellings', () => {
+      expect(parseSize('2 GiB')).toBe(2 * 1024 ** 3);
+      expect(parseSize('200 TiB')).toBe(200 * 1024 ** 4);
+      expect(parseSize('512 B')).toBe(512);
+    });
+
+    it('treats short and human unit spellings as the chosen standard', () => {
+      // Under IEC, MB / M / MiB are all 1024-based (matches webui leniency).
+      expect(parseSize('500MB')).toBe(500 * 1024 ** 2);
+      expect(parseSize('500M')).toBe(500 * 1024 ** 2);
+      expect(parseSize('500MiB')).toBe(500 * 1024 ** 2);
+    });
+
+    it('is case- and whitespace-insensitive', () => {
+      expect(parseSize('200tib')).toBe(200 * 1024 ** 4);
+      expect(parseSize('  2   gib  ')).toBe(2 * 1024 ** 3);
+      expect(parseSize('2gib')).toBe(2 * 1024 ** 3);
+    });
+
+    it('parses decimals', () => {
+      expect(parseSize('1.5 KiB')).toBe(1536);
+    });
+
+    it('assumes the default unit for a bare number', () => {
+      expect(parseSize('200')).toBe(200 * 1024 ** 2); // default MiB
+      expect(parseSize('200', 'KiB')).toBe(200 * 1024);
+      expect(parseSize('200', 'GiB')).toBe(200 * 1024 ** 3);
+    });
+
+    it('uses base-10 multipliers under the SI standard', () => {
+      expect(parseSize('2 GB', 'MiB', 'si')).toBe(2_000_000_000);
+      expect(parseSize('500', 'kB', 'si')).toBe(500_000);
+    });
+
+    it('returns null for empty, malformed, or unknown-unit input', () => {
+      expect(parseSize('')).toBeNull();
+      expect(parseSize(null)).toBeNull();
+      expect(parseSize(undefined)).toBeNull();
+      expect(parseSize('abc')).toBeNull();
+      expect(parseSize('2 GiB extra')).toBeNull();
+      expect(parseSize('2 XiB')).toBeNull();
+      expect(parseSize('2 BB')).toBeNull();
+      expect(parseSize('-5 MiB')).toBeNull();
+    });
+
+    it('round-trips a formatted value back to (approximately) the same bytes', () => {
+      const bytes = 3 * 1024 ** 3;
+      expect(parseSize(formatSize(bytes))).toBe(bytes);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/input/size-conversion.ts
+++ b/projects/truenas-ui/src/lib/input/size-conversion.ts
@@ -1,0 +1,121 @@
+import { filesize } from 'filesize';
+
+/**
+ * Unit standard used to format and parse data sizes.
+ *
+ * - `iec` — base-2 with `KiB`/`MiB`/`GiB` symbols (1 KiB = 1024 B). The TrueNAS
+ *   convention and `tn-input`'s default.
+ * - `si`  — base-10 with `kB`/`MB`/`GB` symbols (1 kB = 1000 B).
+ */
+export type SizeStandard = 'iec' | 'si';
+
+// Ordered binary/decimal prefixes; the array index doubles as the power applied
+// to the base (B = base^0, K = base^1, M = base^2, ...).
+const UNIT_PREFIXES = ['B', 'K', 'M', 'G', 'T', 'P', 'E'] as const;
+
+/**
+ * Formats a raw byte count into a human-readable string (e.g. `2 GiB`).
+ *
+ * Returns an empty string for `null`/`undefined`/empty/non-numeric input so the
+ * field renders blank rather than `NaN`.
+ *
+ * @param bytes The byte count to format.
+ * @param standard Unit standard (defaults to IEC base-2).
+ * @param round Decimal places to round to (defaults to 2).
+ */
+export function formatSize(
+  bytes: number | string | null | undefined,
+  standard: SizeStandard = 'iec',
+  round = 2,
+): string {
+  if (bytes === null || bytes === undefined || bytes === '') {
+    return '';
+  }
+  const num = Number(bytes);
+  if (Number.isNaN(num)) {
+    return '';
+  }
+  // `standard: 'iec'` implies base 2 and KiB-style symbols; `'si'` implies base
+  // 10 and kB-style symbols. filesize derives the base from the standard.
+  return filesize(num, { standard, round });
+}
+
+/**
+ * Parses a human-readable size string into a raw byte count.
+ *
+ * Lenient by design: accepts IEC (`KiB`), short (`KB`), and human (`K`) unit
+ * spellings, optional whitespace, and a bare number (which is interpreted using
+ * `defaultUnit`). The chosen `standard` decides the multiplier — under `iec`,
+ * `MB`/`M`/`MiB` are all treated as 1024-based; under `si` they are 1000-based.
+ *
+ * Returns `null` for empty, malformed, or unrecognized-unit input so callers can
+ * map invalid entries to a null form-model value (never `0`).
+ *
+ * @param raw The human-readable string to parse.
+ * @param defaultUnit Unit assumed when the input carries no unit (defaults to `MiB`).
+ * @param standard Unit standard (defaults to IEC base-2).
+ */
+export function parseSize(
+  raw: string | number | null | undefined,
+  defaultUnit = 'MiB',
+  standard: SizeStandard = 'iec',
+): number | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  const str = String(raw).trim();
+  if (str === '') {
+    return null;
+  }
+
+  // Leading non-negative number (sizes are never negative), optional whitespace,
+  // then an optional unit. Anything trailing the unit makes the whole match fail.
+  const match = str.match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]*)$/);
+  if (!match) {
+    return null;
+  }
+
+  const num = parseFloat(match[1]);
+  if (Number.isNaN(num)) {
+    return null;
+  }
+
+  const exponent = unitExponent(match[2] || defaultUnit);
+  if (exponent === null) {
+    return null;
+  }
+
+  const base = standard === 'si' ? 1000 : 1024;
+  // Round to whole bytes: a byte count is an integer, and rounding absorbs the
+  // floating-point drift of e.g. 1.1 * 1024.
+  return Math.round(num * base ** exponent);
+}
+
+/**
+ * Resolves a unit spelling to its prefix power (B → 0, K → 1, M → 2, ...).
+ *
+ * Accepts the prefix alone (`K`), the short form (`KB`), or the IEC form (`KiB`),
+ * case-insensitively. Returns `null` for anything unrecognized.
+ */
+function unitExponent(unit: string): number | null {
+  const normalized = unit.trim().toUpperCase();
+  if (normalized === '') {
+    return null;
+  }
+  if (normalized === 'B' || normalized === 'BYTE' || normalized === 'BYTES') {
+    return 0;
+  }
+
+  const index = UNIT_PREFIXES.indexOf(normalized.charAt(0) as (typeof UNIT_PREFIXES)[number]);
+  // index 0 is 'B', already handled above; a leading 'B' here (e.g. "BB") is invalid.
+  if (index <= 0) {
+    return null;
+  }
+
+  // Allow the bare prefix ("K"), the short unit ("KB"), or the IEC unit ("KIB").
+  const suffix = normalized.slice(1);
+  if (suffix === '' || suffix === 'B' || suffix === 'IB') {
+    return index;
+  }
+  return null;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './lib/icon-button/icon-button.harness';
 export * from './lib/input/input.component';
 export * from './lib/input/input.harness';
 export * from './lib/input/input.directive';
+export * from './lib/input/size-conversion';
 export * from './lib/chip/chip.component';
 export * from './lib/card';
 export * from './lib/expansion-panel/expansion-panel.component';

--- a/projects/truenas-ui/src/stories/input.stories.ts
+++ b/projects/truenas-ui/src/stories/input.stories.ts
@@ -46,6 +46,19 @@ const meta: Meta<TnInputComponent> = {
       control: 'boolean',
       description: 'Number type: whether decimals are accepted. Set false for integer-only mode.',
     },
+    sizeStandard: {
+      control: { type: 'inline-radio' },
+      options: ['iec', 'si'],
+      description: 'Size type: unit standard — iec (KiB/MiB, base-2) or si (kB/MB, base-10).',
+    },
+    sizeDefaultUnit: {
+      control: 'text',
+      description: 'Size type: unit assumed when the user types a bare number (e.g. MiB).',
+    },
+    sizeRound: {
+      control: 'number',
+      description: 'Size type: decimal places used when formatting the value for display.',
+    },
     testId: {
       control: 'text',
       description: 'Test ID for the input component',
@@ -225,6 +238,53 @@ export const NumberDecimal: Story = {
     testId: 'number-decimal-input',
     disabled: false,
     allowDecimals: true,
+  },
+};
+
+/**
+ * **Size mode.** The form model holds a raw byte count; the field displays and
+ * accepts a human-readable string (`2 GiB`, `500M`, `2 TB`). Bare numbers use
+ * `sizeDefaultUnit`. The display canonicalizes on blur (`2048 KiB` → `2 MiB`).
+ */
+export const Size: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      // The model is bytes; 200 TiB shown below as the initial human-readable value.
+      sizeControl: new FormControl<number | null>(200 * 1024 ** 4, [Validators.min(0)]),
+    },
+    template: `
+      <tn-form-field
+        label="Local User Upload Bandwidth"
+        hint="Examples: 500 KiB, 500M, 2 TB">
+        <tn-input
+          [inputType]="inputType"
+          [placeholder]="placeholder"
+          [disabled]="disabled"
+          [testId]="testId"
+          [sizeStandard]="sizeStandard"
+          [sizeDefaultUnit]="sizeDefaultUnit"
+          [sizeRound]="sizeRound"
+          [formControl]="sizeControl">
+        </tn-input>
+      </tn-form-field>
+      <p style="margin-top: 12px; font-family: monospace;">
+        model (bytes): {{ sizeControl.value === null ? 'null' : sizeControl.value }}
+        ({{ sizeControl.value === null ? 'object' : 'number' }})
+      </p>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
+    },
+  }),
+  args: {
+    inputType: InputType.Size,
+    placeholder: 'e.g. 2 GiB',
+    testId: 'size-input',
+    disabled: false,
+    sizeStandard: 'iec',
+    sizeDefaultUnit: 'MiB',
+    sizeRound: 2,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11959,6 +11959,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"filesize@npm:~11.0.17":
+  version: 11.0.17
+  resolution: "filesize@npm:11.0.17"
+  checksum: 10c0/c7d633559731c70e6400fd0f59d4bfef8e9ca44ee932276ee972bfa03eeab925dc7b8af5747b61a36ac2f04c03a3472c106d7e62797cd2c445ccdd8ed665d44a
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -21251,6 +21258,7 @@ __metadata:
     eslint-plugin-storybook: "npm:10.1.11"
     eslint-plugin-unused-imports: "npm:^4.3.0"
     fast-glob: "npm:^3.3.3"
+    filesize: "npm:~11.0.17"
     husky: "npm:^9.1.7"
     jasmine-core: "npm:~4.3.0"
     jest: "npm:^30.2.0"


### PR DESCRIPTION
Adds an InputType.Size mode to tn-input that stores a raw byte count in the form model while displaying and accepting a human-readable string (e.g. "2 GiB", "500M", "2 TB"), mirroring webui's ix-input format/parse pattern but built in.

- formatSize/parseSize helpers (filesize for formatting; custom lenient parser for the reverse, accepting IEC/short/human unit spellings)
- sizeStandard (iec/si), sizeDefaultUnit, and sizeRound inputs
- emits bytes on type; canonicalizes the display on blur; null (never 0) for empty/invalid input
- TnInputHarness.getByteValue() helper
- unit + component + harness tests, and a Storybook Size story
- declares filesize as a runtime dependency of the published package


https://github.com/user-attachments/assets/6dca3cc0-1fb9-46fd-84d6-04fea73ba0f5

