### PR TITLE
NAS-141633 / 27.0.0-BETA.1 / feat(table): add isRowExpandable predicate to gate per-row expansion

### DIFF
--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -50,7 +50,11 @@
                 <tn-icon
                   class="tn-table__sort-icon"
                   size="sm"
-                  [name]="getSortIcon(column)" />
+                  [name]="
+                    isSorted(column)
+                      ? (sortDirection() === 'asc' ? 'mat-arrow_upward' : 'mat-arrow_downward')
+                      : 'mat-unfold_more'
+                  " />
               }
             </span>
           </th>
@@ -95,7 +99,7 @@
                   (click)="toggleRowExpansion(row)">
                   <tn-icon
                     class="tn-table__expand-icon"
-                    [name]="getExpandIcon(row)" />
+                    [name]="isRowExpanded(row) ? 'mat-keyboard_arrow_up' : 'mat-keyboard_arrow_down'" />
                 </button>
               }
             </td>

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -65,7 +65,7 @@
       <tr
         class="tn-table__row"
         [attr.data-row-index]="rowIdx"
-        [class.tn-table__row--expandable]="expandable()"
+        [class.tn-table__row--expandable]="canExpandRow(row)"
         [class.tn-table__row--expanded]="canExpandRow(row) && isRowExpanded(row)"
         [class.tn-table__row--active]="isRowActive(row)"
         [class.tn-table__row--clickable]="clickable()"

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -66,7 +66,7 @@
         class="tn-table__row"
         [attr.data-row-index]="rowIdx"
         [class.tn-table__row--expandable]="expandable()"
-        [class.tn-table__row--expanded]="isRowExpanded(row)"
+        [class.tn-table__row--expanded]="canExpandRow(row) && isRowExpanded(row)"
         [class.tn-table__row--active]="isRowActive(row)"
         [class.tn-table__row--clickable]="clickable()"
         [attr.tabindex]="clickable() ? 0 : null"

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -86,16 +86,18 @@
           } @else if (column === '__expand') {
             <td class="tn-table__cell tn-table__expand-cell"
               (click)="$event.stopPropagation()">
-              <button
-                type="button"
-                class="tn-table__expand-button"
-                [attr.aria-expanded]="isRowExpanded(row)"
-                [attr.aria-label]="isRowExpanded(row) ? 'Collapse row' : 'Expand row'"
-                (click)="toggleRowExpansion(row)">
-                <tn-icon
-                  class="tn-table__expand-icon"
-                  [name]="getExpandIcon(row)" />
-              </button>
+              @if (canExpandRow(row)) {
+                <button
+                  type="button"
+                  class="tn-table__expand-button"
+                  [attr.aria-expanded]="isRowExpanded(row)"
+                  [attr.aria-label]="isRowExpanded(row) ? 'Collapse row' : 'Expand row'"
+                  (click)="toggleRowExpansion(row)">
+                  <tn-icon
+                    class="tn-table__expand-icon"
+                    [name]="getExpandIcon(row)" />
+                </button>
+              }
             </td>
           } @else {
             <td
@@ -117,7 +119,7 @@
       </tr>
 
       <!-- Detail / Expanded Row -->
-      @if (expandable() && detailRowDef() && isRowExpanded(row)) {
+      @if (detailRowDef() && canExpandRow(row) && isRowExpanded(row)) {
         <tr class="tn-table__detail-row" [@detailExpand]="'expanded'">
           <td
             class="tn-table__detail-cell"

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -1,8 +1,59 @@
-import { signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import type { TnTableDataSource } from './table.component';
 import { TnTableComponent } from './table.component';
+import {
+  TnCellDefDirective,
+  TnDetailRowDefDirective,
+  TnHeaderCellDefDirective,
+  TnTableColumnDirective,
+} from '../table-column/table-column.directive';
+
+// Host with a single sortable column, for asserting the rendered sort-icon name.
+@Component({
+  standalone: true,
+  imports: [TnTableComponent, TnTableColumnDirective, TnHeaderCellDefDirective, TnCellDefDirective],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-table [dataSource]="data" [displayedColumns]="['name']">
+      <ng-container tnColumnDef="name" [sortable]="true">
+        <ng-template tnHeaderCellDef>Name</ng-template>
+        <ng-template let-row tnCellDef>{{ row.name }}</ng-template>
+      </ng-container>
+    </tn-table>
+  `,
+})
+class SortableHostComponent {
+  data = [{ name: 'Alice' }];
+}
+
+// Host with an expandable column + detail row, for asserting the expand-icon name.
+@Component({
+  standalone: true,
+  imports: [
+    TnTableComponent,
+    TnTableColumnDirective,
+    TnHeaderCellDefDirective,
+    TnCellDefDirective,
+    TnDetailRowDefDirective,
+  ],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-table [dataSource]="data" [displayedColumns]="['name']" [expandable]="true">
+      <ng-container tnColumnDef="name">
+        <ng-template tnHeaderCellDef>Name</ng-template>
+        <ng-template let-row tnCellDef>{{ row.name }}</ng-template>
+      </ng-container>
+      <ng-template let-row tnDetailRowDef>{{ row.name }} details</ng-template>
+    </tn-table>
+  `,
+})
+class ExpandableHostComponent {
+  data = [{ name: 'Alice' }];
+}
 
 describe('TnTableComponent', () => {
   let component: TnTableComponent;
@@ -117,12 +168,73 @@ describe('TnTableComponent', () => {
       expect(component.sortDirection()).toBe('');
     });
 
-    it('should return SORT_ICON_NONE for unsorted columns', () => {
-      expect(component.getSortIcon('anything')).toContain('unfold_more');
-    });
-
     it('should report isSorted false when no sort active', () => {
       expect(component.isSorted('col1')).toBe(false);
+    });
+  });
+
+  // The icon names are string literals in the template (so the sprite scanner
+  // finds them); assert they actually reach the rendered <tn-icon name="...">.
+  describe('sort icon rendering', () => {
+    let sortFixture: ComponentFixture<SortableHostComponent>;
+    let table: TnTableComponent;
+
+    const sortIconName = (): string | null =>
+      (sortFixture.nativeElement.querySelector('.tn-table__sort-icon') as HTMLElement | null)?.getAttribute(
+        'name',
+      ) ?? null;
+
+    beforeEach(async () => {
+      // The outer beforeEach already instantiated a module; reset before
+      // reconfiguring with the host component.
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({ imports: [SortableHostComponent] }).compileComponents();
+      sortFixture = TestBed.createComponent(SortableHostComponent);
+      table = sortFixture.debugElement.query(By.directive(TnTableComponent)).componentInstance;
+      sortFixture.detectChanges();
+    });
+
+    it('shows the neutral icon when unsorted', () => {
+      expect(sortIconName()).toBe('mat-unfold_more');
+    });
+
+    it('shows ascending after one sort and descending after two', () => {
+      table.onSortClick('name');
+      sortFixture.detectChanges();
+      expect(sortIconName()).toBe('mat-arrow_upward');
+
+      table.onSortClick('name');
+      sortFixture.detectChanges();
+      expect(sortIconName()).toBe('mat-arrow_downward');
+    });
+  });
+
+  describe('expand icon rendering', () => {
+    let expandFixture: ComponentFixture<ExpandableHostComponent>;
+    let table: TnTableComponent;
+
+    const expandIconName = (): string | null =>
+      (expandFixture.nativeElement.querySelector('.tn-table__expand-icon') as HTMLElement | null)?.getAttribute(
+        'name',
+      ) ?? null;
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [ExpandableHostComponent],
+        providers: [provideNoopAnimations()],
+      }).compileComponents();
+      expandFixture = TestBed.createComponent(ExpandableHostComponent);
+      table = expandFixture.debugElement.query(By.directive(TnTableComponent)).componentInstance;
+      expandFixture.detectChanges();
+    });
+
+    it('renders the down chevron collapsed and the up chevron when expanded', () => {
+      expect(expandIconName()).toBe('mat-keyboard_arrow_down');
+
+      table.toggleRowExpansion(table.data()[0]);
+      expandFixture.detectChanges();
+      expect(expandIconName()).toBe('mat-keyboard_arrow_up');
     });
   });
 

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -1,3 +1,4 @@
+import { signal } from '@angular/core';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import type { TnTableDataSource } from './table.component';
@@ -430,6 +431,26 @@ describe('TnTableComponent', () => {
         // It does not silently reappear expanded when the predicate allows it again.
         fixture.componentRef.setInput('isRowExpandable', () => true);
         fixture.detectChanges();
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
+
+      it('should prune an expanded row when a signal the predicate reads changes', () => {
+        // The predicate's allowed set lives in a separate signal rather than
+        // being swapped via setInput, exercising the effect's signal tracking.
+        const allowedIds = signal(new Set([1, 2]));
+        fixture.componentRef.setInput(
+          'isRowExpandable',
+          (row: { id: number }) => allowedIds().has(row.id),
+        );
+        fixture.detectChanges();
+
+        component.toggleRowExpansion(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        // Disallow the expanded row purely through the signal.
+        allowedIds.set(new Set([2]));
+        fixture.detectChanges();
+
         expect(component.isRowExpanded(testData[0])).toBe(false);
       });
 

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -416,6 +416,33 @@ describe('TnTableComponent', () => {
         fixture.detectChanges();
         expect(component.canExpandRow(testData[0])).toBe(false);
       });
+
+      it('should prune an expanded row once the predicate stops allowing it', () => {
+        component.toggleRowExpansion(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        // Predicate now disallows the already-expanded row.
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id !== 1);
+        fixture.detectChanges();
+
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+
+        // It does not silently reappear expanded when the predicate allows it again.
+        fixture.componentRef.setInput('isRowExpandable', () => true);
+        fixture.detectChanges();
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
+
+      it('should keep expanded rows the predicate still allows', () => {
+        component.toggleRowExpansion(testData[0]);
+        component.toggleRowExpansion(testData[1]);
+
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id === 1);
+        fixture.detectChanges();
+
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+        expect(component.isRowExpanded(testData[1])).toBe(false);
+      });
     });
   });
 });

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -383,5 +383,39 @@ describe('TnTableComponent', () => {
       component.toggleRowExpansion(testData[0]);
       expect(component.isRowExpanded(testData[0])).toBe(false);
     });
+
+    describe('isRowExpandable predicate', () => {
+      it('should treat every row as expandable when no predicate is set', () => {
+        expect(component.canExpandRow(testData[0])).toBe(true);
+        expect(component.canExpandRow(testData[1])).toBe(true);
+      });
+
+      it('should report only rows allowed by the predicate as expandable', () => {
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id === 1);
+        fixture.detectChanges();
+        expect(component.canExpandRow(testData[0])).toBe(true);
+        expect(component.canExpandRow(testData[1])).toBe(false);
+      });
+
+      it('should not toggle a row the predicate disallows', () => {
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id === 1);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[1]);
+        expect(component.isRowExpanded(testData[1])).toBe(false);
+      });
+
+      it('should still toggle a row the predicate allows', () => {
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id === 1);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+      });
+
+      it('should report no row as expandable when expandable is false', () => {
+        fixture.componentRef.setInput('expandable', false);
+        fixture.detectChanges();
+        expect(component.canExpandRow(testData[0])).toBe(false);
+      });
+    });
   });
 });

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -12,6 +12,7 @@ import {
   input,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import type { OnInit } from '@angular/core';
 import { TnCheckboxComponent } from '../checkbox/checkbox.component';
@@ -106,9 +107,13 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * Optional per-row predicate deciding whether an individual row can expand.
    * When omitted, every row is expandable (provided `expandable` is true and a
    * `tnDetailRowDef` is present). Rows for which it returns `false` render no
-   * expand control and cannot be toggled by the chevron, a row click, or the
-   * keyboard, and never render a detail row. Has no effect unless `expandable`
-   * is true. Re-evaluated on each change detection, so it may depend on signals.
+   * expand control, cannot be toggled, and never render a detail row. Has no
+   * effect unless `expandable` is true. Re-evaluated on each change detection,
+   * so it may depend on signals — keep it cheap and pure.
+   *
+   * If the predicate stops allowing an already-expanded row (e.g. it is driven
+   * by dynamic row state), that row is pruned from the expanded set, so it will
+   * not silently reappear expanded should the predicate allow it again later.
    */
   isRowExpandable = input<((row: T) => boolean) | undefined>(undefined);
 
@@ -213,6 +218,25 @@ export class TnTableComponent<T = unknown> implements OnInit {
     effect(() => {
       if (!this.expandable()) {
         this.expandedRows.set(new Set());
+      }
+    });
+
+    // Prune rows the predicate no longer allows from the expanded set, so a row
+    // that flips expandable -> non-expandable -> expandable does not silently
+    // reappear already expanded. Calling the predicate here tracks any signals
+    // it reads, so the prune re-runs when its result changes; the expanded set
+    // is read/written untracked to keep this effect off its own dependency list.
+    effect(() => {
+      const predicate = this.isRowExpandable();
+      if (!predicate) { return; }
+      const expanded = untracked(this.expandedRows);
+      if (expanded.size === 0) { return; }
+      const next = new Set<unknown>();
+      for (const row of expanded) {
+        if (predicate(row as T)) { next.add(row); }
+      }
+      if (next.size !== expanded.size) {
+        untracked(() => this.expandedRows.set(next));
       }
     });
   }

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -222,11 +222,13 @@ export class TnTableComponent<T = unknown> implements OnInit {
 
     // Prune rows the predicate no longer allows from the expanded set, so a row
     // that flips expandable -> non-expandable -> expandable does not silently
-    // reappear already expanded. Reading expandedRows tracked re-runs this on
-    // every toggle, which keeps the predicate's own signal dependencies fresh
-    // (e.g. a predicate like (row) => allowedIds().includes(row.id)) even while
-    // the set is empty. The next.size !== expanded.size guard makes the
-    // self-write converge after one extra run, so there is no infinite loop.
+    // reappear already expanded. While the set is non-empty the predicate runs,
+    // so any signals it reads (e.g. (row) => allowedIds().includes(row.id)) are
+    // tracked and re-prune as they change. When the set is empty we return early
+    // before the predicate runs — there is nothing to prune, and the next toggle
+    // re-runs this effect and re-tracks the predicate's signals. The
+    // next.size !== expanded.size guard makes the self-write converge after one
+    // extra run, so there is no infinite loop.
     effect(() => {
       const predicate = this.isRowExpandable();
       if (!predicate) { return; }

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -24,14 +24,12 @@ import {
 } from '../table-column/table-column.directive';
 import { TnTestIdDirective } from '../test-id';
 
-// Material icons render via the `material-icons` CSS font (see icon.component.ts),
-// so they don't need sprite scanning — the literal `mat-` prefix matches what
-// the runtime icon resolver would produce from a Material library name.
-const SORT_ICON_ASC = 'mat-arrow_upward';
-const SORT_ICON_DESC = 'mat-arrow_downward';
-const SORT_ICON_NONE = 'mat-unfold_more';
-const EXPAND_ICON_DOWN = 'mat-keyboard_arrow_down';
-const EXPAND_ICON_UP = 'mat-keyboard_arrow_up';
+// NOTE: the sort/expand icon names (mat-arrow_upward, mat-keyboard_arrow_down,
+// etc.) are written as string literals directly in the template's `[name]`
+// ternaries, NOT computed here. The icon-sprite scanner only discovers icons
+// from template literals or marker calls; a name returned from a component
+// getter is invisible to it, so the icons would be dropped from the generated
+// sprite and render as nothing. Keep the literals in the template.
 
 export interface TnTableDataSource<T = unknown> {
   data?: T[];
@@ -314,17 +312,6 @@ export class TnTableComponent<T = unknown> implements OnInit {
       column: this.sortColumn() || column,
       direction: this.sortDirection(),
     });
-  }
-
-  getSortIcon(column: string): string {
-    if (this.sortColumn() !== column || this.sortDirection() === '') {
-      return SORT_ICON_NONE;
-    }
-    return this.sortDirection() === 'asc' ? SORT_ICON_ASC : SORT_ICON_DESC;
-  }
-
-  getExpandIcon(row: T): string {
-    return this.isRowExpanded(row) ? EXPAND_ICON_UP : EXPAND_ICON_DOWN;
   }
 
   isSorted(column: string): boolean {

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -12,7 +12,6 @@ import {
   input,
   output,
   signal,
-  untracked,
 } from '@angular/core';
 import type { OnInit } from '@angular/core';
 import { TnCheckboxComponent } from '../checkbox/checkbox.component';
@@ -223,20 +222,22 @@ export class TnTableComponent<T = unknown> implements OnInit {
 
     // Prune rows the predicate no longer allows from the expanded set, so a row
     // that flips expandable -> non-expandable -> expandable does not silently
-    // reappear already expanded. Calling the predicate here tracks any signals
-    // it reads, so the prune re-runs when its result changes; the expanded set
-    // is read/written untracked to keep this effect off its own dependency list.
+    // reappear already expanded. Reading expandedRows tracked re-runs this on
+    // every toggle, which keeps the predicate's own signal dependencies fresh
+    // (e.g. a predicate like (row) => allowedIds().includes(row.id)) even while
+    // the set is empty. The next.size !== expanded.size guard makes the
+    // self-write converge after one extra run, so there is no infinite loop.
     effect(() => {
       const predicate = this.isRowExpandable();
       if (!predicate) { return; }
-      const expanded = untracked(this.expandedRows);
+      const expanded = this.expandedRows();
       if (expanded.size === 0) { return; }
       const next = new Set<unknown>();
       for (const row of expanded) {
         if (predicate(row as T)) { next.add(row); }
       }
       if (next.size !== expanded.size) {
-        untracked(() => this.expandedRows.set(next));
+        this.expandedRows.set(next);
       }
     });
   }

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -103,6 +103,16 @@ export class TnTableComponent<T = unknown> implements OnInit {
   bordered = input<boolean>(false);
 
   /**
+   * Optional per-row predicate deciding whether an individual row can expand.
+   * When omitted, every row is expandable (provided `expandable` is true and a
+   * `tnDetailRowDef` is present). Rows for which it returns `false` render no
+   * expand control and cannot be toggled by the chevron, a row click, or the
+   * keyboard, and never render a detail row. Has no effect unless `expandable`
+   * is true. Re-evaluated on each change detection, so it may depend on signals.
+   */
+  isRowExpandable = input<((row: T) => boolean) | undefined>(undefined);
+
+  /**
    * Marks a single row as "active" — adds the `tn-table__row--active` class
    * and a left-side indicator bar. Set to `null` (default) to clear.
    *
@@ -296,8 +306,21 @@ export class TnTableComponent<T = unknown> implements OnInit {
 
   // --- Expansion methods ---
 
+  /**
+   * Whether a specific row may currently be expanded. True when `expandable` is
+   * set and — when an `isRowExpandable` predicate is provided — that predicate
+   * returns true for the row. Drives the expand control's visibility and gates
+   * every expansion entry point (chevron, row click, keyboard). The `__expand`
+   * column and the detail row are additionally gated on `detailRowDef()`.
+   */
+  canExpandRow(row: T): boolean {
+    if (!this.expandable()) { return false; }
+    const predicate = this.isRowExpandable();
+    return predicate ? predicate(row) : true;
+  }
+
   toggleRowExpansion(row: T): void {
-    if (!this.expandable()) { return; }
+    if (!this.canExpandRow(row)) { return; }
     const expanded = new Set(this.expandedRows());
     if (expanded.has(row)) {
       expanded.delete(row);

--- a/projects/truenas-ui/src/lib/table/table.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.harness.spec.ts
@@ -42,6 +42,7 @@ const TEST_USERS: User[] = [
       [displayedColumns]="['name', 'email']"
       [selectable]="selectable"
       [expandable]="expandable"
+      [isRowExpandable]="isRowExpandable"
       [activeRow]="activeRow"
       [loading]="loading"
       [clickable]="clickable"
@@ -70,6 +71,7 @@ class TableHarnessTestComponent {
   tableData: User[] = [...TEST_USERS];
   selectable = false;
   expandable = false;
+  isRowExpandable: ((row: User) => boolean) | undefined = undefined;
   activeRow: User | null = null;
   loading = false;
   clickable = false;
@@ -260,6 +262,23 @@ describe('TnTableHarness', () => {
       await table.toggleRowExpansion(0);
       await table.toggleRowExpansion(2);
       expect(await table.getExpandedRowCount()).toBe(2);
+    });
+
+    it('should render an expand control on every row by default', async () => {
+      const table = await loader.getHarness(TnTableHarness);
+      expect(await table.hasExpandControl(0)).toBe(true);
+      expect(await table.hasExpandControl(1)).toBe(true);
+      expect(await table.hasExpandControl(2)).toBe(true);
+    });
+
+    it('should not render an expand control on rows the predicate disallows', async () => {
+      component.isRowExpandable = (user) => user.id === 1;
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(TnTableHarness);
+      expect(await table.hasExpandControl(0)).toBe(true);
+      expect(await table.hasExpandControl(1)).toBe(false);
+      expect(await table.hasExpandControl(2)).toBe(false);
     });
   });
 

--- a/projects/truenas-ui/src/lib/table/table.harness.ts
+++ b/projects/truenas-ui/src/lib/table/table.harness.ts
@@ -233,6 +233,21 @@ export class TnTableHarness extends ComponentHarness {
     return row.hasClass('tn-table__row--expanded');
   }
 
+  /**
+   * Checks whether a row exposes an expand control. Returns false for rows made
+   * non-expandable via the table's `isRowExpandable` predicate.
+   *
+   * @param rowIndex Zero-based index of the data row.
+   * @returns Promise resolving to true if the row has an expand button.
+   */
+  async hasExpandControl(rowIndex: number): Promise<boolean> {
+    await this.assertRowExists(rowIndex);
+    const button = await this.locatorForOptional(
+      `.tn-table__row[data-row-index="${rowIndex}"] .tn-table__expand-button`
+    )();
+    return button !== null;
+  }
+
   // --- Clickable rows ---
 
   /**

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -69,6 +69,10 @@ const meta: Meta<TnTableComponent> = {
     displayedColumns: { description: 'Column names to display in order', control: false },
     selectable: { description: 'Show checkbox column for row selection', control: 'boolean' },
     expandable: { description: 'Enable click-to-expand detail rows', control: 'boolean' },
+    isRowExpandable: {
+      description: 'Optional per-row predicate `(row) => boolean`; rows returning false show no expand control',
+      control: false,
+    },
     bordered: { description: 'Adds an outer border around the table', control: 'boolean' },
     activeRow: { description: 'Row reference to mark with the active-row indicator (left bar)', control: false },
     activeBg: { description: 'Override for the active-row background color (any CSS color or var())', control: 'text' },
@@ -221,6 +225,43 @@ export const ExpandableTable: Story = {
           <div style="padding: 8px 0;">
             <strong>{{ user.name }}</strong> — {{ user.email }}<br>
             Role: {{ user.role }} · Status: {{ user.status }}
+          </div>
+        </ng-template>
+      </tn-table>
+    `,
+  }),
+};
+
+export const PerRowExpandable: Story = {
+  render: () => ({
+    props: {
+      tableData: sampleData,
+      tableColumns: ['name', 'email', 'status'],
+      // Only active users can expand; inactive rows show no expand control.
+      canExpand: (user: User) => user.status === 'active',
+    },
+    template: `
+      <tn-table
+        [dataSource]="tableData"
+        [displayedColumns]="tableColumns"
+        [expandable]="true"
+        [isRowExpandable]="canExpand">
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="status">
+          <ng-template tnHeaderCellDef>Status</ng-template>
+          <ng-template let-user tnCellDef>{{ user.status }}</ng-template>
+        </ng-container>
+
+        <ng-template let-user tnDetailRowDef>
+          <div style="padding: 8px 0;">
+            <strong>{{ user.name }}</strong> — {{ user.email }}
           </div>
         </ng-template>
       </tn-table>


### PR DESCRIPTION
Add an optional isRowExpandable input predicate. When provided, rows for which it returns false render no expand control and cannot be toggled via chevron, row click, or keyboard, and never render a detail row. When omitted, behaviour is unchanged (every row expandable when expandable is set and a tnDetailRowDef is present). Gating is centralized in a new canExpandRow() helper used by the template and toggle entry points.