### PR TITLE
NAS-141634 / 27.0.0-BETA.1 / fix(icon): set min-width/min-height to prevent flex squishing

### DIFF
--- a/projects/truenas-ui/src/lib/icon/icon.component.scss
+++ b/projects/truenas-ui/src/lib/icon/icon.component.scss
@@ -10,38 +10,51 @@ tn-icon {
   color: var(--tn-icon-color, currentColor);
 
   // Default sizing (fallback when no size attribute matches)
+  // min-width/min-height prevent the icon from being squished by flex layouts.
   width: var(--tn-icon-size, var(--tn-icon-md));
   height: var(--tn-icon-size, var(--tn-icon-md));
+  min-width: var(--tn-icon-size, var(--tn-icon-md));
+  min-height: var(--tn-icon-size, var(--tn-icon-md));
   font-size: var(--tn-icon-size, var(--tn-icon-md));
 
   // Size presets via attribute selectors
   &[size="xs"] {
     width: var(--tn-icon-xs);
     height: var(--tn-icon-xs);
+    min-width: var(--tn-icon-xs);
+    min-height: var(--tn-icon-xs);
     font-size: var(--tn-icon-xs);
   }
 
   &[size="sm"] {
     width: var(--tn-icon-sm);
     height: var(--tn-icon-sm);
+    min-width: var(--tn-icon-sm);
+    min-height: var(--tn-icon-sm);
     font-size: var(--tn-icon-sm);
   }
 
   &[size="md"] {
     width: var(--tn-icon-md);
     height: var(--tn-icon-md);
+    min-width: var(--tn-icon-md);
+    min-height: var(--tn-icon-md);
     font-size: var(--tn-icon-md);
   }
 
   &[size="lg"] {
     width: var(--tn-icon-lg);
     height: var(--tn-icon-lg);
+    min-width: var(--tn-icon-lg);
+    min-height: var(--tn-icon-lg);
     font-size: var(--tn-icon-lg);
   }
 
   &[size="xl"] {
     width: var(--tn-icon-xl);
     height: var(--tn-icon-xl);
+    min-width: var(--tn-icon-xl);
+    min-height: var(--tn-icon-xl);
     font-size: var(--tn-icon-xl);
   }
 }

--- a/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.spec.ts
@@ -224,6 +224,17 @@ describe('TnIconComponent - Full Size', () => {
     expect(hostEl.style.height).toBe('100%');
   });
 
+  it('should relax host min-width/min-height to 0 when fullSize=true', async () => {
+    fixture.componentRef.setInput('name', 'test');
+    fixture.componentRef.setInput('fullSize', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const hostEl = fixture.nativeElement as HTMLElement;
+    expect(hostEl.style.minWidth).toBe('0');
+    expect(hostEl.style.minHeight).toBe('0');
+  });
+
   it('should not set inline width/height when fullSize=false', async () => {
     fixture.componentRef.setInput('name', 'test');
     fixture.componentRef.setInput('fullSize', false);
@@ -234,6 +245,8 @@ describe('TnIconComponent - Full Size', () => {
     const hostEl = fixture.nativeElement as HTMLElement;
     expect(hostEl.style.width).toBe('');
     expect(hostEl.style.height).toBe('');
+    expect(hostEl.style.minWidth).toBe('');
+    expect(hostEl.style.minHeight).toBe('');
   });
 });
 
@@ -258,6 +271,8 @@ describe('TnIconComponent - Custom Size', () => {
     const hostEl = fixture.nativeElement as HTMLElement;
     expect(hostEl.style.width).toBe('48px');
     expect(hostEl.style.height).toBe('48px');
+    expect(hostEl.style.minWidth).toBe('48px');
+    expect(hostEl.style.minHeight).toBe('48px');
     expect(hostEl.style.fontSize).toBe('48px');
   });
 

--- a/projects/truenas-ui/src/lib/icon/icon.component.ts
+++ b/projects/truenas-ui/src/lib/icon/icon.component.ts
@@ -31,6 +31,8 @@ export interface IconResult {
     '[attr.custom-size]': 'customSize() || null',
     '[style.width]': 'hostDimension()',
     '[style.height]': 'hostDimension()',
+    '[style.min-width]': 'hostMinDimension()',
+    '[style.min-height]': 'hostMinDimension()',
     '[style.font-size]': 'hostFontSize()',
     '[style.color]': 'color() || null',
   }
@@ -99,6 +101,20 @@ export class TnIconComponent {
     const custom = this.customSize();
     if (custom) {return custom;}
     if (this.fullSize()) {return '100%';}
+    return null;
+  });
+
+  /**
+   * Inline min-width/min-height override for the custom/full-size paths.
+   * - customSize: pin the minimum to the custom value so flex layouts can't
+   *   squish it (mirrors the preset min-* rules in the stylesheet).
+   * - fullSize: relax the minimum to 0 so the icon can shrink with its
+   *   container instead of being clamped by the `size` attribute's preset min.
+   */
+  hostMinDimension = computed(() => {
+    const custom = this.customSize();
+    if (custom) {return custom;}
+    if (this.fullSize()) {return '0';}
     return null;
   });
 


### PR DESCRIPTION
Icons rendered inside flex containers could be shrunk below their intended size since only width/height were set. Add matching min-width/min-height for the default fallback and every size preset.

For the customSize/fullSize paths (inline width/height overrides), add inline min-* bindings via hostMinDimension(): customSize pins the minimum to the custom value, while fullSize relaxes it to 0 so the icon can still shrink to fill its container.

fixed issue below:
<img width="553" height="254" alt="Screenshot 2026-06-19 at 12 33 03" src="https://github.com/user-attachments/assets/b4328941-a3bd-4c4b-a98d-eb25af7db673" />
