### PR TITLE
NAS-141448 / 27.0.0-BETA.1 / chore: target Node 24 LTS

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -183,7 +183,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     ]
   },
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "peerDependencies": {
     "rxjs": "^7.5.0",
     "zone.js": "^0.15.0"


### PR DESCRIPTION
## Summary
Update the project to build and run on the current Active Node.js LTS (Node 24, "Krypton", LTS since Oct 2025).

## Changes
- **`.github/workflows/ci-cd.yml`** — bump all 5 `setup-node` steps (lint, test, build, build-storybook, release) from Node 20 → 24
- **`package.json`** — declare `"engines": { "node": ">=24" }`

## Notes
- Node 24 is within Angular 21's supported range (`^20.19 || ^22.12 || ^24`)
- `yarn build` passes locally on Node 24
- No `.nvmrc`: Node version is sourced from `engines.node` + CI config to avoid a duplicate source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)