### PR TITLE
NAS-141438 / 27.0.0-BETA.1 / feat(chip-input): add allowCustomValue to restrict commits to suggestions

### DIFF
--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -83,6 +83,17 @@ export class TnChipInputComponent implements ControlValueAccessor, OnDestroy {
   addOnBlur = input<boolean>(false);
 
   /**
+   * Whether free text not present in `suggestions` may be committed. Defaults to
+   * `true` — any typed value becomes a chip. Set `false` to restrict the field
+   * to its suggestion list (a "pick from the list" control): a commit only
+   * succeeds when the text matches a suggestion (case-insensitively, committing
+   * the suggestion's canonical casing); unmatched text is discarded. Mirrors
+   * `tn-autocomplete`'s `allowCustomValue`. With no `suggestions`, nothing can be
+   * added.
+   */
+  allowCustomValue = input<boolean>(true);
+
+  /**
    * Allow the same value to be added more than once. Off by default.
    * Duplicate detection is exact-match (case-sensitive), so with this off
    * `Angular` and `angular` are still distinct values — only suggestion
@@ -354,9 +365,19 @@ export class TnChipInputComponent implements ControlValueAccessor, OnDestroy {
   }
 
   private addChip(raw: string): void {
-    const value = (raw ?? '').trim();
+    let value = (raw ?? '').trim();
     if (!value || this.isDisabled() || !this.canAddMore()) {
       return;
+    }
+    if (!this.allowCustomValue()) {
+      // Restricted to the suggestion list: commit the canonical suggestion when
+      // the text matches one (case-insensitively), otherwise discard it.
+      const match = this.suggestions().find((suggestion) => suggestion.toLowerCase() === value.toLowerCase());
+      if (!match) {
+        this.clearInput();
+        return;
+      }
+      value = match;
     }
     if (!this.allowDuplicates() && this.values().includes(value)) {
       this.clearInput();

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -21,6 +21,7 @@ import { TnChipInputHarness } from './chip-input.harness';
       [suggestions]="suggestions()"
       [disabled]="disabled()"
       [allowDuplicates]="allowDuplicates()"
+      [allowCustomValue]="allowCustomValue()"
       [addOnBlur]="addOnBlur()"
       [separatorKeys]="separatorKeys()"
       [maxChips]="maxChips()" />
@@ -31,6 +32,7 @@ class TestHostComponent {
   suggestions = signal<string[]>(['Angular', 'React', 'Vue']);
   disabled = signal(false);
   allowDuplicates = signal(false);
+  allowCustomValue = signal(true);
   addOnBlur = signal(false);
   separatorKeys = signal<string[]>(['Enter', ',']);
   maxChips = signal<number | undefined>(undefined);
@@ -186,6 +188,22 @@ describe('TnChipInputHarness', () => {
     await chipInput.pressKey(TestKey.ENTER);
 
     expect(await chipInput.getChips()).toEqual(['React']);
+  });
+
+  it('rejects free text not in suggestions when allowCustomValue is false', async () => {
+    hostComponent.allowCustomValue.set(false);
+    const chipInput = await loader.getHarness(TnChipInputHarness);
+    await chipInput.addChip('NotASuggestion');
+
+    expect(await chipInput.getChips()).toEqual([]);
+  });
+
+  it('commits a matching suggestion (canonical casing) when allowCustomValue is false', async () => {
+    hostComponent.allowCustomValue.set(false);
+    const chipInput = await loader.getHarness(TnChipInputHarness);
+    await chipInput.addChip('angular');
+
+    expect(await chipInput.getChips()).toEqual(['Angular']);
   });
 
   it('reflects the disabled state', async () => {

--- a/projects/truenas-ui/src/stories/chip-input.stories.ts
+++ b/projects/truenas-ui/src/stories/chip-input.stories.ts
@@ -32,6 +32,7 @@ const meta: Meta<TnChipInputComponent> = {
     disabled: { control: 'boolean', description: 'Disables the whole control' },
     addOnBlur: { control: 'boolean', description: 'Commit a pending value when the field loses focus' },
     allowDuplicates: { control: 'boolean', description: 'Allow the same value to be added more than once' },
+    allowCustomValue: { control: 'boolean', description: 'Allow free text not in the suggestion list (off = pick-from-list)' },
     maxChips: { control: 'number', description: 'Maximum number of chips (undefined = no limit)' },
     chipAdded: { action: 'chipAdded' },
     chipRemoved: { action: 'chipRemoved' },
@@ -78,6 +79,28 @@ export const Default: Story = {
     addOnBlur: false,
     allowDuplicates: false,
   },
+};
+
+/**
+ * **Pick from list (`allowCustomValue=false`).** Only values from `suggestions`
+ * can be committed — typing something off-list and pressing Enter discards it; a
+ * matching entry commits with the suggestion's canonical casing.
+ */
+export const RestrictedToSuggestions: Story = {
+  render: () => ({
+    props: { control: new FormControl<string[]>([]), suggestions: frameworks },
+    template: `
+      <tn-form-field label="Frameworks" hint="Choose from the list — custom values are rejected">
+        <tn-chip-input
+          [formControl]="control"
+          [suggestions]="suggestions"
+          [allowCustomValue]="false"
+          placeholder="Pick a framework…" />
+      </tn-form-field>
+    `,
+    moduleMetadata: { imports: [TnFormFieldComponent, ReactiveFormsModule] },
+  }),
+  parameters: { controls: { disable: true } },
 };
 
 /** No suggestion list — a free-form tag entry that accepts any typed value. */


### PR DESCRIPTION
## Summary

Adds an `allowCustomValue` input to `tn-chip-input` (default `true`), mirroring `tn-autocomplete`'s input of the same name.

When `false`, the field becomes a **pick-from-list** control: a commit only succeeds when the typed text matches an entry in `[suggestions]` (case-insensitively, committing the suggestion's canonical casing); off-list text is discarded. With no suggestions, nothing can be added.

## Why

webui's `ix-chips` exposes `[allowNewEntries]="false"` (used by available-apps-header, privilege-form, group-form) — "only values chosen from autocomplete are allowed." `tn-chip-input` previously always committed typed text on Enter, so there was no clean way to express that during the `ix-chips` → `tn-chip-input` migration. `allowCustomValue=false` maps to it directly. Generic and reusable (not webui-specific), and consistent with the sibling `tn-autocomplete` API.

## Changes

- `allowCustomValue` input + enforcement in `addChip()` (default `true` → no behavior change for existing users).
- 2 specs: off-list text rejected; matching text commits canonical casing. (19/19 chip-input specs pass.)
- `RestrictedToSuggestions` story + argType.

## Testing

- `yarn test --testPathPatterns chip-input` → 19/19 pass
- `yarn build` succeeds; `eslint` clean