### PR TITLE
feat(input): add format/parse value transforms

### DIFF
--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -1033,3 +1033,127 @@ describe('TnInputComponent size type with FormControl', () => {
     expect(parseSize(input.value, 'MiB', 'iec')).toBe(hostComponent.control.value);
   });
 });
+
+
+// Stand-ins for the real ix-formatter transforms the forms pass, kept simple so
+// the tests assert the wiring (format/parse plumbing) rather than re-test the
+// formatters themselves.
+//  - bytes <-> "<n> MiB": a model→display formatter paired with a display→model parser
+//  - host -> "https://host": a parse-only transform with no formatter (the URL case)
+function formatMib(value: string | number | null): string {
+  if (value === null || value === '') { return ''; }
+  return `${Number(value) / 1024 ** 2} MiB`;
+}
+function parseMib(value: string): number | null {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)/);
+  return match ? Math.round(Number(match[1]) * 1024 ** 2) : null;
+}
+function parseUrl(value: string): string {
+  return value.startsWith('http') ? value : `https://${value}`;
+}
+
+@Component({
+  selector: 'tn-test-transform-cva-host',
+  standalone: true,
+  imports: [TnInputComponent, ReactiveFormsModule],
+  template: `<tn-input [format]="format" [parse]="parse" [formControl]="control" />`
+})
+class TestTransformCvaHostComponent {
+  format: ((value: string | number | null) => string) | undefined = formatMib;
+  parse: ((value: string) => string | number | null) | undefined = parseMib;
+  control = new FormControl<string | number | null>(null);
+}
+
+
+describe('TnInputComponent with format/parse transforms', () => {
+  let fixture: ComponentFixture<TestTransformCvaHostComponent>;
+  let hostComponent: TestTransformCvaHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestTransformCvaHostComponent],
+      providers: [TnIconTesting.jest.providers()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestTransformCvaHostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render the model through `format` when written', () => {
+    hostComponent.control.setValue(2 * 1024 ** 2);
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    expect(input.value).toBe('2 MiB');
+  });
+
+  it('should emit the `parse`d model while keeping the typed text visible', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '3 MiB';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(hostComponent.control.value).toBe(3 * 1024 ** 2);
+    // Display is left as typed until blur.
+    expect(input.value).toBe('3 MiB');
+  });
+
+  it('should canonicalize the display through `format` on blur', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '3'; // bare number; the stub parser treats it as MiB
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    // parse("3") -> 3 MiB in bytes; format(...) -> "3 MiB" (canonical display)
+    expect(hostComponent.control.value).toBe(3 * 1024 ** 2);
+    expect(input.value).toBe('3 MiB');
+  });
+
+  it('should emit \'\' without calling parse when the field is cleared', () => {
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = '3 MiB';
+    input.dispatchEvent(new Event('input'));
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+
+    expect(hostComponent.control.value).toBe('');
+  });
+
+  it('should not re-emit on blur for an untouched pre-filled control (no false dirty)', () => {
+    hostComponent.control.setValue(2 * 1024 ** 2);
+    fixture.detectChanges();
+    expect(hostComponent.control.dirty).toBe(false);
+
+    const input = fixture.nativeElement.querySelector('input');
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    expect(hostComponent.control.dirty).toBe(false);
+    expect(input.value).toBe('2 MiB');
+  });
+
+  it('should support a parse-only transform and surface it on blur (URL case)', () => {
+    hostComponent.format = undefined;
+    hostComponent.parse = parseUrl;
+    hostComponent.control = new FormControl<string | number | null>(null);
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = 'example.com';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    // Model gets the protocol; display stays as typed until blur.
+    expect(hostComponent.control.value).toBe('https://example.com');
+    expect(input.value).toBe('example.com');
+
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    // On blur the display surfaces the parsed (protocol-prefixed) value.
+    expect(input.value).toBe('https://example.com');
+    expect(hostComponent.control.value).toBe('https://example.com');
+  });
+});

--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -1163,6 +1163,9 @@ describe('TnInputComponent with format/parse transforms', () => {
     expect(hostComponent.control.value).toBeNull();
     expect(strictFormat).not.toHaveBeenCalledWith(null);
     expect(strictParse).not.toHaveBeenCalledWith('');
+    // And the unparseable text is left exactly as typed (mirroring the Size branch),
+    // so a typo isn't silently wiped on blur — the consumer's validators can flag it.
+    expect(input.value).toBe('abc');
   });
 
   it('should support a parse-only transform and surface it on blur (URL case)', () => {

--- a/projects/truenas-ui/src/lib/input/input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.spec.ts
@@ -1134,6 +1134,37 @@ describe('TnInputComponent with format/parse transforms', () => {
     expect(input.value).toBe('2 MiB');
   });
 
+  it('should not hand `format` a falsy model nor call parse(\'\') on blur', () => {
+    // Strict transforms that assume the writeValue/input-path contract: `format`
+    // is only ever given a truthy model, `parse` is never given ''. They throw if
+    // that contract is violated, so a blur over unparseable text (parse -> null)
+    // must not trip them.
+    const strictFormat = jest.fn((value: string | number | null) => {
+      if (!value) { throw new Error(`format called with falsy value: ${value}`); }
+      return `${Number(value) / 1024 ** 2} MiB`;
+    });
+    const strictParse = jest.fn((value: string) => {
+      if (value === '') { throw new Error('parse called with empty string'); }
+      const match = value.trim().match(/^(\d+(?:\.\d+)?)/);
+      return match ? Math.round(Number(match[1]) * 1024 ** 2) : null;
+    });
+    hostComponent.format = strictFormat;
+    hostComponent.parse = strictParse;
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = 'abc'; // unparseable -> strictParse returns null
+    input.dispatchEvent(new Event('input'));
+    expect(() => input.dispatchEvent(new Event('blur'))).not.toThrow();
+    fixture.detectChanges();
+
+    // The unparseable text emits a null model; crucially, format was never handed
+    // that null model and parse was never re-invoked on the resulting empty string.
+    expect(hostComponent.control.value).toBeNull();
+    expect(strictFormat).not.toHaveBeenCalledWith(null);
+    expect(strictParse).not.toHaveBeenCalledWith('');
+  });
+
   it('should support a parse-only transform and surface it on blur (URL case)', () => {
     hostComponent.format = undefined;
     hostComponent.parse = parseUrl;

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -116,6 +116,28 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   sizeRound = input<number>(2);
 
   /**
+   * Optional model→display transform, applied on the standard text path (it is
+   * ignored in `Size`/`Number` modes, which own their own formatting). Mirrors
+   * ix-input's `format`: the form model is rendered through this function — e.g.
+   * a byte count shown as `2 GiB`. Pairs with `parse`, which converts the typed
+   * text back to the model. Only truthy models are formatted; null/empty render
+   * blank. On blur the display is re-derived through this function so it shows
+   * the canonical form.
+   */
+  format = input<((value: string | number | null) => string) | undefined>(undefined);
+
+  /**
+   * Optional display→model transform, applied on the standard text path (it is
+   * ignored in `Size`/`Number` modes). Mirrors ix-input's `parse`: the typed
+   * text is emitted to the form model through this function — e.g. `2 GiB` → a
+   * byte count, or a bare host → a full URL. The field keeps showing what the
+   * user typed until blur, when the display is canonicalized via `format` (if
+   * set) or replaced by the parsed model. An empty field emits `''` without
+   * calling `parse`.
+   */
+  parse = input<((value: string) => string | number | null) | undefined>(undefined);
+
+  /**
    * Whether a `Password` field renders the built-in visibility toggle — the eye
    * button that switches the field between masked and plain-text display.
    * Defaults to true; set false for secrets that must never be revealed.
@@ -152,6 +174,12 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   integerOnly = computed(() => !this.allowDecimals());
   /** True when the field is a password field. */
   isPassword = computed(() => this.inputType() === InputType.Password);
+  /** True when a custom `format` (model→display) transform is provided. */
+  hasFormat = computed(() => !!this.format());
+  /** True when a custom `parse` (display→model) transform is provided. */
+  hasParse = computed(() => !!this.parse());
+  /** True when either custom transform is provided — i.e. the value-transform text path is active. */
+  hasValueTransform = computed(() => this.hasFormat() || this.hasParse());
   /**
    * Whether the password is currently revealed. Not exposed as an input so a
    * reveal is always an explicit user gesture, and linked to the toggle's own
@@ -252,6 +280,17 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
       this.value.set(formatSize(value, this.sizeStandard(), this.sizeRound()));
       return;
     }
+    // Custom value transform (mirrors ix-input's `format`): render the model
+    // through the consumer's formatter, e.g. a byte count shown as "2 GiB".
+    // Guarded on a truthy value to match the formatters' own contract (they
+    // return '' for falsy) and avoid format(0)/format('') surprises; null/empty
+    // fall through to the blank display below. Skipped in Number mode, which
+    // owns its own display.
+    const format = this.format();
+    if (format && value && !this.isNumeric()) {
+      this.value.set(format(value));
+      return;
+    }
     // Display the model verbatim via String(); do NOT sanitize here. Sanitizing a
     // canonical number string would corrupt fractions in integer mode (3.5 -> "35"),
     // silently diverging the display from the form model.
@@ -304,8 +343,14 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
       return;
     }
 
-    this.value.set(target.value);
-    this.onChange(this.value());
+    // Standard text path. With a custom `parse` (mirrors ix-input): keep the
+    // typed text visible and emit the parsed model. An empty field emits '' as
+    // is — never parse('') — so clearing the field clears the model. Without a
+    // transform this collapses to emitting the raw text.
+    const raw = target.value;
+    this.value.set(raw);
+    const parse = this.parse();
+    this.onChange(parse && raw ? parse(raw) : raw);
   }
 
   protected onBlur(): void {
@@ -327,6 +372,24 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
           this.value.set(canonical);
           this.onChange(parseSize(canonical, this.sizeDefaultUnit(), this.sizeStandard()));
         }
+      }
+    } else if (this.hasValueTransform() && this.value() !== '' && !this.isNumeric()) {
+      // Canonicalize the display on blur, mirroring both the Size branch and
+      // ix-input's blur: re-derive the model from the shown text (via `parse`,
+      // if any) then re-render it — through `format` when set, otherwise show
+      // the parsed model verbatim (e.g. stringAsUrlParsing surfacing the
+      // protocol it prepended). Only rewrite + re-emit when the canonical form
+      // actually differs, so an untouched pre-filled control isn't falsely
+      // marked dirty (the same guard the Size branch uses).
+      const parse = this.parse();
+      const format = this.format();
+      const model = parse ? parse(this.value()) : this.value();
+      const canonical = format
+        ? format(model)
+        : model === null || model === undefined ? '' : String(model);
+      if (canonical !== this.value()) {
+        this.value.set(canonical);
+        this.onChange(parse ? parse(canonical) : model);
       }
     }
     this.onTouched();

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -119,10 +119,14 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
    * Optional model→display transform, applied on the standard text path (it is
    * ignored in `Size`/`Number` modes, which own their own formatting). Mirrors
    * ix-input's `format`: the form model is rendered through this function — e.g.
-   * a byte count shown as `2 GiB`. Pairs with `parse`, which converts the typed
-   * text back to the model. Only truthy models are formatted; null/empty render
-   * blank. On blur the display is re-derived through this function so it shows
-   * the canonical form.
+   * a byte count shown as `2 GiB`. Only truthy models are formatted; null/empty
+   * render blank. On blur the display is re-derived through this function so it
+   * shows the canonical form.
+   *
+   * Intended to be paired with `parse` (the inverse transform). On its own,
+   * `format` only canonicalizes the display on blur while the model keeps the
+   * raw typed text, so display and model diverge (`"2 MiB"` shown, `"2"` stored);
+   * supply `parse` whenever the formatted display isn't already a valid model.
    */
   format = input<((value: string | number | null) => string) | undefined>(undefined);
 
@@ -384,12 +388,22 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
       const parse = this.parse();
       const format = this.format();
       const model = parse ? parse(this.value()) : this.value();
-      const canonical = format
+      // Render the model back to display through `format`, but only for a truthy
+      // model — the same guard writeValue applies, so a formatter written to that
+      // contract is never handed null/0/'' on either path (parse can legitimately
+      // return null for unparseable text). A falsy model blanks the field (null/
+      // undefined) or shows its String() form; without `format`, the parsed model
+      // is shown verbatim (e.g. stringAsUrlParsing surfacing the protocol it added).
+      const canonical = format && model
         ? format(model)
         : model === null || model === undefined ? '' : String(model);
       if (canonical !== this.value()) {
         this.value.set(canonical);
-        this.onChange(parse ? parse(canonical) : model);
+        // Re-emit so parse(display) === model holds for the canonicalized text.
+        // This assumes parse is idempotent over its own formatted output
+        // (parse(format(x)) === x), matching the Size branch. Never parse('')
+        // (the input-path contract): a blank canonical re-emits the model as-is.
+        this.onChange(parse && canonical ? parse(canonical) : model);
       }
     }
     this.onTouched();

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -178,12 +178,8 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
   integerOnly = computed(() => !this.allowDecimals());
   /** True when the field is a password field. */
   isPassword = computed(() => this.inputType() === InputType.Password);
-  /** True when a custom `format` (model→display) transform is provided. */
-  hasFormat = computed(() => !!this.format());
-  /** True when a custom `parse` (display→model) transform is provided. */
-  hasParse = computed(() => !!this.parse());
   /** True when either custom transform is provided — i.e. the value-transform text path is active. */
-  hasValueTransform = computed(() => this.hasFormat() || this.hasParse());
+  hasValueTransform = computed(() => !!this.format() || !!this.parse());
   /**
    * Whether the password is currently revealed. Not exposed as an input so a
    * reveal is always an explicit user gesture, and linked to the toggle's own
@@ -388,22 +384,26 @@ export class TnInputComponent implements AfterViewInit, OnDestroy, ControlValueA
       const parse = this.parse();
       const format = this.format();
       const model = parse ? parse(this.value()) : this.value();
-      // Render the model back to display through `format`, but only for a truthy
-      // model — the same guard writeValue applies, so a formatter written to that
-      // contract is never handed null/0/'' on either path (parse can legitimately
-      // return null for unparseable text). A falsy model blanks the field (null/
-      // undefined) or shows its String() form; without `format`, the parsed model
-      // is shown verbatim (e.g. stringAsUrlParsing surfacing the protocol it added).
-      const canonical = format && model
-        ? format(model)
-        : model === null || model === undefined ? '' : String(model);
-      if (canonical !== this.value()) {
-        this.value.set(canonical);
-        // Re-emit so parse(display) === model holds for the canonicalized text.
-        // This assumes parse is idempotent over its own formatted output
-        // (parse(format(x)) === x), matching the Size branch. Never parse('')
-        // (the input-path contract): a blank canonical re-emits the model as-is.
-        this.onChange(parse && canonical ? parse(canonical) : model);
+      // Only canonicalize a truthy model. A falsy model means the typed text didn't
+      // parse (parse legitimately returns null/'' for unparseable input), so — like
+      // the Size branch leaving text untouched when parseSize returns null — keep the
+      // text the user typed so their input isn't silently wiped and the consumer's
+      // validators can flag it. The model was already emitted while typing, so there's
+      // nothing to re-emit here. This truthy guard also matches the one writeValue and
+      // `format` apply, so a formatter written to the ''-for-falsy contract is never
+      // handed null/0/''.
+      if (model) {
+        // Render the model back to display through `format` when set; otherwise show
+        // it verbatim (e.g. stringAsUrlParsing surfacing the protocol it prepended).
+        const canonical = format ? format(model) : String(model);
+        if (canonical !== this.value()) {
+          this.value.set(canonical);
+          // Re-emit the model directly rather than re-parsing the canonical display:
+          // parse is assumed idempotent over its own formatted output
+          // (parse(format(x)) === x, matching the Size branch), so parse(canonical)
+          // would just reproduce `model` — and emitting it avoids a second parse call.
+          this.onChange(model);
+        }
       }
     }
     this.onTouched();

--- a/projects/truenas-ui/src/stories/input.stories.ts
+++ b/projects/truenas-ui/src/stories/input.stories.ts
@@ -80,6 +80,16 @@ const meta: Meta<TnInputComponent> = {
       control: 'boolean',
       description: 'Password type: whether the built-in visibility toggle (eye button) is rendered. Defaults to true.',
     },
+    format: {
+      // A function input — not settable from the controls panel; see the
+      // "With Format And Parse" story for a live example.
+      control: false,
+      description: 'Text path: optional model→display transform (e.g. byte count → "2 GiB"). Pairs with parse. Ignored in Size/Number modes.',
+    },
+    parse: {
+      control: false,
+      description: 'Text path: optional display→model transform (e.g. "2 GiB" → byte count, or bare host → full URL). Pairs with format. Ignored in Size/Number modes.',
+    },
     testId: {
       control: 'text',
       description: 'Test ID for the input component',
@@ -348,6 +358,58 @@ export const Size: Story = {
     sizeDefaultUnit: 'MiB',
     sizeRound: 2,
   },
+};
+
+/**
+ * **Custom transforms (`format` / `parse`).** A generic escape hatch for the
+ * text path: `format` renders the form model for display, `parse` converts the
+ * typed text back to the model. The field shows what the user types until blur,
+ * when the display is canonicalized through `format`. Use it when the built-in
+ * `Size` mode doesn't fit — e.g. a parse-only transform that has no display
+ * counterpart (the URL field below prepends a protocol on blur).
+ *
+ * This mirrors the `ix-input` `format`/`parse` API, so forms migrating off
+ * `ix-input` can pass the same formatter functions unchanged.
+ */
+export const WithFormatAndParse: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      // Byte count <-> "<n> MiB". Stand-in for IxFormatterService.memorySize*.
+      bytesControl: new FormControl<number | null>(2 * 1024 ** 2),
+      formatMib: (value: string | number | null) =>
+        (value === null || value === '') ? '' : `${Number(value) / 1024 ** 2} MiB`,
+      parseMib: (value: string) => {
+        const match = value.trim().match(/^(\d+(?:\.\d+)?)/);
+        return match ? Math.round(Number(match[1]) * 1024 ** 2) : null;
+      },
+      // Parse-only: bare host -> full URL. Stand-in for stringAsUrlParsing.
+      urlControl: new FormControl<string | null>(''),
+      parseUrl: (value: string) => (value.startsWith('http') ? value : `https://${value}`),
+    },
+    template: `
+      <tn-form-field
+        label="Memory Size"
+        hint="format/parse: model is a byte count, field shows MiB; canonicalizes on blur">
+        <tn-input [format]="formatMib" [parse]="parseMib" [formControl]="bytesControl" />
+      </tn-form-field>
+      <p style="margin: 8px 0 20px; font-family: monospace;">
+        model (bytes): {{ bytesControl.value === null ? 'null' : bytesControl.value }}
+      </p>
+
+      <tn-form-field
+        label="Server URL"
+        hint="parse-only: type a bare host (example.com); protocol is prepended on blur">
+        <tn-input [parse]="parseUrl" [formControl]="urlControl" placeholder="example.com" />
+      </tn-form-field>
+      <p style="margin-top: 8px; font-family: monospace;">
+        model: {{ urlControl.value === '' ? "''" : urlControl.value }}
+      </p>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
+    },
+  }),
 };
 
 export const Multiline: Story = {


### PR DESCRIPTION
Add generic format (model→display) and parse (display→model) function inputs to tn-input, mirroring ix-input's API so forms migrating off ix-input can pass the same formatter functions unchanged. Covers cases the built-in Size mode can't express, e.g. a parse-only transform that prepends a URL protocol on blur.

- format renders the model for display on writeValue and canonicalizes on blur; parse converts typed text to the model on input
- transforms apply only on the standard text path (ignored in Size/Number modes); empty input emits '' without calling parse
- blur re-emit is guarded so an untouched pre-filled control isn't falsely marked dirty
- add spec coverage and a WithFormatAndParse Storybook story