### PR TITLE
NAS-141342 / 27.0.0-BETA.1 / feat(select): add allowEmpty input to clear the selection

### DIFF
--- a/projects/truenas-ui/src/lib/date-range-input/time-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/time-input.component.ts
@@ -89,9 +89,11 @@ export class TnTimeInputComponent implements ControlValueAccessor {
   }
 
   // Event handlers
-  onSelectionChange(value: string): void {
+  onSelectionChange(value: string | null): void {
+    // The inner select never sets allowEmpty, so `null` cannot occur here —
+    // the widened type only satisfies tn-select's `selectionChange` contract.
     this._value = value;
-    this.onChange(value);
+    this.onChange(value ?? '');
     this.onTouched();
   }
 }

--- a/projects/truenas-ui/src/lib/select/select.component.html
+++ b/projects/truenas-ui/src/lib/select/select.component.html
@@ -46,8 +46,8 @@
 
     <!-- Options List -->
     <div class="tn-select-options">
-      <!-- Regular Options -->
-      @for (option of options(); track $index) {
+      <!-- Regular Options (preceded by the synthetic empty option when allowEmpty is set) -->
+      @for (option of displayOptions(); track $index) {
         <!-- Option activation lives on the trigger via aria-activedescendant; options have tabindex="-1" and never receive DOM focus. -->
         <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
         <div
@@ -55,6 +55,7 @@
           role="option"
           tabindex="-1"
           tnTestIdType="option"
+          [class.tn-select-empty-option]="isEmptyOption(option)"
           [tnTestId]="optionTestIdParts(option)"
           [attr.id]="optionId(option)"
           [class.selected]="isOptionSelected(option)"
@@ -79,7 +80,7 @@
       <!-- Option Groups -->
       @for (group of optionGroups(); track $index; let isFirst = $first) {
         <!-- Group Separator (not shown before first group if we have regular options) -->
-        @if (!isFirst || options().length > 0) {
+        @if (!isFirst || displayOptions().length > 0) {
           <div
             class="tn-select-separator"
             role="separator">

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -161,6 +161,12 @@
     cursor: not-allowed;
     opacity: 0.6;
   }
+
+  // Synthetic allowEmpty clear option — dimmed so it reads as "no value"
+  // rather than as a regular choice.
+  &.tn-select-empty-option {
+    color: var(--tn-fg2, #6c757d);
+  }
 }
 
 .tn-select-check {

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -53,6 +53,17 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * with i18n requirements can pass a translated string.
    */
   noOptionsLabel = input<string>('No options available');
+  /**
+   * When `true` (single-select mode only), prepends a synthetic "empty"
+   * option to the dropdown so users can unset a chosen value: picking it
+   * resets the selection to `null`, shows the placeholder again, and emits
+   * `null` via `selectionChange` (and to any bound form control). Mirrors
+   * webui ix-select's `--` option. Ignored when `multiple` is set — there,
+   * values are cleared by toggling them off individually.
+   */
+  allowEmpty = input<boolean>(false);
+  /** Label of the empty option rendered when `allowEmpty` is set. */
+  emptyLabel = input<string>('--');
   disabled = input<boolean>(false);
   testId = input<TnTestIdValue>(undefined);
   multiple = input<boolean>(false);
@@ -85,7 +96,11 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    */
   compareWith = input<(a: T | null, b: T | null) => boolean>();
 
-  selectionChange = output<T>();
+  /**
+   * Emits the picked value on each selection in single mode. Emits `null`
+   * when the user picks the `allowEmpty` empty option to clear the field.
+   */
+  selectionChange = output<T | null>();
   /** Emits the full array of selected values after each toggle in multiple mode. */
   multiSelectionChange = output<T[]>();
 
@@ -115,6 +130,28 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
   isDisabled = computed(() => this.disabled() || this.formDisabled());
 
   /**
+   * The synthetic clear-selection option (`allowEmpty`, single mode only).
+   * Its value is `null` cast to `T` so it flows through the same selection
+   * path as real options — `selectedValue`/`writeValue` already model "no
+   * selection" as `null`, so picking it clears the field for free.
+   */
+  protected emptyOption = computed<TnSelectOption<T> | null>(() => {
+    if (!this.allowEmpty() || this.multiple()) {return null;}
+    return { value: null as unknown as T, label: this.emptyLabel() };
+  });
+
+  /** Ungrouped options as rendered: the empty option (when enabled) first. */
+  protected displayOptions = computed<TnSelectOption<T>[]>(() => {
+    const empty = this.emptyOption();
+    return empty ? [empty, ...this.options()] : this.options();
+  });
+
+  /** Whether `option` is the synthetic `allowEmpty` clear option. */
+  protected isEmptyOption(option: TnSelectOption<T>): boolean {
+    return option === this.emptyOption();
+  }
+
+  /**
    * Selectable, non-disabled options in display order (regular options first,
    * then groups). Used by keyboard navigation so we can skip disabled
    * entries and group headers without a separate filter pass.
@@ -123,7 +160,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     const result: { option: TnSelectOption<T>; id: string }[] = [];
     const baseId = `tn-select-opt-${this.idNamespace()}`;
     let i = 0;
-    for (const opt of this.options()) {
+    for (const opt of this.displayOptions()) {
       if (!opt.disabled) {
         result.push({ option: opt, id: `${baseId}-${i}` });
       }
@@ -169,6 +206,12 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * `value`, else its `label`.
    */
   protected optionTestIdParts(option: TnSelectOption<T>): (string | number | null | undefined)[] {
+    // The synthetic empty option gets a fixed `empty` discriminator — its
+    // label (`--` by default) would be stripped entirely by kebab
+    // normalization, leaving a non-unique id.
+    if (this.isEmptyOption(option)) {
+      return scopeTestId(this.testId(), 'empty');
+    }
     const extractor = this.optionTestIdKey();
     let key: string | number | null | undefined;
     if (extractor) {
@@ -244,6 +287,10 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
         this.compareValues(x.option.value, selected),
       );
       this.focusedIndex.set(idx);
+    } else if (this.emptyOption()) {
+      // A cleared value means the empty option (always first) is the current
+      // selection — seed keyboard focus there.
+      this.focusedIndex.set(0);
     } else {
       this.focusedIndex.set(-1);
     }

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -30,7 +30,7 @@ class TestHostComponent {
   disabled = signal(false);
   selectedValue: string | null = null;
 
-  handleSelection(value: string): void {
+  handleSelection(value: string | null): void {
     this.selectedValue = value;
   }
 }
@@ -45,6 +45,7 @@ class TestHostComponent {
       placeholder="Select fruits"
       [options]="options()"
       [multiple]="true"
+      [allowEmpty]="true"
       (selectionChange)="handleSelection($event)" />
   `
 })
@@ -54,9 +55,9 @@ class TestMultiHostComponent {
     { value: 'banana', label: 'Banana' },
     { value: 'cherry', label: 'Cherry' },
   ]);
-  selectedValues: string[] = [];
+  selectedValues: (string | null)[] = [];
 
-  handleSelection(value: string): void {
+  handleSelection(value: string | null): void {
     this.selectedValues.push(value);
   }
 }
@@ -83,7 +84,7 @@ class TestCompareHostComponent {
   compareFn = (a: { id: number } | null, b: { id: number } | null) =>
     a?.id === b?.id;
 
-  handleSelection(value: { id: number; name: string }): void {
+  handleSelection(value: { id: number; name: string } | null): void {
     this.selectedValue = value;
   }
 }
@@ -117,7 +118,7 @@ class TestGroupDisabledHostComponent {
   ]);
   selectedValue: string | null = null;
 
-  handleSelection(value: string): void {
+  handleSelection(value: string | null): void {
     this.selectedValue = value;
   }
 }
@@ -143,6 +144,35 @@ class TestMultiOutputHostComponent {
   ]);
   lastItem: string | null = null;
   lastArray: string[] = [];
+}
+
+@Component({
+  selector: 'tn-test-allow-empty-host',
+  standalone: true,
+  imports: [TnSelectComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      testId="fruit"
+      placeholder="Select a fruit"
+      [options]="options()"
+      [allowEmpty]="allowEmpty()"
+      [emptyLabel]="emptyLabel()"
+      (selectionChange)="handleSelection($event)" />
+  `
+})
+class TestAllowEmptyHostComponent {
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+  ]);
+  allowEmpty = signal(true);
+  emptyLabel = signal('--');
+  selections: (string | null)[] = [];
+
+  handleSelection(value: string | null): void {
+    this.selections.push(value);
+  }
 }
 
 describe('TnSelectHarness', () => {
@@ -269,6 +299,15 @@ describe('TnSelectHarness', () => {
     });
   });
 
+  describe('clear', () => {
+    it('should throw when the select has no empty option', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await expect(select.clear()).rejects.toThrow(
+        'Select has no empty option — set `allowEmpty` to make it clearable.'
+      );
+    });
+  });
+
   describe('getOptions', () => {
     it('should return all option labels', async () => {
       const select = await loader.getHarness(TnSelectHarness);
@@ -380,6 +419,11 @@ describe('TnSelectHarness - multiple mode', () => {
     // via CDK Overlay), not inside the select's host subtree.
     const checkboxes = document.querySelectorAll('tn-checkbox');
     expect(checkboxes.length).toBe(3);
+  });
+
+  it('should ignore allowEmpty in multiple mode', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(await select.getOptions()).toEqual(['Apple', 'Banana', 'Cherry']);
   });
 });
 
@@ -787,5 +831,109 @@ describe('TnSelectComponent — per-option test ids', () => {
     ]);
     fixture.detectChanges();
     expect(openAndGetOptionTestIds()).toEqual(['option-quick-filters-ssd', 'option-quick-filters-hdd']);
+  });
+});
+
+// ===========================================================================
+// allowEmpty — synthetic clear option
+// ===========================================================================
+describe('TnSelectComponent - allowEmpty', () => {
+  let fixture: ComponentFixture<TestAllowEmptyHostComponent>;
+  let hostComponent: TestAllowEmptyHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestAllowEmptyHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestAllowEmptyHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should render the empty option first', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(await select.getOptions()).toEqual(['--', 'Apple', 'Banana']);
+  });
+
+  it('should not render the empty option when allowEmpty is false', async () => {
+    hostComponent.allowEmpty.set(false);
+
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(await select.getOptions()).toEqual(['Apple', 'Banana']);
+  });
+
+  it('should use a custom emptyLabel', async () => {
+    hostComponent.emptyLabel.set('(none)');
+
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(await select.getOptions()).toEqual(['(none)', 'Apple', 'Banana']);
+  });
+
+  it('should clear the selection and emit null via harness clear()', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.selectOption('Banana');
+    expect(await select.getDisplayText()).toBe('Banana');
+
+    await select.clear();
+
+    expect(await select.getDisplayText()).toBe('Select a fruit');
+    expect(hostComponent.selections).toEqual(['banana', null]);
+    expect(await select.isOpen()).toBe(false);
+  });
+
+  it('should clear the selection when the empty option is picked by label', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.selectOption('Apple');
+    await select.selectOption('--');
+
+    expect(await select.getDisplayText()).toBe('Select a fruit');
+    expect(hostComponent.selections).toEqual(['apple', null]);
+  });
+
+  it('should mark the empty option as selected when no value is set', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.open();
+
+    const empty = document.querySelector('.tn-select-empty-option');
+    expect(empty?.classList.contains('selected')).toBe(true);
+    expect(empty?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should emit a stable test id for the empty option', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.open();
+
+    const empty = document.querySelector('.tn-select-empty-option');
+    expect(empty?.getAttribute('data-testid')).toBe('option-fruit-empty');
+  });
+
+  it('should seed keyboard focus on the empty option when nothing is selected', () => {
+    fixture.detectChanges();
+    const trigger = fixture.nativeElement.querySelector('.tn-select-trigger') as HTMLElement;
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+
+    const focused = document.querySelector('.tn-select-option.focused');
+    expect(focused?.classList.contains('tn-select-empty-option')).toBe(true);
+  });
+
+  it('should clear the selection with Enter on the empty option', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.selectOption('Apple');
+
+    const trigger = fixture.nativeElement.querySelector('.tn-select-trigger') as HTMLElement;
+    const press = (key: string) => {
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+      fixture.detectChanges();
+    };
+
+    press('ArrowDown'); // open, focus seeded at the selected option (Apple)
+    press('Home');      // jump to the empty option
+    press('Enter');
+
+    expect(await select.getDisplayText()).toBe('Select a fruit');
+    expect(hostComponent.selections).toEqual(['apple', null]);
   });
 });

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -305,6 +305,8 @@ describe('TnSelectHarness', () => {
       await expect(select.clear()).rejects.toThrow(
         'Select has no empty option — set `allowEmpty` to make it clearable.'
       );
+      // The probe open must not leak past the error.
+      expect(await select.isOpen()).toBe(false);
     });
   });
 

--- a/projects/truenas-ui/src/lib/select/select.harness.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.ts
@@ -200,12 +200,17 @@ export class TnSelectHarness extends ComponentHarness {
    * ```
    */
   async clear(): Promise<void> {
+    // Options only render into the overlay once the dropdown is open, so the
+    // empty option can't be checked for from the closed state.
     await this.open();
     // Dropdown panel is rendered in a CDK overlay (outside the host element),
     // so we search the document root rather than the harness-local subtree.
     const emptyOption = await this.documentRootLocatorFactory()
       .locatorForOptional('.tn-select-empty-option')();
     if (!emptyOption) {
+      // Close again so the misuse error doesn't leave the dropdown open as a
+      // side effect for tests that catch it and keep asserting.
+      await this.close();
       throw new Error('Select has no empty option — set `allowEmpty` to make it clearable.');
     }
     await emptyOption.click();

--- a/projects/truenas-ui/src/lib/select/select.harness.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.ts
@@ -185,6 +185,33 @@ export class TnSelectHarness extends ComponentHarness {
   }
 
   /**
+   * Clears the selection by picking the empty option. Only available when
+   * the select has `allowEmpty` set (single mode); throws otherwise.
+   * Opens the dropdown if needed.
+   *
+   * @returns Promise that resolves when the selection has been cleared.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * await select.selectOption('Banana');
+   * await select.clear();
+   * expect(await select.getDisplayText()).toBe('Select a fruit'); // placeholder
+   * ```
+   */
+  async clear(): Promise<void> {
+    await this.open();
+    // Dropdown panel is rendered in a CDK overlay (outside the host element),
+    // so we search the document root rather than the harness-local subtree.
+    const emptyOption = await this.documentRootLocatorFactory()
+      .locatorForOptional('.tn-select-empty-option')();
+    if (!emptyOption) {
+      throw new Error('Select has no empty option — set `allowEmpty` to make it clearable.');
+    }
+    await emptyOption.click();
+  }
+
+  /**
    * Gets the labels of all available options. Opens the dropdown if needed.
    *
    * @returns Promise resolving to an array of option label strings.

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -38,6 +38,14 @@ const meta: Meta<TnSelectComponent> = {
       control: 'boolean',
       description: 'Whether the select is disabled',
     },
+    allowEmpty: {
+      control: 'boolean',
+      description: 'Prepends an empty option that clears the selection (single mode only)',
+    },
+    emptyLabel: {
+      control: 'text',
+      description: 'Label of the empty option shown when allowEmpty is set',
+    },
     testId: {
       control: 'text',
       description: 'Test ID for the select component',
@@ -347,6 +355,66 @@ export const EmptyWithCustomMessage: Story = {
       imports: [TnFormFieldComponent],
     },
   }),
+};
+
+/**
+ * `allowEmpty` prepends a synthetic empty option (`--` by default, override
+ * with `emptyLabel`) so users can unset a chosen value. Picking it resets the
+ * field to the placeholder and emits `null` via `selectionChange` / the bound
+ * form control. Ignored in `multiple` mode.
+ */
+export const ClearableWithAllowEmpty: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      logSelection: (_value: unknown) => {},
+    },
+    template: `
+      <tn-form-field
+        label="Choose a fruit"
+        hint="Pick the -- option to clear the selection">
+        <tn-select
+          [options]="options"
+          [allowEmpty]="allowEmpty"
+          [emptyLabel]="emptyLabel"
+          [placeholder]="placeholder"
+          (selectionChange)="logSelection($event)">
+        </tn-select>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  args: {
+    options: fruitOptions,
+    allowEmpty: true,
+    emptyLabel: '--',
+    placeholder: 'No fruit selected',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox');
+
+    // Select a value, then clear it through the empty option.
+    await userEvent.click(trigger);
+    const banana = await waitFor(() => {
+      const option = document.querySelector('[data-testid="option-banana"]');
+      if (!option) {throw new Error('option not rendered yet');}
+      return option as HTMLElement;
+    });
+    await userEvent.click(banana);
+    await waitFor(() => expect(trigger.textContent?.trim()).toContain('Banana'));
+
+    await userEvent.click(trigger);
+    const empty = await waitFor(() => {
+      const option = document.querySelector('[data-testid="option-empty"]');
+      if (!option) {throw new Error('empty option not rendered yet');}
+      return option as HTMLElement;
+    });
+    await userEvent.click(empty);
+    await waitFor(() => expect(trigger.textContent?.trim()).toContain('No fruit selected'));
+  },
 };
 
 export const KeyboardNavigation: Story = {


### PR DESCRIPTION
## Summary

`tn-select` has no way to unset a value once chosen — consumers migrating from selects with an empty option lost the ability to clear fields, and the workaround is hand-injecting sentinel options like `{ label: '--', value: '' }` into every option array (which pollutes form state with `''` instead of a real "no value", and only works for string-typed selects).

This adds first-class clear support, modeled on webui `ix-select`'s `--` option:

- **New `allowEmpty` / `emptyLabel` inputs** (single mode only, default off): prepends a synthetic empty option to the dropdown. Picking it resets the value to `null`, restores the placeholder, and propagates `null` to `selectionChange` and any bound form control. Ignored in `multiple` mode, where values are cleared by toggling.
- The empty option rides the existing selection path, so keyboard navigation, `aria-selected`, and focus seeding all work: it shows as selected when the field is empty, and opening the dropdown with no value seeds keyboard focus on it. It emits a stable `option-<base>-empty` test id (its `--` label would be kebab-stripped to nothing) and is rendered dimmed.
- **New `TnSelectHarness.clear()`** picks the empty option, throwing a descriptive error when the select isn't `allowEmpty`. JSDoc flows into the auto-generated Storybook harness docs.
- New `ClearableWithAllowEmpty` story with a select-then-clear play function, plus `allowEmpty`/`emptyLabel` controls.

### Usage

```html
<tn-select [options]="poolOptions" [allowEmpty]="true" placeholder="No pool selected" />
```

## Breaking change

`selectionChange` is now `output<T | null>` since clearing emits `null`. Under `strictTemplates`, handlers typed exactly `(value: T)` must widen to `T | null` (the one internal consumer, `tn-time-input`, is updated in this PR). Runtime behavior is unchanged for selects that don't set `allowEmpty`.

## Testing

- New `allowEmpty` spec suite: render order, custom label, clearing via harness / label / keyboard, `null` emission, selected state, test id, multiple-mode ignore.
- Full Jest suite passes (60 suites, 1295 tests), `yarn lint` clean, `ng build` (strict template check) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)