### PR TITLE
NAS-141529 / 27.0.0-BETA.1 / fix(select): unconstrained max-height and overflow bug

### DIFF
--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -108,7 +108,6 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-height: var(--tn-select-dropdown-max-height);
-  overflow: scroll;
 }
 
 .tn-select-options {

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -2,11 +2,6 @@
   position: relative;
   width: 100%;
   font-family: var(--tn-font-family-body, 'Inter'), sans-serif;
-  // Single source of truth for the dropdown's max-height. The component
-  // reads this via getComputedStyle to decide whether to flip the dropdown
-  // above the trigger — keeping SCSS and TS in lockstep without a duplicated
-  // constant.
-  --tn-select-dropdown-max-height: 200px;
 }
 
 .tn-select-label {
@@ -102,6 +97,9 @@
 }
 
 .tn-select-dropdown {
+  // Single source of truth for the dropdown's max-height.
+  --tn-select-dropdown-max-height: 350px;
+
   // No position / top / left here on purpose: the panel is rendered inside a
   // CDK overlay pane that handles positioning. Adding `position: absolute`
   // collapses the pane to zero height and the panel never becomes visible.
@@ -110,7 +108,7 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-height: var(--tn-select-dropdown-max-height);
-  overflow: hidden;
+  overflow: scroll;
 }
 
 .tn-select-options {


### PR DESCRIPTION
the `--tn-select-dropdown-max-height` variable was unused and non-functional since it was declared in the wrong spot, and the `overflow` needed to be set to `scroll`. also, adjust the max height to 350px instead of 200px, since it just seemed more roomy.

**note:** we can revert to 200px if we'd like. here's a comparison:
| <img width="1091" height="454" alt="image" src="https://github.com/user-attachments/assets/834338a7-873f-4d5d-8810-b0b59fb304d8" /> | <img width="1091" height="554" alt="image" src="https://github.com/user-attachments/assets/80c70545-96fc-438c-be35-fc66d5978c34" /> |
| :---: | :---: |
| 200px | 350px |
