### PR TITLE
NAS-141408 / 27.0.0-BETA.1 / feat(autocomplete)!: adopt label/value option objects

### DIFF
--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -48,7 +48,7 @@
             [class.highlighted]="highlightedIndex() === $index"
             [class.disabled]="option.disabled"
             [attr.id]="uid + '-option-' + $index"
-            [attr.aria-selected]="highlightedIndex() === $index"
+            [attr.aria-selected]="isOptionSelected(option)"
             [attr.aria-disabled]="option.disabled ? true : null"
             (mousedown)="$event.preventDefault()"
             (click)="onOptionClick(option)"

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -51,7 +51,7 @@
             (mousedown)="$event.preventDefault()"
             (click)="onOptionClick(option)"
             (keydown.enter)="onOptionClick(option)">
-            {{ displayWith()(option) }}
+            {{ option.label }}
           </div>
         }
       }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -46,8 +46,10 @@
             role="option"
             tabindex="-1"
             [class.highlighted]="highlightedIndex() === $index"
+            [class.disabled]="option.disabled"
             [attr.id]="uid + '-option-' + $index"
             [attr.aria-selected]="highlightedIndex() === $index"
+            [attr.aria-disabled]="option.disabled ? true : null"
             (mousedown)="$event.preventDefault()"
             (click)="onOptionClick(option)"
             (keydown.enter)="onOptionClick(option)">

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -65,12 +65,18 @@
   color: var(--tn-fg1, #212529);
   transition: background-color 0.15s ease-in-out;
 
-  &:hover {
+  &:hover:not(.disabled) {
     background-color: var(--tn-alt-bg2, #f8f9fa);
   }
 
   &.highlighted {
     background-color: var(--tn-alt-bg1, #f8f9fa);
+  }
+
+  &.disabled {
+    color: var(--tn-fg2, #6c757d);
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 }
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -476,6 +476,57 @@ describe('TnAutocompleteComponent', () => {
       expect(vwHost.control.value).toBe('US');
       expect(getVwInput().value).toBe('United States');
     });
+
+    const focusVw = () => {
+      getVwInput().dispatchEvent(new Event('focus'));
+      vwFixture.detectChanges();
+    };
+
+    const getVwOptions = (): HTMLElement[] =>
+      Array.from(overlayEl.querySelectorAll('.tn-autocomplete__option'));
+
+    it('marks the committed option with aria-selected, independent of the cursor', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+      focusVw();
+
+      const selected = getVwOptions().filter(
+        (opt) => opt.getAttribute('aria-selected') === 'true'
+      );
+      expect(selected.length).toBe(1);
+      expect(selected[0].textContent?.trim()).toBe('Canada');
+    });
+
+    it('pre-highlights the committed option on open so ArrowDown resumes from it', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+      focusVw();
+
+      const highlighted = overlayEl.querySelector('.tn-autocomplete__option.highlighted');
+      expect(highlighted?.textContent?.trim()).toBe('Canada');
+
+      getVwInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      vwFixture.detectChanges();
+      expect(vwHost.control.value).toBe('CA');
+    });
+
+    it('does not pre-highlight when nothing is committed', () => {
+      // All options visible, but no committed value to seed the cursor.
+      focusVw();
+
+      expect(getVwOptions().length).toBeGreaterThan(0);
+      expect(overlayEl.querySelector('.tn-autocomplete__option.highlighted')).toBeNull();
+    });
+
+    it('clears the pre-highlight once the user starts typing', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+      focusVw();
+      expect(overlayEl.querySelector('.tn-autocomplete__option.highlighted')).toBeTruthy();
+
+      typeVw('united');
+      expect(overlayEl.querySelector('.tn-autocomplete__option.highlighted')).toBeNull();
+    });
   });
 
   describe('disabled options', () => {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -75,6 +75,28 @@ class AsyncTestHostComponent {
   openedCount = 0;
 }
 
+@Component({
+  selector: 'tn-value-with-test-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-autocomplete
+      [options]="options()"
+      [displayWith]="displayCountry"
+      [valueWith]="countryCode"
+      [requireSelection]="requireSelection()"
+      [formControl]="control" />
+  `
+})
+class ValueWithHostComponent {
+  options = signal(countries);
+  requireSelection = signal(false);
+  control = new FormControl<string | null>(null);
+  displayCountry = displayCountry;
+  countryCode = (c: Country): string => c.code;
+}
+
 describe('TnAutocompleteComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
@@ -333,6 +355,82 @@ describe('TnAutocompleteComponent', () => {
 
       expect(getInput().value).toBe('');
       expect(host.control.value).toBeNull();
+    });
+  });
+
+  describe('valueWith', () => {
+    let vwFixture: ComponentFixture<ValueWithHostComponent>;
+    let vwHost: ValueWithHostComponent;
+
+    const getVwInput = (): HTMLInputElement =>
+      vwFixture.nativeElement.querySelector('.tn-autocomplete__input');
+
+    const typeVw = (value: string) => {
+      const input = getVwInput();
+      input.value = value;
+      input.dispatchEvent(new Event('input'));
+      vwFixture.detectChanges();
+    };
+
+    beforeEach(() => {
+      vwFixture = TestBed.createComponent(ValueWithHostComponent);
+      vwHost = vwFixture.componentInstance;
+      vwFixture.detectChanges();
+    });
+
+    it('commits the mapped value when an option is selected', () => {
+      typeVw('United S');
+      const option = overlayEl.querySelector<HTMLElement>('.tn-autocomplete__option');
+      option?.click();
+      vwFixture.detectChanges();
+
+      expect(vwHost.control.value).toBe('US');
+      expect(getVwInput().value).toBe('United States');
+    });
+
+    it('displays the matching option label for a written value', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+
+      expect(getVwInput().value).toBe('Canada');
+    });
+
+    it('upgrades a raw written value to its label once options load', () => {
+      vwHost.options.set([]);
+      vwFixture.detectChanges();
+
+      vwHost.control.setValue('MX');
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('MX');
+
+      vwHost.options.set(countries);
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('Mexico');
+    });
+
+    it('commits the mapped value when requireSelection matches typed text on blur', () => {
+      vwHost.requireSelection.set(true);
+      vwFixture.detectChanges();
+
+      typeVw('germany');
+      getVwInput().dispatchEvent(new Event('blur'));
+      vwFixture.detectChanges();
+
+      expect(vwHost.control.value).toBe('DE');
+      expect(getVwInput().value).toBe('Germany');
+    });
+
+    it('reverts to the committed value display when requireSelection rejects text', () => {
+      vwHost.requireSelection.set(true);
+      vwHost.control.setValue('US');
+      vwFixture.detectChanges();
+
+      typeVw('garbage');
+      getVwInput().dispatchEvent(new Event('blur'));
+      vwFixture.detectChanges();
+
+      expect(vwHost.control.value).toBe('US');
+      expect(getVwInput().value).toBe('United States');
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -118,6 +118,29 @@ class DisabledOptionsHostComponent {
   selected: TnAutocompleteOption<string> | null = null;
 }
 
+interface City { id: string; }
+
+@Component({
+  selector: 'tn-object-value-test-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-autocomplete
+      [options]="options"
+      [compareWith]="compareWith()"
+      [formControl]="control" />
+  `
+})
+class ObjectValueHostComponent {
+  options: TnAutocompleteOption<City>[] = [
+    { label: 'Lisbon', value: { id: 'lis' } },
+    { label: 'Porto', value: { id: 'opo' } },
+  ];
+  compareWith = signal<((a: City | null, b: City | null) => boolean) | undefined>(undefined);
+  control = new FormControl<City | null>(null);
+}
+
 describe('TnAutocompleteComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
@@ -618,6 +641,48 @@ describe('TnAutocompleteComponent', () => {
       // Committed as free text, not resolved to the disabled option.
       expect(dHost.control.value).toBe('Banana');
       expect(dHost.selected).toBeNull();
+    });
+  });
+
+  describe('object values without compareWith', () => {
+    let oFixture: ComponentFixture<ObjectValueHostComponent>;
+    let oHost: ObjectValueHostComponent;
+    let warnSpy: jest.SpyInstance;
+
+    const getOInput = (): HTMLInputElement =>
+      oFixture.nativeElement.querySelector('.tn-autocomplete__input');
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      oFixture = TestBed.createComponent(ObjectValueHostComponent);
+      oHost = oFixture.componentInstance;
+      oFixture.detectChanges();
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns once and fails to resolve the label when comparing objects by identity', () => {
+      // A structurally-equal but distinct reference — identity won't match.
+      oHost.control.setValue({ id: 'lis' });
+      oFixture.detectChanges();
+
+      expect(getOInput().value).toBe(String({ id: 'lis' }));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('[tn-autocomplete]');
+      expect(warnSpy.mock.calls[0][0]).toContain('compareWith');
+    });
+
+    it('resolves the label and stays silent when compareWith is provided', () => {
+      oHost.compareWith.set((a, b) => a?.id === b?.id);
+      oFixture.detectChanges();
+
+      oHost.control.setValue({ id: 'opo' });
+      oFixture.detectChanges();
+
+      expect(getOInput().value).toBe('Porto');
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -408,6 +408,18 @@ describe('TnAutocompleteComponent', () => {
       expect(getVwInput().value).toBe('Mexico');
     });
 
+    it('does not downgrade a resolved label when options are later replaced', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('Canada');
+
+      // A server-search picker may replace options after selection — the
+      // committed label must not flip back to the raw 'CA'.
+      vwHost.options.set([]);
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('Canada');
+    });
+
     it('commits the mapped value when requireSelection matches typed text on blur', () => {
       vwHost.requireSelection.set(true);
       vwFixture.detectChanges();

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -91,6 +91,33 @@ class LabelValueHostComponent {
   control = new FormControl<string | null>(null);
 }
 
+@Component({
+  selector: 'tn-disabled-options-test-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-autocomplete
+      [options]="options()"
+      [requireSelection]="requireSelection()"
+      [allowCustomValue]="allowCustomValue()"
+      [formControl]="control"
+      (optionSelected)="selected = $event" />
+  `
+})
+class DisabledOptionsHostComponent {
+  // Banana is disabled — it stays visible but must not be selectable.
+  options = signal<TnAutocompleteOption<string>[]>([
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana', disabled: true },
+    { label: 'Cherry', value: 'cherry' },
+  ]);
+  requireSelection = signal(false);
+  allowCustomValue = signal(false);
+  control = new FormControl<string | null>(null);
+  selected: TnAutocompleteOption<string> | null = null;
+}
+
 describe('TnAutocompleteComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
@@ -448,6 +475,98 @@ describe('TnAutocompleteComponent', () => {
 
       expect(vwHost.control.value).toBe('US');
       expect(getVwInput().value).toBe('United States');
+    });
+  });
+
+  describe('disabled options', () => {
+    let dFixture: ComponentFixture<DisabledOptionsHostComponent>;
+    let dHost: DisabledOptionsHostComponent;
+
+    const getDInput = (): HTMLInputElement =>
+      dFixture.nativeElement.querySelector('.tn-autocomplete__input');
+
+    const getDOptions = (): HTMLElement[] =>
+      Array.from(overlayEl.querySelectorAll('.tn-autocomplete__option'));
+
+    const focusD = () => {
+      getDInput().dispatchEvent(new Event('focus'));
+      dFixture.detectChanges();
+    };
+
+    const pressDKey = (key: string) => {
+      getDInput().dispatchEvent(new KeyboardEvent('keydown', { key }));
+      dFixture.detectChanges();
+    };
+
+    beforeEach(() => {
+      dFixture = TestBed.createComponent(DisabledOptionsHostComponent);
+      dHost = dFixture.componentInstance;
+      dFixture.detectChanges();
+    });
+
+    it('renders a disabled option with the disabled class and aria-disabled', () => {
+      focusD();
+      const banana = getDOptions()[1];
+      expect(banana.classList).toContain('disabled');
+      expect(banana.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('does not commit a disabled option on click', () => {
+      focusD();
+      getDOptions()[1].click();
+      dFixture.detectChanges();
+
+      expect(dHost.control.value).toBeNull();
+      expect(dHost.selected).toBeNull();
+    });
+
+    it('skips disabled options during keyboard navigation', () => {
+      focusD();
+      pressDKey('ArrowDown'); // Apple
+      pressDKey('ArrowDown'); // skips Banana → Cherry
+      pressDKey('Enter');
+
+      expect(dHost.control.value).toBe('cherry');
+    });
+
+    it('wraps past a disabled option going up', () => {
+      focusD();
+      pressDKey('ArrowUp'); // from nothing → last (Cherry)
+      pressDKey('ArrowUp'); // skips Banana → Apple
+      pressDKey('Enter');
+
+      expect(dHost.control.value).toBe('apple');
+    });
+
+    it('rejects a disabled option label under requireSelection', () => {
+      dHost.requireSelection.set(true);
+      dFixture.detectChanges();
+
+      const input = getDInput();
+      input.value = 'banana';
+      input.dispatchEvent(new Event('input'));
+      dFixture.detectChanges();
+      input.dispatchEvent(new Event('blur'));
+      dFixture.detectChanges();
+
+      expect(dHost.control.value).toBeNull();
+      expect(getDInput().value).toBe('');
+    });
+
+    it('treats a disabled option label as a custom value under allowCustomValue', () => {
+      dHost.allowCustomValue.set(true);
+      dFixture.detectChanges();
+
+      const input = getDInput();
+      input.value = 'Banana';
+      input.dispatchEvent(new Event('input'));
+      dFixture.detectChanges();
+      input.dispatchEvent(new Event('blur'));
+      dFixture.detectChanges();
+
+      // Committed as free text, not resolved to the disabled option.
+      expect(dHost.control.value).toBe('Banana');
+      expect(dHost.selected).toBeNull();
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -83,7 +83,7 @@ class AsyncTestHostComponent {
   template: `
     <tn-autocomplete
       [options]="options()"
-      [displayWith]="displayCountry"
+      [displayWith]="displayFn()"
       [valueWith]="countryCode"
       [requireSelection]="requireSelection()"
       [formControl]="control" />
@@ -92,6 +92,27 @@ class AsyncTestHostComponent {
 class ValueWithHostComponent {
   options = signal(countries);
   requireSelection = signal(false);
+  control = new FormControl<string | null>(null);
+  displayFn = signal<(c: Country) => string>(displayCountry);
+  countryCode = (c: Country): string => c.code;
+}
+
+@Component({
+  selector: 'tn-value-with-custom-value-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-autocomplete
+      [options]="options()"
+      [displayWith]="displayCountry"
+      [valueWith]="countryCode"
+      [allowCustomValue]="true"
+      [formControl]="control" />
+  `
+})
+class ValueWithCustomValueHostComponent {
+  options = signal(countries);
   control = new FormControl<string | null>(null);
   displayCountry = displayCountry;
   countryCode = (c: Country): string => c.code;
@@ -406,6 +427,25 @@ describe('TnAutocompleteComponent', () => {
       vwHost.options.set(countries);
       vwFixture.detectChanges();
       expect(getVwInput().value).toBe('Mexico');
+    });
+
+    it('re-renders the committed label when displayWith is swapped', () => {
+      vwHost.control.setValue('CA');
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('Canada');
+
+      vwHost.displayFn.set((c: Country) => `${c.name} (${c.code})`);
+      vwFixture.detectChanges();
+      expect(getVwInput().value).toBe('Canada (CA)');
+    });
+
+    it('warns in dev mode when valueWith is combined with allowCustomValue', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const fixture2 = TestBed.createComponent(ValueWithCustomValueHostComponent);
+      fixture2.detectChanges();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('valueWith and allowCustomValue are contradictory'));
+      warnSpy.mockRestore();
     });
 
     it('does not downgrade a resolved label when options are later replaced', () => {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -3,7 +3,7 @@ import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { TnAutocompleteComponent } from './autocomplete.component';
+import { TnAutocompleteComponent, type TnAutocompleteOption } from './autocomplete.component';
 
 interface Country {
   code: string;
@@ -18,7 +18,7 @@ const countries: Country[] = [
   { code: 'DE', name: 'Germany' },
 ];
 
-const displayCountry = (c: Country): string => c.name;
+const countryOptions = countries.map((c) => ({ label: c.name, value: c.code }));
 
 @Component({
   selector: 'tn-test-host',
@@ -28,7 +28,6 @@ const displayCountry = (c: Country): string => c.name;
   template: `
     <tn-autocomplete
       [options]="options()"
-      [displayWith]="displayCountry"
       [placeholder]="placeholder()"
       [disabled]="disabled()"
       [requireSelection]="requireSelection()"
@@ -38,14 +37,13 @@ const displayCountry = (c: Country): string => c.name;
   `
 })
 class TestHostComponent {
-  options = signal(countries);
+  options = signal(countryOptions);
   placeholder = signal('Search...');
   disabled = signal(false);
   requireSelection = signal(false);
   maxResults = signal(100);
-  control = new FormControl<Country | null>(null);
-  selected: Country | null = null;
-  displayCountry = displayCountry;
+  control = new FormControl<string | null>(null);
+  selected: TnAutocompleteOption<string> | null = null;
 }
 
 @Component({
@@ -66,7 +64,7 @@ class TestHostComponent {
   `
 })
 class AsyncTestHostComponent {
-  options = signal(['alpha', 'beta', 'gamma']);
+  options = signal(['alpha', 'beta', 'gamma'].map((name) => ({ label: name, value: name })));
   loading = signal(false);
   maxResults = signal(Infinity);
   control = new FormControl<string | null>(null);
@@ -76,46 +74,21 @@ class AsyncTestHostComponent {
 }
 
 @Component({
-  selector: 'tn-value-with-test-host',
+  selector: 'tn-label-value-test-host',
   standalone: true,
   imports: [TnAutocompleteComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-autocomplete
       [options]="options()"
-      [displayWith]="displayFn()"
-      [valueWith]="countryCode"
       [requireSelection]="requireSelection()"
       [formControl]="control" />
   `
 })
-class ValueWithHostComponent {
-  options = signal(countries);
+class LabelValueHostComponent {
+  options = signal(countryOptions);
   requireSelection = signal(false);
   control = new FormControl<string | null>(null);
-  displayFn = signal<(c: Country) => string>(displayCountry);
-  countryCode = (c: Country): string => c.code;
-}
-
-@Component({
-  selector: 'tn-value-with-custom-value-host',
-  standalone: true,
-  imports: [TnAutocompleteComponent, ReactiveFormsModule],
-  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
-  template: `
-    <tn-autocomplete
-      [options]="options()"
-      [displayWith]="displayCountry"
-      [valueWith]="countryCode"
-      [allowCustomValue]="true"
-      [formControl]="control" />
-  `
-})
-class ValueWithCustomValueHostComponent {
-  options = signal(countries);
-  control = new FormControl<string | null>(null);
-  displayCountry = displayCountry;
-  countryCode = (c: Country): string => c.code;
 }
 
 describe('TnAutocompleteComponent', () => {
@@ -210,7 +183,7 @@ describe('TnAutocompleteComponent', () => {
       expect(getOptions().length).toBe(5);
     });
 
-    it('should filter by displayWith text', () => {
+    it('should filter by option label text', () => {
       typeInInput('can');
       expect(getOptions().length).toBe(1);
       expect(getOptions()[0].textContent?.trim()).toBe('Canada');
@@ -253,7 +226,7 @@ describe('TnAutocompleteComponent', () => {
       getOptions()[2].click();
       fixture.detectChanges();
 
-      expect(host.selected).toEqual({ code: 'MX', name: 'Mexico' });
+      expect(host.selected).toEqual({ label: 'Mexico', value: 'MX' });
     });
 
     it('should update form control value', () => {
@@ -261,7 +234,7 @@ describe('TnAutocompleteComponent', () => {
       getOptions()[0].click();
       fixture.detectChanges();
 
-      expect(host.control.value).toEqual({ code: 'US', name: 'United States' });
+      expect(host.control.value).toBe('US');
     });
 
     it('should close dropdown after selection', () => {
@@ -320,7 +293,7 @@ describe('TnAutocompleteComponent', () => {
       pressKey('ArrowDown');
       pressKey('Enter');
 
-      expect(host.control.value).toEqual({ code: 'CA', name: 'Canada' });
+      expect(host.control.value).toBe('CA');
       expect(getDropdown()).toBeNull();
     });
 
@@ -334,14 +307,14 @@ describe('TnAutocompleteComponent', () => {
 
   describe('writeValue (CVA)', () => {
     it('should display value set programmatically via form control', () => {
-      host.control.setValue({ code: 'DE', name: 'Germany' });
+      host.control.setValue('DE');
       fixture.detectChanges();
 
       expect(getInput().value).toBe('Germany');
     });
 
     it('should clear input when form control is reset', () => {
-      host.control.setValue({ code: 'GB', name: 'United Kingdom' });
+      host.control.setValue('GB');
       fixture.detectChanges();
       expect(getInput().value).toBe('United Kingdom');
 
@@ -379,9 +352,9 @@ describe('TnAutocompleteComponent', () => {
     });
   });
 
-  describe('valueWith', () => {
-    let vwFixture: ComponentFixture<ValueWithHostComponent>;
-    let vwHost: ValueWithHostComponent;
+  describe('label/value resolution', () => {
+    let vwFixture: ComponentFixture<LabelValueHostComponent>;
+    let vwHost: LabelValueHostComponent;
 
     const getVwInput = (): HTMLInputElement =>
       vwFixture.nativeElement.querySelector('.tn-autocomplete__input');
@@ -394,12 +367,12 @@ describe('TnAutocompleteComponent', () => {
     };
 
     beforeEach(() => {
-      vwFixture = TestBed.createComponent(ValueWithHostComponent);
+      vwFixture = TestBed.createComponent(LabelValueHostComponent);
       vwHost = vwFixture.componentInstance;
       vwFixture.detectChanges();
     });
 
-    it('commits the mapped value when an option is selected', () => {
+    it('commits the option value when an option is selected', () => {
       typeVw('United S');
       const option = overlayEl.querySelector<HTMLElement>('.tn-autocomplete__option');
       option?.click();
@@ -424,28 +397,20 @@ describe('TnAutocompleteComponent', () => {
       vwFixture.detectChanges();
       expect(getVwInput().value).toBe('MX');
 
-      vwHost.options.set(countries);
+      vwHost.options.set(countryOptions);
       vwFixture.detectChanges();
       expect(getVwInput().value).toBe('Mexico');
     });
 
-    it('re-renders the committed label when displayWith is swapped', () => {
+    it('updates the committed label when options are relabeled', () => {
       vwHost.control.setValue('CA');
       vwFixture.detectChanges();
       expect(getVwInput().value).toBe('Canada');
 
-      vwHost.displayFn.set((c: Country) => `${c.name} (${c.code})`);
+      // e.g. a locale change re-emits the same values with new labels.
+      vwHost.options.set(countryOptions.map((opt) => ({ ...opt, label: `${opt.label} (${opt.value})` })));
       vwFixture.detectChanges();
       expect(getVwInput().value).toBe('Canada (CA)');
-    });
-
-    it('warns in dev mode when valueWith is combined with allowCustomValue', () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      const fixture2 = TestBed.createComponent(ValueWithCustomValueHostComponent);
-      fixture2.detectChanges();
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('valueWith and allowCustomValue are contradictory'));
-      warnSpy.mockRestore();
     });
 
     it('does not downgrade a resolved label when options are later replaced', () => {
@@ -460,7 +425,7 @@ describe('TnAutocompleteComponent', () => {
       expect(getVwInput().value).toBe('Canada');
     });
 
-    it('commits the mapped value when requireSelection matches typed text on blur', () => {
+    it('commits the option value when requireSelection matches typed text on blur', () => {
       vwHost.requireSelection.set(true);
       vwFixture.detectChanges();
 
@@ -556,7 +521,7 @@ describe('TnAutocompleteComponent', () => {
       expect(asyncHost.loadMoreCount).toBe(1);
 
       // Appending the next page re-arms the emitter.
-      asyncHost.options.set([...asyncHost.options(), 'delta']);
+      asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
       dropdown?.dispatchEvent(new Event('scroll'));
       expect(asyncHost.loadMoreCount).toBe(2);
@@ -626,7 +591,7 @@ describe('TnAutocompleteComponent', () => {
       expect(asyncHost.loadMoreCount).toBe(1);
 
       // A grown page re-arms and, still underfilled, requests the next one.
-      asyncHost.options.set([...asyncHost.options(), 'delta']);
+      asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
       expect(asyncHost.loadMoreCount).toBe(2);
     });
@@ -638,7 +603,7 @@ describe('TnAutocompleteComponent', () => {
       // A page landed but the consumer is still loading — the visible rows
       // are stale, so scrolling them must not request yet another page.
       asyncHost.loading.set(true);
-      asyncHost.options.set([...asyncHost.options(), 'delta']);
+      asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
 
       const dropdown = overlayEl.querySelector('.tn-autocomplete__dropdown');
@@ -652,7 +617,7 @@ describe('TnAutocompleteComponent', () => {
 
       // The page lands while loading is still set — the check is deferred...
       asyncHost.loading.set(true);
-      asyncHost.options.set([...asyncHost.options(), 'delta']);
+      asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
       expect(asyncHost.loadMoreCount).toBe(1);
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -25,8 +25,10 @@ import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 /**
  * Option shape for `tn-autocomplete` — the `label` is displayed, the `value`
- * is committed to the form control. Structurally identical to
- * `TnSelectOption`, so the same data sources feed both dropdown components.
+ * is committed to the form control, and a truthy `disabled` keeps the row
+ * visible but non-selectable (skipped by keyboard nav, click, and text-match
+ * commits). Structurally identical to `TnSelectOption`, so the same data
+ * sources feed both dropdown components.
  */
 export type TnAutocompleteOption<T = unknown> = TnSelectOption<T>;
 
@@ -356,7 +358,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     if (this.requireSelection()) {
       const term = this.searchTerm();
       const match = this.options().find(
-        (opt) => opt.label.toLowerCase() === term.toLowerCase()
+        (opt) => !opt.disabled && opt.label.toLowerCase() === term.toLowerCase()
       );
 
       if (match) {
@@ -378,6 +380,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   }
 
   onOptionClick(option: TnAutocompleteOption<T>): void {
+    if (option.disabled) {
+      return;
+    }
     this.selectOption(option);
   }
 
@@ -390,27 +395,29 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
         if (!this.isOpen()) {
           this.open();
         } else {
-          this.highlightedIndex.update((i) =>
-            i < options.length - 1 ? i + 1 : 0
-          );
-          this.scrollToHighlighted();
+          const next = this.nextEnabledIndex(this.highlightedIndex(), 1);
+          if (next >= 0) {
+            this.highlightedIndex.set(next);
+            this.scrollToHighlighted();
+          }
         }
         break;
 
       case 'ArrowUp':
         event.preventDefault();
         if (this.isOpen()) {
-          this.highlightedIndex.update((i) =>
-            i > 0 ? i - 1 : options.length - 1
-          );
-          this.scrollToHighlighted();
+          const prev = this.nextEnabledIndex(this.highlightedIndex(), -1);
+          if (prev >= 0) {
+            this.highlightedIndex.set(prev);
+            this.scrollToHighlighted();
+          }
         }
         break;
 
       case 'Enter': {
         event.preventDefault();
         const idx = this.highlightedIndex();
-        if (this.isOpen() && idx >= 0 && idx < options.length) {
+        if (this.isOpen() && idx >= 0 && idx < options.length && !options[idx].disabled) {
           this.selectOption(options[idx]);
         } else if (this.allowCustomValue()) {
           this.commitCustomValue();
@@ -482,6 +489,28 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   // ── Internal ──
 
   /**
+   * Next selectable option index from `from` in `direction` (+1 down, -1 up),
+   * skipping disabled rows and wrapping around. `from` of -1 ("nothing
+   * highlighted") lands on the first row going down, the last going up.
+   * Returns -1 when every visible option is disabled.
+   */
+  private nextEnabledIndex(from: number, direction: 1 | -1): number {
+    const options = this.filteredOptions();
+    const count = options.length;
+    if (count === 0) {
+      return -1;
+    }
+    const start = from < 0 ? (direction === 1 ? -1 : 0) : from;
+    for (let step = 1; step <= count; step++) {
+      const idx = (((start + direction * step) % count) + count) % count;
+      if (!options[idx].disabled) {
+        return idx;
+      }
+    }
+    return -1;
+  }
+
+  /**
    * Commit the current search term as the value (allowCustomValue mode). A
    * display match (case-insensitive, same as the requireSelection path)
    * commits the matching option instead, so picking an existing entry by
@@ -490,11 +519,15 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   private commitCustomValue(): void {
     const term = this.searchTerm();
     const lowerTerm = term.toLowerCase();
-    const match = this.options().find((opt) => opt.label.toLowerCase() === lowerTerm);
+    const match = this.options().find(
+      (opt) => !opt.disabled && opt.label.toLowerCase() === lowerTerm
+    );
     if (match) {
       this.selectOption(match);
       return;
     }
+    // Best-effort guard: silent when options haven't loaded yet (the common
+    // async + allowCustomValue case), where the value type can't be known.
     if (isDevMode() && term !== '' && this.options().some((opt) => typeof opt.value !== 'string')) {
       console.warn(
         '[tn-autocomplete] allowCustomValue committed free text into a control whose option '

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -231,6 +231,9 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
     effect(() => {
       this.options();
       this.valueWith();
+      // Tracked so a swapped display function (e.g. locale change) re-renders
+      // the committed label without waiting for options to change.
+      this.displayWith();
       untracked(() => {
         const mapper = this.valueWith();
         if (this.isOpen() || !mapper) {
@@ -284,6 +287,12 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
         if (this.requireSelection() && this.allowCustomValue()) {
           console.warn(
             '[tn-autocomplete] requireSelection and allowCustomValue are mutually exclusive; allowCustomValue wins.'
+          );
+        }
+        if (this.valueWith() && this.allowCustomValue()) {
+          console.warn(
+            '[tn-autocomplete] valueWith and allowCustomValue are contradictory: a custom commit stores '
+            + 'the raw typed text (the display string), not a valueWith-mapped value.'
           );
         }
       });

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -38,7 +38,7 @@ let nextId = 0;
   templateUrl: './autocomplete.component.html',
   styleUrl: './autocomplete.component.scss',
 })
-export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor, OnDestroy {
+export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValueAccessor, OnDestroy {
   private readonly elementRef = inject(ElementRef);
   private readonly overlay = inject(Overlay);
   private readonly viewContainerRef = inject(ViewContainerRef);
@@ -51,6 +51,17 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
   /** Transform a value to its display string */
   displayWith = input<(value: T) => string>((v: T) => String(v));
+
+  /**
+   * Maps a selected option to the value committed to the form control. By
+   * default the option itself is the value. Provide this when options are
+   * objects but the control should hold a derived primitive (e.g.
+   * `option.value`): written values are resolved back to their option for
+   * display — falling back to `String(value)` until the matching option is
+   * available — and re-resolved when `options` later changes, so an async
+   * option load upgrades the raw fallback to its label.
+   */
+  valueWith = input<((option: T) => V) | undefined>(undefined);
 
   /** Placeholder text for the input */
   placeholder = input<string>('Type to search...');
@@ -155,8 +166,8 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** Index of the currently highlighted option for keyboard nav */
   protected highlightedIndex = signal(-1);
 
-  /** The currently selected value */
-  private selectedValue = signal<T | null>(null);
+  /** The currently committed value (the option itself, or its `valueWith` mapping) */
+  private selectedValue = signal<V | null>(null);
 
   /** CVA disabled state from the form */
   private formDisabled = signal(false);
@@ -187,7 +198,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** Whether there are any results to show */
   protected hasResults = computed(() => this.filteredOptions().length > 0);
 
-  private onChange = (_value: T | null) => {};
+  private onChange = (_value: V | null) => {};
   private onTouched = () => {};
 
   /** Live overlay holding the dropdown panel, or undefined when closed. */
@@ -207,6 +218,23 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   private static readonly loadMoreThresholdPx = 48;
 
   constructor() {
+    // With `valueWith`, a value written before its option loaded displays as
+    // the raw fallback — once options arrive, upgrade the text to the option's
+    // label. Skipped while the panel is open so active typing isn't clobbered.
+    effect(() => {
+      this.options();
+      this.valueWith();
+      untracked(() => {
+        if (this.isOpen() || !this.valueWith()) {
+          return;
+        }
+        const value = this.selectedValue();
+        if (value !== null && value !== undefined) {
+          this.searchTerm.set(this.displayValue(value));
+        }
+      });
+    });
+
     // A changed options COUNT means the consumer answered the last loadMore
     // (or a new result set landed) — re-arm the emitter and request another
     // page if the rows still don't fill the panel. Re-arming on length (not
@@ -258,16 +286,16 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
   // ── ControlValueAccessor ──
 
-  writeValue(value: T | null): void {
+  writeValue(value: V | null): void {
     this.selectedValue.set(value);
     if (value !== null && value !== undefined) {
-      this.searchTerm.set(this.displayWith()(value));
+      this.searchTerm.set(this.displayValue(value));
     } else {
       this.searchTerm.set('');
     }
   }
 
-  registerOnChange(fn: (value: T | null) => void): void {
+  registerOnChange(fn: (value: V | null) => void): void {
     this.onChange = fn;
   }
 
@@ -325,7 +353,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
         // Revert to last valid selection or clear
         const current = this.selectedValue();
         if (current !== null && current !== undefined) {
-          this.searchTerm.set(display(current));
+          this.searchTerm.set(this.displayValue(current));
         } else {
           this.searchTerm.set('');
           this.onChange(null);
@@ -386,7 +414,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
           // text so the upcoming blur doesn't commit the abandoned term.
           const current = this.selectedValue();
           this.searchTerm.set(
-            current !== null && current !== undefined ? this.displayWith()(current) : ''
+            current !== null && current !== undefined ? this.displayValue(current) : ''
           );
         }
         this.close();
@@ -456,21 +484,42 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       this.selectOption(match);
       return;
     }
-    if (isDevMode() && term !== '' && this.options().some((opt) => typeof opt !== 'string')) {
+    if (isDevMode() && term !== '' && this.options().some((opt) => typeof this.toValue(opt) !== 'string')) {
       console.warn(
-        '[tn-autocomplete] allowCustomValue committed free text into a control whose options are '
-        + 'not strings — custom values are only sound for string-valued autocompletes.'
+        '[tn-autocomplete] allowCustomValue committed free text into a control whose committed '
+        + 'values are not strings — custom values are only sound for string-valued autocompletes.'
       );
     }
-    const value = term === '' ? null : (term as unknown as T);
+    const value = term === '' ? null : (term as unknown as V);
     this.selectedValue.set(value);
     this.onChange(value);
   }
 
+  /** The value a given option commits: its `valueWith` mapping, or the option itself. */
+  private toValue(option: T): V {
+    const mapper = this.valueWith();
+    return mapper ? mapper(option) : (option as unknown as V);
+  }
+
+  /**
+   * Resolves a committed value back to its display text. Without `valueWith`
+   * the value IS the option; with it, find the option that maps to the value
+   * and fall back to the raw value's string until that option is available.
+   */
+  private displayValue(value: V): string {
+    const mapper = this.valueWith();
+    if (!mapper) {
+      return this.displayWith()(value as unknown as T);
+    }
+    const match = this.options().find((opt) => mapper(opt) === value);
+    return match ? this.displayWith()(match) : String(value);
+  }
+
   private selectOption(option: T): void {
-    this.selectedValue.set(option);
+    const value = this.toValue(option);
+    this.selectedValue.set(value);
     this.searchTerm.set(this.displayWith()(option));
-    this.onChange(option);
+    this.onChange(value);
     this.optionSelected.emit(option);
     this.close();
   }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -327,7 +327,6 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   onInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.searchTerm.set(value);
-    this.highlightedIndex.set(-1);
     // A new term is a new pagination context — don't hold back its first page.
     this.loadMorePending = false;
     this.searchChange.emit(value);
@@ -339,6 +338,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       // anchored position so it stays attached to the input.
       this.overlayRef?.updatePosition();
     }
+    // Typing is a fresh search, not navigation — no row is pre-highlighted.
+    // Set after open() so it overrides the committed-option seed below.
+    this.highlightedIndex.set(-1);
   }
 
   onFocus(): void {
@@ -486,7 +488,35 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     }
   }
 
+  /**
+   * Whether `option` carries the committed value — drives `aria-selected` so
+   * assistive tech announces the current choice independently of the keyboard
+   * cursor (which is conveyed via `aria-activedescendant`).
+   */
+  protected isOptionSelected(option: TnAutocompleteOption<T>): boolean {
+    const value = this.selectedValue();
+    if (value === null || value === undefined) {
+      return false;
+    }
+    return this.valueMatches(option.value, value);
+  }
+
   // ── Internal ──
+
+  /**
+   * Index of the committed value's option in the visible list, or -1 when
+   * nothing is committed or the match is absent/disabled. Used to seed the
+   * keyboard cursor when the panel opens.
+   */
+  private selectedOptionIndex(): number {
+    const value = this.selectedValue();
+    if (value === null || value === undefined) {
+      return -1;
+    }
+    return this.filteredOptions().findIndex(
+      (opt) => !opt.disabled && this.valueMatches(opt.value, value)
+    );
+  }
 
   /**
    * Next selectable option index from `from` in `direction` (+1 down, -1 up),
@@ -567,7 +597,13 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       return;
     }
     this.isOpen.set(true);
+    // Seed the keyboard cursor on the committed option so ArrowDown resumes
+    // from the current value (and it scrolls into view). -1 when nothing is
+    // committed or the value has no visible, enabled option — e.g. a custom
+    // free-text value, or a value whose option hasn't loaded yet.
+    this.highlightedIndex.set(this.selectedOptionIndex());
     this.attachOverlay();
+    this.scrollToHighlighted();
     this.opened.emit();
   }
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -19,8 +19,16 @@ import type { EmbeddedViewRef, OnDestroy, TemplateRef } from '@angular/core';
 import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { Subscription } from 'rxjs';
+import type { TnSelectOption } from '../select/select.component';
 import { TnSpinnerComponent } from '../spinner/spinner.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+
+/**
+ * Option shape for `tn-autocomplete` — the `label` is displayed, the `value`
+ * is committed to the form control. Structurally identical to
+ * `TnSelectOption`, so the same data sources feed both dropdown components.
+ */
+export type TnAutocompleteOption<T = unknown> = TnSelectOption<T>;
 
 let nextId = 0;
 
@@ -38,7 +46,7 @@ let nextId = 0;
   templateUrl: './autocomplete.component.html',
   styleUrl: './autocomplete.component.scss',
 })
-export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValueAccessor, OnDestroy {
+export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor, OnDestroy {
   private readonly elementRef = inject(ElementRef);
   private readonly overlay = inject(Overlay);
   private readonly viewContainerRef = inject(ViewContainerRef);
@@ -46,26 +54,21 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   /** Unique instance ID for ARIA linkage */
   protected readonly uid = `tn-autocomplete-${nextId++}`;
 
-  /** All available options */
-  options = input<T[]>([]);
-
-  /** Transform a value to its display string */
-  displayWith = input<(value: T) => string>((v: T) => String(v));
+  /**
+   * All available options. The `label` is displayed; the `value` is committed
+   * to the form control. A written value is resolved back to its option's
+   * label for display — falling back to `String(value)` until the matching
+   * option is available, and upgraded once an async option load lands.
+   */
+  options = input<TnAutocompleteOption<T>[]>([]);
 
   /**
-   * Maps a selected option to the value committed to the form control. By
-   * default the option itself is the value. Provide this when options are
-   * objects but the control should hold a derived primitive (e.g.
-   * `option.value`): written values are resolved back to their option for
-   * display — falling back to `String(value)` until the matching option is
-   * available — and re-resolved when `options` later changes, so an async
-   * option load upgrades the raw fallback to its label.
-   *
-   * Mapped values are matched by identity (`===`), so they must be
-   * primitives: a mapper that returns a fresh object per call never matches
-   * and the display stays on the raw fallback.
+   * Custom comparator for matching a written control value against option
+   * values during display resolution. Defaults to identity (`===`), which is
+   * right for primitive values; provide this when option values are objects.
+   * Mirrors `tn-select`'s `compareWith`.
    */
-  valueWith = input<((option: T) => V) | undefined>(undefined);
+  compareWith = input<((a: T | null, b: T | null) => boolean) | undefined>(undefined);
 
   /** Placeholder text for the input */
   placeholder = input<string>('Type to search...');
@@ -94,8 +97,8 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   /** Text shown next to the spinner while `loading` is set. */
   loadingText = input<string>('Loading...');
 
-  /** Custom filter function. Defaults to case-insensitive includes on displayWith text */
-  filterFn = input<((option: T, searchTerm: string) => boolean) | undefined>(undefined);
+  /** Custom filter function. Defaults to case-insensitive includes on the option label */
+  filterFn = input<((option: TnAutocompleteOption<T>, searchTerm: string) => boolean) | undefined>(undefined);
 
   /** Text shown when no options match the search */
   noResultsText = input<string>('No results found');
@@ -120,8 +123,8 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   /** Test ID attribute */
   testId = input<TnTestIdValue>(undefined);
 
-  /** Emits when an option is selected */
-  optionSelected = output<T>();
+  /** Emits the full option (label + value) when one is selected */
+  optionSelected = output<TnAutocompleteOption<T>>();
 
   /**
    * Emits the search term as the user types (not on programmatic writes or
@@ -170,8 +173,8 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   /** Index of the currently highlighted option for keyboard nav */
   protected highlightedIndex = signal(-1);
 
-  /** The currently committed value (the option itself, or its `valueWith` mapping) */
-  private selectedValue = signal<V | null>(null);
+  /** The currently committed value (an option's `value`, or a custom-typed one) */
+  private selectedValue = signal<T | null>(null);
 
   /** CVA disabled state from the form */
   private formDisabled = signal(false);
@@ -184,7 +187,6 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
     const term = this.searchTerm();
     const all = this.options();
     const customFilter = this.filterFn();
-    const display = this.displayWith();
     const max = this.maxResults();
 
     if (!term) {
@@ -194,7 +196,7 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
     const lowerTerm = term.toLowerCase();
     const filtered = customFilter
       ? all.filter((opt) => customFilter(opt, term))
-      : all.filter((opt) => display(opt).toLowerCase().includes(lowerTerm));
+      : all.filter((opt) => opt.label.toLowerCase().includes(lowerTerm));
 
     return filtered.slice(0, max);
   });
@@ -202,7 +204,7 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   /** Whether there are any results to show */
   protected hasResults = computed(() => this.filteredOptions().length > 0);
 
-  private onChange = (_value: V | null) => {};
+  private onChange = (_value: T | null) => {};
   private onTouched = () => {};
 
   /** Live overlay holding the dropdown panel, or undefined when closed. */
@@ -222,30 +224,26 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   private static readonly loadMoreThresholdPx = 48;
 
   constructor() {
-    // With `valueWith`, a value written before its option loaded displays as
-    // the raw fallback — once options arrive, upgrade the text to the option's
-    // label. UPGRADE-ONLY: when no option matches (e.g. a server-search picker
-    // replaced `options` after a selection), the current text is left alone
-    // rather than downgraded back to the raw value. Skipped while the panel is
-    // open so active typing isn't clobbered.
+    // A value written before its option loaded displays as the raw fallback —
+    // once options arrive (or are relabeled, e.g. a locale change), upgrade
+    // the text to the option's label. UPGRADE-ONLY: when no option matches
+    // (e.g. a server-search picker replaced `options` after a selection), the
+    // current text is left alone rather than downgraded back to the raw
+    // value. Skipped while the panel is open so active typing isn't clobbered.
     effect(() => {
       this.options();
-      this.valueWith();
-      // Tracked so a swapped display function (e.g. locale change) re-renders
-      // the committed label without waiting for options to change.
-      this.displayWith();
+      this.compareWith();
       untracked(() => {
-        const mapper = this.valueWith();
-        if (this.isOpen() || !mapper) {
+        if (this.isOpen()) {
           return;
         }
         const value = this.selectedValue();
         if (value === null || value === undefined) {
           return;
         }
-        const match = this.options().find((opt) => mapper(opt) === value);
+        const match = this.options().find((opt) => this.valueMatches(opt.value, value));
         if (match) {
-          this.searchTerm.set(this.displayWith()(match));
+          this.searchTerm.set(match.label);
         }
       });
     });
@@ -289,12 +287,6 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
             '[tn-autocomplete] requireSelection and allowCustomValue are mutually exclusive; allowCustomValue wins.'
           );
         }
-        if (this.valueWith() && this.allowCustomValue()) {
-          console.warn(
-            '[tn-autocomplete] valueWith and allowCustomValue are contradictory: a custom commit stores '
-            + 'the raw typed text (the display string), not a valueWith-mapped value.'
-          );
-        }
       });
     }
   }
@@ -307,7 +299,7 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
 
   // ── ControlValueAccessor ──
 
-  writeValue(value: V | null): void {
+  writeValue(value: T | null): void {
     this.selectedValue.set(value);
     if (value !== null && value !== undefined) {
       this.searchTerm.set(this.displayValue(value));
@@ -316,7 +308,7 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
     }
   }
 
-  registerOnChange(fn: (value: V | null) => void): void {
+  registerOnChange(fn: (value: T | null) => void): void {
     this.onChange = fn;
   }
 
@@ -363,9 +355,8 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
 
     if (this.requireSelection()) {
       const term = this.searchTerm();
-      const display = this.displayWith();
       const match = this.options().find(
-        (opt) => display(opt).toLowerCase() === term.toLowerCase()
+        (opt) => opt.label.toLowerCase() === term.toLowerCase()
       );
 
       if (match) {
@@ -386,7 +377,7 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
     this.onTouched();
   }
 
-  onOptionClick(option: T): void {
+  onOptionClick(option: TnAutocompleteOption<T>): void {
     this.selectOption(option);
   }
 
@@ -498,49 +489,42 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
    */
   private commitCustomValue(): void {
     const term = this.searchTerm();
-    const display = this.displayWith();
     const lowerTerm = term.toLowerCase();
-    const match = this.options().find((opt) => display(opt).toLowerCase() === lowerTerm);
+    const match = this.options().find((opt) => opt.label.toLowerCase() === lowerTerm);
     if (match) {
       this.selectOption(match);
       return;
     }
-    if (isDevMode() && term !== '' && this.options().some((opt) => typeof this.toValue(opt) !== 'string')) {
+    if (isDevMode() && term !== '' && this.options().some((opt) => typeof opt.value !== 'string')) {
       console.warn(
-        '[tn-autocomplete] allowCustomValue committed free text into a control whose committed '
+        '[tn-autocomplete] allowCustomValue committed free text into a control whose option '
         + 'values are not strings — custom values are only sound for string-valued autocompletes.'
       );
     }
-    const value = term === '' ? null : (term as unknown as V);
+    const value = term === '' ? null : (term as unknown as T);
     this.selectedValue.set(value);
     this.onChange(value);
-  }
-
-  /** The value a given option commits: its `valueWith` mapping, or the option itself. */
-  private toValue(option: T): V {
-    const mapper = this.valueWith();
-    return mapper ? mapper(option) : (option as unknown as V);
   }
 
   /**
-   * Resolves a committed value back to its display text. Without `valueWith`
-   * the value IS the option; with it, find the option that maps to the value
-   * and fall back to the raw value's string until that option is available.
+   * Resolves a committed value back to its option's display label, falling
+   * back to the raw value's string until the matching option is available.
    */
-  private displayValue(value: V): string {
-    const mapper = this.valueWith();
-    if (!mapper) {
-      return this.displayWith()(value as unknown as T);
-    }
-    const match = this.options().find((opt) => mapper(opt) === value);
-    return match ? this.displayWith()(match) : String(value);
+  private displayValue(value: T): string {
+    const match = this.options().find((opt) => this.valueMatches(opt.value, value));
+    return match ? match.label : String(value);
   }
 
-  private selectOption(option: T): void {
-    const value = this.toValue(option);
-    this.selectedValue.set(value);
-    this.searchTerm.set(this.displayWith()(option));
-    this.onChange(value);
+  /** Compares option values, honoring `compareWith` when provided. */
+  private valueMatches(a: T | null, b: T | null): boolean {
+    const comparator = this.compareWith();
+    return comparator ? comparator(a, b) : a === b;
+  }
+
+  private selectOption(option: TnAutocompleteOption<T>): void {
+    this.selectedValue.set(option.value);
+    this.searchTerm.set(option.label);
+    this.onChange(option.value);
     this.optionSelected.emit(option);
     this.close();
   }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -225,6 +225,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** Scroll distance (px) from the panel bottom that triggers `loadMore`. */
   private static readonly loadMoreThresholdPx = 48;
 
+  /** Guards the object-without-compareWith warning so it fires only once. */
+  private warnedAboutObjectCompare = false;
+
   constructor() {
     // A value written before its option loaded displays as the raw fallback —
     // once options arrive (or are relabeled, e.g. a locale change), upgrade
@@ -578,10 +581,34 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     return match ? match.label : String(value);
   }
 
-  /** Compares option values, honoring `compareWith` when provided. */
+  /**
+   * Compares option values, honoring `compareWith` when provided. Without one,
+   * falls back to identity (`===`) — which never matches structurally-equal
+   * objects from different references, so display resolution and selection
+   * silently fail. Warn once on that misuse (unconditional, like `tn-select`,
+   * so prod monitoring catches it) and return `false` to make it loud.
+   */
   private valueMatches(a: T | null, b: T | null): boolean {
     const comparator = this.compareWith();
-    return comparator ? comparator(a, b) : a === b;
+    if (comparator) {
+      return comparator(a, b);
+    }
+    if (a === b) {
+      return true;
+    }
+    if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+      if (!this.warnedAboutObjectCompare) {
+        this.warnedAboutObjectCompare = true;
+        console.warn(
+          '[tn-autocomplete] Comparing object option values without a `compareWith` input. ' +
+          'Identity comparison will not match structurally-equal objects from different ' +
+          'references, so the committed value will not resolve to its label. ' +
+          'Provide `[compareWith]="(a, b) => a?.id === b?.id"` (or similar).'
+        );
+      }
+      return false;
+    }
+    return false;
   }
 
   private selectOption(option: TnAutocompleteOption<T>): void {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -60,6 +60,10 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
    * display — falling back to `String(value)` until the matching option is
    * available — and re-resolved when `options` later changes, so an async
    * option load upgrades the raw fallback to its label.
+   *
+   * Mapped values are matched by identity (`===`), so they must be
+   * primitives: a mapper that returns a fresh object per call never matches
+   * and the display stays on the raw fallback.
    */
   valueWith = input<((option: T) => V) | undefined>(undefined);
 
@@ -220,17 +224,25 @@ export class TnAutocompleteComponent<T = unknown, V = T> implements ControlValue
   constructor() {
     // With `valueWith`, a value written before its option loaded displays as
     // the raw fallback — once options arrive, upgrade the text to the option's
-    // label. Skipped while the panel is open so active typing isn't clobbered.
+    // label. UPGRADE-ONLY: when no option matches (e.g. a server-search picker
+    // replaced `options` after a selection), the current text is left alone
+    // rather than downgraded back to the raw value. Skipped while the panel is
+    // open so active typing isn't clobbered.
     effect(() => {
       this.options();
       this.valueWith();
       untracked(() => {
-        if (this.isOpen() || !this.valueWith()) {
+        const mapper = this.valueWith();
+        if (this.isOpen() || !mapper) {
           return;
         }
         const value = this.selectedValue();
-        if (value !== null && value !== undefined) {
-          this.searchTerm.set(this.displayValue(value));
+        if (value === null || value === undefined) {
+          return;
+        }
+        const match = this.options().find((opt) => mapper(opt) === value);
+        if (match) {
+          this.searchTerm.set(this.displayWith()(match));
         }
       });
     });

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.harness.spec.ts
@@ -4,15 +4,10 @@ import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { TnAutocompleteComponent } from './autocomplete.component';
+import { TnAutocompleteComponent, type TnAutocompleteOption } from './autocomplete.component';
 import { TnAutocompleteHarness } from './autocomplete.harness';
 
-interface Fruit {
-  id: string;
-  name: string;
-}
-
-const displayFruit = (fruit: Fruit): string => fruit.name;
+type FruitOption = TnAutocompleteOption<string>;
 
 @Component({
   selector: 'tn-test-host',
@@ -22,7 +17,6 @@ const displayFruit = (fruit: Fruit): string => fruit.name;
   template: `
     <tn-autocomplete
       [options]="options()"
-      [displayWith]="displayFruit"
       [placeholder]="placeholder()"
       [disabled]="disabled()"
       [requireSelection]="requireSelection()"
@@ -32,22 +26,21 @@ const displayFruit = (fruit: Fruit): string => fruit.name;
   `
 })
 class TestHostComponent {
-  options = signal<Fruit[]>([
-    { id: 'apple', name: 'Apple' },
-    { id: 'banana', name: 'Banana' },
-    { id: 'cherry', name: 'Cherry' },
-    { id: 'date', name: 'Date' },
-    { id: 'elderberry', name: 'Elderberry' },
+  options = signal<FruitOption[]>([
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Cherry', value: 'cherry' },
+    { label: 'Date', value: 'date' },
+    { label: 'Elderberry', value: 'elderberry' },
   ]);
   placeholder = signal('Search fruits...');
   disabled = signal(false);
   requireSelection = signal(false);
-  customFilter = signal<((option: Fruit, term: string) => boolean) | undefined>(undefined);
-  control = new FormControl<Fruit | null>(null);
-  selectedValue: Fruit | null = null;
-  displayFruit = displayFruit;
+  customFilter = signal<((option: FruitOption, term: string) => boolean) | undefined>(undefined);
+  control = new FormControl<string | null>(null);
+  selectedValue: FruitOption | null = null;
 
-  handleSelection(value: Fruit): void {
+  handleSelection(value: FruitOption): void {
     this.selectedValue = value;
   }
 }
@@ -133,7 +126,7 @@ describe('TnAutocompleteHarness', () => {
       await ac.selectOption('Cherry');
 
       expect(await ac.getInputValue()).toBe('Cherry');
-      expect(hostComponent.selectedValue).toEqual({ id: 'cherry', name: 'Cherry' });
+      expect(hostComponent.selectedValue).toEqual({ label: 'Cherry', value: 'cherry' });
     });
 
     it('should select an option by regex', async () => {
@@ -141,7 +134,7 @@ describe('TnAutocompleteHarness', () => {
       await ac.selectOption(/ban/i);
 
       expect(await ac.getInputValue()).toBe('Banana');
-      expect(hostComponent.selectedValue).toEqual({ id: 'banana', name: 'Banana' });
+      expect(hostComponent.selectedValue).toEqual({ label: 'Banana', value: 'banana' });
     });
 
     it('should throw when option is not found', async () => {
@@ -155,7 +148,7 @@ describe('TnAutocompleteHarness', () => {
       const ac = await loader.getHarness(TnAutocompleteHarness);
       await ac.selectOption('Apple');
 
-      expect(hostComponent.control.value).toEqual({ id: 'apple', name: 'Apple' });
+      expect(hostComponent.control.value).toBe('apple');
     });
   });
 
@@ -171,7 +164,7 @@ describe('TnAutocompleteHarness', () => {
   describe('filtering', () => {
     it('should use custom filterFn when provided', async () => {
       hostComponent.customFilter.set(
-        (option: Fruit, term: string) => option.name.startsWith(term)
+        (option: FruitOption, term: string) => option.label.startsWith(term)
       );
 
       const ac = await loader.getHarness(TnAutocompleteHarness);

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -192,6 +192,41 @@ export const LabelValuePairs: Story = {
   },
 };
 
+/**
+ * **Disabled options.** Options carrying `disabled: true` stay visible but are
+ * non-selectable — dimmed, skipped by keyboard navigation, and ignored by
+ * click and text-match commits.
+ */
+export const DisabledOptions: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      options: simpleFruits.map((fruit, i) => ({
+        label: fruit,
+        value: fruit,
+        disabled: i % 3 === 1,
+      })),
+    },
+    template: `
+      <tn-form-field
+        label="Fruit"
+        hint="Every third fruit is unavailable">
+        <tn-autocomplete
+          [options]="options"
+          placeholder="Type to search fruits..."
+          (optionSelected)="optionSelected($event)">
+        </tn-autocomplete>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  parameters: {
+    controls: { disable: true },
+  },
+};
+
 export const RequireSelection: Story = {
   render: (args) => ({
     props: {

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -31,17 +31,22 @@ const countries: Country[] = [
   { code: 'NL', name: 'Netherlands' },
 ];
 
-const displayCountry = (country: Country): string => country.name;
+const countryOptions = countries.map((country) => ({ label: country.name, value: country.code }));
 
-const simpleOptions = [
+const simpleFruits = [
   'Apple', 'Banana', 'Cherry', 'Date', 'Elderberry',
   'Fig', 'Grape', 'Honeydew', 'Kiwi', 'Lemon',
   'Mango', 'Nectarine', 'Orange', 'Papaya', 'Quince',
 ];
 
+const simpleOptions = simpleFruits.map((fruit) => ({ label: fruit, value: fruit }));
+
 const manyOptions = Array.from(
   { length: 150 },
-  (_, i) => `Option ${String(i + 1).padStart(3, '0')}`
+  (_, i) => {
+    const name = `Option ${String(i + 1).padStart(3, '0')}`;
+    return { label: name, value: name };
+  }
 );
 
 const meta: Meta<TnAutocompleteComponent<unknown>> = {
@@ -138,21 +143,19 @@ export const Default: Story = {
   },
 };
 
-export const WithDisplayWith: Story = {
+export const LabelValuePairs: Story = {
   render: (args) => ({
     props: {
       ...args,
-      countries,
-      displayCountry,
+      options: countryOptions,
     },
     template: `
       <tn-form-field
         label="Country"
-        hint="Search by country name"
+        hint="Displays the name, commits the ISO code"
         [required]="true">
         <tn-autocomplete
-          [options]="countries"
-          [displayWith]="displayCountry"
+          [options]="options"
           [placeholder]="placeholder"
           [requireSelection]="requireSelection"
           (optionSelected)="optionSelected($event)">
@@ -223,18 +226,16 @@ export const CustomFilter: Story = {
   render: (args) => ({
     props: {
       ...args,
-      countries,
-      displayCountry,
-      startsWithFilter: (option: Country, term: string) =>
-        option.name.toLowerCase().startsWith(term.toLowerCase()),
+      options: countryOptions,
+      startsWithFilter: (option: { label: string }, term: string) =>
+        option.label.toLowerCase().startsWith(term.toLowerCase()),
     },
     template: `
       <tn-form-field
         label="Country (starts-with filter)"
         hint="Only matches from the beginning of the name">
         <tn-autocomplete
-          [options]="countries"
-          [displayWith]="displayCountry"
+          [options]="options"
           [filterFn]="startsWithFilter"
           placeholder="Type to search..."
           (optionSelected)="optionSelected($event)">
@@ -298,24 +299,10 @@ export const LongList: Story = {
 };
 
 /**
- * **Server-driven options with pagination and custom values.** The component
- * emits `opened` when the panel opens (prime the first page before any typing),
- * `searchChange` as the user types, and `loadMore` when the open panel is
- * scrolled to the bottom; the consumer fetches and updates `[options]`, holding
- * `[loading]` while a request is in flight. `[filterFn]` returns `true` because
- * the server already filtered the page. `allowCustomValue` commits free text
- * (e.g. \`/my-custom-port\`) as the value on blur or Enter — for pickers where
- * known entries are suggested but any value is acceptable.
- *
- * This story simulates a 600 ms backend with 100 entries served in pages of 20.
- */
-/**
- * **Label/value separation.** `valueWith` maps the selected option to the value
- * committed to the form control — here a country option commits its two-letter
- * code while the input displays the full name. The bound `FormControl` starts
- * at `'DE'`, so the input renders "Germany" on load: written values resolve
- * back to their option's label (falling back to the raw value until options
- * load).
+ * **CVA round-tripping with written values.** The bound `FormControl` starts at
+ * `'DE'`, so the input renders "Germany" on load: a written value resolves
+ * back to its option's label (falling back to the raw value until options
+ * load), and selections commit the option's `value`.
  */
 export const ValueMapping: Story = {
   render: () => ({
@@ -324,9 +311,7 @@ export const ValueMapping: Story = {
       const committed = signal<string | null>(control.value);
       control.valueChanges.subscribe((value) => committed.set(value));
       return {
-        options: countries,
-        displayCountry,
-        countryCode: (c: Country) => c.code,
+        options: countryOptions,
         control,
         committed,
       };
@@ -335,8 +320,6 @@ export const ValueMapping: Story = {
       <tn-form-field label="Country" hint="Commits the ISO code, displays the name">
         <tn-autocomplete
           [options]="options"
-          [displayWith]="displayCountry"
-          [valueWith]="countryCode"
           [requireSelection]="true"
           [formControl]="control"
           placeholder="Type to search countries...">
@@ -353,11 +336,23 @@ export const ValueMapping: Story = {
   },
 };
 
+/**
+ * **Server-driven options with pagination and custom values.** The component
+ * emits `opened` when the panel opens (prime the first page before any typing),
+ * `searchChange` as the user types, and `loadMore` when the open panel is
+ * scrolled to the bottom; the consumer fetches and updates `[options]`, holding
+ * `[loading]` while a request is in flight. `[filterFn]` returns `true` because
+ * the server already filtered the page. `allowCustomValue` commits free text
+ * (e.g. \`/my-custom-port\`) as the value on blur or Enter — for pickers where
+ * known entries are suggested but any value is acceptable.
+ *
+ * This story simulates a 600 ms backend with 100 entries served in pages of 20.
+ */
 export const AsyncOptions: Story = {
   render: () => ({
     // Signal-driven so async mutations render under zoneless change detection.
     props: (() => {
-      const options = signal<string[]>([]);
+      const options = signal<{ label: string; value: string }[]>([]);
       const loading = signal(false);
       const value = signal<string | null>(null);
       let term = '';
@@ -372,7 +367,7 @@ export const AsyncOptions: Story = {
         timer = setTimeout(() => {
           const all = Array.from({ length: 100 }, (unused, i) => `device-${String(i).padStart(3, '0')}`);
           const matches = all.filter((name) => name.includes(term));
-          options.set(matches.slice(0, (page + 1) * 20));
+          options.set(matches.slice(0, (page + 1) * 20).map((name) => ({ label: name, value: name })));
           loading.set(false);
         }, 600);
       };
@@ -390,7 +385,7 @@ export const AsyncOptions: Story = {
         },
         onSearch: (newTerm: string) => fetchPage(newTerm, 0),
         onLoadMore: () => fetchPage(term, page + 1),
-        onSelected: (selected: string) => value.set(selected),
+        onSelected: (selected: { value: string }) => value.set(selected.value),
       };
     })(),
     template: `

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -111,10 +111,20 @@ type Story = StoryObj<TnAutocompleteComponent<unknown>>;
 
 export const Default: Story = {
   render: (args) => ({
-    props: {
-      ...args,
-      options: simpleOptions,
-    },
+    // The committed value lives on the form control (custom commits flow
+    // through the CVA, not optionSelected) — bind one and mirror it into a
+    // signal so the story can show what actually landed.
+    props: (() => {
+      const control = new FormControl<string | null>(null);
+      const committed = signal<string | null>(control.value);
+      control.valueChanges.subscribe((value) => committed.set(value));
+      return {
+        ...args,
+        options: simpleOptions,
+        control,
+        committed,
+      };
+    })(),
     template: `
       <tn-form-field
         label="Favorite fruit"
@@ -124,20 +134,30 @@ export const Default: Story = {
           [placeholder]="placeholder"
           [disabled]="disabled"
           [requireSelection]="requireSelection"
+          [allowCustomValue]="allowCustomValue"
+          [loading]="loading"
+          [loadingText]="loadingText"
           [noResultsText]="noResultsText"
           [maxResults]="maxResults"
+          [formControl]="control"
           (optionSelected)="optionSelected($event)">
         </tn-autocomplete>
       </tn-form-field>
+      @if (committed() !== null) {
+        <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ committed() }}</code></p>
+      }
     `,
     moduleMetadata: {
-      imports: [TnFormFieldComponent],
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
     },
   }),
   args: {
     placeholder: 'Type to search fruits...',
     disabled: false,
     requireSelection: false,
+    allowCustomValue: false,
+    loading: false,
+    loadingText: 'Loading...',
     noResultsText: 'No fruits found',
     maxResults: 100,
   },
@@ -372,10 +392,16 @@ export const AsyncOptions: Story = {
         }, 600);
       };
 
+      // Custom commits flow through the CVA (onChange), not optionSelected —
+      // bind a real FormControl so they are observable in the story.
+      const control = new FormControl<string | null>(null);
+      control.valueChanges.subscribe((committed) => value.set(committed));
+
       return {
         options,
         loading,
         value,
+        control,
         passthroughFilter: () => true,
         onOpened: () => {
           // Click-to-suggest: prime the first page before the user types.
@@ -385,31 +411,30 @@ export const AsyncOptions: Story = {
         },
         onSearch: (newTerm: string) => fetchPage(newTerm, 0),
         onLoadMore: () => fetchPage(term, page + 1),
-        onSelected: (selected: { value: string }) => value.set(selected.value),
       };
     })(),
     template: `
       <tn-form-field
         label="Port or Hostname"
-        hint="Pick a detected device or type a custom path">
+        hint="Pick a detected device or type a custom path (committed on blur or Enter)">
         <tn-autocomplete
           [options]="options()"
           [loading]="loading()"
           [allowCustomValue]="true"
           [filterFn]="passthroughFilter"
+          [formControl]="control"
           placeholder="Type to search devices..."
           (opened)="onOpened()"
           (searchChange)="onSearch($event)"
-          (loadMore)="onLoadMore()"
-          (optionSelected)="onSelected($event)">
+          (loadMore)="onLoadMore()">
         </tn-autocomplete>
       </tn-form-field>
       @if (value()) {
-        <p style="margin-top: 1rem; font-size: 0.875rem;">Selected: <code>{{ value() }}</code></p>
+        <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ value() }}</code></p>
       }
     `,
     moduleMetadata: {
-      imports: [TnFormFieldComponent],
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
     },
   }),
   parameters: {

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -1,4 +1,5 @@
 import { signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
@@ -311,19 +312,23 @@ export const LongList: Story = {
 /**
  * **Label/value separation.** `valueWith` maps the selected option to the value
  * committed to the form control — here a country option commits its two-letter
- * code while the input displays the full name. Written values resolve back to
- * their option's label (falling back to the raw value until options load).
+ * code while the input displays the full name. The bound `FormControl` starts
+ * at `'DE'`, so the input renders "Germany" on load: written values resolve
+ * back to their option's label (falling back to the raw value until options
+ * load).
  */
 export const ValueMapping: Story = {
   render: () => ({
     props: (() => {
-      const value = signal<string | null>('DE');
+      const control = new FormControl<string | null>('DE');
+      const committed = signal<string | null>(control.value);
+      control.valueChanges.subscribe((value) => committed.set(value));
       return {
         options: countries,
         displayCountry,
         countryCode: (c: Country) => c.code,
-        value,
-        onSelected: (c: Country) => value.set(c.code),
+        control,
+        committed,
       };
     })(),
     template: `
@@ -333,14 +338,14 @@ export const ValueMapping: Story = {
           [displayWith]="displayCountry"
           [valueWith]="countryCode"
           [requireSelection]="true"
-          placeholder="Type to search countries..."
-          (optionSelected)="onSelected($event)">
+          [formControl]="control"
+          placeholder="Type to search countries...">
         </tn-autocomplete>
       </tn-form-field>
-      <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ value() }}</code></p>
+      <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ committed() }}</code></p>
     `,
     moduleMetadata: {
-      imports: [TnFormFieldComponent],
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
     },
   }),
   parameters: {

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -308,6 +308,46 @@ export const LongList: Story = {
  *
  * This story simulates a 600 ms backend with 100 entries served in pages of 20.
  */
+/**
+ * **Label/value separation.** `valueWith` maps the selected option to the value
+ * committed to the form control — here a country option commits its two-letter
+ * code while the input displays the full name. Written values resolve back to
+ * their option's label (falling back to the raw value until options load).
+ */
+export const ValueMapping: Story = {
+  render: () => ({
+    props: (() => {
+      const value = signal<string | null>('DE');
+      return {
+        options: countries,
+        displayCountry,
+        countryCode: (c: Country) => c.code,
+        value,
+        onSelected: (c: Country) => value.set(c.code),
+      };
+    })(),
+    template: `
+      <tn-form-field label="Country" hint="Commits the ISO code, displays the name">
+        <tn-autocomplete
+          [options]="options"
+          [displayWith]="displayCountry"
+          [valueWith]="countryCode"
+          [requireSelection]="true"
+          placeholder="Type to search countries..."
+          (optionSelected)="onSelected($event)">
+        </tn-autocomplete>
+      </tn-form-field>
+      <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ value() }}</code></p>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  parameters: {
+    controls: { disable: true },
+  },
+};
+
 export const AsyncOptions: Story = {
   render: () => ({
     // Signal-driven so async mutations render under zoneless change detection.


### PR DESCRIPTION
## Summary

`tn-autocomplete` committed the option object itself to the form control, which blocked pickers whose options carry distinct label/value pairs — e.g. a driver picker that displays a human-readable description but must commit `key$name` to the model. This PR moves the component to the **option-object model the rest of the library already uses**: options are `TnAutocompleteOption<T>` (`{ label, value }` — structurally identical to `TnSelectOption`, so the same data sources feed both dropdown components). The label is displayed and filtered on; the value is committed to the form control — combobox semantics. This completes the migration path opened by #122.

**Why option objects instead of Material-style mapping functions:** an earlier iteration of this PR added a `valueWith` mapper alongside the existing `displayWith`. Review surfaced a string of footguns inherent to the function-pair design — identity-equality mismatches on mapped values, a semantic contradiction with `allowCustomValue`, display staleness when the display function changes. Carrying label and value together on the option eliminates all of them structurally, and keeps a single option contract across `tn-select` and `tn-autocomplete`.

## API

- **`options: TnAutocompleteOption<T>[]`** — `label` displayed/filtered, `value` committed. The `displayWith` input is removed.
- **`compareWith?: (a, b) => boolean`** — mirrors `tn-select`; used when resolving a written control value back to its option (object-typed values). Defaults to `===`.
- **Written-value display resolution** — a written value renders its option's label, falling back to `String(value)` until the matching option is available (async loads upgrade the fallback once they land). Upgrade-only: when options are later replaced and nothing matches (server-search pickers), the resolved label is never downgraded back to the raw value. Relabeled options (e.g. a locale change) re-render the committed label.
- **`optionSelected`** emits the full option (label + value); `filterFn` receives the option.
- **`allowCustomValue`** commits the typed text as the value; the dev-mode soundness warning samples option *values*.
- All async primitives from #122 (`searchChange` / `loadMore` / `loading` / `opened`) are unchanged.

## Breaking

Consumers passing `options: T[]` (+ optional `displayWith`) must wrap options as `{ label, value }` pairs. Pre-1.0, single known consumer (the TrueNAS webui port picker), which adapts via the same `Option[]` helpers it already uses for `tn-select`.

## Testing

- 65/65 specs passing — the label/value resolution suite covers commit-on-select, written-value resolution, raw-fallback upgrade, relabel re-render, no-downgrade on options replacement, and `requireSelection` commits
- Stories reworked to option objects: `LabelValuePairs`, CVA round-tripping `ValueMapping` (control initialized to `'DE'` renders "Germany" on load), async `AsyncOptions`
- `ng build` + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)