### PR TITLE
NAS-141663 / 27.0.0-BETA.1 / fix(select): keep dropdown panel inside the viewport near screen edges

### DIFF
--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -108,6 +108,12 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-height: var(--tn-select-dropdown-max-height);
+
+  // The overlay's push-on-screen behavior can only slide a panel that is
+  // narrower than the viewport; a wider one would still clip at the edge.
+  // Cap the width so long option labels wrap instead. The 16px mirrors the
+  // 8px-per-side withViewportMargin(8) in attachOverlay() — keep in sync.
+  max-width: calc(100vw - 16px);
 }
 
 .tn-select-options {
@@ -120,6 +126,11 @@
   display: flex;
   align-items: center;
   padding: 0.5rem 0.75rem;
+
+  // When the panel hits its viewport-capped max-width, wrap labels rather
+  // than overflow — ellipsis here could make same-prefix options
+  // indistinguishable. `anywhere` also breaks space-less tokens (paths, ids).
+  overflow-wrap: anywhere;
   cursor: pointer;
   color: var(--tn-fg1, #212529);
   transition: background-color 0.15s ease-in-out;

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -108,12 +108,6 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-height: var(--tn-select-dropdown-max-height);
-
-  // The overlay's push-on-screen behavior can only slide a panel that is
-  // narrower than the viewport; a wider one would still clip at the edge.
-  // Cap the width so long option labels wrap instead. The 16px mirrors the
-  // 8px-per-side withViewportMargin(8) in attachOverlay() — keep in sync.
-  max-width: calc(100vw - 16px);
 }
 
 .tn-select-options {
@@ -127,9 +121,10 @@
   align-items: center;
   padding: 0.5rem 0.75rem;
 
-  // When the panel hits its viewport-capped max-width, wrap labels rather
-  // than overflow — ellipsis here could make same-prefix options
-  // indistinguishable. `anywhere` also breaks space-less tokens (paths, ids).
+  // When the panel hits the overlay pane's maxWidth (set in attachOverlay()),
+  // wrap labels rather than overflow — ellipsis here could make same-prefix
+  // options indistinguishable. `anywhere` also breaks space-less tokens
+  // (paths, ids).
   overflow-wrap: anywhere;
   cursor: pointer;
   color: var(--tn-fg1, #212529);

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -321,12 +321,23 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
    */
   private attachOverlay(): void {
     const trigger = this.triggerEl().nativeElement;
+    // Flexible dimensions must stay OFF: with them on, CDK treats a panel
+    // squeezed against the viewport edge as a valid "flexible fit" (no
+    // minWidth is set, so any width fits), never falls through to the
+    // end-aligned positions or push, and the panel content gets clipped at
+    // the screen edge. Rigid dimensions + push keep the panel fully visible;
+    // height is already capped by the panel's own max-height.
     const positionStrategy = this.overlay
       .position()
       .flexibleConnectedTo(trigger)
+      .withFlexibleDimensions(false)
+      .withPush(true)
+      .withViewportMargin(8)
       .withPositions([
         { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
         { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -4 },
+        { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top', offsetY: 4 },
+        { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom', offsetY: -4 },
       ]);
 
     this.overlayRef = this.overlay.create({

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -21,6 +21,10 @@ export interface TnSelectOptionGroup<T = unknown> {
   disabled?: boolean;
 }
 
+// Minimum gap the dropdown panel keeps from each viewport edge. Also derives
+// the pane's maxWidth (viewport minus both margins) — see attachOverlay().
+const VIEWPORT_MARGIN_PX = 8;
+
 @Component({
   selector: 'tn-select',
   standalone: true,
@@ -334,8 +338,8 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       .withPush(true)
       // Push can only rescue a panel narrower than the narrowed viewport
       // (clientWidth - 2 * margin); the pane maxWidth below covers the
-      // wider-than-viewport case. Its 16px is 2 * this margin — keep in sync.
-      .withViewportMargin(8)
+      // wider-than-viewport case.
+      .withViewportMargin(VIEWPORT_MARGIN_PX)
       .withPositions([
         { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
         { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -4 },
@@ -353,8 +357,8 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       // against the overlay container, which CDK sizes to clientWidth
       // (scrollbar excluded) — the same base its position math uses — so the
       // capped pane always fits the push viewport exactly. 100vw includes the
-      // scrollbar and would overshoot by its width. 16px = 2 * viewport margin.
-      maxWidth: 'calc(100% - 16px)',
+      // scrollbar and would overshoot by its width.
+      maxWidth: `calc(100% - ${2 * VIEWPORT_MARGIN_PX}px)`,
     });
 
     const portal = new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef);

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -332,9 +332,9 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       .flexibleConnectedTo(trigger)
       .withFlexibleDimensions(false)
       .withPush(true)
-      // Push can only rescue a panel narrower than the viewport; the panel's
-      // max-width: calc(100vw - 16px) in the SCSS covers the wider-than-viewport
-      // case. The margin here and that 16px are paired — keep in sync.
+      // Push can only rescue a panel narrower than the narrowed viewport
+      // (clientWidth - 2 * margin); the pane maxWidth below covers the
+      // wider-than-viewport case. Its 16px is 2 * this margin — keep in sync.
       .withViewportMargin(8)
       .withPositions([
         { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
@@ -348,6 +348,13 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-transparent-backdrop',
+      // Cap the pane so option labels wrap instead of clipping when they are
+      // wider than the viewport. Percentage, not 100vw: the pane resolves %
+      // against the overlay container, which CDK sizes to clientWidth
+      // (scrollbar excluded) — the same base its position math uses — so the
+      // capped pane always fits the push viewport exactly. 100vw includes the
+      // scrollbar and would overshoot by its width. 16px = 2 * viewport margin.
+      maxWidth: 'calc(100% - 16px)',
     });
 
     const portal = new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef);

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -332,6 +332,9 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       .flexibleConnectedTo(trigger)
       .withFlexibleDimensions(false)
       .withPush(true)
+      // Push can only rescue a panel narrower than the viewport; the panel's
+      // max-width: calc(100vw - 16px) in the SCSS covers the wider-than-viewport
+      // case. The margin here and that 16px are paired — keep in sync.
       .withViewportMargin(8)
       .withPositions([
         { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -333,6 +333,64 @@ export const FlipUpDropdown: Story = {
   },
 };
 
+// Trigger hugs the right viewport edge while the options are much wider than
+// the trigger — the panel must right-align (or push left) instead of spilling
+// past the screen edge and getting clipped.
+export const NearRightEdge: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      logSelection: (_value: unknown) => {},
+    },
+    template: `
+      <div style="display: flex; justify-content: flex-end;">
+        <div style="width: 120px;">
+          <tn-form-field
+            label="Category"
+            hint="Trigger sits at the right edge — the panel stays on screen">
+            <tn-select
+              [options]="options"
+              placeholder="Tasks"
+              (selectionChange)="logSelection($event)">
+            </tn-select>
+          </tn-form-field>
+        </div>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent],
+    },
+  }),
+  args: {
+    options: [
+      { value: 'applications', label: 'Applications' },
+      { value: 'kmip', label: 'Key Management Interoperability Protocol' },
+      { value: 'network', label: 'Network' },
+      { value: 'connect', label: 'TrueNAS Connect Service' },
+      { value: 'ups', label: 'UPS' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox');
+
+    await userEvent.click(trigger);
+    const panel = await waitFor(() => {
+      const el = document.querySelector('.tn-select-dropdown');
+      if (!el) {throw new Error('dropdown panel not rendered yet');}
+      return el as HTMLElement;
+    });
+
+    // The whole panel must sit within the viewport — a right edge beyond the
+    // window width means options are clipped off screen.
+    await waitFor(() => {
+      const rect = panel.getBoundingClientRect();
+      expect(rect.right).toBeLessThanOrEqual(document.documentElement.clientWidth);
+      expect(rect.left).toBeGreaterThanOrEqual(0);
+    });
+  },
+};
+
 export const EmptyWithCustomMessage: Story = {
   render: (args) => ({
     props: {

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -383,10 +383,10 @@ export const NearRightEdge: Story = {
 
     // The whole panel must sit within the viewport — a right edge beyond the
     // window width means options are clipped off screen.
-    await waitFor(() => {
+    await waitFor(async () => {
       const rect = panel.getBoundingClientRect();
-      expect(rect.right).toBeLessThanOrEqual(document.documentElement.clientWidth);
-      expect(rect.left).toBeGreaterThanOrEqual(0);
+      await expect(rect.right).toBeLessThanOrEqual(document.documentElement.clientWidth);
+      await expect(rect.left).toBeGreaterThanOrEqual(0);
     });
   },
 };


### PR DESCRIPTION
## Problem

When a `tn-select` trigger sits near the right edge of the viewport and its options are wider than the trigger, the dropdown panel spills past the screen edge and the option text gets clipped (seen in the webui alert-settings Category select):

- The position strategy only defined start-aligned below/above positions.
- CDK's `withFlexibleDimensions` default (**true**) made things worse: with no `minWidth` configured, CDK shrinks the overlay's bounding box to the viewport edge and counts that as a successful "flexible fit", so the push-on-screen behavior never kicks in. The panel content overflows the shrunk box and is clipped at the viewport.

## Fix

In `attachOverlay()`:

- `withFlexibleDimensions(false)` — make the panel's width rigid so CDK can't "fit" it by squeezing it against the edge (height is already capped by the panel's own `max-height`).
- `withPush(true)` + `withViewportMargin(8)` — panel is pushed fully on-screen with a small gutter.
- End-aligned fallback positions — a trigger near the right edge gets a right-aligned panel instead of one shoved leftward.

## Testing

- New `NearRightEdge` story reproduces the bug setup (narrow trigger flush right, long option labels); its play function opens the dropdown and asserts the panel's bounding rect stays within the viewport, guarding against regression in Storybook interaction tests.
- All 69 existing select unit tests pass.
- Verified manually in Storybook.

No consumer-side changes needed — the webui picks this up on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)