### PR TITLE
NAS-141659 / 27.0.0-BETA.1 / feat(select): add showSelectAll row for multi-select

### DIFF
--- a/projects/truenas-ui/src/lib/select/select.component.html
+++ b/projects/truenas-ui/src/lib/select/select.component.html
@@ -60,7 +60,6 @@
           [class.selected]="allSelected()"
           [class.focused]="isSelectAllFocused()"
           [attr.aria-selected]="allSelected()"
-          [attr.aria-checked]="selectAllIndeterminate() ? 'mixed' : allSelected()"
           (mousedown)="$event.preventDefault()"
           (click)="toggleSelectAll()">
           <tn-checkbox

--- a/projects/truenas-ui/src/lib/select/select.component.html
+++ b/projects/truenas-ui/src/lib/select/select.component.html
@@ -46,6 +46,34 @@
 
     <!-- Options List -->
     <div class="tn-select-options">
+      <!-- Select-all row (multiple mode with showSelectAll). Toggles every
+           selectable option; its checkbox reflects all/some/none. -->
+      @if (showSelectAllRow()) {
+        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+        <div
+          class="tn-select-option tn-select-select-all"
+          role="option"
+          tabindex="-1"
+          tnTestIdType="option"
+          [tnTestId]="selectAllTestIdParts()"
+          [attr.id]="selectAllId()"
+          [class.selected]="allSelected()"
+          [class.focused]="isSelectAllFocused()"
+          [attr.aria-selected]="allSelected()"
+          (mousedown)="$event.preventDefault()"
+          (click)="toggleSelectAll()">
+          <tn-checkbox
+            class="tn-select-check"
+            label=""
+            [checked]="allSelected()"
+            [indeterminate]="selectAllIndeterminate()"
+            [disabled]="true"
+            [hideLabel]="true" />
+          {{ selectAllLabel() }}
+        </div>
+        <div class="tn-select-separator" role="separator"></div>
+      }
+
       <!-- Regular Options (preceded by the synthetic empty option when allowEmpty is set) -->
       @for (option of displayOptions(); track $index) {
         <!-- Option activation lives on the trigger via aria-activedescendant; options have tabindex="-1" and never receive DOM focus. -->

--- a/projects/truenas-ui/src/lib/select/select.component.html
+++ b/projects/truenas-ui/src/lib/select/select.component.html
@@ -60,6 +60,7 @@
           [class.selected]="allSelected()"
           [class.focused]="isSelectAllFocused()"
           [attr.aria-selected]="allSelected()"
+          [attr.aria-checked]="selectAllIndeterminate() ? 'mixed' : allSelected()"
           (mousedown)="$event.preventDefault()"
           (click)="toggleSelectAll()">
           <tn-checkbox

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -166,6 +166,12 @@
   }
 }
 
+// Select-all row — a regular option row, but weighted so it reads as the
+// aggregate toggle rather than one of the choices below it.
+.tn-select-select-all {
+  font-weight: 600;
+}
+
 .tn-select-check {
   margin-right: 0.5rem;
   flex-shrink: 0;

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -21,6 +21,15 @@ export interface TnSelectOptionGroup<T = unknown> {
   disabled?: boolean;
 }
 
+/**
+ * A keyboard-navigable row in the open dropdown. Either the synthetic
+ * "select all" action (multiple mode with `showSelectAll`) or a real option.
+ * Both carry the stable DOM `id` used for `aria-activedescendant`.
+ */
+type TnSelectNavEntry<T> =
+  | { kind: 'select-all'; id: string }
+  | { kind: 'option'; option: TnSelectOption<T>; id: string };
+
 @Component({
   selector: 'tn-select',
   standalone: true,
@@ -65,6 +74,16 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
   /** Label of the empty option rendered when `allowEmpty` is set. */
   emptyLabel = input<string>('--');
   disabled = input<boolean>(false);
+  /**
+   * When `true` (multiple mode only), renders a "select all" row at the top of
+   * the dropdown that toggles every selectable (non-disabled) option on/off in
+   * one click. Mirrors webui ix-select's `[showSelectAll]`. Ignored in single
+   * mode. Its checkbox reflects the aggregate state: checked when all are
+   * selected, indeterminate when only some are.
+   */
+  showSelectAll = input<boolean>(false);
+  /** Label of the select-all row rendered when `showSelectAll` is set. */
+  selectAllLabel = input<string>('Select All');
   testId = input<TnTestIdValue>(undefined);
   /** Test-id base, falling back to the bound control name when `testId` is unset. */
   protected resolvedTestId = controlTestId(this.testId);
@@ -159,20 +178,25 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * then groups). Used by keyboard navigation so we can skip disabled
    * entries and group headers without a separate filter pass.
    */
-  navigableOptions = computed(() => {
-    const result: { option: TnSelectOption<T>; id: string }[] = [];
+  navigableOptions = computed<TnSelectNavEntry<T>[]>(() => {
+    const result: TnSelectNavEntry<T>[] = [];
+    // The select-all row is the first navigable entry when shown, so
+    // ArrowDown from the closed trigger lands on it before the options.
+    if (this.showSelectAllRow()) {
+      result.push({ kind: 'select-all', id: this.selectAllId() });
+    }
     const baseId = `tn-select-opt-${this.idNamespace()}`;
     let i = 0;
     for (const opt of this.displayOptions()) {
       if (!opt.disabled) {
-        result.push({ option: opt, id: `${baseId}-${i}` });
+        result.push({ kind: 'option', option: opt, id: `${baseId}-${i}` });
       }
       i++;
     }
     for (const group of this.optionGroups()) {
       for (const opt of group.options) {
         if (!opt.disabled && !group.disabled) {
-          result.push({ option: opt, id: `${baseId}-${i}` });
+          result.push({ kind: 'option', option: opt, id: `${baseId}-${i}` });
         }
         i++;
       }
@@ -189,7 +213,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
 
   /** Stable DOM id for an option; matches what navigableOptions() assigns. */
   optionId(option: TnSelectOption<T>): string | null {
-    const entry = this.navigableOptions().find((x) => x.option === option);
+    const entry = this.navigableOptions().find((x) => x.kind === 'option' && x.option === option);
     return entry?.id ?? null;
   }
 
@@ -197,7 +221,8 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
   isOptionFocused(option: TnSelectOption<T>): boolean {
     const idx = this.focusedIndex();
     const nav = this.navigableOptions();
-    return idx >= 0 && idx < nav.length && nav[idx].option === option;
+    const entry = idx >= 0 && idx < nav.length ? nav[idx] : null;
+    return entry?.kind === 'option' && entry.option === option;
   }
 
   /**
@@ -286,7 +311,7 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     const selected = this.selectedValue();
     if (selected !== null && selected !== undefined) {
       const idx = this.navigableOptions().findIndex((x) =>
-        this.compareValues(x.option.value, selected),
+        x.kind === 'option' && this.compareValues(x.option.value, selected),
       );
       this.focusedIndex.set(idx);
     } else if (this.emptyOption()) {
@@ -479,6 +504,75 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     return this.options().length > 0 || this.optionGroups().length > 0;
   });
 
+  /**
+   * Values of every selectable (non-disabled) option, across ungrouped options
+   * and enabled groups. This is the set the select-all row operates on —
+   * disabled options and options in disabled groups are excluded because they
+   * can't be toggled individually either.
+   */
+  protected selectableValues = computed<T[]>(() => {
+    const values: T[] = [];
+    for (const opt of this.options()) {
+      if (!opt.disabled) {values.push(opt.value);}
+    }
+    for (const group of this.optionGroups()) {
+      if (group.disabled) {continue;}
+      for (const opt of group.options) {
+        if (!opt.disabled) {values.push(opt.value);}
+      }
+    }
+    return values;
+  });
+
+  /** Whether the select-all row is shown (multiple mode, opted in, with options). */
+  protected showSelectAllRow = computed(() =>
+    this.multiple() && this.showSelectAll() && this.selectableValues().length > 0,
+  );
+
+  /** Stable DOM id of the select-all row, for aria-activedescendant. */
+  protected selectAllId = computed(() => `tn-select-selectall-${this.idNamespace()}`);
+
+  /** True when every selectable option is currently selected. */
+  protected allSelected = computed<boolean>(() => {
+    const selectable = this.selectableValues();
+    if (selectable.length === 0) {return false;}
+    const selected = this.selectedValues();
+    return selectable.every((v) => selected.some((s) => this.compareValues(s, v)));
+  });
+
+  /** True when some — but not all — selectable options are selected. */
+  protected selectAllIndeterminate = computed<boolean>(() => {
+    if (this.allSelected()) {return false;}
+    const selected = this.selectedValues();
+    return this.selectableValues().some((v) => selected.some((s) => this.compareValues(s, v)));
+  });
+
+  /** Test-id segments for the select-all row; mirrors ix-select's `[name, 'select-all']`. */
+  protected selectAllTestIdParts(): (string | number | null | undefined)[] {
+    return scopeTestId(this.resolvedTestId(), 'select-all');
+  }
+
+  /**
+   * Toggles every selectable option: clears them all when they're all already
+   * selected, otherwise selects them all. Preserves the multi-select "open"
+   * behaviour — the dropdown stays open so the user can keep adjusting.
+   */
+  protected toggleSelectAll(): void {
+    if (this.isDisabled()) {return;}
+    const updated = this.allSelected() ? [] : [...this.selectableValues()];
+    this.selectedValues.set(updated);
+    this.onChange(updated);
+    this.multiSelectionChange.emit(updated);
+    this.cdr.markForCheck();
+  }
+
+  /** Whether the select-all row is the keyboard-highlighted item. */
+  protected isSelectAllFocused(): boolean {
+    const idx = this.focusedIndex();
+    const nav = this.navigableOptions();
+    return idx >= 0 && idx < nav.length && nav[idx].kind === 'select-all';
+  }
+
   /** One-shot guard so the object-compare warning fires at most once per instance. */
   private warnedAboutObjectCompare = false;
 
@@ -619,7 +713,12 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     const idx = this.focusedIndex();
     const nav = this.navigableOptions();
     if (idx < 0 || idx >= nav.length) {return;}
-    this.onOptionClick(nav[idx].option);
+    const entry = nav[idx];
+    if (entry.kind === 'select-all') {
+      this.toggleSelectAll();
+    } else {
+      this.onOptionClick(entry.option);
+    }
   }
 
   private scrollFocusedIntoView(): void {

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -556,10 +556,18 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * Toggles every selectable option: clears them all when they're all already
    * selected, otherwise selects them all. Preserves the multi-select "open"
    * behaviour — the dropdown stays open so the user can keep adjusting.
+   *
+   * Disabled-but-selected values (e.g. a disabled option pre-selected via
+   * `writeValue`) are preserved on both paths: the user can't toggle those
+   * rows individually, so select-all must not silently discard them either.
    */
   protected toggleSelectAll(): void {
     if (this.isDisabled()) {return;}
-    const updated = this.allSelected() ? [] : [...this.selectableValues()];
+    const selectable = this.selectableValues();
+    const preserved = this.selectedValues().filter(
+      (v) => !selectable.some((s) => this.compareValues(s, v)),
+    );
+    const updated = this.allSelected() ? preserved : [...preserved, ...selectable];
     this.selectedValues.set(updated);
     this.onChange(updated);
     this.multiSelectionChange.emit(updated);

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -509,16 +509,23 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    * and enabled groups. This is the set the select-all row operates on —
    * disabled options and options in disabled groups are excluded because they
    * can't be toggled individually either.
+   *
+   * Values are deduped with `compareValues` so a value that appears both
+   * ungrouped and inside a group isn't pushed twice — that would make
+   * select-all diverge from `toggleOption()`, which never produces duplicates.
    */
   protected selectableValues = computed<T[]>(() => {
     const values: T[] = [];
+    const push = (value: T): void => {
+      if (!values.some((v) => this.compareValues(v, value))) {values.push(value);}
+    };
     for (const opt of this.options()) {
-      if (!opt.disabled) {values.push(opt.value);}
+      if (!opt.disabled) {push(opt.value);}
     }
     for (const group of this.optionGroups()) {
       if (group.disabled) {continue;}
       for (const opt of group.options) {
-        if (!opt.disabled) {values.push(opt.value);}
+        if (!opt.disabled) {push(opt.value);}
       }
     }
     return values;

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -174,6 +174,40 @@ class TestGroupDisabledHostComponent {
 }
 
 @Component({
+  selector: 'tn-test-select-all-dup-host',
+  standalone: true,
+  imports: [TnSelectComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      placeholder="Select fruits"
+      [options]="options()"
+      [optionGroups]="groups()"
+      [multiple]="true"
+      [showSelectAll]="true"
+      [formControl]="control" />
+  `
+})
+class TestSelectAllDuplicateHostComponent {
+  // 'apple' appears both ungrouped and inside a group — select-all must not
+  // add it twice.
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+  ]);
+  groups = signal<TnSelectOptionGroup<string>[]>([
+    {
+      label: 'More',
+      options: [
+        { value: 'apple', label: 'Apple (again)' },
+        { value: 'cherry', label: 'Cherry' },
+      ]
+    },
+  ]);
+  control = new FormControl<string[]>([]);
+}
+
+@Component({
   selector: 'tn-test-multi-output-host',
   standalone: true,
   imports: [TnSelectComponent],
@@ -596,6 +630,31 @@ describe('TnSelectHarness - select all with pre-selected disabled option', () =>
     await select.toggleSelectAll();
     expect(hostComponent.control.value).toEqual(['cherry']);
     expect(await select.isSelectAllChecked()).toBe(false);
+  });
+});
+
+describe('TnSelectHarness - select all with duplicate value across group', () => {
+  let fixture: ComponentFixture<TestSelectAllDuplicateHostComponent>;
+  let hostComponent: TestSelectAllDuplicateHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestSelectAllDuplicateHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestSelectAllDuplicateHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should not add a value twice when it appears ungrouped and in a group', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.toggleSelectAll();
+    // 'apple' is present in both the ungrouped options and the group, but the
+    // selection must contain it exactly once — matching toggleOption's behaviour.
+    expect(hostComponent.control.value).toEqual(['apple', 'banana', 'cherry']);
+    expect(await select.isSelectAllChecked()).toBe(true);
   });
 });
 

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -89,6 +89,30 @@ class TestSelectAllHostComponent {
 }
 
 @Component({
+  selector: 'tn-test-select-all-preselected-host',
+  standalone: true,
+  imports: [TnSelectComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      placeholder="Select fruits"
+      [options]="options()"
+      [multiple]="true"
+      [showSelectAll]="true"
+      [formControl]="control" />
+  `
+})
+class TestSelectAllPreselectedHostComponent {
+  // Cherry is disabled but pre-selected — select-all must not discard it.
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry', disabled: true },
+  ]);
+  control = new FormControl<string[]>(['cherry']);
+}
+
+@Component({
   selector: 'tn-test-compare-host',
   standalone: true,
   imports: [TnSelectComponent],
@@ -539,6 +563,39 @@ describe('TnSelectHarness - select all', () => {
     const plainLoader = TestbedHarnessEnvironment.loader(plain);
     const select = await plainLoader.getHarness(TnSelectHarness);
     await expect(select.toggleSelectAll()).rejects.toThrow('no select-all row');
+  });
+});
+
+describe('TnSelectHarness - select all with pre-selected disabled option', () => {
+  let fixture: ComponentFixture<TestSelectAllPreselectedHostComponent>;
+  let hostComponent: TestSelectAllPreselectedHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestSelectAllPreselectedHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestSelectAllPreselectedHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should keep the disabled selection when selecting all', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.toggleSelectAll();
+    // Cherry (disabled, pre-selected) survives alongside the newly selected enabled options.
+    expect(hostComponent.control.value).toEqual(['cherry', 'apple', 'banana']);
+    expect(await select.isSelectAllChecked()).toBe(true);
+  });
+
+  it('should keep the disabled selection when clearing all', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    // First select-all, then toggle again to clear — the disabled value must remain.
+    await select.toggleSelectAll();
+    await select.toggleSelectAll();
+    expect(hostComponent.control.value).toEqual(['cherry']);
+    expect(await select.isSelectAllChecked()).toBe(false);
   });
 });
 

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -64,6 +64,31 @@ class TestMultiHostComponent {
 }
 
 @Component({
+  selector: 'tn-test-select-all-host',
+  standalone: true,
+  imports: [TnSelectComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      testId="fruit"
+      placeholder="Select fruits"
+      [options]="options()"
+      [multiple]="true"
+      [showSelectAll]="true"
+      (multiSelectionChange)="lastArray = $event" />
+  `
+})
+class TestSelectAllHostComponent {
+  // Cherry is disabled — select-all must skip it.
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry', disabled: true },
+  ]);
+  lastArray: string[] = [];
+}
+
+@Component({
   selector: 'tn-test-compare-host',
   standalone: true,
   imports: [TnSelectComponent],
@@ -444,6 +469,76 @@ describe('TnSelectHarness - multiple mode', () => {
   it('should ignore allowEmpty in multiple mode', async () => {
     const select = await loader.getHarness(TnSelectHarness);
     expect(await select.getOptions()).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+});
+
+describe('TnSelectHarness - select all', () => {
+  let fixture: ComponentFixture<TestSelectAllHostComponent>;
+  let hostComponent: TestSelectAllHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestSelectAllHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestSelectAllHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should not list the select-all row among the options', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    expect(await select.getOptions()).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  it('should select every enabled option, skipping disabled ones', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.toggleSelectAll();
+    // Cherry is disabled, so it stays out of the selection.
+    expect(hostComponent.lastArray).toEqual(['apple', 'banana']);
+    expect(await select.getDisplayText()).toBe('Apple, Banana');
+    expect(await select.isSelectAllChecked()).toBe(true);
+  });
+
+  it('should clear the selection when toggled while all selected', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.toggleSelectAll();
+    await select.toggleSelectAll();
+    expect(hostComponent.lastArray).toEqual([]);
+    expect(await select.getDisplayText()).toBe('Select fruits');
+    expect(await select.isSelectAllChecked()).toBe(false);
+  });
+
+  it('should read as unchecked when only some options are selected', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.selectOption('Apple');
+    // Partial selection: the row is neither fully checked nor cleared.
+    expect(await select.isSelectAllChecked()).toBe(false);
+    const indeterminate = document.querySelector(
+      '.tn-select-select-all .tn-checkbox--indeterminate',
+    );
+    expect(indeterminate).not.toBeNull();
+  });
+
+  it('should keep the dropdown open after toggling', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.toggleSelectAll();
+    expect(await select.isOpen()).toBe(true);
+  });
+
+  it('should carry a scoped test id on the select-all row', async () => {
+    const select = await loader.getHarness(TnSelectHarness);
+    await select.open();
+    const row = document.querySelector('.tn-select-select-all');
+    expect(row?.getAttribute('data-testid')).toBe('option-fruit-select-all');
+  });
+
+  it('should throw from toggleSelectAll when the row is absent', async () => {
+    const plain = TestBed.createComponent(TestMultiHostComponent);
+    const plainLoader = TestbedHarnessEnvironment.loader(plain);
+    const select = await plainLoader.getHarness(TnSelectHarness);
+    await expect(select.toggleSelectAll()).rejects.toThrow('no select-all row');
   });
 });
 

--- a/projects/truenas-ui/src/lib/select/select.harness.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.ts
@@ -167,7 +167,10 @@ export class TnSelectHarness extends ComponentHarness {
     await this.open();
     // Dropdown panel is rendered in a CDK overlay (outside the host element),
     // so we search the document root rather than the harness-local subtree.
-    const options = await this.documentRootLocatorFactory().locatorForAll('.tn-select-option')();
+    // Exclude the select-all row (`.tn-select-select-all`) — it's a bulk
+    // action, not a choice; use `toggleSelectAll()` for it.
+    const options = await this.documentRootLocatorFactory()
+      .locatorForAll('.tn-select-option:not(.tn-select-select-all)')();
 
     for (const option of options) {
       const text = (await option.text()).trim();
@@ -232,7 +235,9 @@ export class TnSelectHarness extends ComponentHarness {
     await this.open();
     // Dropdown panel is rendered in a CDK overlay (outside the host element),
     // so we search the document root rather than the harness-local subtree.
-    const options = await this.documentRootLocatorFactory().locatorForAll('.tn-select-option')();
+    // The select-all row is excluded — it's a bulk action, not an option.
+    const options = await this.documentRootLocatorFactory()
+      .locatorForAll('.tn-select-option:not(.tn-select-select-all)')();
     const labels: string[] = [];
 
     for (const option of options) {
@@ -240,6 +245,48 @@ export class TnSelectHarness extends ComponentHarness {
     }
 
     return labels;
+  }
+
+  /**
+   * Toggles the select-all row (multiple mode with `showSelectAll`). Opens the
+   * dropdown if needed. Throws when the select-all row isn't present.
+   *
+   * @returns Promise that resolves once the row has been clicked.
+   *
+   * @example
+   * ```typescript
+   * const select = await loader.getHarness(TnSelectHarness);
+   * await select.toggleSelectAll(); // selects every option
+   * await select.toggleSelectAll(); // clears them again
+   * ```
+   */
+  async toggleSelectAll(): Promise<void> {
+    await this.open();
+    // Rendered in the CDK overlay, outside the host subtree.
+    const row = await this.documentRootLocatorFactory()
+      .locatorForOptional('.tn-select-select-all')();
+    if (!row) {
+      await this.close();
+      throw new Error('Select has no select-all row — set `multiple` and `showSelectAll`.');
+    }
+    await row.click();
+  }
+
+  /**
+   * Whether the select-all checkbox reads as fully checked (all options
+   * selected). Opens the dropdown if needed. Throws when the row isn't present.
+   *
+   * @returns Promise resolving to true when every option is selected.
+   */
+  async isSelectAllChecked(): Promise<boolean> {
+    await this.open();
+    const row = await this.documentRootLocatorFactory()
+      .locatorForOptional('.tn-select-select-all')();
+    if (!row) {
+      await this.close();
+      throw new Error('Select has no select-all row — set `multiple` and `showSelectAll`.');
+    }
+    return row.hasClass('selected');
   }
 }
 

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -46,6 +46,10 @@ const meta: Meta<TnSelectComponent> = {
       control: 'text',
       description: 'Label of the empty option shown when allowEmpty is set',
     },
+    showSelectAll: {
+      control: 'boolean',
+      description: 'Adds a select-all row that toggles every option (multiple mode only)',
+    },
     testId: {
       control: 'text',
       description: 'Test ID for the select component',
@@ -216,6 +220,41 @@ export const MultipleSelection: Story = {
           placeholder="Choose fruits"
           [options]="options"
           [multiple]="true"
+          (multiSelectionChange)="logSelection($event)">
+        </tn-select>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  args: {
+    options: fruitOptions,
+  },
+};
+
+/**
+ * `showSelectAll` adds a "Select All" row at the top of the dropdown (multiple
+ * mode only). Clicking it selects every enabled option; clicking it again when
+ * all are selected clears them. Its checkbox is indeterminate while only some
+ * options are picked. Mirrors the old ix-select `[showSelectAll]`.
+ */
+export const MultipleWithSelectAll: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      logSelection: (_value: unknown) => {
+      }
+    },
+    template: `
+      <tn-form-field
+        label="Select fruits"
+        hint="Use the Select All row to toggle everything at once">
+        <tn-select
+          placeholder="Choose fruits"
+          [options]="options"
+          [multiple]="true"
+          [showSelectAll]="true"
           (multiSelectionChange)="logSelection($event)">
         </tn-select>
       </tn-form-field>


### PR DESCRIPTION
Restores parity with the old ix-select [showSelectAll]. When multiple mode is enabled and showSelectAll is set, a "Select All" row is rendered at the top of the dropdown that toggles every enabled option in one click.

- Tri-state checkbox: checked when all selected, indeterminate when only some are, empty otherwise (tn-checkbox already supports indeterminate).
- Integrated into keyboard navigation via aria-activedescendant so the row is reachable with Arrow keys and activated with Enter/Space.
- Operates on non-disabled options only; keeps the dropdown open after toggling (multi-select convention).
- Harness gains toggleSelectAll()/isSelectAllChecked(); the row is excluded from getOptions()/selectOption().
- Adds a MultipleWithSelectAll story and a showSelectAll control.