### PR TITLE
NAS-141630 / 27.0.0-BETA.1 / fix(banner): partial matching on `HarnessPredicate`

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
@@ -123,4 +123,14 @@ describe('TnBannerHarness', () => {
     );
     expect(banner).toBeTruthy();
   });
+
+  it('should partial match on  strings containing special characters', async () => {
+    hostComponent.message.set('Look! I\'m calling a function: fxn()');
+    fixture.detectChanges();
+
+    const banner = await loader.getHarness(
+      TnBannerHarness.with({ textContains: 'fxn()' })
+    );
+    expect(banner).toBeTruthy();
+  });
 });

--- a/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
@@ -113,4 +113,14 @@ describe('TnBannerHarness', () => {
       TnBannerHarness.with({ textContains: 'NonExistentText12345' })
     )).toBe(false);
   });
+
+  it('should partial match with strings', async () => {
+    hostComponent.message.set('Error: timeout occurred');
+    fixture.detectChanges();
+
+    const banner = await loader.getHarness(
+      TnBannerHarness.with({ textContains: 'Error:' })
+    );
+    expect(banner).toBeTruthy();
+  });
 });

--- a/projects/truenas-ui/src/lib/banner/banner.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.ts
@@ -55,7 +55,7 @@ export class TnBannerHarness extends ComponentHarness {
           // strings trigger exact matching in `stringMatches`, but since we call the option
           // `textContains`, this would be misleading. here, we convert strings to a Regex
           // to trigger partial matching behavior on `stringMatches`.
-          typeof text === 'string' ? new RegExp(RegExp.escape(text)) : text
+          typeof text === 'string' ? new RegExp(helperEscapeRegex(text)) : text
         )
       );
   }
@@ -84,4 +84,14 @@ export class TnBannerHarness extends ComponentHarness {
 export interface BannerHarnessFilters extends BaseHarnessFilters {
   /** Filters by text content within banner. Supports string or regex matching. */
   textContains?: string | RegExp;
+}
+
+/**
+ * helper function to stand-in for `RegExp.escape`, since that doesn't
+ * exist in our deployment target of ES2023.
+ * @param text a string to escape.
+ * @returns an escaped string, safe for using in the `RegExp` constructor.
+ */
+function helperEscapeRegex(text: string): string {
+  return text.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }

--- a/projects/truenas-ui/src/lib/banner/banner.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.ts
@@ -50,7 +50,13 @@ export class TnBannerHarness extends ComponentHarness {
   static with(options: BannerHarnessFilters = {}) {
     return new HarnessPredicate(TnBannerHarness, options)
       .addOption('textContains', options.textContains, (harness, text) =>
-        HarnessPredicate.stringMatches(harness.getText(), text)
+        HarnessPredicate.stringMatches(
+          harness.getText(),
+          // strings trigger exact matching in `stringMatches`, but since we call the option
+          // `textContains`, this would be misleading. here, we convert strings to a Regex
+          // to trigger partial matching behavior on `stringMatches`.
+          typeof text === 'string' ? new RegExp(text) : text
+        )
       );
   }
 

--- a/projects/truenas-ui/src/lib/banner/banner.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.ts
@@ -55,7 +55,7 @@ export class TnBannerHarness extends ComponentHarness {
           // strings trigger exact matching in `stringMatches`, but since we call the option
           // `textContains`, this would be misleading. here, we convert strings to a Regex
           // to trigger partial matching behavior on `stringMatches`.
-          typeof text === 'string' ? new RegExp(text) : text
+          typeof text === 'string' ? new RegExp(RegExp.escape(text)) : text
         )
       );
   }


### PR DESCRIPTION
the `HarnessPredicate`'s option `textContains` did not perform partial matching if given a string, and would instead perform exact matching. this patch updates the behavior to perform partial matching by converting strings to case-sensitive regexes and adds a unit test for the changed behavior.