### PR TITLE
NAS-141337 / 27.0.0-BETA.1 / feat(input): add password visibility toggle

### DIFF
--- a/projects/truenas-ui/src/lib/input/input.component.html
+++ b/projects/truenas-ui/src/lib/input/input.component.html
@@ -1,7 +1,7 @@
 <div
   class="tn-input-container"
   [class.tn-input-container--has-prefix]="hasPrefixIcon()"
-  [class.tn-input-container--has-suffix]="hasSuffixIcon()"
+  [class.tn-input-container--has-suffix]="hasSuffixIcon() || hasPasswordToggle()"
 >
   <!-- Prefix icon -->
   @if (hasPrefixIcon()) {
@@ -65,6 +65,22 @@
         [name]="suffixIcon()!"
         [library]="suffixIconLibrary()"
       />
+    </button>
+  }
+
+  <!-- Password visibility toggle -->
+  @if (hasPasswordToggle()) {
+    <button
+      type="button"
+      class="tn-input__visibility-toggle"
+      tnTestIdType="button"
+      [tnTestId]="passwordToggleTestId()"
+      [attr.aria-label]="passwordVisible() ? 'Hide password' : 'Show password'"
+      [attr.aria-pressed]="passwordVisible()"
+      [disabled]="isDisabled()"
+      (click)="togglePasswordVisibility()"
+    >
+      <tn-icon size="sm" aria-hidden="true" [name]="passwordToggleIcon()" />
     </button>
   }
 </div>

--- a/projects/truenas-ui/src/lib/input/input.component.html
+++ b/projects/truenas-ui/src/lib/input/input.component.html
@@ -68,7 +68,9 @@
     </button>
   }
 
-  <!-- Password visibility toggle -->
+  <!-- Password visibility toggle. State is conveyed via the swapping
+       aria-label alone — no aria-pressed, which would contradict a label that
+       already names the action ("Hide password, pressed" is ambiguous). -->
   @if (hasPasswordToggle()) {
     <button
       type="button"
@@ -76,7 +78,6 @@
       tnTestIdType="button"
       [tnTestId]="passwordToggleTestId()"
       [attr.aria-label]="passwordVisible() ? 'Hide password' : 'Show password'"
-      [attr.aria-pressed]="passwordVisible()"
       [disabled]="isDisabled()"
       (click)="togglePasswordVisibility()"
     >

--- a/projects/truenas-ui/src/lib/input/input.component.scss
+++ b/projects/truenas-ui/src/lib/input/input.component.scss
@@ -77,8 +77,10 @@
   pointer-events: none;
 }
 
-// Suffix action button
-.tn-input__suffix-action {
+// Suffix action button & password visibility toggle (distinct classes so
+// tests/harnesses can target each, same visual treatment)
+.tn-input__suffix-action,
+.tn-input__visibility-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -117,7 +119,8 @@
 // Accessibility improvements
 @media (prefers-reduced-motion: reduce) {
   .tn-input-container,
-  .tn-input__suffix-action {
+  .tn-input__suffix-action,
+  .tn-input__visibility-toggle {
     transition: none;
   }
 }

--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -115,6 +115,112 @@ describe('TnInputComponent', () => {
     });
   });
 
+  describe('password visibility toggle', () => {
+    const getToggle = (): HTMLButtonElement | null =>
+      fixture.nativeElement.querySelector('.tn-input__visibility-toggle');
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('inputType', InputType.Password);
+      fixture.detectChanges();
+    });
+
+    it('should render the toggle on password fields', () => {
+      expect(getToggle()).toBeTruthy();
+    });
+
+    it('should not render the toggle on non-password fields', () => {
+      fixture.componentRef.setInput('inputType', InputType.PlainText);
+      fixture.detectChanges();
+
+      expect(getToggle()).toBeNull();
+    });
+
+    it('should not render the toggle when showPasswordToggle is false', () => {
+      fixture.componentRef.setInput('showPasswordToggle', false);
+      fixture.detectChanges();
+
+      expect(getToggle()).toBeNull();
+    });
+
+    it('should yield to a consumer-provided suffix icon', () => {
+      fixture.componentRef.setInput('suffixIcon', 'close-circle');
+      fixture.detectChanges();
+
+      expect(getToggle()).toBeNull();
+      expect(fixture.nativeElement.querySelector('.tn-input__suffix-action')).toBeTruthy();
+    });
+
+    it('should come back masked when the field leaves and re-enters password mode', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('text');
+
+      fixture.componentRef.setInput('inputType', InputType.PlainText);
+      fixture.detectChanges();
+      fixture.componentRef.setInput('inputType', InputType.Password);
+      fixture.detectChanges();
+
+      expect(input.type).toBe('password');
+      expect(getToggle()!.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('should flip the input type between password and text on click', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      expect(input.type).toBe('password');
+
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('text');
+
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('password');
+    });
+
+    it('should reflect the state in aria-label and aria-pressed', () => {
+      const toggle = getToggle()!;
+      expect(toggle.getAttribute('aria-label')).toBe('Show password');
+      expect(toggle.getAttribute('aria-pressed')).toBe('false');
+
+      toggle.click();
+      fixture.detectChanges();
+      expect(toggle.getAttribute('aria-label')).toBe('Hide password');
+      expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('should emit a role-first test id scoped by the testId base', () => {
+      fixture.componentRef.setInput('testId', 'login-password');
+      fixture.detectChanges();
+
+      expect(getToggle()!.getAttribute('data-testid')).toBe('button-toggle-password-login-password');
+    });
+
+    it('should emit the bare role test id when no testId is set', () => {
+      expect(getToggle()!.getAttribute('data-testid')).toBe('button-toggle-password');
+    });
+
+    it('should disable the toggle with the input', () => {
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+
+      expect(getToggle()!.disabled).toBe(true);
+    });
+
+    it('should preserve the value while toggling', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      input.value = 'hunter2';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      getToggle()!.click();
+      fixture.detectChanges();
+
+      expect(input.value).toBe('hunter2');
+      expect(input.type).toBe('text');
+    });
+  });
+
   describe('value changes', () => {
     it('should update value on input event', () => {
       const input = fixture.nativeElement.querySelector('input');

--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -162,7 +162,45 @@ describe('TnInputComponent', () => {
       fixture.detectChanges();
 
       expect(input.type).toBe('password');
-      expect(getToggle()!.getAttribute('aria-pressed')).toBe('false');
+      expect(getToggle()!.getAttribute('aria-label')).toBe('Show password');
+    });
+
+    it('should re-mask when showPasswordToggle is turned off while revealed', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('text');
+
+      fixture.componentRef.setInput('showPasswordToggle', false);
+      fixture.detectChanges();
+
+      expect(getToggle()).toBeNull();
+      expect(input.type).toBe('password');
+    });
+
+    it('should re-mask when a suffix icon replaces the toggle while revealed', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('text');
+
+      fixture.componentRef.setInput('suffixIcon', 'close-circle');
+      fixture.detectChanges();
+
+      expect(getToggle()).toBeNull();
+      expect(input.type).toBe('password');
+    });
+
+    it('should re-mask when the field is disabled while revealed', () => {
+      const input = fixture.nativeElement.querySelector('input');
+      getToggle()!.click();
+      fixture.detectChanges();
+      expect(input.type).toBe('text');
+
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+
+      expect(input.type).toBe('password');
     });
 
     it('should flip the input type between password and text on click', () => {
@@ -178,15 +216,16 @@ describe('TnInputComponent', () => {
       expect(input.type).toBe('password');
     });
 
-    it('should reflect the state in aria-label and aria-pressed', () => {
+    it('should reflect the state in the aria-label, without aria-pressed', () => {
       const toggle = getToggle()!;
       expect(toggle.getAttribute('aria-label')).toBe('Show password');
-      expect(toggle.getAttribute('aria-pressed')).toBe('false');
+      // No aria-pressed: it would contradict a label that names the action.
+      expect(toggle.hasAttribute('aria-pressed')).toBe(false);
 
       toggle.click();
       fixture.detectChanges();
       expect(toggle.getAttribute('aria-label')).toBe('Hide password');
-      expect(toggle.getAttribute('aria-pressed')).toBe('true');
+      expect(toggle.hasAttribute('aria-pressed')).toBe(false);
     });
 
     it('should emit a role-first test id scoped by the testId base', () => {

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -112,12 +112,14 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   isPassword = computed(() => this.inputType() === InputType.Password);
   /**
    * Whether the password is currently revealed. Not exposed as an input so a
-   * reveal is always an explicit user gesture, and linked to `isPassword` so
-   * entering/leaving password mode resets to masked — a field that flips back
-   * to `Password` must not come back already revealed.
+   * reveal is always an explicit user gesture, and linked to the toggle's own
+   * availability so a revealed value never outlives the control that revealed
+   * it: whenever the toggle goes away (the field leaves password mode,
+   * `showPasswordToggle` flips off, a `suffixIcon` replaces it) or the field
+   * is disabled, the field snaps back to masked.
    */
   protected passwordVisible = linkedSignal({
-    source: this.isPassword,
+    source: () => this.hasPasswordToggle() && !this.isDisabled(),
     computation: () => false,
   });
   /** The `type` attribute actually rendered. Number and size modes use a text input: number avoids the native type="number" footguns, size must accept unit letters. A revealed password renders as text — flipping the type attribute is the standard reveal mechanism and preserves value and caret. */

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -1,9 +1,10 @@
 import { FocusMonitor, A11yModule } from '@angular/cdk/a11y';
 import type { ElementRef, AfterViewInit, OnDestroy} from '@angular/core';
-import { Component, viewChild, inject, input, output, computed, signal, forwardRef } from '@angular/core';
+import { Component, viewChild, inject, input, output, computed, signal, linkedSignal, forwardRef } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { InputType } from '../enums/input-type.enum';
+import { tnIconMarker } from '../icon/icon-marker';
 import type { IconLibraryType } from '../icon/icon.component';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
@@ -80,6 +81,15 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
    */
   sizeRound = input<number>(2);
 
+  /**
+   * Whether a `Password` field renders the built-in visibility toggle — the eye
+   * button that switches the field between masked and plain-text display.
+   * Defaults to true; set false for secrets that must never be revealed.
+   * Setting `suffixIcon` suppresses the toggle automatically (a custom suffix
+   * control replaces it). Ignored unless `inputType` is `Password`.
+   */
+  showPasswordToggle = input<boolean>(true);
+
   // Icon inputs
   prefixIcon = input<string | undefined>(undefined);
   prefixIconLibrary = input<IconLibraryType | undefined>(undefined);
@@ -98,8 +108,24 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   isSize = computed(() => this.inputType() === InputType.Size);
   /** True when the field only accepts whole numbers (i.e. `allowDecimals` is false). */
   integerOnly = computed(() => !this.allowDecimals());
-  /** The `type` attribute actually rendered. Number and size modes use a text input: number avoids the native type="number" footguns, size must accept unit letters. */
-  resolvedType = computed(() => (this.isNumeric() || this.isSize() ? InputType.PlainText : this.inputType()));
+  /** True when the field is a password field. */
+  isPassword = computed(() => this.inputType() === InputType.Password);
+  /**
+   * Whether the password is currently revealed. Not exposed as an input so a
+   * reveal is always an explicit user gesture, and linked to `isPassword` so
+   * entering/leaving password mode resets to masked — a field that flips back
+   * to `Password` must not come back already revealed.
+   */
+  protected passwordVisible = linkedSignal({
+    source: this.isPassword,
+    computation: () => false,
+  });
+  /** The `type` attribute actually rendered. Number and size modes use a text input: number avoids the native type="number" footguns, size must accept unit letters. A revealed password renders as text — flipping the type attribute is the standard reveal mechanism and preserves value and caret. */
+  resolvedType = computed(() => {
+    if (this.isNumeric() || this.isSize()) {return InputType.PlainText;}
+    if (this.isPassword() && this.passwordVisible()) {return InputType.PlainText;}
+    return this.inputType();
+  });
   /** `inputmode` hint: numeric keypad for integers, decimal keypad otherwise. Null (omitted) outside number mode — size fields accept unit letters, so they keep the full keyboard. */
   numericInputMode = computed<'numeric' | 'decimal' | null>(() => {
     if (!this.isNumeric()) {return null;}
@@ -107,6 +133,34 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   });
   /** Number and size modes are always single-line; they win over `multiline` if both are set. */
   showTextarea = computed(() => this.multiline() && !this.isNumeric() && !this.isSize());
+  /**
+   * The visibility toggle renders only on single-line password fields (a
+   * password+multiline combo renders a textarea, which has no `type` to flip),
+   * and yields to a consumer-provided `suffixIcon` — a custom suffix control
+   * replaces the built-in toggle rather than stacking a second button.
+   */
+  protected hasPasswordToggle = computed(() =>
+    this.isPassword() && this.showPasswordToggle() && !this.showTextarea() && !this.hasSuffixIcon()
+  );
+  /**
+   * Icon for the visibility toggle, mirroring the field's current state: a
+   * slashed eye while masked, an open eye while revealed. The literal
+   * `tnIconMarker` calls double as build-time markers that pull both icons
+   * into the sprite.
+   */
+  protected passwordToggleIcon = computed(() =>
+    this.passwordVisible() ? tnIconMarker('eye', 'mdi') : tnIconMarker('eye-off', 'mdi')
+  );
+  /**
+   * Role-first test-id segments for the visibility toggle:
+   * `button-toggle-password[-<testId>]`. The toggle is fixed field chrome, so
+   * the role leads (matching the dialog-shell close/fullscreen convention) and
+   * automation can target every password toggle with one prefix selector.
+   */
+  protected passwordToggleTestId = computed<(string | number | null | undefined)[]>(() => {
+    const base = this.testId();
+    return ['toggle-password', ...(Array.isArray(base) ? base : [base])];
+  });
 
   // Unique per instance: a hard-coded id produced duplicate ids when multiple
   // tn-inputs share a page (invalid HTML, and it breaks any future label `for=`,
@@ -229,6 +283,10 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
       }
     }
     this.onTouched();
+  }
+
+  protected togglePasswordVisibility(): void {
+    this.passwordVisible.update((visible) => !visible);
   }
 
   /** Strips any character that can't appear in the current numeric mode (single leading '-', single '.' for decimals). */

--- a/projects/truenas-ui/src/lib/input/input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.harness.spec.ts
@@ -417,6 +417,58 @@ describe('TnInputHarness', () => {
     });
   });
 
+  describe('password visibility toggle', () => {
+    beforeEach(() => {
+      hostComponent.inputType.set(InputType.Password);
+      fixture.detectChanges();
+    });
+
+    it('should report the toggle on password fields', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      expect(await input.hasPasswordToggle()).toBe(true);
+    });
+
+    it('should not report the toggle on non-password fields', async () => {
+      hostComponent.inputType.set(InputType.PlainText);
+      fixture.detectChanges();
+
+      const input = await loader.getHarness(TnInputHarness);
+      expect(await input.hasPasswordToggle()).toBe(false);
+    });
+
+    it('should start masked and reveal/mask on toggle', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      expect(await input.isPasswordRevealed()).toBe(false);
+
+      await input.togglePasswordVisibility();
+      expect(await input.isPasswordRevealed()).toBe(true);
+
+      await input.togglePasswordVisibility();
+      expect(await input.isPasswordRevealed()).toBe(false);
+    });
+
+    it('should preserve the value across toggles', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      await input.setValue('hunter2');
+
+      await input.togglePasswordVisibility();
+      expect(await input.getValue()).toBe('hunter2');
+    });
+
+    it('should not confuse the toggle with a suffix action', async () => {
+      const input = await loader.getHarness(TnInputHarness);
+      expect(await input.hasSuffixAction()).toBe(false);
+    });
+
+    it('should throw when toggling a field without a toggle', async () => {
+      hostComponent.inputType.set(InputType.PlainText);
+      fixture.detectChanges();
+
+      const input = await loader.getHarness(TnInputHarness);
+      await expect(input.togglePasswordVisibility()).rejects.toThrow('No password visibility toggle found on this input.');
+    });
+  });
+
   describe('focus / blur', () => {
     it('should focus the input', async () => {
       const input = await loader.getHarness(TnInputHarness);

--- a/projects/truenas-ui/src/lib/input/input.harness.ts
+++ b/projects/truenas-ui/src/lib/input/input.harness.ts
@@ -34,6 +34,7 @@ export class TnInputHarness extends ComponentHarness {
   private prefixIconEl = this.locatorForOptional('tn-icon.tn-input__prefix-icon');
   private suffixButton = this.locatorForOptional('.tn-input__suffix-action');
   private suffixIconEl = this.locatorForOptional(TnIconHarness.with({ ancestor: '.tn-input__suffix-action' }));
+  private visibilityToggle = this.locatorForOptional('.tn-input__visibility-toggle');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for an input
@@ -250,6 +251,46 @@ export class TnInputHarness extends ComponentHarness {
       throw new Error('No suffix action button found on this input.');
     }
     return button.click();
+  }
+
+  /**
+   * Checks whether the password visibility toggle is present.
+   *
+   * @returns Promise resolving to true if the toggle button exists.
+   */
+  async hasPasswordToggle(): Promise<boolean> {
+    const toggle = await this.visibilityToggle();
+    return toggle !== null;
+  }
+
+  /**
+   * Whether the password is currently revealed (the field renders as plain text).
+   *
+   * Only meaningful on password-type inputs; resolves false while masked.
+   *
+   * @returns Promise resolving to true when the value is shown in plain text.
+   */
+  async isPasswordRevealed(): Promise<boolean> {
+    const toggle = await this.visibilityToggle();
+    if (!toggle) {
+      return false;
+    }
+    const input = await this.inputEl();
+    return (await input.getProperty<string>('type')) === 'text';
+  }
+
+  /**
+   * Clicks the password visibility toggle, switching between masked and
+   * plain-text display.
+   *
+   * @returns Promise that resolves when the click action is complete.
+   */
+  async togglePasswordVisibility(): Promise<void> {
+    const toggle = await this.visibilityToggle();
+    if (!toggle) {
+      throw new Error('No password visibility toggle found on this input.');
+    }
+    return toggle.click();
   }
 
   /**

--- a/projects/truenas-ui/src/stories/input.stories.ts
+++ b/projects/truenas-ui/src/stories/input.stories.ts
@@ -15,6 +15,7 @@ tnIconMarker('close-circle', 'mdi');
 tnIconMarker('email', 'mdi');
 tnIconMarker('eye', 'mdi');
 tnIconMarker('eye-off', 'mdi');
+tnIconMarker('lock', 'mdi');
 
 const meta: Meta<TnInputComponent> = {
   title: 'Components/Input',
@@ -58,6 +59,10 @@ const meta: Meta<TnInputComponent> = {
     sizeRound: {
       control: 'number',
       description: 'Size type: decimal places used when formatting the value for display.',
+    },
+    showPasswordToggle: {
+      control: 'boolean',
+      description: 'Password type: whether the built-in visibility toggle (eye button) is rendered. Defaults to true.',
     },
     testId: {
       control: 'text',
@@ -159,6 +164,47 @@ export const WithError: Story = {
     placeholder: 'Enter your email',
     testId: 'error-input',
     disabled: false,
+  },
+};
+
+/**
+ * **Password.** `inputType="password"` renders a built-in visibility toggle:
+ * an eye button that switches the field between masked and plain-text display.
+ * The field always starts masked. Set `showPasswordToggle` to `false` to omit
+ * the toggle (e.g. for secrets that must never be revealed).
+ */
+export const Password: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      passwordControl: new FormControl('foobar'),
+    },
+    template: `
+      <tn-form-field label="Password">
+        <tn-input
+          [inputType]="inputType"
+          [placeholder]="placeholder"
+          [disabled]="disabled"
+          [testId]="testId"
+          [showPasswordToggle]="showPasswordToggle"
+          [prefixIcon]="prefixIcon"
+          [prefixIconLibrary]="prefixIconLibrary"
+          [formControl]="passwordControl">
+        </tn-input>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
+    },
+  }),
+  args: {
+    inputType: InputType.Password,
+    placeholder: 'Enter your password',
+    testId: 'password-input',
+    disabled: false,
+    showPasswordToggle: true,
+    prefixIcon: 'lock',
+    prefixIconLibrary: 'mdi' as const,
   },
 };
 


### PR DESCRIPTION
Password-type tn-inputs now render a built-in eye button that switches the field between masked and plain-text display by flipping the native type attribute. The field always starts masked and the revealed state is internal, so a reveal is always an explicit user gesture.

- New showPasswordToggle input (default true) to opt out for secrets that must never be revealed or when wiring a custom suffix control
- Toggle carries aria-label, aria-pressed, and a role-first test id (button-toggle-password[-<testId>], matching the dialog convention)
- Distinct tn-input__visibility-toggle class sharing suffix-action styling, so suffix-action selectors stay unambiguous
- Harness: hasPasswordToggle / isPasswordRevealed / togglePasswordVisibility
- Storybook: Password story with lock prefix and toggle control

https://github.com/user-attachments/assets/6a6b7575-55b4-47b1-bbfc-a40de2086927

