### PR TITLE
NAS-141660 / 27.0.0-BETA.1 / fix(expansion-panel): zero content padding when collapsed so no content shows through

### DIFF
--- a/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
+++ b/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
@@ -177,8 +177,8 @@
 }
 
 // CSS-only collapse (no Angular animations dependency): the content row animates
-// between 0fr and 1fr. The inner wrapper carries the padding and clips overflow,
-// so a collapsed panel has zero height with no residual padding.
+// between 0fr and 1fr. The inner wrapper clips overflow so content is hidden as
+// the row shrinks.
 .tn-expansion-panel__content {
   display: grid;
   grid-template-rows: 1fr;
@@ -186,12 +186,21 @@
 
   &--collapsed {
     grid-template-rows: 0fr;
+
+    // A 0fr track can't shrink below the item's minimum contribution, which
+    // includes the item's own padding even with min-height: 0 — leaving the
+    // collapsed row padding-bottom tall, with the first line of content
+    // showing through. Zero it so the row truly reaches 0.
+    .tn-expansion-panel__content-inner {
+      padding-bottom: 0;
+    }
   }
 }
 
 .tn-expansion-panel__content-inner {
   min-height: 0;
   overflow: hidden;
+  transition: padding-bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 // Honor reduced-motion now that the collapse is CSS-driven: snap open/closed and
@@ -203,7 +212,8 @@
   .tn-expansion-panel__title,
   .tn-expansion-panel__indicator,
   .tn-expansion-panel__indicator svg,
-  .tn-expansion-panel__content {
+  .tn-expansion-panel__content,
+  .tn-expansion-panel__content-inner {
     transition: none;
   }
 }


### PR DESCRIPTION
## Problem

A collapsed `tn-expansion-panel` still shows the first line of its projected content below the header (spotted on webui's Boot Pool Status page, where \"Status: SCANNING\" leaks under the collapsed SCRUB panel).

## Root cause

The collapse uses the grid `0fr` trick, but the `--padding-*` variants put padding directly on `.tn-expansion-panel__content-inner` — the grid item. A `0fr` track cannot shrink below the item's **minimum contribution**, which includes the item's own padding even with `min-height: 0`. The collapsed row therefore stays `padding-bottom` (24px for medium) tall, and since `overflow: hidden` clips at the padding edge, one line of content remains visible. Measured live: collapsed content grid was 24px, not 0.

## Fix

Zero `padding-bottom` on the inner wrapper while collapsed (source order beats the `--padding-*` rules at equal specificity), and transition it with the same curve/duration as the row so the animation stays smooth. Also added the inner wrapper to the `prefers-reduced-motion` block.

Verified in webui by injecting the same rule into the live page: collapsed content height goes 24px → 0.