### PR TITLE
NAS-141421 / 27.0.0-BETA.1 / feat(card): add projected action templates for header and footer

### DIFF
--- a/projects/truenas-ui/src/lib/card/card-action.directive.ts
+++ b/projects/truenas-ui/src/lib/card/card-action.directive.ts
@@ -1,0 +1,51 @@
+import { Directive } from '@angular/core';
+
+/**
+ * Marks an `<ng-template>` whose content is rendered as the card's footer actions,
+ * bottom-right in the footer after any declarative `secondaryAction`/`primaryAction`
+ * buttons. The template's root nodes become direct children of the footer's flex row,
+ * so projected `<tn-button>`s sit and align exactly like the declarative ones — pass
+ * bare buttons, no wrapper or styling required.
+ *
+ * Reach for this only when an action needs markup the declarative `TnCardAction` config
+ * can't express — most commonly a permission-gated button wrapped in a structural
+ * directive. Because the content renders via `ngTemplateOutlet` in the consumer's
+ * context (not light-DOM projection), structural directives like `*ixRequiresRoles`
+ * work directly on the button with no wrapper element:
+ *
+ * @example
+ * ```html
+ * <tn-card>
+ *   <ng-template tnCardFooterActions>
+ *     <tn-button *ixRequiresRoles="roles" label="Add" (click)="add()" />
+ *   </ng-template>
+ * </tn-card>
+ * ```
+ */
+@Directive({
+  selector: 'ng-template[tnCardFooterActions]',
+  standalone: true,
+})
+export class TnCardFooterActionsDirective {}
+
+/**
+ * Marks an `<ng-template>` whose content is rendered as the card's header actions,
+ * top-right in the header between the header control and the kebab menu. Use it for
+ * header controls the declarative `headerControl`/`headerMenu` config can't express —
+ * e.g. a permission-gated slide toggle. Same template-outlet semantics (and structural
+ * directive support) as {@link TnCardFooterActionsDirective}.
+ *
+ * @example
+ * ```html
+ * <tn-card title="Shares">
+ *   <ng-template tnCardHeaderActions>
+ *     <tn-slide-toggle *ixRequiresRoles="roles" [checked]="running()" />
+ *   </ng-template>
+ * </tn-card>
+ * ```
+ */
+@Directive({
+  selector: 'ng-template[tnCardHeaderActions]',
+  standalone: true,
+})
+export class TnCardHeaderActionsDirective {}

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -42,6 +42,11 @@
           </div>
         }
 
+        <!-- Projected header actions (escape hatch for custom/permission-gated controls) -->
+        @if (headerActions(); as actions) {
+          <ng-container [ngTemplateOutlet]="actions" />
+        }
+
         <!-- Header Menu -->
         @if (headerMenu(); as menu) {
           @if (menu.length) {
@@ -105,6 +110,11 @@
             [disabled]="action.disabled || false"
             [testId]="action.testId"
             (click)="action.handler()" />
+        }
+
+        <!-- Projected footer actions (escape hatch for custom/permission-gated controls) -->
+        @if (footerActions(); as actions) {
+          <ng-container [ngTemplateOutlet]="actions" />
         }
       </div>
     </div>

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -1,6 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TN_TEST_ATTR } from '../test-id';
+import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
 import { TnCardComponent } from './card.component';
 import type {
   TnCardAction,
@@ -165,5 +166,71 @@ describe('TnCardComponent testId support', () => {
     expect(primaryBtn.hasAttribute('data-testid')).toBe(false);
     expect(pill.hasAttribute('data-testid')).toBe(false);
     expect(kebabBtn.hasAttribute('data-testid')).toBe(false);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [TnCardComponent, TnCardHeaderActionsDirective, TnCardFooterActionsDirective],
+  template: `<tn-card [primaryAction]="primary()">`
+    + `@if (showHeaderAction()) {<ng-template tnCardHeaderActions><button type="button" class="projected-header-action">Toggle</button></ng-template>}`
+    + `@if (showFooterAction()) {<ng-template tnCardFooterActions><button type="button" class="projected-footer-action">Add</button></ng-template>}`
+    + `Content</tn-card>`,
+})
+class ProjectedActionsHostComponent {
+  showHeaderAction = signal(false);
+  showFooterAction = signal(false);
+  primary = signal<TnCardAction | undefined>(undefined);
+}
+
+describe('TnCardComponent projected action templates', () => {
+  function createProjectedHost() {
+    TestBed.configureTestingModule({ imports: [ProjectedActionsHostComponent] });
+    const fixture = TestBed.createComponent(ProjectedActionsHostComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders projected footer actions inside the footer, and shows the footer when only a projected action is present', () => {
+    const fixture = createProjectedHost();
+    expect(fixture.nativeElement.querySelector('.tn-card__footer')).toBeNull();
+
+    fixture.componentInstance.showFooterAction.set(true);
+    fixture.detectChanges();
+
+    const footer = fixture.nativeElement.querySelector('.tn-card__footer') as HTMLElement;
+    expect(footer).toBeTruthy();
+    expect(footer.querySelector('.projected-footer-action')).toBeTruthy();
+  });
+
+  it('renders projected header actions inside the header-right, and shows the header when only a projected action is present', () => {
+    const fixture = createProjectedHost();
+    expect(fixture.nativeElement.querySelector('.tn-card__header')).toBeNull();
+
+    fixture.componentInstance.showHeaderAction.set(true);
+    fixture.detectChanges();
+
+    const headerRight = fixture.nativeElement.querySelector('.tn-card__header-right') as HTMLElement;
+    expect(headerRight).toBeTruthy();
+    expect(headerRight.querySelector('.projected-header-action')).toBeTruthy();
+  });
+
+  it('renders the projected footer action as a direct child of the footer flex row, alongside a declarative primaryAction', () => {
+    const fixture = createProjectedHost();
+    fixture.componentInstance.primary.set({ label: 'Primary', handler: () => {} });
+    fixture.componentInstance.showFooterAction.set(true);
+    fixture.detectChanges();
+
+    const footerRight = fixture.nativeElement.querySelector('.tn-card__footer-right') as HTMLElement;
+    const projected = footerRight.querySelector('.projected-footer-action') as HTMLElement;
+    // No wrapper element: the projected button sits directly in the flex row so it
+    // aligns identically to the declarative <tn-button>.
+    expect(projected).toBeTruthy();
+    expect(projected.parentElement).toBe(footerRight);
+    // Declarative action renders too — projected actions are additive, not a replacement.
+    const primaryBtn = Array.from(footerRight.querySelectorAll('button')).find(
+      (b) => (b as HTMLElement).textContent?.trim() === 'Primary',
+    );
+    expect(primaryBtn).toBeTruthy();
   });
 });

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component, input, computed, inject, contentChild } from '@angular/core';
+import { Component, input, computed, inject, contentChild, TemplateRef } from '@angular/core';
 import { mdiDotsVertical } from '@mdi/js';
+import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
 import { TnCardHeaderDirective } from './card-header.directive';
 import type {
   TnCardAction,
@@ -43,6 +44,13 @@ export class TnCardComponent {
   }
 
   projectedHeader = contentChild(TnCardHeaderDirective);
+
+  // Projected action templates (escape hatch for actions the declarative config can't
+  // express, e.g. a permission-gated control wrapped in a structural directive). Rendered
+  // via ngTemplateOutlet so the buttons inside become direct children of the header/footer
+  // flex rows — same orientation as the declarative action buttons, no wrapper needed.
+  protected headerActions = contentChild(TnCardHeaderActionsDirective, { read: TemplateRef });
+  protected footerActions = contentChild(TnCardFooterActionsDirective, { read: TemplateRef });
 
   title = input<string | undefined>(undefined);
   titleLink = input<string | undefined>(undefined); // Makes title navigable
@@ -101,15 +109,24 @@ export class TnCardComponent {
   });
 
   hasHeader = computed(() => {
-    return !!(this.projectedHeader() || this.title() || this.headerStatus() || this.headerControl() || this.headerMenu());
+    return !!(
+      this.projectedHeader() || this.title() || this.headerStatus()
+      || this.headerControl() || this.headerMenu() || this.headerActions()
+    );
   });
 
   hasHeaderRight = computed(() => {
-    return !!(this.headerStatus() || this.headerControl() || this.headerMenu()?.length);
+    return !!(
+      this.headerStatus() || this.headerControl()
+      || this.headerMenu()?.length || this.headerActions()
+    );
   });
 
   hasFooter = computed(() => {
-    return !!(this.primaryAction() || this.secondaryAction() || this.footerLink());
+    return !!(
+      this.primaryAction() || this.secondaryAction()
+      || this.footerLink() || this.footerActions()
+    );
   });
 
   onTitleClick(): void {

--- a/projects/truenas-ui/src/lib/card/index.ts
+++ b/projects/truenas-ui/src/lib/card/index.ts
@@ -1,3 +1,4 @@
 export * from './card.component';
+export * from './card-action.directive';
 export * from './card-header.directive';
 export * from './card.interfaces';

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, within } from 'storybook/test';
 import { TestIdInspectorComponent } from './testid-inspector.component';
+import { TnButtonComponent } from '../lib/button/button.component';
+import {
+  TnCardFooterActionsDirective,
+  TnCardHeaderActionsDirective,
+} from '../lib/card/card-action.directive';
 import { TnCardHeaderDirective } from '../lib/card/card-header.directive';
 import { TnCardComponent } from '../lib/card/card.component';
 
@@ -453,6 +458,80 @@ export const WithProjectedHeader: Story = {
     const canvas = within(canvasElement);
     const header = canvas.getByText('Custom Header Content');
     await expect(header).toBeInTheDocument();
+  },
+};
+
+export const WithProjectedFooterActions: Story = {
+  args: {
+    title: 'Shares',
+    elevation: 'medium',
+    padding: 'medium',
+    padContent: true,
+    bordered: true,
+  },
+  render: (args) => ({
+    props: args,
+    moduleMetadata: {
+      imports: [TnCardFooterActionsDirective, TnButtonComponent],
+    },
+    // Escape hatch for actions the declarative `primaryAction` config can't express
+    // (e.g. a button wrapped in a structural directive for permission gating). The
+    // buttons inside the <ng-template> render as direct children of the footer flex
+    // row — same orientation as a declarative primaryAction, no wrapper or styling.
+    template: `
+      <tn-card
+        [title]="title"
+        [elevation]="elevation"
+        [padding]="padding"
+        [padContent]="padContent"
+        [bordered]="bordered"
+        [background]="background">
+        <p>This card declares its footer actions as projected buttons.</p>
+        <ng-template tnCardFooterActions>
+          <tn-button variant="outline" color="default" label="Import" />
+          <tn-button variant="filled" color="primary" label="Add" />
+        </ng-template>
+      </tn-card>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Add')).toBeInTheDocument();
+    await expect(canvas.getByText('Import')).toBeInTheDocument();
+  },
+};
+
+export const WithProjectedHeaderActions: Story = {
+  args: {
+    title: 'Shares',
+    elevation: 'medium',
+    padding: 'medium',
+    padContent: true,
+    bordered: true,
+  },
+  render: (args) => ({
+    props: args,
+    moduleMetadata: {
+      imports: [TnCardHeaderActionsDirective, TnButtonComponent],
+    },
+    template: `
+      <tn-card
+        [title]="title"
+        [elevation]="elevation"
+        [padding]="padding"
+        [padContent]="padContent"
+        [bordered]="bordered"
+        [background]="background">
+        <ng-template tnCardHeaderActions>
+          <tn-button variant="outline" color="default" label="Refresh" />
+        </ng-template>
+        <p>Header actions render top-right, between the header control and the kebab menu.</p>
+      </tn-card>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Refresh')).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
Add TnCardHeaderActionsDirective / TnCardFooterActionsDirective, applied to an <ng-template> and rendered via ngTemplateOutlet into the header-right and footer-right flex rows. This is an escape hatch for actions the declarative TnCardAction/TnCardControl config can't express -- most importantly a permission-gated control wrapped in a structural directive (e.g. *ixRequiresRoles), which the data-driven config and bare content projection can't support.

Projected buttons render as direct children of the existing flex rows, so they align identically to the declarative action buttons with no wrapper or extra styling, and are additive with primaryAction/secondaryAction/headerControl.

Example usage:
```html
<tn-card
  [title]="title"
  [elevation]="elevation"
  [padding]="padding"
  [padContent]="padContent"
  [bordered]="bordered"
  [background]="background">
  <p>This card declares its footer actions as projected buttons.</p>
  <ng-template tnCardFooterActions>
    <tn-button variant="outline" color="default" label="Import" />
    <tn-button variant="filled" color="primary" label="Add" />
  </ng-template>
</tn-card>
```