### PR TITLE
NAS-141589 / 27.0.0-BETA.1 / feat(banner): add default slot for arbitrary projected content

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner.component.html
+++ b/projects/truenas-ui/src/lib/banner/banner.component.html
@@ -3,28 +3,36 @@
   [ngClass]="classes()"
   [attr.role]="ariaRole()"
 >
-  <div class="tn-banner__main">
-    <div class="tn-banner__icon">
-      <tn-icon
-        library="mdi"
-        size="md"
-        aria-hidden="true"
-        [name]="iconName()"
-      />
-    </div>
-
-    <div class="tn-banner__content">
-      <div class="tn-banner__heading">
-        {{ heading() }}
+  @if (hasStructuredContent()) {
+    <div class="tn-banner__main">
+      <div class="tn-banner__icon">
+        <tn-icon
+          library="mdi"
+          size="md"
+          aria-hidden="true"
+          [name]="iconName()"
+        />
       </div>
 
-      @if (message()) {
-        <div class="tn-banner__message">
-          {{ message() }}
-        </div>
-      }
+      <div class="tn-banner__content">
+        @if (heading()) {
+          <div class="tn-banner__heading">
+            {{ heading() }}
+          </div>
+        }
+
+        @if (message()) {
+          <div class="tn-banner__message">
+            {{ message() }}
+          </div>
+        }
+      </div>
     </div>
-  </div>
+  } @else {
+    <div class="tn-banner__main">
+      <ng-content />
+    </div>
+  }
 
   @if (hasAction()) {
     <div class="tn-banner__action">

--- a/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
@@ -24,13 +24,27 @@ class BannerWithActionTestComponent {}
 })
 class BannerWithoutActionTestComponent {}
 
+@Component({
+  standalone: true,
+  imports: [TnBannerComponent],
+  template: `
+    <tn-banner [heading]="heading" [message]="message">
+      <div class="projected-content">Projected Content</div>
+    </tn-banner>
+  `
+})
+class BannerWithProjectedContentTestComponent {
+  heading: string | undefined = undefined;
+  message: string | undefined = undefined;
+}
+
 describe('TnBannerComponent', () => {
   let component: TnBannerComponent;
   let fixture: ComponentFixture<TnBannerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TnBannerComponent, BannerWithActionTestComponent, BannerWithoutActionTestComponent],
+      imports: [TnBannerComponent, BannerWithActionTestComponent, BannerWithoutActionTestComponent, BannerWithProjectedContentTestComponent],
       providers: [provideHttpClient()]
     }).compileComponents();
 
@@ -218,6 +232,55 @@ describe('TnBannerComponent', () => {
       const actionButton = hostFixture.nativeElement.querySelector('[tnBannerAction]');
       expect(actionButton).toBeTruthy();
       expect(actionButton.textContent.trim()).toBe('Action Button');
+    });
+  });
+
+  describe('arbitrary content projection', () => {
+    it('should render projected content when neither heading nor message is provided', () => {
+      const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
+      hostFixture.detectChanges();
+
+      const projected = hostFixture.nativeElement.querySelector('.projected-content');
+      expect(projected).toBeTruthy();
+      expect(projected.textContent.trim()).toBe('Projected Content');
+
+      // Structured layout should not render
+      expect(hostFixture.nativeElement.querySelector('.tn-banner__content')).toBeNull();
+    });
+
+    it('should not display projected content when heading is provided', () => {
+      const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
+      hostFixture.componentInstance.heading = 'Real Heading';
+      hostFixture.detectChanges();
+
+      expect(hostFixture.nativeElement.querySelector('.projected-content')).toBeNull();
+
+      const heading = hostFixture.nativeElement.querySelector('.tn-banner__heading');
+      expect(heading.textContent.trim()).toBe('Real Heading');
+    });
+
+    it('should not display projected content when only message is provided', () => {
+      const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
+      hostFixture.componentInstance.message = 'Real Message';
+      hostFixture.detectChanges();
+
+      expect(hostFixture.nativeElement.querySelector('.projected-content')).toBeNull();
+
+      const message = hostFixture.nativeElement.querySelector('.tn-banner__message');
+      expect(message.textContent.trim()).toBe('Real Message');
+    });
+
+    it('should render the type icon alongside structured content but not in projection mode', () => {
+      const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
+      hostFixture.detectChanges();
+
+      // Projection mode: no icon
+      expect(hostFixture.nativeElement.querySelector('.tn-banner__icon')).toBeNull();
+
+      // Structured mode: icon present
+      hostFixture.componentInstance.heading = 'Heading';
+      hostFixture.detectChanges();
+      expect(hostFixture.nativeElement.querySelector('.tn-banner__icon')).toBeTruthy();
     });
   });
 });

--- a/projects/truenas-ui/src/lib/banner/banner.component.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.ts
@@ -51,8 +51,17 @@ export class TnBannerComponent {
   /** Signal indicating whether action content has been projected */
   protected hasAction = computed(() => this.actionContent().length > 0);
 
+  /**
+   * Signal indicating whether the built-in structured layout (icon + heading/message)
+   * should be rendered. When neither heading nor message is provided, the banner
+   * instead renders arbitrary projected content from the default slot.
+   */
+  protected hasStructuredContent = computed(
+    () => !!this.heading() || !!this.message()
+  );
+
   // Signal-based inputs (modern Angular 19+)
-  heading = input.required<string>();
+  heading = input<string | undefined>(undefined);
   message = input<string | undefined>(undefined);
   type = input<TnBannerType>('info');
   bordered = input<boolean>(false);

--- a/projects/truenas-ui/src/stories/banner.stories.ts
+++ b/projects/truenas-ui/src/stories/banner.stories.ts
@@ -28,7 +28,7 @@ const meta: Meta<TnBannerComponent> = {
   argTypes: {
     heading: {
       control: 'text',
-      description: 'Main heading text (required)',
+      description: 'Main heading text. Optional — when neither heading nor message is provided, the banner renders arbitrary projected content instead.',
     },
     message: {
       control: 'text',
@@ -212,6 +212,30 @@ export const MultipleBorderedTypes: Story = {
           [bordered]="true">
         </tn-banner>
       </div>
+    `,
+  }),
+};
+
+export const ProjectedContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'When neither `heading` nor `message` is provided, the banner renders arbitrary content from its default slot instead of the built-in icon/heading/message layout. Useful for fully custom banner contents.'
+      }
+    }
+  },
+  render: () => ({
+    moduleMetadata: {
+      imports: [TnBannerComponent],
+    },
+    template: `
+      <tn-banner type="warning">
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <strong>Custom layout:</strong>
+          <span>Mix any markup you like here — the default content is bypassed.</span>
+          <code style="padding: 2px 6px; background: var(--tn-alt-bg2, #2c2c2c); border-radius: 4px;">v2.0</code>
+        </div>
+      </tn-banner>
     `,
   }),
 };


### PR DESCRIPTION
Make heading optional and render arbitrary projected content from the default slot when neither heading nor message is provided. When either input is set, the built-in icon/heading/message layout takes precedence and projected content is ignored.

Use case:
<img width="510" height="500" alt="Screenshot 2026-06-29 at 11 02 52 AM" src="https://github.com/user-attachments/assets/8a941f01-3416-4a56-83f9-52ef00245dce" />
