### PR TITLE
NAS-141632 / 27.0.0-BETA.1 / fix(slider): sync form value to thumb position and emit on drag

### DIFF
--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -26,7 +26,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
     '[attr.aria-labelledby]': 'ariaLabelledby()',
     '(input)': 'onInput($event)',
     '(change)': 'onChange($event)',
-    '(blur)': 'onTouched()',
+    '(blur)': 'notifyTouched()',
     '(mousedown)': 'onMouseDown($event)',
     '(touchstart)': 'onTouchStart($event)'
   }
@@ -45,6 +45,7 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     ariaLabel: () => string | undefined;
     ariaLabelledby: () => string | undefined;
     updateValue: (value: number) => void;
+    markTouched: () => void;
     getSliderRect: () => DOMRect;
   }; // Will be set by parent slider component
 
@@ -176,7 +177,18 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   onChange(_event: Event): void {
+    this.notifyTouched();
+  }
+
+  /**
+   * Marks the bound control touched. Calls the thumb's own `onTouched` (for a
+   * thumb-bound control) and forwards to the linked slider (for a
+   * slider-host-bound control) — the thumb is the only interactive element, so
+   * the slider relies on it to ever become touched.
+   */
+  notifyTouched(): void {
     this.onTouched();
+    this.slider?.markTouched();
   }
 
   onMouseDown(event: MouseEvent): void {
@@ -218,7 +230,7 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     if (this.isPointerDown) {
       this.isPointerDown = false;
       this.isDragging = false;
-      this.onTouched();
+      this.notifyTouched();
       this.removeGlobalListeners();
     }
   };
@@ -235,7 +247,7 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     if (this.isPointerDown) {
       this.isPointerDown = false;
       this.isDragging = false;
-      this.onTouched();
+      this.notifyTouched();
       this.removeGlobalListeners();
     }
   };

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -22,6 +22,8 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
     '[attr.step]': 'slider?.step()',
     '[value]': 'slider?.value()',
     '[attr.aria-valuetext]': 'ariaValueText()',
+    '[attr.aria-label]': 'ariaLabel()',
+    '[attr.aria-labelledby]': 'ariaLabelledby()',
     '(input)': 'onInput($event)',
     '(change)': 'onChange($event)',
     '(blur)': 'onTouched()',
@@ -40,6 +42,8 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     value: () => number;
     labelPrefix: () => string;
     labelSuffix: () => string;
+    ariaLabel: () => string | undefined;
+    ariaLabelledby: () => string | undefined;
     updateValue: (value: number) => void;
     getSliderRect: () => DOMRect;
   }; // Will be set by parent slider component
@@ -65,9 +69,18 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
 
   private elementRef = inject(ElementRef<HTMLInputElement>);
 
+  // An accessible name set directly on the <input tnSliderThumb> (e.g.
+  // aria-label="Volume"). Captured up front so the host's [attr.aria-label]
+  // binding can fall back to it instead of clobbering it when the parent slider
+  // doesn't supply one. See ariaLabel()/ariaLabelledby().
+  private fallbackAriaLabel: string | null = null;
+  private fallbackAriaLabelledby: string | null = null;
+
   ngOnInit() {
     // Make the native input visually hidden but still accessible
     const input = this.elementRef.nativeElement;
+    this.fallbackAriaLabel = input.getAttribute('aria-label');
+    this.fallbackAriaLabelledby = input.getAttribute('aria-labelledby');
     input.style.opacity = '0';
     input.style.position = 'absolute';
     input.style.width = '100%';
@@ -244,11 +257,25 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   /**
-   * Commit a value that originated outside the native input (a thumb drag, or a
-   * track click routed here by the parent slider). Syncs `currentValue`, the
-   * native input, and emits to the form. The slider's own `onChange` only reaches
-   * a slider-bound control, so a thumb-bound control relies on this to stay in
-   * sync. Expects an already clamped/stepped value (slider.value()).
+   * Resolve the accessible name for the range input: the parent slider's
+   * `aria-label`/`aria-labelledby` input when set, otherwise a value placed
+   * directly on the `<input tnSliderThumb>`. Returning the fallback keeps the
+   * host binding from wiping a directly-set label. Null removes the attribute.
+   */
+  ariaLabel(): string | null {
+    return this.slider?.ariaLabel() ?? this.fallbackAriaLabel;
+  }
+
+  ariaLabelledby(): string | null {
+    return this.slider?.ariaLabelledby() ?? this.fallbackAriaLabelledby;
+  }
+
+  /**
+   * Commit a value that originated outside the native input (a thumb drag).
+   * Syncs `currentValue`, the native input, and emits to the form. The slider's
+   * own `onChange` only reaches a slider-bound control, so a thumb-bound control
+   * relies on this to stay in sync. Expects an already clamped/stepped value
+   * (slider.value()).
    */
   commit(value: number): void {
     this.currentValue = value;

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -46,9 +46,13 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   private onChangeCallback = (_value: number) => {};
   private isDragging = false;
   // Last value written by the form. Retained so the parent slider can pick it up
-  // once the (later) ngAfterViewInit link is established — writeValue often runs
-  // before the slider sets `this.slider`.
+  // once it links the thumb (ngAfterContentInit) — writeValue can run before the
+  // slider sets `this.slider`.
   private currentValue = 0;
+  // Whether the form has actually written a value to this thumb. Lets the parent
+  // slider distinguish "form wrote 0" from "thumb never bound" so it doesn't
+  // clobber its own form value with this default. See getValue()/hasFormValue().
+  private hasWrittenValue = false;
 
   private elementRef = inject(ElementRef<HTMLInputElement>);
 
@@ -74,16 +78,33 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     return this.currentValue;
   }
 
+  /**
+   * Whether the form has written a value to this thumb. The slider checks this
+   * before adopting getValue() so an unbound thumb's default 0 never overwrites
+   * a value bound directly on the slider.
+   */
+  hasFormValue(): boolean {
+    return this.hasWrittenValue;
+  }
+
   // ControlValueAccessor implementation
   writeValue(value: number): void {
     const nextValue = value ?? 0;
-    this.currentValue = nextValue;
-    if (this.elementRef.nativeElement) {
-      this.elementRef.nativeElement.value = nextValue.toString();
-    }
+    this.hasWrittenValue = true;
     // Propagate to the parent slider so its value signal (and thus the thumb
     // position / track fill) reflects the form value, not just the native input.
-    this.slider?.updateValue(nextValue);
+    // When linked, mirror the slider's clamped/stepped result so currentValue and
+    // the native input agree with it; otherwise retain the raw value for the
+    // slider to adopt (and clamp) once it links the thumb in ngAfterContentInit.
+    if (this.slider) {
+      this.slider.updateValue(nextValue);
+      this.currentValue = this.slider.value();
+    } else {
+      this.currentValue = nextValue;
+    }
+    if (this.elementRef.nativeElement) {
+      this.elementRef.nativeElement.value = this.currentValue.toString();
+    }
   }
 
   registerOnChange(fn: (value: number) => void): void {
@@ -102,9 +123,15 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   onInput(event: Event): void {
+    // While dragging, the global pointer handlers (updateValueFromPosition) own
+    // value commits; the native range also fires input here, so skip it to avoid
+    // a redundant double emit. Keyboard/click changes don't set isDragging and
+    // still flow through here.
+    if (this.isDragging) {return;}
+
     const input = event.target as HTMLInputElement;
     const value = parseFloat(input.value);
-    
+
     if (this.slider) {
       this.slider.updateValue(value);
     }

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -104,6 +104,10 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     // slider to adopt (and clamp) once it links the thumb in ngAfterContentInit.
     if (this.slider) {
       this.slider.updateValue(nextValue);
+      // Note: we don't emit the clamped result back to the form control, so an
+      // out-of-range write (e.g. setValue(143) on a 0–100 slider) leaves the model
+      // holding 143 while the slider renders 100. This mirrors native
+      // <input type="range">, which also doesn't reconcile the bound value.
       this.currentValue = this.slider.value();
     } else {
       this.currentValue = nextValue;

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -21,6 +21,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
     '[attr.max]': 'slider?.max()',
     '[attr.step]': 'slider?.step()',
     '[value]': 'slider?.value()',
+    '[attr.aria-valuetext]': 'ariaValueText()',
     '(input)': 'onInput($event)',
     '(change)': 'onChange($event)',
     '(blur)': 'onTouched()',
@@ -37,6 +38,8 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     max: () => number;
     step: () => number;
     value: () => number;
+    labelPrefix: () => string;
+    labelSuffix: () => string;
     updateValue: (value: number) => void;
     getSliderRect: () => DOMRect;
   }; // Will be set by parent slider component
@@ -109,11 +112,17 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
       // holding 143 while the slider renders 100. This mirrors native
       // <input type="range">, which also doesn't reconcile the bound value.
       this.currentValue = this.slider.value();
+      // When linked, the host `[value]="slider?.value()"` binding writes the
+      // native input on the next change-detection pass, so a manual write here
+      // would only be re-overwritten — leave it to the binding to keep one source
+      // of truth.
     } else {
       this.currentValue = nextValue;
-    }
-    if (this.elementRef.nativeElement) {
-      this.elementRef.nativeElement.value = this.currentValue.toString();
+      // Unlinked: no host binding value yet (slider?.value() is undefined), so set
+      // the native input directly until the slider links and takes over.
+      if (this.elementRef.nativeElement) {
+        this.elementRef.nativeElement.value = this.currentValue.toString();
+      }
     }
   }
 
@@ -142,6 +151,10 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
 
     const input = event.target as HTMLInputElement;
     const value = parseFloat(input.value);
+    // An empty/garbage value parses to NaN, which clampValue can't sanitize
+    // (Math.max/min with NaN stay NaN). Native range inputs shouldn't produce
+    // this, but guard so a NaN never reaches the form or slider value.
+    if (!Number.isFinite(value)) {return;}
 
     if (this.slider) {
       this.slider.updateValue(value);
@@ -227,12 +240,35 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     // updateValue only moves the visual thumb; commit the (clamped/stepped) value
     // to the form and native input so dragging actually emits changes — otherwise
     // only click (native input event) updates the model.
-    const committed = this.slider.value();
-    this.currentValue = committed;
+    this.commit(this.slider.value());
+  }
+
+  /**
+   * Commit a value that originated outside the native input (a thumb drag, or a
+   * track click routed here by the parent slider). Syncs `currentValue`, the
+   * native input, and emits to the form. The slider's own `onChange` only reaches
+   * a slider-bound control, so a thumb-bound control relies on this to stay in
+   * sync. Expects an already clamped/stepped value (slider.value()).
+   */
+  commit(value: number): void {
+    this.currentValue = value;
     if (this.elementRef.nativeElement) {
-      this.elementRef.nativeElement.value = committed.toString();
+      this.elementRef.nativeElement.value = value.toString();
     }
-    this.onChangeCallback(committed);
+    this.onChangeCallback(value);
+  }
+
+  /**
+   * Builds an aria-valuetext when the slider has a label prefix/suffix so screen
+   * readers announce "50 km/h" rather than the bare number. Returns null when
+   * neither is set, letting the native range's valuenow announcement stand.
+   */
+  ariaValueText(): string | null {
+    if (!this.slider) {return null;}
+    const prefix = this.slider.labelPrefix();
+    const suffix = this.slider.labelSuffix();
+    if (!prefix && !suffix) {return null;}
+    return `${prefix}${this.slider.value()}${suffix}`;
   }
 
   private cleanup(): void {

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -44,6 +44,12 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   onTouched = () => {};
 
   private onChangeCallback = (_value: number) => {};
+  // Pointer is held down on the thumb (set on mousedown/touchstart). Drives the
+  // global move/up listeners.
+  private isPointerDown = false;
+  // The pointer has actually moved since going down — i.e. a genuine drag. Only
+  // set once movement occurs (onGlobalMouseMove/onGlobalTouchMove), never on the
+  // initial press, so a plain click still commits through onInput. See onInput.
   private isDragging = false;
   // Last value written by the form. Retained so the parent slider can pick it up
   // once it links the thumb (ngAfterContentInit) — writeValue can run before the
@@ -123,10 +129,11 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   onInput(event: Event): void {
-    // While dragging, the global pointer handlers (updateValueFromPosition) own
-    // value commits; the native range also fires input here, so skip it to avoid
-    // a redundant double emit. Keyboard/click changes don't set isDragging and
-    // still flow through here.
+    // Once a drag is underway, the global pointer handlers
+    // (updateValueFromPosition) own value commits; the native range also fires
+    // input here, so skip it to avoid a redundant double emit. A plain click sets
+    // isPointerDown but not isDragging (no movement), so its native input commits
+    // here; keyboard changes set neither and also flow through.
     if (this.isDragging) {return;}
 
     const input = event.target as HTMLInputElement;
@@ -144,14 +151,14 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
 
   onMouseDown(event: MouseEvent): void {
     if (this.disabled()) {return;}
-    this.isDragging = true;
+    this.isPointerDown = true;
     this.addGlobalListeners();
     event.stopPropagation(); // Prevent track click
   }
 
   onTouchStart(event: TouchEvent): void {
     if (this.disabled()) {return;}
-    this.isDragging = true;
+    this.isPointerDown = true;
     this.addGlobalListeners();
     event.stopPropagation(); // Prevent track click
   }
@@ -171,13 +178,15 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   private onGlobalMouseMove = (event: MouseEvent): void => {
-    if (!this.isDragging || this.disabled()) {return;}
+    if (!this.isPointerDown || this.disabled()) {return;}
+    this.isDragging = true;
     event.preventDefault();
     this.updateValueFromPosition(event.clientX);
   };
 
   private onGlobalMouseUp = (): void => {
-    if (this.isDragging) {
+    if (this.isPointerDown) {
+      this.isPointerDown = false;
       this.isDragging = false;
       this.onTouched();
       this.removeGlobalListeners();
@@ -185,14 +194,16 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   };
 
   private onGlobalTouchMove = (event: TouchEvent): void => {
-    if (!this.isDragging || this.disabled()) {return;}
+    if (!this.isPointerDown || this.disabled()) {return;}
+    this.isDragging = true;
     event.preventDefault();
     const touch = event.touches[0];
     this.updateValueFromPosition(touch.clientX);
   };
 
   private onGlobalTouchEnd = (): void => {
-    if (this.isDragging) {
+    if (this.isPointerDown) {
+      this.isPointerDown = false;
       this.isDragging = false;
       this.onTouched();
       this.removeGlobalListeners();

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -45,6 +45,10 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
 
   private onChangeCallback = (_value: number) => {};
   private isDragging = false;
+  // Last value written by the form. Retained so the parent slider can pick it up
+  // once the (later) ngAfterViewInit link is established — writeValue often runs
+  // before the slider sets `this.slider`.
+  private currentValue = 0;
 
   private elementRef = inject(ElementRef<HTMLInputElement>);
 
@@ -65,11 +69,21 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     this.cleanup();
   }
 
+  /** Value last written by the form, for the slider to read once linked. */
+  getValue(): number {
+    return this.currentValue;
+  }
+
   // ControlValueAccessor implementation
   writeValue(value: number): void {
+    const nextValue = value ?? 0;
+    this.currentValue = nextValue;
     if (this.elementRef.nativeElement) {
-      this.elementRef.nativeElement.value = value?.toString() || '0';
+      this.elementRef.nativeElement.value = nextValue.toString();
     }
+    // Propagate to the parent slider so its value signal (and thus the thumb
+    // position / track fill) reflects the form value, not just the native input.
+    this.slider?.updateValue(nextValue);
   }
 
   registerOnChange(fn: (value: number) => void): void {
@@ -168,6 +182,15 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     const newValue = minVal + (percentage * (maxVal - minVal));
 
     this.slider.updateValue(newValue);
+    // updateValue only moves the visual thumb; commit the (clamped/stepped) value
+    // to the form and native input so dragging actually emits changes — otherwise
+    // only click (native input event) updates the model.
+    const committed = this.slider.value();
+    this.currentValue = committed;
+    if (this.elementRef.nativeElement) {
+      this.elementRef.nativeElement.value = committed.toString();
+    }
+    this.onChangeCallback(committed);
   }
 
   private cleanup(): void {

--- a/projects/truenas-ui/src/lib/slider/slider.component.html
+++ b/projects/truenas-ui/src/lib/slider/slider.component.html
@@ -26,8 +26,7 @@
   <div
     #thumbVisual
     class="tn-slider-thumb-visual"
-    [style.left.%]="fillPercentage()"
-    [style.transform]="'translateX(-10px)'">
+    [style.left.%]="fillPercentage()">
     <div class="tn-slider-thumb-knob"></div>
     @if ((labelType() === 'handle' || labelType() === 'both') && showLabel()) {
       <div

--- a/projects/truenas-ui/src/lib/slider/slider.component.html
+++ b/projects/truenas-ui/src/lib/slider/slider.component.html
@@ -1,12 +1,18 @@
+<!--
+  Pointer interaction (click-to-position and press-drag, anywhere on the track)
+  is handled by the projected native range input, which overlays the whole
+  container (see TnSliderThumbDirective): a click jumps the thumb and fires
+  `input` → onInput; a press-and-move runs the directive's global drag handlers.
+  No container-level click handler is needed — and one wouldn't fire anyway, as
+  the overlay calls stopPropagation() on its own pointer events.
+-->
 <div
   #sliderContainer
   class="tn-slider-container"
   tnTestIdType="slider"
   [tnTestId]="testId()"
   [attr.aria-disabled]="isDisabled()"
-  [attr.data-disabled]="isDisabled()"
-  (mousedown)="onTrackClick($event)"
-  (touchstart)="onTrackClick($event)">
+  [attr.data-disabled]="isDisabled()">
 
   <div class="tn-slider-track">
     <div class="tn-slider-track-inactive"></div>

--- a/projects/truenas-ui/src/lib/slider/slider.component.html
+++ b/projects/truenas-ui/src/lib/slider/slider.component.html
@@ -24,7 +24,6 @@
   </div>
 
   <div
-    #thumbVisual
     class="tn-slider-thumb-visual"
     [style.left.%]="fillPercentage()">
     <div class="tn-slider-thumb-knob"></div>

--- a/projects/truenas-ui/src/lib/slider/slider.component.html
+++ b/projects/truenas-ui/src/lib/slider/slider.component.html
@@ -26,7 +26,8 @@
   <div
     #thumbVisual
     class="tn-slider-thumb-visual"
-    [style.transform]="'translateX(' + thumbPosition() + 'px)'">
+    [style.left.%]="fillPercentage()"
+    [style.transform]="'translateX(-10px)'">
     <div class="tn-slider-thumb-knob"></div>
     @if ((labelType() === 'handle' || labelType() === 'both') && showLabel()) {
       <div

--- a/projects/truenas-ui/src/lib/slider/slider.component.scss
+++ b/projects/truenas-ui/src/lib/slider/slider.component.scss
@@ -97,18 +97,24 @@
   }
 }
 
+// Knob width — shared so the visual thumb's centering offset stays in sync with it.
+$knob-width: 20px;
+
 // Visual thumb indicator (real DOM element) - fader style
 .tn-slider-thumb-visual {
   position: absolute;
   top: 50%;
   left: 0;
+  // Center on the knob's own half-width (kept off `transform` so `left` can
+  // animate value changes instead of snapping).
+  margin-left: -$knob-width * 0.5;
   pointer-events: none;
   z-index: 3;
-  transition: transform 0.1s ease-out;
+  transition: left 0.1s ease-out;
 }
 
 .tn-slider-thumb-knob {
-  width: 20px;
+  width: $knob-width;
   height: 24px;
   background: var(--tn-primary, #007bff);
   border: 2px solid var(--tn-bg1, white);

--- a/projects/truenas-ui/src/lib/slider/slider.component.scss
+++ b/projects/truenas-ui/src/lib/slider/slider.component.scss
@@ -82,19 +82,23 @@
     cursor: not-allowed;
   }
   
-  // Focus styles - show visual thumb when focused
+  // Focus styles - the visible focus ring is drawn on the knob instead (see below).
   &:focus {
     outline: none;
   }
-  
+
   &:focus-visible {
     outline: none;
-    
-    + .tn-slider-visual-thumb {
-      outline: 2px solid var(--tn-primary, #007bff);
-      outline-offset: 2px;
-    }
   }
+}
+
+// Keyboard focus ring on the knob. The hidden <input> is projected via <ng-content>
+// and sits *after* the visual thumb in the DOM, so a sibling combinator can't reach
+// back to it — match the container with :has() instead. ::ng-deep is required because
+// the projected input is scoped to the consumer, not this component.
+:host ::ng-deep .tn-slider-container:has(.tn-slider-thumb:focus-visible) .tn-slider-thumb-knob {
+  outline: 2px solid var(--tn-primary, #007bff);
+  outline-offset: 2px;
 }
 
 // Knob width — shared so the visual thumb's centering offset stays in sync with it.

--- a/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
@@ -43,13 +43,31 @@ class SliderBoundHostComponent {
   standalone: true,
   imports: [TnSliderComponent, TnSliderThumbDirective],
   template: `
-    <tn-slider [aria-label]="sliderLabel()">
+    <tn-slider [aria-label]="sliderLabel()" [aria-labelledby]="sliderLabelledby()">
       <input tnSliderThumb />
     </tn-slider>
   `
 })
 class AriaSliderHostComponent {
   sliderLabel = signal<string | undefined>(undefined);
+  sliderLabelledby = signal<string | undefined>(undefined);
+}
+
+// Slider with a label prefix/suffix and a thumb-bound value, for aria-valuetext.
+@Component({
+  selector: 'tn-test-host-valuetext',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective, ReactiveFormsModule],
+  template: `
+    <tn-slider [labelPrefix]="prefix()" [labelSuffix]="suffix()" [min]="0" [max]="100">
+      <input tnSliderThumb [formControl]="control" />
+    </tn-slider>
+  `
+})
+class ValueTextHostComponent {
+  prefix = signal('');
+  suffix = signal('');
+  control = new FormControl<number>(50);
 }
 
 // Label set directly on the thumb input (static attribute); slider's is toggled.
@@ -126,6 +144,23 @@ describe('TnSliderComponent', () => {
       expect(slider().value()).toBe(42);
     });
 
+    it('commits a drag (mousedown + mousemove) to the form control', () => {
+      // Regression: dragging must emit through commit(), not just the native
+      // input event a click fires. mousedown arms the pointer, the first
+      // mousemove flips isDragging and drives updateValueFromPosition → commit.
+      const input = fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+      // jsdom has no layout, so pin the track geometry: 200px wide from x=0.
+      jest.spyOn(slider(), 'getSliderRect').mockReturnValue({ left: 0, width: 200 } as DOMRect);
+
+      input.dispatchEvent(new MouseEvent('mousedown'));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100 })); // 50% → 50
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe(50);
+      expect(slider().value()).toBe(50);
+    });
+
     it('commits a plain click (mousedown + input with no movement)', () => {
       // Regression: mousedown must not pre-set the drag flag, otherwise the
       // native input fired by a click-to-set is swallowed and the value reverts.
@@ -150,6 +185,7 @@ describe('TnSliderComponent', () => {
 
   describe('value-accessor binding on the slider host', () => {
     let fixture: ComponentFixture<SliderBoundHostComponent>;
+    let host: SliderBoundHostComponent;
 
     const slider = (): TnSliderComponent =>
       fixture.debugElement.children[0].componentInstance as TnSliderComponent;
@@ -160,6 +196,7 @@ describe('TnSliderComponent', () => {
       }).compileComponents();
 
       fixture = TestBed.createComponent(SliderBoundHostComponent);
+      host = fixture.componentInstance;
       fixture.detectChanges();
     });
 
@@ -167,6 +204,19 @@ describe('TnSliderComponent', () => {
       // Regression: ngAfterContentInit must not adopt the thumb's default 0 when the
       // form is bound to the slider host instead of the thumb input.
       expect(slider().value()).toBe(60);
+    });
+
+    it('marks the slider-bound control touched when the thumb is interacted with', () => {
+      // Regression: the thumb is the only interactive element, so it must forward
+      // touched to the slider — otherwise a slider-host-bound control never
+      // transitions to touched and touched-gated validation never shows.
+      const input = fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+      expect(host.control.touched).toBe(false);
+
+      input.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(host.control.touched).toBe(true);
     });
   });
 
@@ -202,6 +252,43 @@ describe('TnSliderComponent', () => {
       fixture.componentInstance.sliderLabel.set('Volume');
       fixture.detectChanges();
       expect(thumbInput(fixture).getAttribute('aria-label')).toBe('Volume');
+    });
+
+    it('forwards the slider aria-labelledby onto the focusable range input', async () => {
+      await TestBed.configureTestingModule({ imports: [AriaSliderHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(AriaSliderHostComponent);
+      fixture.componentInstance.sliderLabelledby.set('volume-label');
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-labelledby')).toBe('volume-label');
+    });
+  });
+
+  describe('aria-valuetext', () => {
+    const thumbInput = (fixture: ComponentFixture<unknown>): HTMLInputElement =>
+      fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+
+    let fixture: ComponentFixture<ValueTextHostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [ValueTextHostComponent] }).compileComponents();
+      fixture = TestBed.createComponent(ValueTextHostComponent);
+    });
+
+    it('builds aria-valuetext from the label prefix/suffix and current value', () => {
+      fixture.componentInstance.suffix.set(' km/h');
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-valuetext')).toBe('50 km/h');
+    });
+
+    it('applies a label prefix too', () => {
+      fixture.componentInstance.prefix.set('$');
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-valuetext')).toBe('$50');
+    });
+
+    it('sets no aria-valuetext when neither prefix nor suffix is set', () => {
+      fixture.detectChanges();
+      expect(thumbInput(fixture).hasAttribute('aria-valuetext')).toBe(false);
     });
   });
 });

--- a/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
@@ -111,6 +111,25 @@ describe('TnSliderComponent', () => {
       expect(slider().value()).toBe(70);
     });
 
+    it('commits a track click to the thumb-bound form control', () => {
+      // Regression: track clicks route through the slider's updateValue, whose
+      // onChange is a noop when the form is bound to the inner thumb. The click
+      // must reach the thumb's commit path so control.value updates too.
+      const sliderEl = slider();
+      const container = fixture.nativeElement.querySelector('.tn-slider-container') as HTMLElement;
+      jest.spyOn(sliderEl, 'getSliderRect').mockReturnValue({
+        left: 0,
+        width: 200,
+      } as DOMRect);
+
+      // Click at 50% of a 0–100 slider → 50.
+      container.dispatchEvent(new MouseEvent('mousedown', { clientX: 100 }));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe(50);
+      expect(sliderEl.value()).toBe(50);
+    });
+
     it('treats a null form value as 0 rather than throwing', () => {
       host.control.setValue(null);
       fixture.detectChanges();

--- a/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
@@ -37,6 +37,36 @@ class SliderBoundHostComponent {
   control = new FormControl<number>(60);
 }
 
+// Label declared on the slider; thumb input has none of its own.
+@Component({
+  selector: 'tn-test-host-aria-slider',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective],
+  template: `
+    <tn-slider [aria-label]="sliderLabel()">
+      <input tnSliderThumb />
+    </tn-slider>
+  `
+})
+class AriaSliderHostComponent {
+  sliderLabel = signal<string | undefined>(undefined);
+}
+
+// Label set directly on the thumb input (static attribute); slider's is toggled.
+@Component({
+  selector: 'tn-test-host-aria-input',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective],
+  template: `
+    <tn-slider [aria-label]="sliderLabel()">
+      <input tnSliderThumb aria-label="Brightness" />
+    </tn-slider>
+  `
+})
+class AriaInputHostComponent {
+  sliderLabel = signal<string | undefined>(undefined);
+}
+
 describe('TnSliderComponent', () => {
   describe('value-accessor binding on the thumb input', () => {
     let fixture: ComponentFixture<ThumbBoundHostComponent>;
@@ -111,25 +141,6 @@ describe('TnSliderComponent', () => {
       expect(slider().value()).toBe(70);
     });
 
-    it('commits a track click to the thumb-bound form control', () => {
-      // Regression: track clicks route through the slider's updateValue, whose
-      // onChange is a noop when the form is bound to the inner thumb. The click
-      // must reach the thumb's commit path so control.value updates too.
-      const sliderEl = slider();
-      const container = fixture.nativeElement.querySelector('.tn-slider-container') as HTMLElement;
-      jest.spyOn(sliderEl, 'getSliderRect').mockReturnValue({
-        left: 0,
-        width: 200,
-      } as DOMRect);
-
-      // Click at 50% of a 0–100 slider → 50.
-      container.dispatchEvent(new MouseEvent('mousedown', { clientX: 100 }));
-      fixture.detectChanges();
-
-      expect(host.control.value).toBe(50);
-      expect(sliderEl.value()).toBe(50);
-    });
-
     it('treats a null form value as 0 rather than throwing', () => {
       host.control.setValue(null);
       fixture.detectChanges();
@@ -156,6 +167,41 @@ describe('TnSliderComponent', () => {
       // Regression: ngAfterContentInit must not adopt the thumb's default 0 when the
       // form is bound to the slider host instead of the thumb input.
       expect(slider().value()).toBe(60);
+    });
+  });
+
+  describe('accessible name passthrough', () => {
+    const thumbInput = (fixture: ComponentFixture<unknown>): HTMLInputElement =>
+      fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+
+    it('forwards the slider aria-label onto the focusable range input', async () => {
+      await TestBed.configureTestingModule({ imports: [AriaSliderHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(AriaSliderHostComponent);
+      fixture.componentInstance.sliderLabel.set('Volume');
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-label')).toBe('Volume');
+    });
+
+    it('sets no aria-label when neither the slider nor the input provides one', async () => {
+      await TestBed.configureTestingModule({ imports: [AriaSliderHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(AriaSliderHostComponent);
+      fixture.detectChanges();
+      expect(thumbInput(fixture).hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('leaves a label set directly on the input intact when the slider has none', async () => {
+      await TestBed.configureTestingModule({ imports: [AriaInputHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(AriaInputHostComponent);
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-label')).toBe('Brightness');
+    });
+
+    it('prefers the slider aria-label over one set directly on the input', async () => {
+      await TestBed.configureTestingModule({ imports: [AriaInputHostComponent] }).compileComponents();
+      const fixture = TestBed.createComponent(AriaInputHostComponent);
+      fixture.componentInstance.sliderLabel.set('Volume');
+      fixture.detectChanges();
+      expect(thumbInput(fixture).getAttribute('aria-label')).toBe('Volume');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
@@ -57,7 +57,7 @@ describe('TnSliderComponent', () => {
 
     it('adopts the form control value written before the thumb is linked', () => {
       // The control's initial value (35) is written via the thumb's writeValue
-      // before ngAfterViewInit links it; the slider must end up reflecting it.
+      // before ngAfterContentInit links it; the slider must end up reflecting it.
       expect(slider().value()).toBe(35);
       expect(slider().fillPercentage()).toBe(35);
     });
@@ -96,6 +96,21 @@ describe('TnSliderComponent', () => {
       expect(slider().value()).toBe(42);
     });
 
+    it('commits a plain click (mousedown + input with no movement)', () => {
+      // Regression: mousedown must not pre-set the drag flag, otherwise the
+      // native input fired by a click-to-set is swallowed and the value reverts.
+      const input = fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+
+      input.dispatchEvent(new MouseEvent('mousedown'));
+      input.value = '70';
+      input.dispatchEvent(new Event('input'));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe(70);
+      expect(slider().value()).toBe(70);
+    });
+
     it('treats a null form value as 0 rather than throwing', () => {
       host.control.setValue(null);
       fixture.detectChanges();
@@ -119,7 +134,7 @@ describe('TnSliderComponent', () => {
     });
 
     it('keeps the slider-bound value and is not clobbered by the unbound thumb default', () => {
-      // Regression: ngAfterViewInit must not adopt the thumb's default 0 when the
+      // Regression: ngAfterContentInit must not adopt the thumb's default 0 when the
       // form is bound to the slider host instead of the thumb input.
       expect(slider().value()).toBe(60);
     });

--- a/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.spec.ts
@@ -1,0 +1,127 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnSliderThumbDirective } from './slider-thumb.directive';
+import { TnSliderComponent } from './slider.component';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective, ReactiveFormsModule],
+  template: `
+    <tn-slider [min]="min()" [max]="max()" [step]="step()">
+      <input tnSliderThumb [formControl]="control" />
+    </tn-slider>
+  `
+})
+class ThumbBoundHostComponent {
+  min = signal(0);
+  max = signal(100);
+  step = signal(1);
+  control = new FormControl<number>(35);
+}
+
+@Component({
+  selector: 'tn-test-host-slider',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective, ReactiveFormsModule],
+  // Form bound to the tn-slider host; the inner thumb is left unbound.
+  template: `
+    <tn-slider [formControl]="control" [min]="0" [max]="100" [step]="1">
+      <input tnSliderThumb />
+    </tn-slider>
+  `
+})
+class SliderBoundHostComponent {
+  control = new FormControl<number>(60);
+}
+
+describe('TnSliderComponent', () => {
+  describe('value-accessor binding on the thumb input', () => {
+    let fixture: ComponentFixture<ThumbBoundHostComponent>;
+    let host: ThumbBoundHostComponent;
+
+    const slider = (): TnSliderComponent =>
+      fixture.debugElement.children[0].componentInstance as TnSliderComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ThumbBoundHostComponent],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ThumbBoundHostComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('adopts the form control value written before the thumb is linked', () => {
+      // The control's initial value (35) is written via the thumb's writeValue
+      // before ngAfterViewInit links it; the slider must end up reflecting it.
+      expect(slider().value()).toBe(35);
+      expect(slider().fillPercentage()).toBe(35);
+    });
+
+    it('reflects later form updates on the slider value and fill', () => {
+      host.control.setValue(80);
+      fixture.detectChanges();
+
+      expect(slider().value()).toBe(80);
+      expect(slider().fillPercentage()).toBe(80);
+    });
+
+    it('clamps and steps the written value', () => {
+      host.step.set(10);
+      fixture.detectChanges();
+      host.control.setValue(143); // above max → clamps to 100
+      fixture.detectChanges();
+      expect(slider().value()).toBe(100);
+
+      host.control.setValue(-5); // below min → clamps to 0
+      fixture.detectChanges();
+      expect(slider().value()).toBe(0);
+
+      host.control.setValue(12); // snaps to nearest step of 10
+      fixture.detectChanges();
+      expect(slider().value()).toBe(10);
+    });
+
+    it('writes back to the form control when the thumb input changes', () => {
+      const input = fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+      input.value = '42';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe(42);
+      expect(slider().value()).toBe(42);
+    });
+
+    it('treats a null form value as 0 rather than throwing', () => {
+      host.control.setValue(null);
+      fixture.detectChanges();
+      expect(slider().value()).toBe(0);
+    });
+  });
+
+  describe('value-accessor binding on the slider host', () => {
+    let fixture: ComponentFixture<SliderBoundHostComponent>;
+
+    const slider = (): TnSliderComponent =>
+      fixture.debugElement.children[0].componentInstance as TnSliderComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [SliderBoundHostComponent],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SliderBoundHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('keeps the slider-bound value and is not clobbered by the unbound thumb default', () => {
+      // Regression: ngAfterViewInit must not adopt the thumb's default 0 when the
+      // form is bound to the slider host instead of the thumb input.
+      expect(slider().value()).toBe(60);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -153,6 +153,16 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     this.onTouched = fn;
   }
 
+  /**
+   * Marks a slider-host-bound control as touched. The inner thumb is the only
+   * interactive element, so it forwards its touch events here (on blur / pointer
+   * release) — otherwise a control bound to the `tn-slider` host would never
+   * transition to touched and touched-gated validation would never show.
+   */
+  markTouched(): void {
+    this.onTouched();
+  }
+
   setDisabledState(isDisabled: boolean): void {
     this.formDisabled.set(isDisabled);
   }

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -49,6 +49,16 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
    * is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
   testId = input<TnTestIdValue>(undefined);
+  /**
+   * Accessible name forwarded to the inner range input — the focusable element
+   * screen readers actually announce. Set this (or `aria-labelledby`) when the
+   * slider isn't already labelled by a `tn-form-field`/`<label>`, otherwise a
+   * standalone `<tn-slider><input tnSliderThumb></tn-slider>` announces only
+   * "slider". A label set directly on the `input[tnSliderThumb]` is used as a
+   * fallback when neither is provided here.
+   */
+  ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
+  ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
 
   thumbDirective = contentChild.required(TnSliderThumbDirective);
   sliderContainer = viewChild.required<ElementRef<HTMLDivElement>>('sliderContainer');
@@ -168,26 +178,6 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
 
   getSliderRect(): DOMRect {
     return this.sliderContainer().nativeElement.getBoundingClientRect();
-  }
-
-  onTrackClick(event: MouseEvent | TouchEvent): void {
-    if (this.isDisabled()) {return;}
-
-    event.preventDefault();
-    const rect = this.getSliderRect();
-    const clientX = event instanceof MouseEvent ? event.clientX : event.touches[0].clientX;
-    const percentage = (clientX - rect.left) / rect.width;
-    const minVal = this.min();
-    const maxVal = this.max();
-    const newValue = minVal + (percentage * (maxVal - minVal));
-
-    this.updateValue(newValue);
-    // updateValue emits via this slider's onChange, which only reaches a
-    // slider-bound control. When the form is bound to the inner thumb input
-    // instead, route the committed value through the thumb so its form control,
-    // native input, and currentValue stay in sync — same path drag uses.
-    this.thumbDirective().commit(this.value());
-    this.onTouched();
   }
 
   private clampValue(value: number): number {

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -1,5 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import type { ElementRef, OnDestroy, AfterViewInit} from '@angular/core';
+import type { ElementRef, OnDestroy, AfterViewInit, AfterContentInit} from '@angular/core';
 import { Component, contentChild, input, forwardRef, signal, computed, viewChild, effect } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -26,7 +26,17 @@ export type LabelType = 'none' | 'handle' | 'track' | 'both';
     '[attr.aria-disabled]': 'isDisabled()'
   }
 })
-export class TnSliderComponent implements ControlValueAccessor, OnDestroy, AfterViewInit {
+/**
+ * Range slider with an optional value label.
+ *
+ * Form binding: both this component and the inner `input[tnSliderThumb]`
+ * directive are `NG_VALUE_ACCESSOR` providers, so a `formControl`/`ngModel` can
+ * be attached to either element. Bind to the `tn-slider` host for the simplest
+ * usage; binding to the inner thumb input also works and the slider adopts that
+ * value on init (see {@link ngAfterViewInit}). Avoid binding to both at once —
+ * pick one element per control to keep a single source of truth.
+ */
+export class TnSliderComponent implements ControlValueAccessor, OnDestroy, AfterContentInit, AfterViewInit {
   min = input<number>(0);
   max = input<number>(100);
   step = input<number>(1);
@@ -89,17 +99,25 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     });
   }
 
-  ngAfterViewInit() {
-    // Initialize thumb directive if present
+  ngAfterContentInit() {
+    // Link the projected thumb directive. Done in AfterContentInit (not
+    // AfterViewInit) so the link exists before the thumb's host bindings settle,
+    // avoiding a null→value flip on its [disabled]/[min]/[value] bindings.
     const thumbDirective = this.thumbDirective();
     if (thumbDirective) {
       thumbDirective.slider = this;
-      // The form's initial writeValue() runs before this link exists, so adopt the
-      // value the thumb already received — otherwise the slider keeps its default 0
-      // and the thumb/fill render at the wrong (e.g. negative) position.
-      this.value.set(this.clampValue(thumbDirective.getValue()));
+      // When the form is bound to the inner thumb input, its initial writeValue()
+      // may run before this link exists, so adopt the value the thumb received —
+      // otherwise the slider keeps its default 0 and the thumb/fill render at the
+      // wrong position. Only adopt when the thumb was actually written to, so a
+      // value bound directly on the slider isn't clobbered by the thumb's default.
+      if (thumbDirective.hasFormValue()) {
+        this.value.set(this.clampValue(thumbDirective.getValue()));
+      }
     }
+  }
 
+  ngAfterViewInit() {
     // Set up handle interaction listeners if labelType is handle or both
     const currentLabelType = this.labelType();
     if ((currentLabelType === 'handle' || currentLabelType === 'both') && this._showLabel()) {

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -67,14 +67,6 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     return this.fillPercentage() / 100;
   });
 
-  // Computed position for thumb (in pixels from left)
-  thumbPosition = computed(() => {
-    const containerWidth = this.sliderContainer()?.nativeElement?.offsetWidth || 0;
-    const percentage = this.fillPercentage();
-    // Center the thumb (20px width, so -10px offset)
-    return (containerWidth * percentage / 100) - 10;
-  });
-
   // Public signals for label management
   showLabel = this._showLabel.asReadonly();
   labelVisible = this._labelVisible.asReadonly();
@@ -102,8 +94,11 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     const thumbDirective = this.thumbDirective();
     if (thumbDirective) {
       thumbDirective.slider = this;
+      // The form's initial writeValue() runs before this link exists, so adopt the
+      // value the thumb already received — otherwise the slider keeps its default 0
+      // and the thumb/fill render at the wrong (e.g. negative) position.
+      this.value.set(this.clampValue(thumbDirective.getValue()));
     }
-    this.updateThumbPosition();
 
     // Set up handle interaction listeners if labelType is handle or both
     const currentLabelType = this.labelType();

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -52,7 +52,6 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
 
   thumbDirective = contentChild.required(TnSliderThumbDirective);
   sliderContainer = viewChild.required<ElementRef<HTMLDivElement>>('sliderContainer');
-  thumbVisual = viewChild.required<ElementRef<HTMLDivElement>>('thumbVisual');
 
   private onChange = (_value: number) => {};
   private onTouched = () => {};

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -33,7 +33,7 @@ export type LabelType = 'none' | 'handle' | 'track' | 'both';
  * directive are `NG_VALUE_ACCESSOR` providers, so a `formControl`/`ngModel` can
  * be attached to either element. Bind to the `tn-slider` host for the simplest
  * usage; binding to the inner thumb input also works and the slider adopts that
- * value on init (see {@link ngAfterViewInit}). Avoid binding to both at once —
+ * value on init (see {@link ngAfterContentInit}). Avoid binding to both at once —
  * pick one element per control to keep a single source of truth.
  */
 export class TnSliderComponent implements ControlValueAccessor, OnDestroy, AfterContentInit, AfterViewInit {
@@ -153,7 +153,6 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     const clampedValue = this.clampValue(newValue);
     this.value.set(clampedValue);
     this.onChange(clampedValue);
-    this.updateThumbPosition();
   }
 
   enableLabel(): void {
@@ -185,11 +184,6 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
 
     this.updateValue(newValue);
     this.onTouched();
-  }
-
-  private updateThumbPosition(): void {
-    // Thumb position is now handled by computed signal and template binding
-    // No manual DOM manipulation needed
   }
 
   private clampValue(value: number): number {

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -182,6 +182,11 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
     const newValue = minVal + (percentage * (maxVal - minVal));
 
     this.updateValue(newValue);
+    // updateValue emits via this slider's onChange, which only reaches a
+    // slider-bound control. When the form is bound to the inner thumb input
+    // instead, route the committed value through the thumb so its form control,
+    // native input, and currentValue stay in sync — same path drag uses.
+    this.thumbDirective().commit(this.value());
     this.onTouched();
   }
 

--- a/projects/truenas-ui/src/stories/slider.stories.ts
+++ b/projects/truenas-ui/src/stories/slider.stories.ts
@@ -1,3 +1,4 @@
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
@@ -78,7 +79,7 @@ export const Default: Story = {
           [labelType]="labelType"
           [labelPrefix]="labelPrefix"
           [labelSuffix]="labelSuffix">
-          <input ixSliderThumb value="50">
+          <input tnSliderThumb value="50">
         </tn-slider>
       </tn-form-field>
     `,
@@ -105,6 +106,30 @@ export const Default: Story = {
 };
 
 /**
+ * **Reactive form binding.** Binds a `FormControl` to the inner
+ * `input[tnSliderThumb]`. The slider adopts the control's initial value on init
+ * and the thumb/track fill reflect it; dragging or clicking writes back to the
+ * control. Live value shown below the slider.
+ */
+export const ReactiveForm: Story = {
+  render: () => {
+    const control = new FormControl(35);
+    return {
+      props: { control },
+      template: `
+        <tn-slider [min]="0" [max]="100" [step]="5" labelType="both" labelSuffix="%">
+          <input tnSliderThumb [formControl]="control">
+        </tn-slider>
+        <p>Value: {{ control.value }}</p>
+      `,
+      moduleMetadata: {
+        imports: [ReactiveFormsModule, TnSliderComponent, TnSliderThumbDirective],
+      },
+    };
+  },
+};
+
+/**
  * **Test IDs (default).** `tn-slider` emits the `slider-` prefix on its
  * container (which owns the track-click handlers), under `data-testid`
  * (default) / `data-test`. `testId="volume"` → `slider-volume`. With no
@@ -117,7 +142,7 @@ export const TestIds: Story = {
     template: `
       <tn-testid-inspector>
         <tn-slider [min]="0" [max]="100" [testId]="testId">
-          <input ixSliderThumb value="50">
+          <input tnSliderThumb value="50">
         </tn-slider>
       </tn-testid-inspector>
     `,
@@ -136,7 +161,7 @@ export const ScopedTestIds: Story = {
     template: `
       <tn-testid-inspector>
         <tn-slider [min]="0" [max]="100" [testId]="testId">
-          <input ixSliderThumb value="50">
+          <input tnSliderThumb value="50">
         </tn-slider>
       </tn-testid-inspector>
     `,

--- a/projects/truenas-ui/src/stories/slider.stories.ts
+++ b/projects/truenas-ui/src/stories/slider.stories.ts
@@ -131,9 +131,8 @@ export const ReactiveForm: Story = {
 
 /**
  * **Test IDs (default).** `tn-slider` emits the `slider-` prefix on its
- * container (which owns the track-click handlers), under `data-testid`
- * (default) / `data-test`. `testId="volume"` → `slider-volume`. With no
- * `testId`, nothing is emitted. Table read live.
+ * container, under `data-testid` (default) / `data-test`. `testId="volume"` →
+ * `slider-volume`. With no `testId`, nothing is emitted. Table read live.
  */
 export const TestIds: Story = {
   args: { testId: 'volume' },


### PR DESCRIPTION
writeValue() now propagates the form value to the parent slider so the thumb position and track fill reflect the bound value, and retains the last written value so the slider can adopt it in ngAfterViewInit (the initial writeValue runs before the thumb is linked to the slider).

Dragging now commits the clamped/stepped value back to the form and native input, so drag actually emits changes instead of only click.

Position the thumb via left:% + a fixed -10px centering offset rather than a JS-computed pixel position, removing the thumbPosition computed.