### PR TITLE
NAS-141344 / 27.0.0-BETA.1 / feat(button): add type input so tn-button can act as a form submit button

### DIFF
--- a/projects/truenas-ui/src/lib/button/button.component.html
+++ b/projects/truenas-ui/src/lib/button/button.component.html
@@ -39,8 +39,8 @@
 } @else {
   <button
     #button
-    type="button"
     tnTestIdType="button"
+    [attr.type]="type()"
     [ngClass]="classes()"
     [ngStyle]="{ 'background-color': backgroundColor() }"
     [disabled]="disabled()"

--- a/projects/truenas-ui/src/lib/button/button.component.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.spec.ts
@@ -111,6 +111,35 @@ describe('TnButtonComponent', () => {
     });
   });
 
+  describe('type', () => {
+    it('defaults to type="button" so it never submits an enclosing form by accident', () => {
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.getAttribute('type')).toBe('button');
+    });
+
+    it('renders type="submit" when requested', () => {
+      fixture.componentRef.setInput('type', 'submit');
+      fixture.detectChanges();
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.getAttribute('type')).toBe('submit');
+    });
+
+    it('submits an enclosing form when a submit-typed button is clicked', () => {
+      const form = document.createElement('form');
+      form.appendChild(fixture.nativeElement);
+      document.body.appendChild(form);
+      const submitSpy = jest.fn((event: Event) => event.preventDefault());
+      form.addEventListener('submit', submitSpy);
+
+      fixture.componentRef.setInput('type', 'submit');
+      fixture.detectChanges();
+      fixture.nativeElement.querySelector('button').click();
+
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+      form.remove();
+    });
+  });
+
   describe('onClick event', () => {
     it('should emit onClick event when clicked', () => {
       const clickSpy = jest.fn();

--- a/projects/truenas-ui/src/lib/button/button.component.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.ts
@@ -21,6 +21,14 @@ export class TnButtonComponent implements AfterViewInit {
   label = input<string>('Button');
   disabled = input<boolean>(false);
   /**
+   * Native `type` of the rendered `<button>`. Defaults to `button` so stray
+   * clicks never submit an enclosing form. Set to `submit` for a form's save
+   * button — this is what makes pressing Enter in a form field fire the
+   * form's `(submit)`/`(ngSubmit)` handler; a `(onClick)` binding alone does
+   * not. Ignored in anchor mode (`href`/`routerLink`).
+   */
+  type = input<'button' | 'submit' | 'reset'>('button');
+  /**
    * Semantic test-id base for the rendered element. The library prepends the
    * element type (`button`) and renders the result under whichever attribute
    * name is configured via `TN_TEST_ATTR` (default `data-testid`) — e.g.

--- a/projects/truenas-ui/src/lib/button/button.harness.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.ts
@@ -88,6 +88,25 @@ export class TnButtonHarness extends ComponentHarness {
   }
 
   /**
+   * Gets the native `type` of the rendered `<button>` (`button`, `submit`, or
+   * `reset`). Returns `null` for anchor-mode renders.
+   *
+   * @example
+   * ```typescript
+   * const saveBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+   * expect(await saveBtn.getType()).toBe('submit');
+   * ```
+   */
+  async getType(): Promise<string | null> {
+    const button = await this._button();
+    const tagName = (await button.getProperty<string>('tagName')).toLowerCase();
+    if (tagName !== 'button') {
+      return null;
+    }
+    return button.getAttribute('type');
+  }
+
+  /**
    * Gets the resolved URL of the rendered element. Returns the `href` for
    * anchor-mode renders (both plain `href` and `routerLink`) and `null` for
    * button-mode renders.

--- a/projects/truenas-ui/src/stories/button.stories.ts
+++ b/projects/truenas-ui/src/stories/button.stories.ts
@@ -25,6 +25,11 @@ const meta: Meta<TnButtonComponent> = {
       control: 'select',
       options: ['filled', 'outline'],
     },
+    type: {
+      control: 'select',
+      options: ['button', 'submit', 'reset'],
+      description: 'Native button type. Use "submit" for a form\'s save button so Enter in a field submits the form.',
+    },
     primary: {
       control: 'boolean',
     },
@@ -185,6 +190,45 @@ export const DisabledLink: Story = {
 
     await expect(link.getAttribute('aria-disabled')).toBe('true');
     await expect(link.hasAttribute('href')).toBe(false);
+  },
+};
+
+/**
+ * **Form submit.** `tn-button` renders `type="button"` by default, so it never
+ * submits an enclosing form. For a form's save button, set `type="submit"` —
+ * that is what makes pressing Enter in any form field fire the form's
+ * `(submit)`/`(ngSubmit)` handler. Wiring only `(onClick)` on the save button
+ * leaves Enter a no-op and the form's `(submit)` binding dead.
+ */
+export const FormSubmit: Story = {
+  args: { color: 'primary', variant: 'filled', label: 'Save', type: 'submit' },
+  decorators: [moduleMetadata({ imports: [TnButtonComponent] })],
+  render: (args) => ({
+    props: { ...args, onSubmit: (event: Event) => event.preventDefault() },
+    template: `
+      <form (submit)="onSubmit($event)">
+        <input name="username" placeholder="Username" style="display: block; margin-bottom: 8px;" />
+        <tn-button [color]="color" [variant]="variant" [label]="label" [type]="type" />
+      </form>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const form = canvasElement.querySelector('form')!;
+    let submitCount = 0;
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submitCount++;
+    });
+
+    // Enter inside a field submits the form because the save button is type="submit"
+    const field = canvas.getByPlaceholderText('Username');
+    await userEvent.type(field, 'admin{enter}');
+    await expect(submitCount).toBe(1);
+
+    // Clicking the save button submits too
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+    await expect(submitCount).toBe(2);
   },
 };
 


### PR DESCRIPTION
tn-button hardcoded type="button" on its native element, so consumers could not render a real submit button. Forms wiring Save via (onClick)="onSubmit()" lost Enter-to-submit entirely and their form (submit) bindings became dead code.

Add a type input ('button' | 'submit' | 'reset', default 'button' so existing usages are unchanged), bind it on the native button (ignored in anchor mode), expose getType() on the harness, and cover it with spec tests plus a FormSubmit story whose play function verifies Enter in a field submits the enclosing form.