### PR TITLE
NAS-141591 / 27.0.0-BETA.1 / feat(file-input): add tn-file-input control for local file upload

### DIFF
--- a/projects/truenas-ui/src/lib/file-input/file-input.component.html
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.html
@@ -1,0 +1,26 @@
+<div class="tn-file-input__container" tnTestIdType="file-input" [tnTestId]="testId()">
+  <input
+    #fileInput
+    type="file"
+    class="tn-file-input__native"
+    tabindex="-1"
+    aria-hidden="true"
+    [accept]="accept()"
+    [multiple]="multiple()"
+    [disabled]="isDisabled()"
+    (change)="onFilesSelected($event)">
+
+  <button
+    type="button"
+    class="tn-file-input__button"
+    [disabled]="isDisabled()"
+    (click)="openFileDialog()">
+    {{ buttonLabel() }}
+  </button>
+
+  @if (showFileName()) {
+    <span class="tn-file-input__filename" [class.tn-file-input__filename--empty]="!hasFiles()">
+      {{ hasFiles() ? fileNames() : noFileText() }}
+    </span>
+  }
+</div>

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.html
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.html
@@ -19,8 +19,16 @@
     (onClick)="openFileDialog()" />
 
   @if (showFileName()) {
-    <span class="tn-file-input__filename" aria-live="polite" [class.tn-file-input__filename--empty]="!hasFiles()">
+    <span class="tn-file-input__filename" [class.tn-file-input__filename--empty]="!hasFiles()">
       {{ hasFiles() ? fileNames() : noFileText() }}
     </span>
   }
+
+  <!--
+    Always-present live region so screen readers are told what was picked even
+    when the visible file name is suppressed (showFileName=false).
+  -->
+  <span class="tn-file-input__announcer" aria-live="polite">
+    {{ hasFiles() ? fileNames() : '' }}
+  </span>
 </div>

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.html
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.html
@@ -1,4 +1,4 @@
-<div class="tn-file-input__container" tnTestIdType="file-input" [tnTestId]="testId()">
+<div class="tn-file-input__container" tnTestIdType="file-input" [tnTestId]="testId()" (focusout)="onBlur()">
   <input
     #fileInput
     type="file"
@@ -19,7 +19,7 @@
     (onClick)="openFileDialog()" />
 
   @if (showFileName()) {
-    <span class="tn-file-input__filename" [class.tn-file-input__filename--empty]="!hasFiles()">
+    <span class="tn-file-input__filename" aria-live="polite" [class.tn-file-input__filename--empty]="!hasFiles()">
       {{ hasFiles() ? fileNames() : noFileText() }}
     </span>
   }

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.html
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.html
@@ -10,13 +10,13 @@
     [disabled]="isDisabled()"
     (change)="onFilesSelected($event)">
 
-  <button
-    type="button"
+  <tn-button
     class="tn-file-input__button"
+    color="default"
+    [label]="buttonLabel()"
     [disabled]="isDisabled()"
-    (click)="openFileDialog()">
-    {{ buttonLabel() }}
-  </button>
+    [ariaLabel]="ariaLabel()"
+    (onClick)="openFileDialog()" />
 
   @if (showFileName()) {
     <span class="tn-file-input__filename" [class.tn-file-input__filename--empty]="!hasFiles()">

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.scss
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.scss
@@ -8,8 +8,10 @@
   gap: 12px;
 }
 
-// Visually hidden, but still focusable target for the native dialog.
-.tn-file-input__native {
+// Visually hidden: the native input (a focusable dialog target) and the
+// screen-reader announcer for selection changes.
+.tn-file-input__native,
+.tn-file-input__announcer {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.scss
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.scss
@@ -30,6 +30,7 @@
 .tn-file-input__filename {
   font-size: 14px;
   color: var(--tn-fg1);
+  max-width: 30ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.scss
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.scss
@@ -1,0 +1,54 @@
+:host {
+  display: inline-block;
+}
+
+.tn-file-input__container {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+// Visually hidden, but still focusable target for the native dialog.
+.tn-file-input__native {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tn-file-input__button {
+  display: inline-block;
+  cursor: pointer;
+  border: 0;
+  font-weight: 500;
+  line-height: 1;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  padding: 11px 20px;
+  box-shadow: rgba(0, 0, 0, 0.15) 0 0 0 1px inset;
+  background-color: var(--tn-btn-default-bg);
+  color: var(--tn-btn-default-txt);
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+}
+
+.tn-file-input__filename {
+  font-size: 14px;
+  color: var(--tn-fg1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &--empty {
+    color: var(--tn-fg2);
+  }
+}

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.scss
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.scss
@@ -21,24 +21,10 @@
   border: 0;
 }
 
+// Visual styling lives in tn-button; only keep it from forcing its host to
+// stretch within the inline layout.
 .tn-file-input__button {
-  display: inline-block;
-  cursor: pointer;
-  border: 0;
-  font-weight: 500;
-  line-height: 1;
-  font-family: 'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  padding: 11px 20px;
-  box-shadow: rgba(0, 0, 0, 0.15) 0 0 0 1px inset;
-  background-color: var(--tn-btn-default-bg);
-  color: var(--tn-btn-default-txt);
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    pointer-events: none;
-  }
+  flex-shrink: 0;
 }
 
 .tn-file-input__filename {

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
@@ -62,6 +62,9 @@ describe('TnFileInputComponent', () => {
   const getFilename = (): HTMLElement | null =>
     getContainer().querySelector('.tn-file-input__filename');
 
+  const getAnnouncer = (): HTMLElement =>
+    getContainer().querySelector('.tn-file-input__announcer') as HTMLElement;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
@@ -100,6 +103,17 @@ describe('TnFileInputComponent', () => {
     host.showFileName.set(false);
     fixture.detectChanges();
     expect(getFilename()).toBeNull();
+  });
+
+  it('announces the selection to screen readers even when the file name is hidden', () => {
+    host.showFileName.set(false);
+    fixture.detectChanges();
+    expect(getAnnouncer().getAttribute('aria-live')).toBe('polite');
+    expect(getAnnouncer().textContent?.trim()).toBe('');
+
+    selectFiles(getNative(), [new File(['data'], 'report.pdf')]);
+    fixture.detectChanges();
+    expect(getAnnouncer().textContent?.trim()).toBe('report.pdf');
   });
 
   it('opens the native dialog when the button is clicked', () => {

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
@@ -1,0 +1,196 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnFileInputComponent } from './file-input.component';
+import { TnFileInputHarness } from './file-input.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnFileInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-file-input
+      testId="main"
+      [buttonLabel]="buttonLabel()"
+      [accept]="accept()"
+      [multiple]="multiple()"
+      [disabled]="disabled()"
+      [showFileName]="showFileName()"
+      [formControl]="control"
+      (change)="onChange($event)" />
+  `
+})
+class TestHostComponent {
+  buttonLabel = signal('Choose File');
+  accept = signal<string | undefined>(undefined);
+  multiple = signal(false);
+  disabled = signal(false);
+  showFileName = signal(true);
+  control = new FormControl<File | File[] | null>(null);
+  lastEmitted: File | File[] | null | undefined = undefined;
+  onChange(value: File | File[] | null): void {
+    this.lastEmitted = value;
+  }
+}
+
+/** Forces the native input to report `files` and fires a `change` event. */
+function selectFiles(input: HTMLInputElement, files: File[]): void {
+  Object.defineProperty(input, 'files', {
+    configurable: true,
+    value: files,
+  });
+  input.dispatchEvent(new Event('change'));
+}
+
+describe('TnFileInputComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  const getContainer = (): HTMLElement =>
+    fixture.nativeElement.querySelector('[data-testid="file-input-main"]');
+
+  const getButton = (): HTMLButtonElement =>
+    getContainer().querySelector('.tn-file-input__button') as HTMLButtonElement;
+
+  const getNative = (): HTMLInputElement =>
+    getContainer().querySelector('input[type="file"]') as HTMLInputElement;
+
+  const getFilename = (): HTMLElement | null =>
+    getContainer().querySelector('.tn-file-input__filename');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates and renders the trigger button', () => {
+    expect(getButton()).toBeTruthy();
+    expect(getButton().textContent?.trim()).toBe('Choose File');
+  });
+
+  it('uses a custom button label', () => {
+    host.buttonLabel.set('Upload');
+    fixture.detectChanges();
+    expect(getButton().textContent?.trim()).toBe('Upload');
+  });
+
+  it('forwards accept and multiple to the native input', () => {
+    host.accept.set('.tar,.txt');
+    host.multiple.set(true);
+    fixture.detectChanges();
+    expect(getNative().getAttribute('accept')).toBe('.tar,.txt');
+    expect(getNative().multiple).toBe(true);
+  });
+
+  it('shows the empty-state text when nothing is selected', () => {
+    expect(getFilename()?.textContent?.trim()).toBe('No file chosen');
+    expect(getFilename()?.classList).toContain('tn-file-input__filename--empty');
+  });
+
+  it('hides the file name when showFileName is false', () => {
+    host.showFileName.set(false);
+    fixture.detectChanges();
+    expect(getFilename()).toBeNull();
+  });
+
+  it('opens the native dialog when the button is clicked', () => {
+    const spy = jest.spyOn(getNative(), 'click');
+    getButton().click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the dialog when disabled', () => {
+    host.disabled.set(true);
+    fixture.detectChanges();
+    const spy = jest.spyOn(getNative(), 'click');
+    getButton().click();
+    expect(spy).not.toHaveBeenCalled();
+    expect(getButton().disabled).toBe(true);
+    expect(getNative().disabled).toBe(true);
+  });
+
+  it('emits a single File and updates the form value on selection', () => {
+    const file = new File(['data'], 'report.pdf', { type: 'application/pdf' });
+    selectFiles(getNative(), [file]);
+    fixture.detectChanges();
+
+    expect(host.lastEmitted).toBe(file);
+    expect(host.control.value).toBe(file);
+    expect(getFilename()?.textContent?.trim()).toBe('report.pdf');
+    expect(getFilename()?.classList).not.toContain('tn-file-input__filename--empty');
+  });
+
+  it('emits an array of Files when multiple is enabled', () => {
+    host.multiple.set(true);
+    fixture.detectChanges();
+    const a = new File(['a'], 'a.txt');
+    const b = new File(['b'], 'b.txt');
+    selectFiles(getNative(), [a, b]);
+    fixture.detectChanges();
+
+    expect(host.lastEmitted).toEqual([a, b]);
+    expect(host.control.value).toEqual([a, b]);
+    expect(getFilename()?.textContent?.trim()).toBe('a.txt, b.txt');
+  });
+
+  it('clears the selection when the form value is reset', () => {
+    const file = new File(['data'], 'report.pdf');
+    selectFiles(getNative(), [file]);
+    fixture.detectChanges();
+    expect(getFilename()?.textContent?.trim()).toBe('report.pdf');
+
+    host.control.reset();
+    fixture.detectChanges();
+    expect(getFilename()?.textContent?.trim()).toBe('No file chosen');
+    expect(getNative().value).toBe('');
+  });
+
+  it('reflects the form control disabled state', () => {
+    host.control.disable();
+    fixture.detectChanges();
+    expect(getButton().disabled).toBe(true);
+    expect(getNative().disabled).toBe(true);
+  });
+
+  describe('harness', () => {
+    let loader: HarnessLoader;
+
+    beforeEach(() => {
+      loader = TestbedHarnessEnvironment.loader(fixture);
+    });
+
+    it('reads the button text', async () => {
+      const harness = await loader.getHarness(TnFileInputHarness);
+      expect(await harness.getButtonText()).toBe('Choose File');
+    });
+
+    it('reports the empty file-name state', async () => {
+      const harness = await loader.getHarness(TnFileInputHarness);
+      expect(await harness.hasFile()).toBe(false);
+      expect(await harness.getFileName()).toBe('No file chosen');
+    });
+
+    it('reports disabled state', async () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+      const harness = await loader.getHarness(TnFileInputHarness);
+      expect(await harness.isDisabled()).toBe(true);
+    });
+
+    it('finds by testId and reads it back', async () => {
+      const harness = await loader.getHarness(
+        TnFileInputHarness.with({ testId: 'file-input-main' })
+      );
+      expect(await harness.getTestId()).toBe('file-input-main');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
@@ -161,6 +161,24 @@ describe('TnFileInputComponent', () => {
     expect(getNative().disabled).toBe(true);
   });
 
+  it('marks the control as touched when focus leaves it', () => {
+    expect(host.control.touched).toBe(false);
+    getContainer().dispatchEvent(new FocusEvent('focusout'));
+    expect(host.control.touched).toBe(true);
+  });
+
+  it('clears the native value before opening so re-picking the same file fires change', () => {
+    const native = getNative();
+    const clickSpy = jest.spyOn(native, 'click');
+    const valueSetter = jest.fn();
+    Object.defineProperty(native, 'value', { configurable: true, get: () => '', set: valueSetter });
+
+    getButton().click();
+
+    expect(valueSetter).toHaveBeenCalledWith('');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
   describe('harness', () => {
     let loader: HarnessLoader;
 

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.spec.ts
@@ -21,7 +21,7 @@ import { TnFileInputHarness } from './file-input.harness';
       [disabled]="disabled()"
       [showFileName]="showFileName()"
       [formControl]="control"
-      (change)="onChange($event)" />
+      (selectionChange)="onSelectionChange($event)" />
   `
 })
 class TestHostComponent {
@@ -32,7 +32,7 @@ class TestHostComponent {
   showFileName = signal(true);
   control = new FormControl<File | File[] | null>(null);
   lastEmitted: File | File[] | null | undefined = undefined;
-  onChange(value: File | File[] | null): void {
+  onSelectionChange(value: File | File[] | null): void {
     this.lastEmitted = value;
   }
 }
@@ -54,7 +54,7 @@ describe('TnFileInputComponent', () => {
     fixture.nativeElement.querySelector('[data-testid="file-input-main"]');
 
   const getButton = (): HTMLButtonElement =>
-    getContainer().querySelector('.tn-file-input__button') as HTMLButtonElement;
+    getContainer().querySelector('.tn-file-input__button .storybook-button') as HTMLButtonElement;
 
   const getNative = (): HTMLInputElement =>
     getContainer().querySelector('input[type="file"]') as HTMLInputElement;

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.ts
@@ -1,0 +1,127 @@
+import type { ElementRef } from '@angular/core';
+import { Component, computed, forwardRef, input, output, signal, viewChild } from '@angular/core';
+import type { ControlValueAccessor } from '@angular/forms';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+
+/**
+ * A minimal file-selection form control. Renders a styled "Choose File" button
+ * that opens the native file dialog and exposes the picked `File`(s) both as a
+ * `(change)` output and as the value of an Angular form control.
+ *
+ * The selected file name(s) are shown next to the button (toggle with
+ * `showFileName`). Use inside a `<tn-form-field>` to get a label, required
+ * asterisk and help tooltip.
+ *
+ * Like every native file input, the browser forbids programmatically setting
+ * the chosen files for security reasons. Writing a non-`null` value via a form
+ * control therefore only updates the displayed name; writing `null`/`''` clears
+ * the control. User selection is the only way to populate real `File` objects.
+ *
+ * @example
+ * ```html
+ * <tn-form-field label="Update File" [required]="true" tooltip="Upload a .tar file">
+ *   <tn-file-input accept=".tar" formControlName="update" (change)="onFile($event)" />
+ * </tn-form-field>
+ * ```
+ */
+@Component({
+  selector: 'tn-file-input',
+  standalone: true,
+  imports: [TnTestIdDirective],
+  templateUrl: './file-input.component.html',
+  styleUrl: './file-input.component.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TnFileInputComponent),
+      multi: true
+    }
+  ],
+  host: {
+    'class': 'tn-file-input'
+  }
+})
+export class TnFileInputComponent implements ControlValueAccessor {
+  fileInputEl = viewChild.required<ElementRef<HTMLInputElement>>('fileInput');
+
+  /** Label rendered inside the trigger button. */
+  buttonLabel = input<string>('Choose File');
+  /**
+   * Native `accept` attribute forwarded to the file input — a comma-separated
+   * list of extensions and/or MIME types (e.g. `".tar,.txt"`, `"image/*"`).
+   */
+  accept = input<string | undefined>(undefined);
+  /** Allow selecting more than one file. The value becomes a `File[]`. */
+  multiple = input<boolean>(false);
+  disabled = input<boolean>(false);
+  /** Whether to render the selected file name(s) beside the button. */
+  showFileName = input<boolean>(true);
+  /** Text shown beside the button when no file is selected. */
+  noFileText = input<string>('No file chosen');
+  /**
+   * Semantic test-id base. Rendered under whichever attribute name is configured
+   * via `TN_TEST_ATTR` (default `data-testid`).
+   */
+  testId = input<TnTestIdValue>(undefined);
+
+  /** Emitted whenever the selection changes. `null` when the input is cleared. */
+  change = output<File | File[] | null>();
+
+  // Selected files, kept for display and for the form value.
+  protected selectedFiles = signal<File[]>([]);
+
+  private formDisabled = signal<boolean>(false);
+  protected isDisabled = computed(() => this.disabled() || this.formDisabled());
+
+  protected fileNames = computed(() => this.selectedFiles().map(file => file.name).join(', '));
+  protected hasFiles = computed(() => this.selectedFiles().length > 0);
+
+  private onChange = (_value: File | File[] | null) => {};
+  private onTouched = () => {};
+
+  // ControlValueAccessor
+  writeValue(value: File | File[] | null): void {
+    // Native file inputs cannot be populated programmatically; we only mirror
+    // the value for display and treat null/empty as a clear of the control.
+    if (value === null || value === undefined || (typeof value === 'string' && value === '')) {
+      this.selectedFiles.set([]);
+      this.fileInputEl().nativeElement.value = '';
+    } else {
+      this.selectedFiles.set(Array.isArray(value) ? value : [value]);
+    }
+  }
+
+  registerOnChange(fn: (value: File | File[] | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.formDisabled.set(isDisabled);
+  }
+
+  protected openFileDialog(): void {
+    if (this.isDisabled()) {return;}
+    this.fileInputEl().nativeElement.click();
+  }
+
+  protected onFilesSelected(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    const files = target.files ? Array.from(target.files) : [];
+    this.selectedFiles.set(files);
+
+    const value = this.toValue(files);
+    this.onChange(value);
+    this.onTouched();
+    this.change.emit(value);
+  }
+
+  private toValue(files: File[]): File | File[] | null {
+    if (files.length === 0) {return null;}
+    return this.multiple() ? files : files[0];
+  }
+}

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.ts
@@ -2,6 +2,7 @@ import type { ElementRef } from '@angular/core';
 import { Component, computed, forwardRef, input, output, signal, viewChild } from '@angular/core';
 import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { TnButtonComponent } from '../button/button.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 /**
@@ -28,7 +29,7 @@ import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 @Component({
   selector: 'tn-file-input',
   standalone: true,
-  imports: [TnTestIdDirective],
+  imports: [TnButtonComponent, TnTestIdDirective],
   templateUrl: './file-input.component.html',
   styleUrl: './file-input.component.scss',
   providers: [
@@ -60,13 +61,25 @@ export class TnFileInputComponent implements ControlValueAccessor {
   /** Text shown beside the button when no file is selected. */
   noFileText = input<string>('No file chosen');
   /**
+   * Accessible label for the trigger button, forwarded to `tn-button`. Set this
+   * when the visible "Choose File" text alone doesn't convey what is being
+   * uploaded — e.g. pass the field label so a screen reader announces
+   * "Update File" rather than just "Choose File". (`tn-form-field`'s `<label>`
+   * is not programmatically associated with the projected control.)
+   */
+  ariaLabel = input<string | undefined>(undefined);
+  /**
    * Semantic test-id base. Rendered under whichever attribute name is configured
    * via `TN_TEST_ATTR` (default `data-testid`).
    */
   testId = input<TnTestIdValue>(undefined);
 
-  /** Emitted whenever the selection changes. `null` when the input is cleared. */
-  change = output<File | File[] | null>();
+  /**
+   * Emitted whenever the selection changes. `null` when the input is cleared.
+   * Named `selectionChange` (not `change`) to avoid colliding with the native
+   * `change` event bubbling from the inner file input.
+   */
+  selectionChange = output<File | File[] | null>();
 
   // Selected files, kept for display and for the form value.
   protected selectedFiles = signal<File[]>([]);
@@ -117,7 +130,7 @@ export class TnFileInputComponent implements ControlValueAccessor {
     const value = this.toValue(files);
     this.onChange(value);
     this.onTouched();
-    this.change.emit(value);
+    this.selectionChange.emit(value);
   }
 
   private toValue(files: File[]): File | File[] | null {

--- a/projects/truenas-ui/src/lib/file-input/file-input.component.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.component.ts
@@ -15,9 +15,10 @@ import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
  * asterisk and help tooltip.
  *
  * Like every native file input, the browser forbids programmatically setting
- * the chosen files for security reasons. Writing a non-`null` value via a form
- * control therefore only updates the displayed name; writing `null`/`''` clears
- * the control. User selection is the only way to populate real `File` objects.
+ * the chosen files for security reasons. Writing a non-empty value via a form
+ * control therefore only updates the displayed name; writing `null` (or an empty
+ * array) clears the control. User selection is the only way to populate real
+ * `File` objects.
  *
  * @example
  * ```html
@@ -97,7 +98,7 @@ export class TnFileInputComponent implements ControlValueAccessor {
   writeValue(value: File | File[] | null): void {
     // Native file inputs cannot be populated programmatically; we only mirror
     // the value for display and treat null/empty as a clear of the control.
-    if (value === null || value === undefined || (typeof value === 'string' && value === '')) {
+    if (value == null || (Array.isArray(value) && value.length === 0)) {
       this.selectedFiles.set([]);
       this.fileInputEl().nativeElement.value = '';
     } else {
@@ -119,7 +120,15 @@ export class TnFileInputComponent implements ControlValueAccessor {
 
   protected openFileDialog(): void {
     if (this.isDisabled()) {return;}
+    // Clear the native value first so re-picking the same file still fires
+    // `change` (browsers suppress it when the selection is identical).
+    this.fileInputEl().nativeElement.value = '';
     this.fileInputEl().nativeElement.click();
+  }
+
+  /** Marks the control as touched when focus leaves it (e.g. for validation). */
+  protected onBlur(): void {
+    this.onTouched();
   }
 
   protected onFilesSelected(event: Event): void {

--- a/projects/truenas-ui/src/lib/file-input/file-input.harness.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.harness.ts
@@ -16,7 +16,8 @@ export class TnFileInputHarness extends ComponentHarness {
   /** The selector for the host element of a `TnFileInputComponent` instance. */
   static hostSelector = 'tn-file-input';
 
-  private _button = this.locatorFor('.tn-file-input__button');
+  // The trigger is a `tn-button`; target its rendered `<button>` element.
+  private _button = this.locatorFor('.tn-file-input__button .storybook-button');
   private _native = this.locatorFor('input[type="file"]');
   private _filename = this.locatorForOptional('.tn-file-input__filename');
 

--- a/projects/truenas-ui/src/lib/file-input/file-input.harness.ts
+++ b/projects/truenas-ui/src/lib/file-input/file-input.harness.ts
@@ -1,0 +1,141 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for interacting with `tn-file-input` in tests.
+ *
+ * @example
+ * ```typescript
+ * const fileInput = await loader.getHarness(TnFileInputHarness.with({ testId: 'update' }));
+ * expect(await fileInput.getButtonText()).toBe('Choose File');
+ * expect(await fileInput.hasFile()).toBe(false);
+ * expect(await fileInput.getFileName()).toBe('No file chosen');
+ * ```
+ */
+export class TnFileInputHarness extends ComponentHarness {
+  /** The selector for the host element of a `TnFileInputComponent` instance. */
+  static hostSelector = 'tn-file-input';
+
+  private _button = this.locatorFor('.tn-file-input__button');
+  private _native = this.locatorFor('input[type="file"]');
+  private _filename = this.locatorForOptional('.tn-file-input__filename');
+
+  /**
+   * Gets a `HarnessPredicate` to search for a file input with specific attributes.
+   *
+   * @param options Options for filtering which instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * const fileInput = await loader.getHarness(TnFileInputHarness.with({ testId: 'update' }));
+   * ```
+   */
+  static with(options: FileInputHarnessFilters = {}) {
+    return new HarnessPredicate(TnFileInputHarness, options)
+      .addOption('buttonText', options.buttonText, (harness, text) =>
+        HarnessPredicate.stringMatches(harness.getButtonText(), text)
+      )
+      .addOption('testId', options.testId, async (harness, testId) =>
+        (await harness.getTestId()) === testId
+      );
+  }
+
+  /**
+   * Gets the trigger button's text.
+   *
+   * @returns Promise resolving to the button label.
+   *
+   * @example
+   * ```typescript
+   * expect(await fileInput.getButtonText()).toBe('Choose File');
+   * ```
+   */
+  async getButtonText(): Promise<string> {
+    return (await (await this._button()).text()).trim();
+  }
+
+  /**
+   * Gets the displayed file-name text (or the empty-state text).
+   *
+   * @returns Promise resolving to the text, or null when the name is hidden.
+   *
+   * @example
+   * ```typescript
+   * expect(await fileInput.getFileName()).toBe('No file chosen');
+   * ```
+   */
+  async getFileName(): Promise<string | null> {
+    const filename = await this._filename();
+    return filename ? (await filename.text()).trim() : null;
+  }
+
+  /**
+   * Whether a file is currently selected. A native file input reports an empty
+   * `value` until the user picks a file, so this reflects real user selection.
+   *
+   * @returns Promise resolving to true when a file has been chosen.
+   *
+   * @example
+   * ```typescript
+   * expect(await fileInput.hasFile()).toBe(false);
+   * ```
+   */
+  async hasFile(): Promise<boolean> {
+    const native = await this._native();
+    const value = (await native.getProperty<string>('value')) ?? '';
+    return value !== '';
+  }
+
+  /**
+   * Whether the control is disabled.
+   *
+   * @returns Promise resolving to true if the button is disabled.
+   *
+   * @example
+   * ```typescript
+   * expect(await fileInput.isDisabled()).toBe(true);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const button = await this._button();
+    return (await button.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Opens the native file dialog by clicking the trigger button. The browser
+   * does not let tests pick a real file, so this is mainly useful for asserting
+   * click handling and focus behaviour.
+   *
+   * @example
+   * ```typescript
+   * await fileInput.open();
+   * ```
+   */
+  async open(): Promise<void> {
+    await (await this._button()).click();
+  }
+
+  /**
+   * Gets the test-id attribute value from the container.
+   *
+   * @returns Promise resolving to the test-id, or null when unset.
+   *
+   * @example
+   * ```typescript
+   * expect(await fileInput.getTestId()).toBe('file-input-update');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const container = await this.locatorFor('.tn-file-input__container')();
+    return (await container.getAttribute('data-testid')) ?? (await container.getAttribute('data-test'));
+  }
+}
+
+/** A set of criteria for filtering a list of `TnFileInputHarness` instances. */
+export interface FileInputHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the trigger button's text. Supports string or regex matching. */
+  buttonText?: string | RegExp;
+  /** Filters by data-testid attribute. */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -19,6 +19,8 @@ export * from './lib/input/input.component';
 export * from './lib/input/input.harness';
 export * from './lib/input/input.directive';
 export * from './lib/input/size-conversion';
+export * from './lib/file-input/file-input.component';
+export * from './lib/file-input/file-input.harness';
 export * from './lib/chip/chip.component';
 export * from './lib/chip/chip.harness';
 export * from './lib/chip-input/chip-input.component';

--- a/projects/truenas-ui/src/stories/file-input.stories.ts
+++ b/projects/truenas-ui/src/stories/file-input.stories.ts
@@ -1,0 +1,96 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { TnFileInputComponent } from '../lib/file-input/file-input.component';
+import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+
+const meta: Meta<TnFileInputComponent> = {
+  title: 'Components/File Input',
+  component: TnFileInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, FormsModule, ReactiveFormsModule, TnFormFieldComponent],
+    }),
+  ],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A minimal file-selection form control: a styled "Choose File" button that opens the native file dialog and emits the picked `File`(s). Wrap it in `<tn-form-field>` for a label, required asterisk and help tooltip.',
+      },
+    },
+  },
+  argTypes: {
+    buttonLabel: { control: 'text', description: 'Label rendered inside the trigger button' },
+    accept: { control: 'text', description: 'Native accept attribute (extensions / MIME types)' },
+    multiple: { control: 'boolean', description: 'Allow selecting multiple files' },
+    disabled: { control: 'boolean', description: 'Whether the control is disabled' },
+    showFileName: { control: 'boolean', description: 'Show the selected file name(s) beside the button' },
+    noFileText: { control: 'text', description: 'Text shown when no file is selected' },
+    testId: { control: 'text', description: 'Test ID for automated testing' },
+    change: { action: 'change', description: 'Emitted when the selection changes' },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<TnFileInputComponent>;
+
+export const Default: Story = {
+  args: {
+    buttonLabel: 'Choose File',
+    multiple: false,
+    disabled: false,
+    showFileName: true,
+    noFileText: 'No file chosen',
+  },
+};
+
+export const InFormField: Story = {
+  name: 'In Form Field',
+  render: (args) => ({
+    props: args,
+    template: `
+      <tn-form-field label="Update File" [required]="true" tooltip="Upload a .tar update file">
+        <tn-file-input
+          [buttonLabel]="buttonLabel"
+          [accept]="accept"
+          [multiple]="multiple"
+          [disabled]="disabled"
+          [showFileName]="showFileName" />
+      </tn-form-field>
+    `,
+  }),
+  args: {
+    buttonLabel: 'Choose File',
+    accept: '.tar',
+    showFileName: true,
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    buttonLabel: 'Choose Files',
+    multiple: true,
+    showFileName: true,
+  },
+};
+
+export const AcceptImages: Story = {
+  name: 'Accept Images Only',
+  args: {
+    buttonLabel: 'Choose Image',
+    accept: 'image/*',
+    showFileName: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    buttonLabel: 'Choose File',
+    disabled: true,
+    showFileName: true,
+  },
+};

--- a/projects/truenas-ui/src/stories/file-input.stories.ts
+++ b/projects/truenas-ui/src/stories/file-input.stories.ts
@@ -29,8 +29,9 @@ const meta: Meta<TnFileInputComponent> = {
     disabled: { control: 'boolean', description: 'Whether the control is disabled' },
     showFileName: { control: 'boolean', description: 'Show the selected file name(s) beside the button' },
     noFileText: { control: 'text', description: 'Text shown when no file is selected' },
+    ariaLabel: { control: 'text', description: 'Accessible label forwarded to the trigger button' },
     testId: { control: 'text', description: 'Test ID for automated testing' },
-    change: { action: 'change', description: 'Emitted when the selection changes' },
+    selectionChange: { action: 'selectionChange', description: 'Emitted when the selection changes' },
   },
   tags: ['autodocs'],
 };
@@ -55,6 +56,7 @@ export const InFormField: Story = {
     template: `
       <tn-form-field label="Update File" [required]="true" tooltip="Upload a .tar update file">
         <tn-file-input
+          ariaLabel="Update File"
           [buttonLabel]="buttonLabel"
           [accept]="accept"
           [multiple]="multiple"


### PR DESCRIPTION
## Summary

Adds a new `tn-file-input` form control: a styled **"Choose File"** button that opens the native file dialog and exposes the picked `File`(s) both as a `(change)` output and as the value of an Angular form control (`File | File[] | null`).

This is distinct from the existing `tn-file-picker`, which browses the **server-side** TrueNAS filesystem — `tn-file-input` is for selecting **local files to upload**.

The label, required asterisk and help tooltip come from the existing `tn-form-field` wrapper, so this component stays minimal (just the button + optional selected-filename text).

## Usage

```html
<tn-form-field label="Update File" [required]="true" tooltip="Upload a .tar update file">
  <tn-file-input accept=".tar" formControlName="update" (change)="onFile($event)" />
</tn-form-field>
```

## API

- **Inputs:** `buttonLabel` (`'Choose File'`), `accept`, `multiple`, `disabled`, `showFileName`, `noFileText`, `testId`
- **Output:** `change` → `File | File[] | null`
- **Forms:** implements `ControlValueAccessor`; writing `null`/`''` clears it.

> Note: browsers forbid programmatically setting a file input's contents, so `writeValue` with a non-null value only updates the displayed name — actual `File` objects come from user selection. Documented in the component JSDoc.

## What's included

- Standalone component (`.ts`/`.html`/`.scss`) using theme tokens
- CDK test harness (`getButtonText`, `getFileName`, `hasFile`, `isDisabled`, `open`, `with({ testId, buttonText })`)
- Jest specs — 15 tests (DOM + harness), all passing
- Storybook stories — Default, In Form Field, Multiple, Accept Images, Disabled
- Exported component + harness in `public-api.ts`

## Verification

- `yarn test` — 15/15 passing
- `eslint` — clean
- `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)