### PR TITLE
NAS-141526 / 27.0.0-BETA.1 / feat(card): add router-link title and title tooltip support

### DIFF
--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -5,15 +5,39 @@
       <div class="tn-card__header-left">
         <ng-content select="[tnCardHeader]" />
         @if (!projectedHeader() && title()) {
-          <h3
-            class="tn-card__title"
-            [class.tn-card__title--link]="titleLink()"
-            [attr.tabindex]="titleLink() ? 0 : null"
-            [attr.role]="titleLink() ? 'button' : null"
-            (click)="onTitleClick()"
-            (keydown.enter)="onTitleClick()"
-            (keydown.space)="onTitleClick()">
-            {{ title() }}
+          <h3 class="tn-card__title">
+            @if (isTitleRouterLink()) {
+              <a
+                class="tn-card__title-link"
+                [routerLink]="titleRouterLink()"
+                [queryParams]="titleQueryParams()">
+                {{ title() }}
+                <tn-icon class="tn-card__title-link-icon" name="open-in-new" library="mdi" size="sm" [attr.aria-hidden]="true" />
+              </a>
+            } @else if (titleLink()) {
+              <span
+                class="tn-card__title-link"
+                role="button"
+                tabindex="0"
+                (click)="onTitleClick()"
+                (keydown.enter)="onTitleClick()"
+                (keydown.space)="onTitleClick()">
+                {{ title() }}
+                <tn-icon class="tn-card__title-link-icon" name="open-in-new" library="mdi" size="sm" [attr.aria-hidden]="true" />
+              </span>
+            } @else {
+              {{ title() }}
+            }
+
+            @if (titleTooltip(); as tooltip) {
+              <button
+                type="button"
+                class="tn-card__title-tooltip"
+                [attr.aria-label]="tooltip"
+                [tnTooltip]="tooltip">
+                <tn-icon name="help-circle" library="mdi" size="sm" [attr.aria-hidden]="true" />
+              </button>
+            }
           </h3>
         }
       </div>

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -21,7 +21,7 @@
                 tabindex="0"
                 (click)="onTitleClick()"
                 (keydown.enter)="onTitleClick()"
-                (keydown.space)="onTitleClick()">
+                (keydown.space)="onTitleClick(); $event.preventDefault()">
                 {{ title() }}
                 <tn-icon class="tn-card__title-link-icon" name="open-in-new" library="mdi" size="sm" [attr.aria-hidden]="true" />
               </span>
@@ -33,7 +33,7 @@
               <button
                 type="button"
                 class="tn-card__title-tooltip"
-                [attr.aria-label]="tooltip"
+                aria-label="More information"
                 [tnTooltip]="tooltip">
                 <tn-icon name="help-circle" library="mdi" size="sm" [attr.aria-hidden]="true" />
               </button>

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -100,19 +100,53 @@
 }
 
 .tn-card__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--tn-fg1, #1f2937);
   line-height: 1.5;
+}
 
-  &--link {
-    cursor: pointer;
-    transition: color 0.2s ease;
+// Clickable title — an `<a [routerLink]>` for `titleRouterLink`, or a
+// role="button" span for the legacy `titleLink`. Inherits the title typography
+// and adds link affordances plus the trailing "open" icon.
+.tn-card__title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease;
 
-    &:hover {
-      color: var(--tn-primary, #2563eb);
-    }
+  &:hover {
+    color: var(--tn-primary, #2563eb);
+  }
+}
+
+.tn-card__title-link-icon {
+  flex-shrink: 0;
+}
+
+// Separate help affordance: a button carrying the title tooltip, rendered as an
+// icon next to the title rather than attached to the title text itself.
+.tn-card__title-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--tn-fg2, #6c757d);
+  cursor: help;
+  line-height: 0;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--tn-fg1, #1f2937);
   }
 }
 

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { TN_TEST_ATTR } from '../test-id';
 import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
 import { TnCardComponent } from './card.component';
@@ -232,5 +233,69 @@ describe('TnCardComponent projected action templates', () => {
       (b) => (b as HTMLElement).textContent?.trim() === 'Primary',
     );
     expect(primaryBtn).toBeTruthy();
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [TnCardComponent],
+  template: `<tn-card [title]="title()" [titleRouterLink]="routerLink()" [titleTooltip]="tooltip()">Content</tn-card>`,
+})
+class TitleHostComponent {
+  title = signal<string | undefined>('Recent Orders');
+  routerLink = signal<string | unknown[] | undefined>(undefined);
+  tooltip = signal<string | undefined>(undefined);
+}
+
+describe('TnCardComponent title router link & tooltip', () => {
+  function createTitleHost() {
+    TestBed.configureTestingModule({
+      imports: [TitleHostComponent],
+      providers: [provideRouter([])],
+    });
+    const fixture = TestBed.createComponent(TitleHostComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders the title as a routerLink anchor with a trailing link icon when titleRouterLink is set', () => {
+    const fixture = createTitleHost();
+    fixture.componentInstance.routerLink.set(['/orders', 'recent']);
+    fixture.detectChanges();
+
+    const anchor = fixture.nativeElement.querySelector('.tn-card__title a') as HTMLAnchorElement | null;
+    expect(anchor).toBeTruthy();
+    // RouterLink resolves the commands array to a client-side href.
+    expect(anchor?.getAttribute('href')).toBe('/orders/recent');
+    expect(anchor?.textContent).toContain('Recent Orders');
+    // The link carries a trailing icon so it reads visually as a link...
+    const linkIcon = anchor?.querySelector('.tn-card__title-link-icon');
+    expect(linkIcon).toBeTruthy();
+    // ...but the icon is decorative: hidden from the a11y tree so it does not
+    // pollute the link's accessible name (which stays just "Recent Orders").
+    expect(linkIcon?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders a plain h3 with no link or link icon when titleRouterLink is absent', () => {
+    const fixture = createTitleHost();
+
+    const title = fixture.nativeElement.querySelector('.tn-card__title') as HTMLElement;
+    expect(title.tagName.toLowerCase()).toBe('h3');
+    expect(title.querySelector('a')).toBeNull();
+    expect(title.querySelector('.tn-card__title-link-icon')).toBeNull();
+  });
+
+  it('renders titleTooltip as a separate help-icon button (not on the title text) only when set', () => {
+    const fixture = createTitleHost();
+
+    // No tooltip: no help affordance is rendered.
+    expect(fixture.nativeElement.querySelector('.tn-card__title-tooltip')).toBeNull();
+
+    fixture.componentInstance.tooltip.set('Open the full orders page');
+    fixture.detectChanges();
+
+    const tooltipButton = fixture.nativeElement.querySelector('.tn-card__title-tooltip') as HTMLElement | null;
+    expect(tooltipButton).toBeTruthy();
+    expect(tooltipButton?.getAttribute('aria-label')).toBe('Open the full orders page');
   });
 });

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -296,6 +296,8 @@ describe('TnCardComponent title router link & tooltip', () => {
 
     const tooltipButton = fixture.nativeElement.querySelector('.tn-card__title-tooltip') as HTMLElement | null;
     expect(tooltipButton).toBeTruthy();
-    expect(tooltipButton?.getAttribute('aria-label')).toBe('Open the full orders page');
+    // The button's accessible name is generic; the tooltip text is exposed as the
+    // description (aria-describedby) so a screen reader doesn't read it twice.
+    expect(tooltipButton?.getAttribute('aria-label')).toBe('More information');
   });
 });

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -148,7 +148,7 @@ export class TnCardComponent {
     );
   });
 
-  isTitleRouterLink = computed(() => this.titleRouterLink() !== undefined);
+  isTitleRouterLink = computed(() => !!this.titleRouterLink());
 
   onTitleClick(): void {
     const link = this.titleLink();

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, input, computed, inject, contentChild, TemplateRef } from '@angular/core';
-import { mdiDotsVertical } from '@mdi/js';
+import { RouterLink } from '@angular/router';
+import { mdiDotsVertical, mdiHelpCircle, mdiOpenInNew } from '@mdi/js';
 import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
 import { TnCardHeaderDirective } from './card-header.directive';
 import type {
@@ -18,12 +19,14 @@ import type { TnMenuItem } from '../menu/menu.component';
 import { TnMenuComponent } from '../menu/menu.component';
 import { TnSlideToggleComponent } from '../slide-toggle/slide-toggle.component';
 import { TnTestIdDirective } from '../test-id';
+import { TnTooltipDirective } from '../tooltip/tooltip.directive';
 
 @Component({
   selector: 'tn-card',
   standalone: true,
   imports: [
     CommonModule,
+    RouterLink,
     TnButtonComponent,
     TnIconComponent,
     TnIconButtonComponent,
@@ -31,6 +34,7 @@ import { TnTestIdDirective } from '../test-id';
     TnMenuComponent,
     TnMenuTriggerDirective,
     TnTestIdDirective,
+    TnTooltipDirective,
   ],
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
@@ -53,7 +57,20 @@ export class TnCardComponent {
   protected footerActions = contentChild(TnCardFooterActionsDirective, { read: TemplateRef });
 
   title = input<string | undefined>(undefined);
-  titleLink = input<string | undefined>(undefined); // Makes title navigable
+  titleLink = input<string | undefined>(undefined); // External href: navigates via window.location
+
+  /**
+   * Angular router commands for a title that navigates within the app. When set,
+   * the title renders as an `<a [routerLink]>` so it participates in client-side
+   * (SPA) routing — unlike `titleLink`, which performs a full-page
+   * `window.location` navigation. Same accepted shapes as `[routerLink]`
+   * (`string | unknown[]`). Takes precedence over `titleLink`.
+   */
+  titleRouterLink = input<string | unknown[] | undefined>(undefined);
+  titleQueryParams = input<Record<string, unknown> | undefined>(undefined);
+
+  /** Help/hover text shown on the title via the tooltip directive. */
+  titleTooltip = input<string | undefined>(undefined);
   elevation = input<'none' | 'low' | 'medium' | 'high'>('medium');
   padding = input<'small' | 'medium' | 'large'>('medium');
   padContent = input<boolean>(true);
@@ -83,6 +100,8 @@ export class TnCardComponent {
   private registerMdiIcons(): void {
     const mdiIcons: Record<string, string> = {
       'dots-vertical': mdiDotsVertical,
+      'help-circle': mdiHelpCircle,
+      'open-in-new': mdiOpenInNew,
     };
 
     // Register MDI library with resolver for card icons
@@ -128,6 +147,8 @@ export class TnCardComponent {
       || this.footerLink() || this.footerActions()
     );
   });
+
+  isTitleRouterLink = computed(() => this.titleRouterLink() !== undefined);
 
   onTitleClick(): void {
     const link = this.titleLink();

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -150,8 +150,9 @@ export const TitleRouterLinkAndTooltip: Story = {
     // RouterLink resolves the href to an absolute URL in the browser, so just
     // assert the link is a real anchor with an href rather than an exact value.
     await expect(link).toHaveAttribute('href');
-    // The tooltip is a separate help affordance, not folded into the title text.
-    await expect(canvas.getByRole('button', { name: 'Open the full orders page' })).toBeInTheDocument();
+    // The tooltip is a separate help affordance (generic name; the tooltip text
+    // is its description), not folded into the title text.
+    await expect(canvas.getByRole('button', { name: 'More information' })).toBeInTheDocument();
   },
 };
 

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -1,3 +1,5 @@
+import { provideRouter } from '@angular/router';
+import { applicationConfig } from '@storybook/angular';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { expect, within } from 'storybook/test';
 import { TestIdInspectorComponent } from './testid-inspector.component';
@@ -42,7 +44,15 @@ const meta: Meta<TnCardComponent> = {
     },
     titleLink: {
       control: 'text',
-      description: 'URL to navigate to when title is clicked',
+      description: 'External URL; navigates via window.location when the title is clicked',
+    },
+    titleRouterLink: {
+      control: 'text',
+      description: 'Angular router commands; renders the title as an in-app (SPA) link',
+    },
+    titleTooltip: {
+      control: 'text',
+      description: 'Help/hover text shown on the title',
     },
     headerStatus: {
       control: 'object',
@@ -103,6 +113,45 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const card = canvas.getByText('Card Title');
     await expect(card).toBeInTheDocument();
+  },
+};
+
+export const TitleRouterLinkAndTooltip: Story = {
+  decorators: [applicationConfig({ providers: [provideRouter([])] })],
+  args: {
+    title: 'Recent Orders',
+    titleRouterLink: '/orders',
+    titleTooltip: 'Open the full orders page',
+    elevation: 'medium',
+    padding: 'medium',
+    padContent: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tn-card
+        [title]="title"
+        [titleRouterLink]="titleRouterLink"
+        [titleTooltip]="titleTooltip"
+        [elevation]="elevation"
+        [padding]="padding"
+        [padContent]="padContent"
+      >
+        <p>The title is an in-app router link (client-side navigation) and carries a tooltip.</p>
+      </tn-card>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The decorative open-in-new icon is aria-hidden, so the link's accessible
+    // name stays just the title text (not "Recent Orders open-in-new").
+    const link = canvas.getByRole('link', { name: 'Recent Orders' });
+    await expect(link).toBeInTheDocument();
+    // RouterLink resolves the href to an absolute URL in the browser, so just
+    // assert the link is a real anchor with an href rather than an exact value.
+    await expect(link).toHaveAttribute('href');
+    // The tooltip is a separate help affordance, not folded into the title text.
+    await expect(canvas.getByRole('button', { name: 'Open the full orders page' })).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
## What

Add native support for two card-title features so consumers don't have to project a custom `[tnCardHeader]` title:

- **`titleRouterLink`** (+ `titleQueryParams`) — renders the title as an `<a [routerLink]>` for **client-side (SPA) navigation**, with a trailing `open-in-new` icon so it reads visually as a link. (The existing `titleLink` does a full-page `window.location` reload and stays supported.)
- **`titleTooltip`** — renders a **separate `help-circle` icon button** next to the title that carries the tooltip — not attached to the title text.

## Why

The plain `title` input is text-only, and `titleLink` navigates via a full-page reload. Cards that need an in-app link title (with the conventional "open" affordance) or a title help tooltip previously had to project a custom `<h3 [tnCardHeader]>`. That also misses the library's view-encapsulated `.tn-card__title` styling, so projected titles fall back to the browser-default heading size.

## Accessibility

The trailing `open-in-new` and `help-circle` icons are decorative. Because `tn-icon` always emits `role="img"` with an `aria-label` (falling back to the icon name), they would otherwise pollute the link's accessible name (e.g. "Recent Orders open-in-new"). They're marked `aria-hidden`, so the link's accessible name stays just the title text. The tooltip button carries an `aria-label`.

## Tests

- New `card.component.spec.ts` cases: router-link anchor + decorative (aria-hidden) link icon, plain `<h3>` with no link when absent, and the tooltip rendered as a separate help-icon button (with `aria-label`) only when set.
- New `TitleRouterLinkAndTooltip` Storybook story (generic example) with a play function asserting the link role/name and the separate tooltip button.
- `jest` (13/13 card tests), `eslint`, and `ng build` all pass.
