### PR TITLE
NAS-141866 / 27.0.0-BETA.1 / feat(file-picker): open-on-click popup and single-slash / root breadcrumb

### DIFF
--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
@@ -5,6 +5,7 @@
       <button
         class="breadcrumb-segment"
         [class.current]="last"
+        [class.nameless]="!segment.name"
         [disabled]="last"
         [attr.aria-label]="segment.name === '…' || !segment.name ? 'Navigate to ' + segment.path : null"
         (click)="navigateToPath(segment.path)">

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -72,6 +72,12 @@
       margin-right: 2px;
       color: var(--tn-alt-fg1);
     }
+
+    // A `/` root has an empty name — its leading slash IS the whole segment,
+    // so drop its trailing separator or the breadcrumb would read "/ / mnt".
+    &.nameless:not(:last-child)::after {
+      content: none;
+    }
   }
 }
 

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
@@ -425,6 +425,25 @@ describe('TnFilePickerPopupComponent', () => {
       expect(breadcrumbLabels()).toEqual(['dev/zvol']);
     });
 
+    it('should render a single leading slash for the / root instead of a doubled separator', () => {
+      fixture.componentRef.setInput('rootPath', '/');
+      fixture.componentRef.setInput('currentPath', '/mnt/dozer');
+      fixture.detectChanges();
+
+      // The root segment has no name — its leading slash pseudo-element is the
+      // whole segment, and the `nameless` class suppresses its trailing
+      // separator so the breadcrumb reads "/ mnt / dozer", not "/ / mnt / dozer".
+      expect(breadcrumbLabels()).toEqual(['', 'mnt', 'dozer']);
+      const rootSegment = fixture.debugElement.query(By.css('.breadcrumb-segment'));
+      expect((rootSegment.nativeElement as HTMLElement).classList).toContain('nameless');
+
+      const navigateSpy = jest.fn();
+      component.pathNavigate.subscribe(navigateSpy);
+      (rootSegment.nativeElement as HTMLElement).click();
+
+      expect(navigateSpy).toHaveBeenCalledWith('/');
+    });
+
     it('should render every path segment and navigate to the custom root via its segment', () => {
       fixture.componentRef.setInput('rootPath', '/dev/zvol');
       fixture.componentRef.setInput('currentPath', '/dev/zvol/tank/vm');

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
@@ -8,6 +8,7 @@
       [placeholder]="placeholder()"
       [readonly]="!allowManualInput()"
       [disabled]="isDisabled()"
+      (focus)="onInputFocus()"
       (change)="onPathCommit($event)">
 
     <button

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
@@ -8,7 +8,7 @@
       [placeholder]="placeholder()"
       [readonly]="!allowManualInput()"
       [disabled]="isDisabled()"
-      (focus)="onInputFocus()"
+      (click)="onInputClick()"
       (change)="onPathCommit($event)">
 
     <button

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -49,36 +49,51 @@ describe('TnFilePickerComponent', () => {
     });
   });
 
-  describe('Open On Focus', () => {
-    function focusInput(): void {
-      const input = fixture.nativeElement.querySelector('.tn-file-picker-input') as HTMLInputElement;
-      input.dispatchEvent(new FocusEvent('focus'));
+  describe('Open On Click', () => {
+    function getInput(): HTMLInputElement {
+      return fixture.nativeElement.querySelector('.tn-file-picker-input') as HTMLInputElement;
+    }
+
+    function clickInput(): void {
+      getInput().dispatchEvent(new MouseEvent('click'));
       fixture.detectChanges();
     }
 
-    it('should open the popup when the input is focused while empty', () => {
-      fixture.componentRef.setInput('openOnFocus', true);
+    it('should open the popup when the input is clicked while empty', () => {
+      fixture.componentRef.setInput('openOnClick', true);
       fixture.detectChanges();
 
-      focusInput();
+      clickInput();
 
       expect(component.isOpen()).toBe(true);
     });
 
-    it('should not open the popup on focus when a path is already selected', () => {
-      fixture.componentRef.setInput('openOnFocus', true);
+    it('should not open the popup on click when a path is already selected', () => {
+      fixture.componentRef.setInput('openOnClick', true);
       fixture.detectChanges();
       component.writeValue('/mnt/tank');
 
-      focusInput();
+      clickInput();
 
       expect(component.isOpen()).toBe(false);
     });
 
-    it('should not open the popup on focus by default', () => {
+    it('should not open the popup on click by default', () => {
       fixture.detectChanges();
 
-      focusInput();
+      clickInput();
+
+      expect(component.isOpen()).toBe(false);
+    });
+
+    it('should not open the popup on keyboard focus, only on click', () => {
+      fixture.componentRef.setInput('openOnClick', true);
+      fixture.detectChanges();
+
+      // A keyboard user tabbing through a form must not trigger the overlay —
+      // the popup does not trap focus, so it would be left open behind them.
+      getInput().dispatchEvent(new FocusEvent('focus'));
+      fixture.detectChanges();
 
       expect(component.isOpen()).toBe(false);
     });

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -49,6 +49,41 @@ describe('TnFilePickerComponent', () => {
     });
   });
 
+  describe('Open On Focus', () => {
+    function focusInput(): void {
+      const input = fixture.nativeElement.querySelector('.tn-file-picker-input') as HTMLInputElement;
+      input.dispatchEvent(new FocusEvent('focus'));
+      fixture.detectChanges();
+    }
+
+    it('should open the popup when the input is focused while empty', () => {
+      fixture.componentRef.setInput('openOnFocus', true);
+      fixture.detectChanges();
+
+      focusInput();
+
+      expect(component.isOpen()).toBe(true);
+    });
+
+    it('should not open the popup on focus when a path is already selected', () => {
+      fixture.componentRef.setInput('openOnFocus', true);
+      fixture.detectChanges();
+      component.writeValue('/mnt/tank');
+
+      focusInput();
+
+      expect(component.isOpen()).toBe(false);
+    });
+
+    it('should not open the popup on focus by default', () => {
+      fixture.detectChanges();
+
+      focusInput();
+
+      expect(component.isOpen()).toBe(false);
+    });
+  });
+
   describe('Programmatic API', () => {
     it('should re-fetch the current listing on refresh()', async () => {
       const getChildren = jest.fn().mockResolvedValue([]);

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -58,13 +58,16 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
   createActions = input<FilePickerCreateAction[]>([]);
   allowManualInput = input<boolean>(true);
   /**
-   * Open the picker popup as soon as the input receives focus while no path is
-   * selected yet — an empty field means the user is about to pick something, so
-   * the browser opens without the extra click on the folder button. A field
-   * that already holds a path keeps plain focus behavior (the user may just
-   * want to edit the text).
+   * Open the picker popup when the input is clicked while no path is selected
+   * yet — an empty field means the user is about to pick something, so the
+   * browser opens without the extra click on the folder button. A field that
+   * already holds a path keeps plain click behavior (the user may just want to
+   * edit the text). Deliberately pointer-only: opening on focus would pop the
+   * overlay on keyboard users tabbing through a form and leave it open behind
+   * them; tabbing never opens it, and the folder button stays the keyboard
+   * path to the popup.
    */
-  openOnFocus = input<boolean>(false);
+  openOnClick = input<boolean>(false);
   placeholder = input<string>('Select file or folder');
   disabled = input<boolean>(false);
   /**
@@ -197,13 +200,9 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
     this.onTouched();
   }
 
-  /**
-   * `openOnFocus` entry point. Safe against reopen loops: closing the popup
-   * never programmatically refocuses the input, so a close can't retrigger
-   * this — only a genuine focus transition into the input can.
-   */
-  onInputFocus(): void {
-    if (this.openOnFocus() && !this.selectedPath()) {
+  /** `openOnClick` entry point. */
+  onInputClick(): void {
+    if (this.openOnClick() && !this.selectedPath()) {
       this.openFilePicker();
     }
   }

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -57,6 +57,14 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
   /** Consumer-defined creation flows shown as buttons in the popup footer. */
   createActions = input<FilePickerCreateAction[]>([]);
   allowManualInput = input<boolean>(true);
+  /**
+   * Open the picker popup as soon as the input receives focus while no path is
+   * selected yet — an empty field means the user is about to pick something, so
+   * the browser opens without the extra click on the folder button. A field
+   * that already holds a path keeps plain focus behavior (the user may just
+   * want to edit the text).
+   */
+  openOnFocus = input<boolean>(false);
   placeholder = input<string>('Select file or folder');
   disabled = input<boolean>(false);
   /**
@@ -187,6 +195,17 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
     }
 
     this.onTouched();
+  }
+
+  /**
+   * `openOnFocus` entry point. Safe against reopen loops: closing the popup
+   * never programmatically refocuses the input, so a close can't retrigger
+   * this — only a genuine focus transition into the input can.
+   */
+  onInputFocus(): void {
+    if (this.openOnFocus() && !this.selectedPath()) {
+      this.openFilePicker();
+    }
   }
 
   openFilePicker(): void {

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -34,9 +34,9 @@ const meta: Meta<TnFilePickerComponent> = {
       control: 'boolean',
       description: 'Whether the file picker is disabled',
     },
-    openOnFocus: {
+    openOnClick: {
       control: 'boolean',
-      description: 'Open the picker popup when the input receives focus while no path is selected',
+      description: 'Open the picker popup when the input is clicked while no path is selected',
     },
     startPath: {
       control: 'text',
@@ -177,6 +177,11 @@ fileExtensions = input<string[] | undefined>(undefined);
 allowManualInput = input<boolean>(true);
 \`\`\`
 **Description:** Allow users to type paths directly in the input field. Paths are committed on Enter or blur (not per keystroke) and must stay within \`rootPath\`; clearing the field clears the selection.
+
+\`\`\`typescript
+openOnClick = input<boolean>(false);
+\`\`\`
+**Description:** Open the picker popup when the input is clicked while no path is selected — an empty field signals the user is about to pick something. Pointer-only by design: keyboard users tabbing through a form never get the overlay opened on them; the folder button remains the keyboard path.
 
 \`\`\`typescript
 placeholder = input<string>('Select file or folder');
@@ -1345,7 +1350,7 @@ export const FilesystemRoot: Story = {
   }
 };
 
-export const OpenOnFocus: Story = {
+export const OpenOnClick: Story = {
   render: (args) => ({
     props: {
       ...args,
@@ -1354,10 +1359,10 @@ export const OpenOnFocus: Story = {
       } as FilePickerCallbacks
     },
     template: `
-      <tn-form-field label="Opens on focus while empty">
+      <tn-form-field label="Opens on click while empty">
         <tn-file-picker
           [mode]="mode"
-          [openOnFocus]="openOnFocus"
+          [openOnClick]="openOnClick"
           [rootPath]="rootPath"
           [startPath]="startPath"
           [callbacks]="callbacks">
@@ -1370,16 +1375,16 @@ export const OpenOnFocus: Story = {
   }),
   args: {
     mode: 'any',
-    openOnFocus: true,
+    openOnClick: true,
     rootPath: '/mnt',
     startPath: '/mnt'
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Focusing the empty input opens the popup without pressing the folder button
+    // Clicking the empty input opens the popup without pressing the folder button
     const input = canvas.getByRole('textbox');
-    input.focus();
+    await userEvent.click(input);
 
     await waitFor(() => {
       void expect(screen.queryByText('dozer')).toBeInTheDocument();
@@ -1388,7 +1393,7 @@ export const OpenOnFocus: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'With `openOnFocus`, focusing the input while no path is selected opens the browsing popup immediately — the empty field signals the user is about to pick something. A field that already holds a path keeps plain focus behavior so the text can be edited.'
+        story: 'With `openOnClick`, clicking the input while no path is selected opens the browsing popup immediately — the empty field signals the user is about to pick something. A field that already holds a path keeps plain click behavior so the text can be edited. The trigger is deliberately pointer-only: keyboard users tabbing through a form never get the overlay popped open on them, and the folder button remains the keyboard path.'
       }
     }
   }

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -34,6 +34,10 @@ const meta: Meta<TnFilePickerComponent> = {
       control: 'boolean',
       description: 'Whether the file picker is disabled',
     },
+    openOnFocus: {
+      control: 'boolean',
+      description: 'Open the picker popup when the input receives focus while no path is selected',
+    },
     startPath: {
       control: 'text',
       description: 'Initial directory path',
@@ -1268,6 +1272,123 @@ export const DeepNesting: Story = {
     docs: {
       description: {
         story: 'Exercises long paths in the header: deep paths collapse their middle into a "…" breadcrumb segment that navigates to the parent of the first visible directory, and the popup keeps a fixed width while navigating.'
+      }
+    }
+  }
+};
+
+const slashRootFilesystem: Record<string, FileSystemItem[]> = {
+  '/': [
+    { path: '/mnt', name: 'mnt', type: 'folder' },
+    { path: '/dev/zvol', name: 'dev/zvol', type: 'folder' },
+  ],
+  '/mnt': [
+    { path: '/mnt/dozer', name: 'dozer', type: 'dataset' },
+  ],
+  '/mnt/dozer': [
+    { path: '/mnt/dozer/foo', name: 'foo', type: 'dataset' },
+  ],
+};
+
+export const FilesystemRoot: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      callbacks: {
+        getChildren: async (path: string) => slashRootFilesystem[path] || []
+      } as FilePickerCallbacks
+    },
+    template: `
+      <tn-form-field label="Rooted at /">
+        <tn-file-picker
+          [mode]="mode"
+          [rootPath]="rootPath"
+          [startPath]="startPath"
+          [callbacks]="callbacks">
+        </tn-file-picker>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, TnFilePickerComponent],
+    }
+  }),
+  args: {
+    mode: 'any',
+    rootPath: '/',
+    startPath: '/mnt/dozer'
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const folderButton = canvas.getByRole('button', { name: /open file picker/i });
+    await userEvent.click(folderButton);
+
+    await waitFor(() => {
+      void expect(screen.queryByText('foo')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    // The `/` root renders as a nameless segment whose leading slash IS the
+    // segment; its trailing separator is suppressed so the breadcrumb reads
+    // "/ mnt / dozer" rather than "/ / mnt / dozer".
+    void expect(screen.getByText('mnt')).toBeInTheDocument();
+    void expect(screen.getByText('dozer')).toBeInTheDocument();
+    const rootSegment = document.querySelector('.breadcrumb-segment');
+    void expect(rootSegment).toHaveClass('nameless');
+    void expect(rootSegment).toHaveTextContent('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A picker confined to the filesystem root: with `rootPath="/"` the root breadcrumb segment has no name, so it renders as a single clickable slash instead of doubling the separator.'
+      }
+    }
+  }
+};
+
+export const OpenOnFocus: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      callbacks: {
+        getChildren: async (path: string) => slashRootFilesystem[path] || []
+      } as FilePickerCallbacks
+    },
+    template: `
+      <tn-form-field label="Opens on focus while empty">
+        <tn-file-picker
+          [mode]="mode"
+          [openOnFocus]="openOnFocus"
+          [rootPath]="rootPath"
+          [startPath]="startPath"
+          [callbacks]="callbacks">
+        </tn-file-picker>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, TnFilePickerComponent],
+    }
+  }),
+  args: {
+    mode: 'any',
+    openOnFocus: true,
+    rootPath: '/mnt',
+    startPath: '/mnt'
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Focusing the empty input opens the popup without pressing the folder button
+    const input = canvas.getByRole('textbox');
+    input.focus();
+
+    await waitFor(() => {
+      void expect(screen.queryByText('dozer')).toBeInTheDocument();
+    }, { timeout: 2000 });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'With `openOnFocus`, focusing the input while no path is selected opens the browsing popup immediately — the empty field signals the user is about to pick something. A field that already holds a path keeps plain focus behavior so the text can be edited.'
       }
     }
   }


### PR DESCRIPTION
Two file-picker improvements driven by the webui ix-explorer migration:

## `openOnClick` input

Clicking the input while no path is selected opens the browsing popup immediately — an empty field means the user is about to pick something, so the extra click on the folder button is skipped. A field that already holds a path keeps plain click behavior so the text stays editable. Opt-in, default `false`.

The trigger is deliberately **pointer-only** (review follow-up: originally `openOnFocus`): the popup does not trap focus, so opening on focus would pop the overlay on keyboard users tabbing through a form and leave it open behind them. With click, tabbing never opens it and the folder button (aria-labelled) remains the keyboard path. Also safe against reopen loops — closing the popup never programmatically refocuses the input.

## Single-slash breadcrumb for a `/` root

With `rootPath="/"` the root segment's name is empty, so its `::before` slash and `::after` separator rendered back-to-back as `/ / mnt / dozer`. Nameless segments now get a `nameless` class that suppresses only their trailing separator, so the breadcrumb reads `/ mnt / dozer` with the leading slash still clickable to navigate to the root. This never showed in existing stories because they all use `/mnt`-style roots — webui's ix-explorer roots at `/` whenever its `rootNodes` are dynamic, multiple, or relative.

## Coverage

- Popup spec: `/` root renders a nameless, still-navigable root segment.
- Component spec: popup opens on empty-click, stays closed with a value, by default, and on keyboard focus.
- New stories: `FilesystemRoot` (rootPath `/`) and `OpenOnClick`, both with play functions; `openOnClick` added to the inline API reference.