### PR TITLE
NAS-141525 / 27.0.0-BETA.1 / feat(button): add icon support with selectable left/right position

### DIFF
--- a/projects/truenas-ui/src/lib/button/button.component.html
+++ b/projects/truenas-ui/src/lib/button/button.component.html
@@ -1,10 +1,10 @@
 <ng-template #content>
   @if (icon() && iconPosition() === 'left') {
-    <tn-icon class="storybook-button__icon" size="sm" [name]="icon()!" />
+    <tn-icon class="storybook-button__icon" size="sm" aria-hidden="true" [name]="icon()!" />
   }
   <span class="storybook-button__label" [innerHTML]="label() | tnLabelMarkup"></span>
   @if (icon() && iconPosition() === 'right') {
-    <tn-icon class="storybook-button__icon" size="sm" [name]="icon()!" />
+    <tn-icon class="storybook-button__icon" size="sm" aria-hidden="true" [name]="icon()!" />
   }
 </ng-template>
 

--- a/projects/truenas-ui/src/lib/button/button.component.html
+++ b/projects/truenas-ui/src/lib/button/button.component.html
@@ -1,3 +1,13 @@
+<ng-template #content>
+  @if (icon() && iconPosition() === 'left') {
+    <tn-icon class="storybook-button__icon" size="sm" [name]="icon()!" />
+  }
+  <span class="storybook-button__label" [innerHTML]="label() | tnLabelMarkup"></span>
+  @if (icon() && iconPosition() === 'right') {
+    <tn-icon class="storybook-button__icon" size="sm" [name]="icon()!" />
+  }
+</ng-template>
+
 @if (isRouterLink()) {
   <a
     #button
@@ -16,7 +26,7 @@
     [tnTestId]="testId()"
     (click)="handleAnchorClick($event)"
   >
-    <span [innerHTML]="label() | tnLabelMarkup"></span>
+    <ng-container [ngTemplateOutlet]="content" />
   </a>
 } @else if (isAnchor()) {
   <a
@@ -34,7 +44,7 @@
     [tnTestId]="testId()"
     (click)="handleAnchorClick($event)"
   >
-    <span [innerHTML]="label() | tnLabelMarkup"></span>
+    <ng-container [ngTemplateOutlet]="content" />
   </a>
 } @else {
   <button
@@ -48,6 +58,6 @@
     [tnTestId]="testId()"
     (click)="onClick.emit($event)"
   >
-    <span [innerHTML]="label() | tnLabelMarkup"></span>
+    <ng-container [ngTemplateOutlet]="content" />
   </button>
 }

--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -24,6 +24,20 @@
   }
 }
 
+.storybook-button--has-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.storybook-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 a.storybook-button {
   text-decoration: none;
   text-align: center;

--- a/projects/truenas-ui/src/lib/button/button.component.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.spec.ts
@@ -140,6 +140,59 @@ describe('TnButtonComponent', () => {
     });
   });
 
+  describe('icon', () => {
+    it('renders no icon by default', () => {
+      const icon = fixture.nativeElement.querySelector('tn-icon');
+      expect(icon).toBeNull();
+      expect(component.classes()).not.toContain('storybook-button--has-icon');
+    });
+
+    it('renders a tn-icon with the given name when icon is set', () => {
+      fixture.componentRef.setInput('icon', 'check');
+      fixture.detectChanges();
+      const icon = fixture.nativeElement.querySelector('tn-icon');
+      expect(icon).toBeTruthy();
+      expect(icon.getAttribute('name')).toBe('check');
+    });
+
+    it('adds the has-icon class when an icon is present', () => {
+      fixture.componentRef.setInput('icon', 'check');
+      fixture.detectChanges();
+      expect(component.classes()).toContain('storybook-button--has-icon');
+    });
+
+    it('renders the icon before the label by default (left)', () => {
+      fixture.componentRef.setInput('icon', 'check');
+      fixture.componentRef.setInput('label', 'Save');
+      fixture.detectChanges();
+      const children = Array.from(fixture.nativeElement.querySelector('button').children);
+      const iconIndex = children.findIndex((el) => (el as Element).tagName.toLowerCase() === 'tn-icon');
+      const labelIndex = children.findIndex((el) => (el as Element).classList.contains('storybook-button__label'));
+      expect(iconIndex).toBeGreaterThanOrEqual(0);
+      expect(iconIndex).toBeLessThan(labelIndex);
+    });
+
+    it('renders the icon after the label when iconPosition is right', () => {
+      fixture.componentRef.setInput('icon', 'check');
+      fixture.componentRef.setInput('iconPosition', 'right');
+      fixture.componentRef.setInput('label', 'Save');
+      fixture.detectChanges();
+      const children = Array.from(fixture.nativeElement.querySelector('button').children);
+      const iconIndex = children.findIndex((el) => (el as Element).tagName.toLowerCase() === 'tn-icon');
+      const labelIndex = children.findIndex((el) => (el as Element).classList.contains('storybook-button__label'));
+      expect(iconIndex).toBeGreaterThan(labelIndex);
+    });
+
+    it('renders the icon in anchor (href) mode too', () => {
+      fixture.componentRef.setInput('href', 'https://truenas.com');
+      fixture.componentRef.setInput('icon', 'open-in-new');
+      fixture.detectChanges();
+      const icon = fixture.nativeElement.querySelector('a tn-icon');
+      expect(icon).toBeTruthy();
+      expect(icon.getAttribute('name')).toBe('open-in-new');
+    });
+  });
+
   describe('onClick event', () => {
     it('should emit onClick event when clicked', () => {
       const clickSpy = jest.fn();

--- a/projects/truenas-ui/src/lib/button/button.component.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.spec.ts
@@ -155,6 +155,13 @@ describe('TnButtonComponent', () => {
       expect(icon.getAttribute('name')).toBe('check');
     });
 
+    it('marks the icon as aria-hidden so its name does not leak into the button accessible name', () => {
+      fixture.componentRef.setInput('icon', 'check');
+      fixture.detectChanges();
+      const icon = fixture.nativeElement.querySelector('tn-icon');
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
+
     it('adds the has-icon class when an icon is present', () => {
       fixture.componentRef.setInput('icon', 'check');
       fixture.detectChanges();

--- a/projects/truenas-ui/src/lib/button/button.component.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.ts
@@ -2,13 +2,14 @@ import { CommonModule } from '@angular/common';
 import type { AfterViewInit } from '@angular/core';
 import { Component, ElementRef, computed, inject, input, output, viewChild } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TnIconComponent } from '../icon/icon.component';
 import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 @Component({
   selector: 'tn-button',
   standalone: true,
-  imports: [CommonModule, RouterLink, TnTestIdDirective, LabelMarkupPipe],
+  imports: [CommonModule, RouterLink, TnTestIdDirective, LabelMarkupPipe, TnIconComponent],
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
 })
@@ -20,6 +21,17 @@ export class TnButtonComponent implements AfterViewInit {
   variant = input<'filled' | 'outline'>('filled');
   backgroundColor = input<string | undefined>(undefined);
   label = input<string>('Button');
+  /**
+   * Optional icon rendered alongside the label. Accepts any name resolvable by
+   * `tn-icon` (sprite/registry/library). Use `iconPosition` to place it before
+   * or after the label.
+   */
+  icon = input<string | undefined>(undefined);
+  /**
+   * Side of the label the `icon` sits on. `left` (default) renders the icon
+   * before the label; `right` renders it after. No effect when `icon` is unset.
+   */
+  iconPosition = input<'left' | 'right'>('left');
   disabled = input<boolean>(false);
   /**
    * Native `type` of the rendered `<button>`. Defaults to `button` so stray
@@ -87,7 +99,11 @@ export class TnButtonComponent implements AfterViewInit {
       }
     }
 
-    return ['storybook-button', `storybook-button--${this.size}`, mode];
+    const classes = ['storybook-button', `storybook-button--${this.size}`, mode];
+    if (this.icon()) {
+      classes.push('storybook-button--has-icon');
+    }
+    return classes;
   });
 
   handleAnchorClick(event: MouseEvent): void {

--- a/projects/truenas-ui/src/lib/button/button.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.spec.ts
@@ -11,10 +11,11 @@ import { TnButtonHarness } from './button.harness';
   selector: 'tn-test-host',
   standalone: true,
   imports: [TnButtonComponent],
-  template: `<tn-button [label]="label()" [disabled]="disabled()" (onClick)="handleClick($event)" />`
+  template: `<tn-button [label]="label()" [icon]="icon()" [disabled]="disabled()" (onClick)="handleClick($event)" />`
 })
 class TestHostComponent {
   label = signal('Test Button');
+  icon = signal<string | undefined>(undefined);
   disabled = signal(false);
   clickCount = 0;
 
@@ -149,6 +150,30 @@ describe('TnButtonHarness', () => {
 
       const button = await loader.getHarness(TnButtonHarness.with({ label: /submit/i }));
       expect(button).toBeTruthy();
+    });
+  });
+
+  describe('icon', () => {
+    it('reports no icon by default', async () => {
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.hasIcon()).toBe(false);
+      expect(await button.getIconName()).toBeNull();
+    });
+
+    it('reports the icon name when one is set', async () => {
+      hostComponent.icon.set('check');
+
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.hasIcon()).toBe(true);
+      expect(await button.getIconName()).toBe('check');
+    });
+
+    it('does not leak icon text into the label', async () => {
+      hostComponent.label.set('Save');
+      hostComponent.icon.set('check');
+
+      const button = await loader.getHarness(TnButtonHarness);
+      expect(await button.getLabel()).toBe('Save');
     });
   });
 

--- a/projects/truenas-ui/src/lib/button/button.harness.ts
+++ b/projects/truenas-ui/src/lib/button/button.harness.ts
@@ -26,6 +26,8 @@ export class TnButtonHarness extends ComponentHarness {
   static hostSelector = 'tn-button';
 
   private _button = this.locatorFor('button, a');
+  private _label = this.locatorForOptional('.storybook-button__label');
+  private _icon = this.locatorForOptional('tn-icon');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button
@@ -63,8 +65,46 @@ export class TnButtonHarness extends ComponentHarness {
    * ```
    */
   async getLabel(): Promise<string> {
+    // Prefer the dedicated label span so a rendered icon's text content (sprite
+    // fallback glyphs) never leaks into the label. Fall back to the full
+    // element text for resilience if the span is ever absent.
+    const label = await this._label();
+    if (label) {
+      return (await label.text()).trim();
+    }
     const button = await this._button();
     return (await button.text()).trim();
+  }
+
+  /**
+   * Gets the `name` of the icon rendered inside the button, or `null` when the
+   * button has no icon.
+   *
+   * @example
+   * ```typescript
+   * const saveBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+   * expect(await saveBtn.getIconName()).toBe('check');
+   * ```
+   */
+  async getIconName(): Promise<string | null> {
+    const icon = await this._icon();
+    if (!icon) {
+      return null;
+    }
+    return icon.getAttribute('name');
+  }
+
+  /**
+   * Reports whether the button renders an icon.
+   *
+   * @example
+   * ```typescript
+   * const saveBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+   * expect(await saveBtn.hasIcon()).toBe(true);
+   * ```
+   */
+  async hasIcon(): Promise<boolean> {
+    return (await this._icon()) !== null;
   }
 
   /**

--- a/projects/truenas-ui/src/stories/button.stories.ts
+++ b/projects/truenas-ui/src/stories/button.stories.ts
@@ -4,9 +4,14 @@ import { expect, userEvent, within } from 'storybook/test';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
 
 // Load harness documentation
 const harnessDoc = loadHarnessDoc('button');
+
+// Register icons used in the icon stories so they are included in the sprite.
+const iconCheck = tnIconMarker('check', 'mdi');
+const iconArrowRight = tnIconMarker('arrow-right', 'mdi');
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
 const meta: Meta<TnButtonComponent> = {
@@ -32,6 +37,15 @@ const meta: Meta<TnButtonComponent> = {
     },
     primary: {
       control: 'boolean',
+    },
+    icon: {
+      control: 'text',
+      description: 'Optional icon rendered alongside the label (any tn-icon name).',
+    },
+    iconPosition: {
+      control: 'inline-radio',
+      options: ['left', 'right'],
+      description: 'Side of the label the icon sits on. No effect when icon is unset.',
     },
     href: {
       control: 'text',
@@ -139,6 +153,54 @@ export const OutlineWarn: Story = {
 
     await expect(outlineWarnButton.classList.contains('button-outline-warn')).toBe(true);
     await userEvent.click(outlineWarnButton);
+  },
+};
+
+/**
+ * **Icon (left).** Set `icon` to render a `tn-icon` alongside the label.
+ * `iconPosition` defaults to `left`, placing the icon before the label.
+ */
+export const IconLeft: Story = {
+  args: {
+    color: 'primary',
+    variant: 'filled',
+    label: 'Save',
+    icon: iconCheck,
+    iconPosition: 'left',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    const icon = button.querySelector('tn-icon');
+    const label = button.querySelector('.storybook-button__label');
+
+    await expect(icon).toBeTruthy();
+    // Icon precedes the label in the DOM for left placement.
+    await expect(icon!.compareDocumentPosition(label!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  },
+};
+
+/**
+ * **Icon (right).** Set `iconPosition="right"` to render the icon after the
+ * label — useful for "next"/"continue" affordances.
+ */
+export const IconRight: Story = {
+  args: {
+    color: 'primary',
+    variant: 'outline',
+    label: 'Next',
+    icon: iconArrowRight,
+    iconPosition: 'right',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    const icon = button.querySelector('tn-icon');
+    const label = button.querySelector('.storybook-button__label');
+
+    await expect(icon).toBeTruthy();
+    // Icon follows the label in the DOM for right placement.
+    await expect(label!.compareDocumentPosition(icon!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   },
 };
 


### PR DESCRIPTION
## Summary

Adds optional icon support to `tn-button` with selectable left/right positioning.

```html
<tn-button label="Save" icon="mdi-check" />
<tn-button label="Next" icon="mdi-arrow-right" iconPosition="right" />
```

## Changes

- **`button.component.ts`** — New inputs: `icon` (any `tn-icon` name, unset by default) and `iconPosition` (`'left' | 'right'`, default `'left'`). Imports `TnIconComponent`; `classes()` adds a `storybook-button--has-icon` modifier when an icon is set.
- **`button.component.html`** — Content extracted into a shared `<ng-template>` rendered via `ngTemplateOutlet` across all three render modes (button, href anchor, routerLink), so the icon works uniformly in link mode. Icon renders before/after the `.storybook-button__label` span based on `iconPosition`.
- **`button.component.scss`** — `--has-icon` switches to `inline-flex` with `gap: 8px`; icon gets `flex-shrink: 0` so it never squishes.
- **`button.harness.ts`** — `getLabel()` reads the dedicated label span so an icon's glyph text never leaks into the label (falls back to full text). Adds `getIconName()` and `hasIcon()`.
- **Tests/Stories** — Component + harness specs for both positions and anchor mode; `IconLeft`/`IconRight` stories with DOM-ordering play assertions; `icon`/`iconPosition` controls.

## Notes

- Sprite assets are intentionally **not** included — they regenerate via the full Storybook scan in the build pipeline; committing a partial local regeneration would drop unrelated icons.

## Testing

- `yarn test --testPathPatterns=button` — 127 passed
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)