### PR TITLE
NAS-141365 / 27.0.0-BETA.1 / feat(form-field): render tooltip inline when no label is set

### DIFF
--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -1,31 +1,27 @@
 <div class="tn-form-field" tnTestIdType="form-field" [tnTestId]="testId()">
   <!-- Label -->
-  @if (label() || tooltip()) {
+  @if (label()) {
     <div class="tn-form-field-label-row">
-      @if (label()) {
-        <label class="tn-form-field-label" [class.required]="showRequired()">
-          {{ label() }}
-          @if (showRequired()) {
-            <span class="required-asterisk" aria-label="required">*</span>
-          }
-        </label>
-      }
+      <label class="tn-form-field-label" [class.required]="showRequired()">
+        {{ label() }}
+        @if (showRequired()) {
+          <span class="required-asterisk" aria-label="required">*</span>
+        }
+      </label>
       @if (tooltip()) {
-        <button
-          type="button"
-          class="tn-form-field-tooltip"
-          [attr.aria-label]="tooltip()"
-          [tnTooltip]="tooltip()"
-          [tnTooltipPosition]="tooltipPosition()">
-          <tn-icon name="help-circle" library="mdi" size="sm" />
-        </button>
+        <ng-container [ngTemplateOutlet]="tooltipButton" />
       }
     </div>
   }
 
   <!-- Form Control Content -->
-  <div class="tn-form-field-wrapper">
+  <div
+    class="tn-form-field-wrapper"
+    [class.tn-form-field-wrapper--inline-tooltip]="showInlineTooltip()">
     <ng-content />
+    @if (showInlineTooltip()) {
+      <ng-container [ngTemplateOutlet]="tooltipButton" />
+    }
   </div>
 
   <!-- Hint or Error Message -->
@@ -47,3 +43,14 @@
     </div>
   }
 </div>
+
+<ng-template #tooltipButton>
+  <button
+    type="button"
+    class="tn-form-field-tooltip"
+    [attr.aria-label]="tooltip()"
+    [tnTooltip]="tooltip()"
+    [tnTooltipPosition]="tooltipPosition()">
+    <tn-icon name="help-circle" library="mdi" size="sm" />
+  </button>
+</ng-template>

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -17,8 +17,11 @@
   <!-- Form Control Content -->
   <div
     class="tn-form-field-wrapper"
-    [class.tn-form-field-wrapper--inline-tooltip]="showInlineTooltip()">
+    [class.tn-form-field-wrapper--inline]="showInlineExtras()">
     <ng-content />
+    @if (showInlineRequired()) {
+      <span class="required-asterisk" aria-label="required">*</span>
+    }
     @if (showInlineTooltip()) {
       <ng-container [ngTemplateOutlet]="tooltipButton" />
     }

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -82,6 +82,14 @@
   }
 }
 
+// Label-less mode: the help icon sits inline after the projected control
+// (which renders its own label, e.g. tn-checkbox).
+.tn-form-field-wrapper--inline-tooltip {
+  align-items: center;
+  display: flex;
+  gap: 0.375rem;
+}
+
 .tn-form-field-subscript {
   min-height: 1.25rem;
   margin-top: 0.25rem;

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -82,12 +82,18 @@
   }
 }
 
-// Label-less mode: the help icon sits inline after the projected control
-// (which renders its own label, e.g. tn-checkbox).
-.tn-form-field-wrapper--inline-tooltip {
+// Label-less mode: the required asterisk and help icon sit inline after the
+// projected control (which renders its own label, e.g. tn-checkbox). This
+// targets compact, self-labeled controls — a full-width control would shrink
+// toward its content width in the flex row; give such fields a label instead.
+.tn-form-field-wrapper--inline {
   align-items: center;
   display: flex;
   gap: 0.375rem;
+
+  .required-asterisk {
+    color: var(--tn-error, #dc3545);
+  }
 }
 
 .tn-form-field-subscript {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -58,6 +58,10 @@ export class TnFormFieldComponent implements AfterContentInit {
    * one, the icon renders inline after the projected control instead — for
    * controls that carry their own label (e.g. `tn-checkbox`), where a detached
    * icon row above the control would look orphaned.
+   *
+   * Inline mode targets compact, self-labeled controls: the wrapper becomes a
+   * flex row, so a full-width control (e.g. a label-less `tn-input`) would
+   * shrink toward its content width. Give such fields a `label` instead.
    */
   tooltip = input<string>('');
   /** Placement of the tooltip relative to its help icon. */
@@ -97,8 +101,9 @@ export class TnFormFieldComponent implements AfterContentInit {
   /**
    * Whether the required indicator renders: forced via the `required` input, or
    * inferred from the projected control's validators (mirrors Angular Material's
-   * `hasValidator(Validators.required)` approach — reference equality, so composed
-   * or custom required-like validators need the explicit input).
+   * `hasValidator(Validators.required)` approach, extended to `requiredTrue` for
+   * boolean controls — reference equality, so composed or custom required-like
+   * validators need the explicit input).
    */
   protected showRequired = computed(() => this.required() || this.controlState().required);
 
@@ -107,6 +112,16 @@ export class TnFormFieldComponent implements AfterContentInit {
    * than in the label row — true when a tooltip is set but no label is.
    */
   protected showInlineTooltip = computed(() => !!this.tooltip() && !this.label());
+
+  /**
+   * Whether the required indicator renders inline after the projected control —
+   * with no label there is no label row to host the asterisk, so a required
+   * self-labeled control (e.g. a consent `tn-checkbox`) still gets one.
+   */
+  protected showInlineRequired = computed(() => !this.label() && this.showRequired());
+
+  /** Whether the wrapper hosts any inline extras and lays out as a flex row. */
+  protected showInlineExtras = computed(() => this.showInlineTooltip() || this.showInlineRequired());
 
   protected hasError = computed(() => {
     const state = this.controlState();
@@ -144,7 +159,8 @@ export class TnFormFieldComponent implements AfterContentInit {
         invalid: !!control.invalid,
         interacted: !!(control.dirty || control.touched),
         errors: control.errors ?? null,
-        required: !!control.control?.hasValidator(Validators.required),
+        required: !!(control.control?.hasValidator(Validators.required)
+          || control.control?.hasValidator(Validators.requiredTrue)),
       });
     }
   }

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,4 +1,5 @@
 
+import { NgTemplateOutlet } from '@angular/common';
 import type { AfterContentInit } from '@angular/core';
 import { Component, input, computed, signal, contentChild, inject, isDevMode, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -28,7 +29,7 @@ interface ControlStateSnapshot {
 @Component({
   selector: 'tn-form-field',
   standalone: true,
-  imports: [TnTestIdDirective, TnIconComponent, TnTooltipDirective],
+  imports: [NgTemplateOutlet, TnTestIdDirective, TnIconComponent, TnTooltipDirective],
   templateUrl: './form-field.component.html',
   styleUrls: ['./form-field.component.scss']
 })
@@ -50,7 +51,14 @@ export class TnFormFieldComponent implements AfterContentInit {
   testId = input<TnTestIdValue>(undefined);
   subscriptSizing = input<SubscriptSizing>('dynamic');
 
-  /** Optional tooltip shown via a help icon next to the label. */
+  /**
+   * Optional tooltip shown via a help icon.
+   *
+   * With a `label`, the icon renders next to the label in the label row. Without
+   * one, the icon renders inline after the projected control instead — for
+   * controls that carry their own label (e.g. `tn-checkbox`), where a detached
+   * icon row above the control would look orphaned.
+   */
   tooltip = input<string>('');
   /** Placement of the tooltip relative to its help icon. */
   tooltipPosition = input<TooltipPosition>('above');
@@ -93,6 +101,12 @@ export class TnFormFieldComponent implements AfterContentInit {
    * or custom required-like validators need the explicit input).
    */
   protected showRequired = computed(() => this.required() || this.controlState().required);
+
+  /**
+   * Whether the tooltip icon renders inline after the projected control rather
+   * than in the label row — true when a tooltip is set but no label is.
+   */
+  protected showInlineTooltip = computed(() => !!this.tooltip() && !this.label());
 
   protected hasError = computed(() => {
     const state = this.controlState();

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -212,6 +212,13 @@ describe('TnFormFieldHarness', () => {
   });
 
   describe('label-less control', () => {
+    it('should render the required asterisk inline when no label is set', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'form-field-agree' })
+      );
+      expect(await field.isRequired()).toBe(true);
+    });
+
     it('should surface validation errors from a projected checkbox', async () => {
       const field = await loader.getHarness(
         TnFormFieldHarness.with({ testId: 'form-field-agree' })

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -9,13 +9,14 @@ import { TnFormFieldComponent } from './form-field.component';
 import { TN_FORM_FIELD_ERRORS } from './form-field.errors';
 import type { TnFormFieldErrorMessages, TnFormFieldErrorResolver } from './form-field.errors';
 import { TnFormFieldHarness } from './form-field.harness';
+import { TnCheckboxComponent } from '../checkbox/checkbox.component';
 import { TnIconTesting } from '../icon/icon-testing';
 import { TnInputComponent } from '../input/input.component';
 
 @Component({
   selector: 'tn-test-host',
   standalone: true,
-  imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
+  imports: [TnFormFieldComponent, TnInputComponent, TnCheckboxComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-form-field label="Name" testId="name" tooltip="Your full legal name" [required]="true">
@@ -41,6 +42,10 @@ import { TnInputComponent } from '../input/input.component';
     <tn-form-field label="Dynamic" testId="dynamic" subscriptSizing="dynamic" hint="A dynamic hint">
       <tn-input [formControl]="dynamicControl" />
     </tn-form-field>
+
+    <tn-form-field testId="agree" tooltip="Why we need your consent">
+      <tn-checkbox label="I agree" [formControl]="agreeControl" />
+    </tn-form-field>
   `
 })
 class TestHostComponent {
@@ -50,6 +55,7 @@ class TestHostComponent {
   customControl = new FormControl('', customValidator());
   fixedControl = new FormControl('');
   dynamicControl = new FormControl('', Validators.required);
+  agreeControl = new FormControl(false, Validators.requiredTrue);
 }
 
 function customValidator(): ValidatorFn {
@@ -107,7 +113,7 @@ describe('TnFormFieldHarness', () => {
 
     it('should find all form fields', async () => {
       const fields = await loader.getAllHarnesses(TnFormFieldHarness);
-      expect(fields.length).toBe(6);
+      expect(fields.length).toBe(7);
     });
   });
 
@@ -184,6 +190,39 @@ describe('TnFormFieldHarness', () => {
       );
       expect(await field.hasTooltip()).toBe(false);
       expect(await field.getTooltip()).toBeNull();
+    });
+
+    it('should render the tooltip in the label row when a label is set', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'form-field-name' })
+      );
+      expect(await field.hasTooltip()).toBe(true);
+      expect(await field.isTooltipInline()).toBe(false);
+    });
+
+    it('should render the tooltip inline after the control when no label is set', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'form-field-agree' })
+      );
+      expect(await field.getLabel()).toBe('');
+      expect(await field.hasTooltip()).toBe(true);
+      expect(await field.isTooltipInline()).toBe(true);
+      expect(await field.getTooltip()).toBe('Why we need your consent');
+    });
+  });
+
+  describe('label-less control', () => {
+    it('should surface validation errors from a projected checkbox', async () => {
+      const field = await loader.getHarness(
+        TnFormFieldHarness.with({ testId: 'form-field-agree' })
+      );
+      expect(await field.hasError()).toBe(false);
+
+      fixture.componentInstance.agreeControl.markAsTouched();
+      fixture.componentInstance.agreeControl.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(await field.hasError()).toBe(true);
     });
   });
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -193,8 +193,10 @@ export class TnFormFieldHarness extends ComponentHarness {
    */
   async isRequired(): Promise<boolean> {
     const label = await this._label();
-    if (!label) { return false; }
-    return label.hasClass('required');
+    if (label) { return label.hasClass('required'); }
+    // Label-less mode renders the asterisk inline after the projected control.
+    const inlineAsterisk = await this.locatorForOptional('.tn-form-field-wrapper .required-asterisk')();
+    return inlineAsterisk !== null;
   }
 
   /**

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -164,6 +164,23 @@ export class TnFormFieldHarness extends ComponentHarness {
   }
 
   /**
+   * Checks whether the tooltip help icon renders inline after the projected
+   * control (label-less mode) rather than in the label row.
+   *
+   * @returns Promise resolving to true if the inline tooltip trigger is present.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ testId: 'enable-fxp' }));
+   * expect(await field.isTooltipInline()).toBe(true);
+   * ```
+   */
+  async isTooltipInline(): Promise<boolean> {
+    const inline = await this.locatorForOptional('.tn-form-field-wrapper .tn-form-field-tooltip')();
+    return inline !== null;
+  }
+
+  /**
    * Checks whether the form field is marked as required.
    *
    * @returns Promise resolving to true if the required asterisk is present.

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -350,6 +350,8 @@ export const WithCheckbox: Story = {
         [hint]="hint"
         [required]="required"
         [testId]="testId"
+        [tooltip]="tooltip"
+        [tooltipPosition]="tooltipPosition"
         [subscriptSizing]="subscriptSizing">
         <tn-checkbox
           label="I agree to the terms and conditions">
@@ -365,6 +367,41 @@ export const WithCheckbox: Story = {
     hint: 'Please review our terms before proceeding',
     required: true,
     testId: 'terms-field',
+  },
+};
+
+export const CheckboxWithInlineTooltip: Story = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <tn-form-field
+        [tooltip]="tooltip"
+        [tooltipPosition]="tooltipPosition"
+        [testId]="testId"
+        [subscriptSizing]="subscriptSizing">
+        <tn-checkbox
+          label="Enable FXP">
+        </tn-checkbox>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnCheckboxComponent],
+    },
+  }),
+  args: {
+    tooltip: 'FXP allows direct server-to-server file transfers. It is disabled by default for security.',
+    tooltipPosition: 'above',
+    testId: 'enable-fxp-field',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When no `label` is set, the tooltip help icon renders inline after the projected control '
+          + 'instead of in the label row — for controls that carry their own label, like `tn-checkbox`. '
+          + 'The field still surfaces validation errors and hints in the subscript area.',
+      },
+    },
   },
 };
 


### PR DESCRIPTION
A label-less tn-form-field previously rendered its tooltip help icon alone in the label row, floating detached above the projected control. Controls that carry their own label (tn-checkbox, tn-slide-toggle) therefore could not use tn-form-field for tooltips, forcing consumers to hand-roll a flex wrapper with a separate tooltip widget — and lose the form-field's error/hint subscript in the process.

- Label row now renders only when [label] is set
- With [tooltip] but no [label], the help icon renders inline after the projected control (flex row, centered, 0.375rem gap)
- Subscript machinery is unchanged, so label-less controls gain validation error display for free
- Harness: new isTooltipInline(); story: CheckboxWithInlineTooltip
- Story: WithCheckbox now binds [tooltip]/[tooltipPosition] so the Storybook controls actually apply


<img width="317" height="70" alt="image" src="https://github.com/user-attachments/assets/09b90ddf-4464-4bdd-b80c-5f0f899f0b7f" />

<img width="312" height="99" alt="image" src="https://github.com/user-attachments/assets/2f08ce74-9713-4317-9e20-9443d7cee6c4" />
