### PR TITLE
NAS-141644 / 27.0.0-BETA.1 / fix(select): dismiss dropdown on any outside click

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -657,3 +657,102 @@ tn-dialog-shell {
   box-shadow: none;
   margin: 0;
 }
+
+/* ================================
+   CDK Overlay base styles
+   ================================
+   Mirrors @angular/cdk/overlay-prebuilt.css. These structural rules are
+   REQUIRED for any component built on the CDK connected-position overlay
+   (tn-select, tn-autocomplete, tn-tooltip, tn-file-picker, tn-date-input…).
+   Consuming apps that only import this themes.css would otherwise never load
+   them, with two visible symptoms:
+
+     1. pointer-events: none on the overlay container is INHERITED by the
+        connected-position bounding box (a flex column anchored to the trigger
+        that is typically far wider/taller than the visible panel). Without it
+        the bounding box keeps the default `auto` and silently eats clicks in
+        the empty area around the panel — so a no-backdrop dropdown like
+        tn-select can't be dismissed by clicking "outside" it (the click lands
+        on the bounding box, which is technically inside the overlay, so CDK's
+        outsidePointerEvents() never fires).
+     2. .cdk-overlay-pane { max-height: 100% } keeps panels constrained to the
+        viewport so their internal `overflow-y: auto` regions actually scroll.
+
+   Only .cdk-overlay-pane re-enables pointer-events: auto, so the panel itself
+   stays interactive while everything around it is click-through. */
+.cdk-overlay-container,
+.cdk-global-overlay-wrapper {
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.cdk-overlay-container {
+  position: fixed;
+  z-index: 1000;
+}
+
+.cdk-overlay-container:empty {
+  display: none;
+}
+
+.cdk-global-overlay-wrapper {
+  display: flex;
+  position: absolute;
+  z-index: 1000;
+}
+
+.cdk-overlay-pane {
+  position: absolute;
+  pointer-events: auto;
+  box-sizing: border-box;
+  display: flex;
+  max-width: 100%;
+  max-height: 100%;
+  z-index: 1000;
+}
+
+.cdk-overlay-connected-position-bounding-box {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  min-width: 1px;
+  min-height: 1px;
+  z-index: 1000;
+}
+
+.cdk-overlay-backdrop {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: auto;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  opacity: 0;
+  z-index: 1000;
+  transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.cdk-overlay-backdrop-showing {
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop {
+  transition: visibility 1ms linear, opacity 1ms linear;
+  visibility: hidden;
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing {
+  opacity: 0;
+  visibility: visible;
+}
+
+.cdk-global-scrollblock {
+  position: fixed;
+  width: 100%;
+  overflow-y: scroll;
+}

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -1,8 +1,8 @@
 
 import { Overlay, type OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, ElementRef, forwardRef, inject, input, output, signal, viewChild, ViewContainerRef } from '@angular/core';
-import type { OnDestroy, TemplateRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, forwardRef, inject, input, output, signal, viewChild, ViewContainerRef } from '@angular/core';
+import type { ElementRef, OnDestroy, TemplateRef } from '@angular/core';
 import type { ControlValueAccessor } from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { Subscription } from 'rxjs';
@@ -227,7 +227,6 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
   private onChange = (_value: T | T[] | null) => {};
   private onTouched = () => {};
 
-  private elementRef = inject(ElementRef);
   private cdr = inject(ChangeDetectorRef);
   private overlay = inject(Overlay);
   private viewContainerRef = inject(ViewContainerRef);
@@ -303,11 +302,19 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    *
    * Why an overlay (vs. an inline absolutely-positioned panel):
    *   - Escapes parent `overflow: hidden`/clipping in surrounding layouts.
-   *   - `outsidePointerEvents()` notifies on outside pointerdown WITHOUT
-   *     intercepting the click (no backdrop) — so the user's click reaches
-   *     the underlying target while the select closes silently.
    *   - Position is recomputed on scroll so the panel stays attached.
-   *   - Width is matched to the trigger so the panel doesn't jump in size.
+   *
+   * Dismissal uses a transparent, full-viewport backdrop (`backdropClick()`).
+   * We previously ran backdrop-less with `outsidePointerEvents()`, but that
+   * only closes when the click lands strictly OUTSIDE the overlay pane — and
+   * the pane was sized to the (often full-width) trigger while the panel itself
+   * is only as wide as its content. The empty pane area to the right of the
+   * options stayed `pointer-events: auto`, so clicks there never counted as
+   * "outside" and the dropdown wouldn't close. A transparent backdrop closes on
+   * ANY click outside the panel regardless of pane geometry — the standard
+   * pattern used by native `<select>` and Material's `mat-select`. We therefore
+   * also drop the explicit `width`: the pane sizes to the panel content so the
+   * clickable surface matches what the user sees.
    */
   private attachOverlay(): void {
     const trigger = this.triggerEl().nativeElement;
@@ -322,28 +329,20 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     this.overlayRef = this.overlay.create({
       positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
-      hasBackdrop: false,
-      width: trigger.offsetWidth,
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-transparent-backdrop',
     });
 
     const portal = new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef);
     this.overlayRef.attach(portal);
 
-    // Click-outside (non-intercepting). The pointer event still reaches the
-    // element the user clicked; we just notice and close.
-    //
-    // Important: ignore events whose target is inside the select host. A
-    // pointerdown on the trigger is "outside the overlay" from CDK's POV but
-    // it's our own toggle target — letting closeDropdown fire here races the
-    // trigger's click handler and the dropdown immediately reopens.
+    // Dismiss on any click outside the panel. The transparent backdrop spans
+    // the viewport and captures the click, so this fires no matter where the
+    // user clicks (including the empty area beside a narrow panel). Clicking
+    // the trigger while open also hits the backdrop — it closes here and the
+    // trigger's own click never fires, so there's no reopen race.
     this.overlaySubs.push(
-      this.overlayRef.outsidePointerEvents().subscribe((event: MouseEvent) => {
-        const target = event.target as Node | null;
-        if (target && this.elementRef.nativeElement.contains(target)) {
-          return;
-        }
-        this.closeDropdown(false);
-      }),
+      this.overlayRef.backdropClick().subscribe(() => this.closeDropdown(false)),
     );
 
     // Escape as a fallback (the trigger keydown handler covers the common case,

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -272,6 +272,23 @@ describe('TnSelectHarness', () => {
       // class for us to assert on — covered by CDK's own tests.
       expect(document.querySelector('.tn-select-dropdown')).not.toBeNull();
     });
+
+    it('should close when the backdrop (outside click) is clicked', async () => {
+      const select = await loader.getHarness(TnSelectHarness);
+      await select.open();
+      expect(await select.isOpen()).toBe(true);
+
+      // A click anywhere outside the panel lands on the transparent backdrop
+      // that CDK renders over the viewport. This is the dismiss path that was
+      // previously broken: the backdrop-less overlay only closed on clicks
+      // strictly outside the (oversized) pane, so clicks in the empty area
+      // beside a narrow panel never dismissed it.
+      const backdrop = document.querySelector<HTMLElement>('.cdk-overlay-backdrop');
+      expect(backdrop).not.toBeNull();
+      backdrop!.click();
+
+      expect(await select.isOpen()).toBe(false);
+    });
   });
 
   describe('selectOption', () => {

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -657,3 +657,102 @@ tn-dialog-shell {
   box-shadow: none;
   margin: 0;
 }
+
+/* ================================
+   CDK Overlay base styles
+   ================================
+   Mirrors @angular/cdk/overlay-prebuilt.css. These structural rules are
+   REQUIRED for any component built on the CDK connected-position overlay
+   (tn-select, tn-autocomplete, tn-tooltip, tn-file-picker, tn-date-input…).
+   Consuming apps that only import this themes.css would otherwise never load
+   them, with two visible symptoms:
+
+     1. pointer-events: none on the overlay container is INHERITED by the
+        connected-position bounding box (a flex column anchored to the trigger
+        that is typically far wider/taller than the visible panel). Without it
+        the bounding box keeps the default `auto` and silently eats clicks in
+        the empty area around the panel — so a no-backdrop dropdown like
+        tn-select can't be dismissed by clicking "outside" it (the click lands
+        on the bounding box, which is technically inside the overlay, so CDK's
+        outsidePointerEvents() never fires).
+     2. .cdk-overlay-pane { max-height: 100% } keeps panels constrained to the
+        viewport so their internal `overflow-y: auto` regions actually scroll.
+
+   Only .cdk-overlay-pane re-enables pointer-events: auto, so the panel itself
+   stays interactive while everything around it is click-through. */
+.cdk-overlay-container,
+.cdk-global-overlay-wrapper {
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.cdk-overlay-container {
+  position: fixed;
+  z-index: 1000;
+}
+
+.cdk-overlay-container:empty {
+  display: none;
+}
+
+.cdk-global-overlay-wrapper {
+  display: flex;
+  position: absolute;
+  z-index: 1000;
+}
+
+.cdk-overlay-pane {
+  position: absolute;
+  pointer-events: auto;
+  box-sizing: border-box;
+  display: flex;
+  max-width: 100%;
+  max-height: 100%;
+  z-index: 1000;
+}
+
+.cdk-overlay-connected-position-bounding-box {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  min-width: 1px;
+  min-height: 1px;
+  z-index: 1000;
+}
+
+.cdk-overlay-backdrop {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: auto;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  opacity: 0;
+  z-index: 1000;
+  transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.cdk-overlay-backdrop-showing {
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop {
+  transition: visibility 1ms linear, opacity 1ms linear;
+  visibility: hidden;
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing {
+  opacity: 0;
+  visibility: visible;
+}
+
+.cdk-global-scrollblock {
+  position: fixed;
+  width: 100%;
+  overflow-y: scroll;
+}


### PR DESCRIPTION



https://github.com/user-attachments/assets/ad5127fb-7345-4364-9c30-3a6922695d5c

The dropdown could not be closed by clicking the empty area beside a narrow panel under a wide trigger. The CDK overlay ran without a backdrop and relied on outsidePointerEvents(), but the pane was sized to the full-width trigger while the panel itself is only content-wide. The empty pane band to the right of the options kept pointer-events: auto, so clicks there counted as inside the overlay and never triggered dismissal.

Switch to the standard select dismissal model (native <select> / mat-select): a transparent, full-viewport backdrop that closes on any outside click regardless of pane geometry. Drop the explicit overlay width so the pane sizes to the panel content, matching the clickable surface to what the user sees, and remove the now-unnecessary trigger-vs-host outside-click guard.

Also embed the CDK overlay base styles (mirroring
@angular/cdk/overlay-prebuilt.css) into the shipped themes.css. They were never imported, so consuming apps lost the overlay container's pointer-events scoping and the pane's max-height: 100% — the latter is why the dropdown's internal scroll didn't engage in NAS.

Add a regression test that opens the dropdown and dismisses it via a backdrop click.





