### PR TITLE
NAS-141861 / 27.0.0-BETA.1 / feat(file-picker): add harness and derived test ids

### DIFF
--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
@@ -4,6 +4,8 @@
     @for (segment of currentPath() | tnTruncatePath : rootPath(); track $index; let last = $last) {
       <button
         class="breadcrumb-segment"
+        tnTestIdType="button"
+        [tnTestId]="breadcrumbTestId(segment.name)"
         [class.current]="last"
         [disabled]="last"
         [attr.aria-label]="segment.name === '…' || !segment.name ? 'Navigate to ' + segment.path : null"
@@ -45,6 +47,7 @@
           <tn-checkbox
             [hideLabel]="true"
             [label]="'Select ' + item.name"
+            [testId]="itemTestId(item)"
             [checked]="isSelected(item)"
             [disabled]="!!item.disabled"
             (click)="$event.stopPropagation()"
@@ -70,6 +73,8 @@
                   class="inline-create-input"
                   spellcheck="false"
                   autocomplete="off"
+                  tnTestIdType="input"
+                  [tnTestId]="inlineCreateTestId()"
                   [attr.aria-label]="creation.action.label + ' name'"
                   [attr.aria-invalid]="creation.error ? true : null"
                   [attr.aria-describedby]="creation.error ? inlineErrorId : null"
@@ -94,6 +99,8 @@
         } @else {
         <div
              class="file-name-cell"
+             tnTestIdType="option"
+             [tnTestId]="itemTestId(item)"
              [class.selected]="isSelected(item)"
              [class.disabled]="!!item.dimmed"
              [class.zfs-object]="isZfsObject(item)">
@@ -123,6 +130,8 @@
             <button
               type="button"
               class="navigate-button"
+              tnTestIdType="button"
+              [tnTestId]="navigateTestId(item)"
               [attr.aria-label]="'Open ' + item.name"
               [attr.title]="'Open ' + item.name"
               (click)="onNavigateClick($event, item)"
@@ -182,6 +191,7 @@
         <tn-button
           variant="outline"
           label="Clear Selection"
+          [testId]="clearSelectionTestId()"
           (onClick)="onClearSelection()" />
       } @else if (allowCurrentDirectorySelection()) {
         <span class="selection-count current-directory-selection">
@@ -198,6 +208,7 @@
         <tn-button
           variant="outline"
           [label]="action.label"
+          [testId]="createActionTestId(action)"
           [disabled]="!!inlineCreation()"
           (onClick)="onCreateAction(action)" />
       }
@@ -205,6 +216,7 @@
            would race the selection submit -->
       <tn-button
         label="Select"
+        [testId]="selectTestId()"
         [disabled]="(selectedItems().length === 0 && !allowCurrentDirectorySelection()) || !!inlineCreation()"
         (onClick)="onSubmit()" />
     </div>

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
@@ -805,4 +805,70 @@ describe('TnFilePickerPopupComponent', () => {
       expect(contentElement).toBeFalsy();
     });
   });
+
+  describe('Test IDs', () => {
+    function testIdOf(selector: string): string | null | undefined {
+      const el = fixture.debugElement.query(By.css(selector));
+      return (el?.nativeElement as HTMLElement | undefined)?.getAttribute('data-testid');
+    }
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('testIdBase', 'backup-target');
+    });
+
+    it('scopes item rows by the base and the item name', () => {
+      fixture.detectChanges();
+
+      expect(testIdOf('[data-testid="option-backup-target-documents"]')).toBeTruthy();
+      // Non-alphanumerics in names kebab-normalize: database.db → database-db
+      expect(testIdOf('[data-testid="option-backup-target-database-db"]')).toBeTruthy();
+    });
+
+    it('scopes the multi-select checkbox like its row', () => {
+      fixture.componentRef.setInput('multiSelect', true);
+      fixture.detectChanges();
+
+      expect(testIdOf('[data-testid="checkbox-backup-target-documents"]')).toBeTruthy();
+    });
+
+    it('derives role-first ids for navigation chrome', () => {
+      fixture.detectChanges();
+
+      expect(testIdOf('[data-testid="button-navigate-backup-target-documents"]')).toBeTruthy();
+      expect(testIdOf('[data-testid="button-breadcrumb-backup-target-mnt"]')).toBeTruthy();
+      expect(testIdOf('[data-testid="button-breadcrumb-backup-target-tank"]')).toBeTruthy();
+    });
+
+    it('derives role-first ids for the footer buttons', () => {
+      fixture.componentRef.setInput('multiSelect', true);
+      fixture.componentRef.setInput('selectedItems', ['/mnt/tank/documents']);
+      fixture.componentRef.setInput('createActions', [{ id: 'dataset', label: 'Create Dataset' }]);
+      fixture.detectChanges();
+
+      expect(testIdOf('[data-testid="button-select-backup-target"]')).toBeTruthy();
+      expect(testIdOf('[data-testid="button-clear-selection-backup-target"]')).toBeTruthy();
+      // Create actions are content children, so the base leads: button-<base>-<action id>
+      expect(testIdOf('[data-testid="button-backup-target-dataset"]')).toBeTruthy();
+    });
+
+    it('scopes the inline creation input', () => {
+      fixture.componentRef.setInput('createActions', [
+        { id: 'folder', label: 'New Folder', create: jest.fn() },
+      ]);
+      fixture.detectChanges();
+      (fixture.debugElement.query(By.css('.footer-actions button')).nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(testIdOf('[data-testid="input-create-backup-target"]')).toBeTruthy();
+    });
+
+    it('falls back to bare-role ids with no base', () => {
+      fixture.componentRef.setInput('testIdBase', undefined);
+      fixture.detectChanges();
+
+      // Only one popup can be open at a time, so bare roles stay addressable
+      expect(testIdOf('[data-testid="option-documents"]')).toBeTruthy();
+      expect(testIdOf('[data-testid="button-select"]')).toBeTruthy();
+    });
+  });
 });

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.ts
@@ -16,6 +16,7 @@ import { TnIconComponent } from '../icon/icon.component';
 import { FileSizePipe } from '../pipes/file-size/file-size.pipe';
 import { TnTableComponent } from '../table/table.component';
 import { TnTableColumnDirective, TnHeaderCellDefDirective, TnCellDefDirective } from '../table-column/table-column.directive';
+import { TnTestIdDirective, scopeTestId, type TnTestIdValue } from '../test-id';
 
 /** Uniquifies the inline-creation error id across popup instances. */
 let nextInlineErrorId = 0;
@@ -51,7 +52,8 @@ interface DisplayedFileItem extends FileSystemItem {
     ScrollingModule,
     A11yModule,
     FileSizePipe,
-    TruncatePathPipe
+    TruncatePathPipe,
+    TnTestIdDirective
 ],
   templateUrl: './file-picker-popup.component.html',
   styleUrl: './file-picker-popup.component.scss',
@@ -83,6 +85,14 @@ export class TnFilePickerPopupComponent implements AfterViewChecked {
   selectedItems = input<string[]>([]);
   loading = input<boolean>(false);
   fileExtensions = input<string[] | undefined>(undefined);
+  /**
+   * Test-id base the owning picker resolved (explicit `testId`, else the bound
+   * control's name). Scopes every derived id inside the popup so ids stay
+   * unique across pickers; with no base the ids fall back to their bare role
+   * (`button-select`, `option-<name>`), which stays addressable because only
+   * one popup can be open at a time.
+   */
+  testIdBase = input<TnTestIdValue>(undefined);
 
   private iconRegistry = inject(TnIconRegistryService);
   private elementRef = inject(ElementRef);
@@ -155,6 +165,55 @@ export class TnFilePickerPopupComponent implements AfterViewChecked {
    * selection.
    */
   allowCurrentDirectorySelection = computed(() => allowsCurrentDirectorySelection(this.mode()));
+
+  /**
+   * The `testIdBase` normalized to a flat segment array for role-first ids.
+   * Nothing is dropped here — `composeTestId` (via `[tnTestId]`) filters falsy
+   * segments, so an unset base collapses to the bare role.
+   */
+  private readonly baseSegments = computed<(string | number | null | undefined)[]>(() => {
+    const base = this.testIdBase();
+    return Array.isArray(base) ? base : [base];
+  });
+
+  /**
+   * Role-first segments for the footer chrome, mirroring tn-dialog-shell's
+   * `button-close-<base>` convention: `button-select[-<base>]` and
+   * `button-clear-selection[-<base>]`.
+   */
+  protected readonly selectTestId = computed(() => ['select', ...this.baseSegments()]);
+  protected readonly clearSelectionTestId = computed(() => ['clear-selection', ...this.baseSegments()]);
+  /** Role-first segments for the inline creation input: `input-create[-<base>]`. */
+  protected readonly inlineCreateTestId = computed(() => ['create', ...this.baseSegments()]);
+
+  /**
+   * Base-first segments for a listed item's row (`option[-<base>]-<name>`) and
+   * its multi-select checkbox (`checkbox[-<base>]-<name>`). The item NAME is
+   * the discriminator (not the full path): it is unique within the listed
+   * directory and keeps ids stable as the user browses.
+   */
+  itemTestId(item: FileSystemItem): TnTestIdValue {
+    return scopeTestId(this.testIdBase(), item.name);
+  }
+
+  /** Role-first segments for an item's navigation chevron: `button-navigate[-<base>]-<name>`. */
+  navigateTestId(item: FileSystemItem): TnTestIdValue {
+    return ['navigate', ...this.baseSegments(), item.name];
+  }
+
+  /**
+   * Role-first segments for a breadcrumb segment: `button-breadcrumb[-<base>]-<name>`.
+   * The truncation ellipsis normalizes to nothing, leaving that segment at
+   * `button-breadcrumb[-<base>]` — still unique, as at most one is rendered.
+   */
+  breadcrumbTestId(name: string): TnTestIdValue {
+    return ['breadcrumb', ...this.baseSegments(), name];
+  }
+
+  /** Base-first segments for a consumer-defined create action: `button[-<base>]-<action id>`. */
+  createActionTestId(action: FilePickerCreateAction): TnTestIdValue {
+    return scopeTestId(this.testIdBase(), action.id);
+  }
 
   filteredFileItems = computed<DisplayedFileItem[]>(() => {
     const items = this.fileItems();

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.html
@@ -1,8 +1,10 @@
-<div class="tn-file-picker-container" tnTestIdType="file-picker" [tnTestId]="testId()">
+<div class="tn-file-picker-container" tnTestIdType="file-picker" [tnTestId]="resolvedTestId()">
   <div #wrapper ixInput class="tn-file-picker-wrapper" style="padding-right: 40px;">
     <input
       type="text"
       class="tn-file-picker-input"
+      tnTestIdType="input"
+      [tnTestId]="resolvedTestId()"
       [class.error]="hasError()"
       [value]="selectedPath()"
       [placeholder]="placeholder()"
@@ -14,6 +16,8 @@
       type="button"
       class="tn-file-picker-toggle"
       aria-label="Open file picker"
+      tnTestIdType="button"
+      [tnTestId]="toggleTestId()"
       [disabled]="isDisabled()"
       (click)="openFilePicker()">
       <tn-icon name="folder" library="mdi" />
@@ -23,6 +27,9 @@
   <ng-template #filePickerTemplate>
     <tn-file-picker-popup
       class="tn-file-picker-popup"
+      tnTestIdType="file-picker-popup"
+      [tnTestId]="resolvedTestId()"
+      [testIdBase]="resolvedTestId()"
       [mode]="mode()"
       [multiSelect]="multiSelect()"
       [createActions]="createActions()"

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -1,6 +1,8 @@
 import { provideHttpClient } from '@angular/common/http';
+import { Component } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TnFilePickerComponent } from './file-picker.component';
 
@@ -339,5 +341,71 @@ describe('TnFilePickerComponent', () => {
 
       expect(getChildren).toHaveBeenCalledWith('/mnt/backups');
     });
+  });
+
+  describe('Test IDs', () => {
+    it('derives the container, input, and toggle ids from an explicit testId', () => {
+      fixture.componentRef.setInput('testId', 'backup-target');
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('.tn-file-picker-container')?.getAttribute('data-testid')).toBe('file-picker-backup-target');
+      expect(el.querySelector('input')?.getAttribute('data-testid')).toBe('input-backup-target');
+      expect(el.querySelector('.tn-file-picker-toggle')?.getAttribute('data-testid')).toBe('button-toggle-backup-target');
+    });
+
+    it('emits no attributes with no testId and no bound control', () => {
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('.tn-file-picker-container')?.hasAttribute('data-testid')).toBe(false);
+      expect(el.querySelector('input')?.hasAttribute('data-testid')).toBe(false);
+      expect(el.querySelector('.tn-file-picker-toggle')?.hasAttribute('data-testid')).toBe(false);
+    });
+
+    it('scopes the portaled popup with the resolved base', () => {
+      fixture.componentRef.setInput('testId', 'backup-target');
+      fixture.detectChanges();
+
+      component.openFilePicker();
+      fixture.detectChanges();
+
+      const popup = document.querySelector('tn-file-picker-popup');
+      expect(popup?.getAttribute('data-testid')).toBe('file-picker-popup-backup-target');
+
+      component.close();
+    });
+  });
+});
+
+@Component({
+  selector: 'tn-test-form-name-host',
+  standalone: true,
+  imports: [TnFilePickerComponent, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <tn-file-picker formControlName="backupPath" />
+    </form>
+  `
+})
+class TestFormNameHostComponent {
+  form = new FormGroup({ backupPath: new FormControl<string | null>(null) });
+}
+
+describe('TnFilePickerComponent test-id fallback', () => {
+  it('derives data-testid from formControlName when no testId is set', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestFormNameHostComponent, NoopAnimationsModule],
+      providers: [provideHttpClient()]
+    }).compileComponents();
+    const fixture = TestBed.createComponent(TestFormNameHostComponent);
+    fixture.detectChanges();
+
+    // No explicit testId: the control name `backupPath` becomes the base,
+    // exactly what consumers hand-write today as testId="backup-path".
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.tn-file-picker-container')?.getAttribute('data-testid')).toBe('file-picker-backup-path');
+    expect(el.querySelector('input')?.getAttribute('data-testid')).toBe('input-backup-path');
+    expect(el.querySelector('.tn-file-picker-toggle')?.getAttribute('data-testid')).toBe('button-toggle-backup-path');
   });
 });

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -16,7 +16,7 @@ import { allowsCurrentDirectorySelection } from './file-picker.utils';
 import { isPathWithinRoot, normalizeRootPath } from './path-utils';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnInputDirective } from '../input/input.directive';
-import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { TnTestIdDirective, composeTestId, controlTestId, scopeTestId, type TnTestIdValue } from '../test-id';
 
 @Component({
   selector: 'tn-file-picker',
@@ -60,8 +60,12 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
   placeholder = input<string>('Select file or folder');
   disabled = input<boolean>(false);
   /**
-   * Test-id applied to the file-picker container. Rendered under whichever attribute name
-   * is configured via `TN_TEST_ATTR` (default `data-testid`).
+   * Test-id base applied to the file-picker container (`file-picker-` prefixed)
+   * and derived onto the inner chrome: the path input (`input-<base>`), the
+   * browse toggle (`button-toggle-<base>`), and the popup and its contents.
+   * Falls back to the bound control's name (`formControlName` etc.) when unset.
+   * Rendered under whichever attribute name is configured via `TN_TEST_ATTR`
+   * (default `data-testid`).
    */
   testId = input<TnTestIdValue>(undefined);
   startPath = input<string>('/mnt');
@@ -95,6 +99,23 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
 
   // Computed disabled state (combines input and form state)
   isDisabled = computed(() => this.disabled() || this.formDisabled());
+
+  /** Explicit `testId` wins; otherwise the bound control's name (formControlName etc.). */
+  protected resolvedTestId = controlTestId(this.testId);
+
+  /**
+   * Role-first test-id segments for the browse toggle: `button-toggle-<base>`.
+   * Gated on a usable base — with several pickers on a page a bare
+   * `button-toggle` on each would be non-unique, so unidentified pickers
+   * stay attribute-free (mirroring tn-tree's toggle derivation).
+   */
+  protected toggleTestId = computed<TnTestIdValue>(() => {
+    const base = this.resolvedTestId();
+    if (composeTestId(undefined, base) === '') {
+      return undefined;
+    }
+    return scopeTestId('toggle', ...(Array.isArray(base) ? base : [base]));
+  });
 
   // Root the picker is confined to when rootPath is not provided, with
   // trailing slashes collapsed so confinement checks compare exact paths

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.harness.spec.ts
@@ -1,0 +1,245 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnFilePickerComponent } from './file-picker.component';
+import { TnFilePickerHarness } from './file-picker.harness';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnFilePickerComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-file-picker
+      [multiSelect]="multiSelect()"
+      [allowManualInput]="allowManualInput()"
+      [placeholder]="placeholder()"
+      [disabled]="disabled()"
+      [testId]="testId()"
+      [formControl]="control" />
+  `
+})
+class TestHostComponent {
+  multiSelect = signal(false);
+  allowManualInput = signal(true);
+  placeholder = signal('Select file or folder');
+  disabled = signal(false);
+  testId = signal<string | undefined>('source-path');
+  control = new FormControl<string | string[] | null>(null);
+}
+
+describe('TnFilePickerHarness', () => {
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness', async () => {
+    const picker = await loader.getHarness(TnFilePickerHarness);
+    expect(picker).toBeTruthy();
+  });
+
+  describe('with', () => {
+    it('finds by placeholder', async () => {
+      const picker = await loader.getHarness(
+        TnFilePickerHarness.with({ placeholder: 'Select file or folder' })
+      );
+      expect(picker).toBeTruthy();
+    });
+
+    it('finds by rendered testId', async () => {
+      const picker = await loader.getHarness(
+        TnFilePickerHarness.with({ testId: 'file-picker-source-path' })
+      );
+      expect(await picker.getTestId()).toBe('file-picker-source-path');
+    });
+
+    it('does not match a wrong testId', async () => {
+      const pickers = await loader.getAllHarnesses(
+        TnFilePickerHarness.with({ testId: 'file-picker-other' })
+      );
+      expect(pickers).toHaveLength(0);
+    });
+  });
+
+  describe('getValue / setValue', () => {
+    it('returns empty string initially', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.getValue()).toBe('');
+    });
+
+    it('reflects a form control value', async () => {
+      hostComponent.control.setValue('/mnt/tank/media');
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.getValue()).toBe('/mnt/tank/media');
+    });
+
+    it('commits a typed path to the form control', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.setValue('/mnt/tank/media');
+      expect(await picker.getValue()).toBe('/mnt/tank/media');
+      expect(hostComponent.control.value).toBe('/mnt/tank/media');
+    });
+
+    it('clears the selection when set to an empty string', async () => {
+      hostComponent.control.setValue('/mnt/tank/media');
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.setValue('');
+      expect(await picker.getValue()).toBe('');
+      expect(hostComponent.control.value).toBe('');
+    });
+
+    it('rejects paths outside the root without changing the value', async () => {
+      hostComponent.control.setValue('/mnt/tank');
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.setValue('/etc/passwd');
+      expect(hostComponent.control.value).toBe('/mnt/tank');
+    });
+
+    it('does not commit when manual input is disallowed', async () => {
+      hostComponent.allowManualInput.set(false);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.setValue('/mnt/tank/media');
+      expect(hostComponent.control.value).toBeNull();
+    });
+  });
+
+  describe('getPlaceholder', () => {
+    it('returns the placeholder', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.getPlaceholder()).toBe('Select file or folder');
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('returns false when enabled', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isDisabled()).toBe(false);
+    });
+
+    it('returns true when disabled via input', async () => {
+      hostComponent.disabled.set(true);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isDisabled()).toBe(true);
+    });
+
+    it('returns true when the form control is disabled', async () => {
+      hostComponent.control.disable();
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('isReadonly', () => {
+    it('returns false when manual input is allowed', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isReadonly()).toBe(false);
+    });
+
+    it('returns true when manual input is disallowed', async () => {
+      hostComponent.allowManualInput.set(false);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isReadonly()).toBe(true);
+    });
+  });
+
+  describe('popup', () => {
+    it('is closed initially and opens via open()', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      expect(await picker.isOpen()).toBe(false);
+      await picker.open();
+      expect(await picker.isOpen()).toBe(true);
+    });
+
+    it('does not open while disabled', async () => {
+      hostComponent.disabled.set(true);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      expect(await picker.isOpen()).toBe(false);
+    });
+
+    it('close() dismisses the popup without applying the pending selection', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await picker.clickItem('Documents');
+      await picker.close();
+      expect(await picker.isOpen()).toBe(false);
+      expect(hostComponent.control.value).toBeNull();
+    });
+
+    it('lists the visible item names', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      // Names come from the component's built-in mock data (no callbacks configured)
+      expect(await picker.getItemNames()).toEqual(['Documents', 'Downloads', 'dataset1', 'example.txt']);
+    });
+
+    it('shows the breadcrumb for the current path', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      expect(await picker.getBreadcrumbSegments()).toEqual(['mnt']);
+    });
+
+    it('selects an item and applies it with clickSelect()', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await picker.clickItem('Documents');
+      await picker.clickSelect();
+      expect(await picker.isOpen()).toBe(false);
+      expect(hostComponent.control.value).toBe('/mnt/Documents');
+      expect(await picker.getValue()).toBe('/mnt/Documents');
+    });
+
+    it('applies multiple items in multi-select mode', async () => {
+      hostComponent.multiSelect.set(true);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await picker.clickItem('Documents');
+      await picker.clickItem('example.txt');
+      await picker.clickSelect();
+      expect(hostComponent.control.value).toEqual(['/mnt/Documents', '/mnt/example.txt']);
+      // Multi-select displays paths joined with comma-space
+      expect(await picker.getValue()).toBe('/mnt/Documents, /mnt/example.txt');
+    });
+
+    it('throws when clicking a missing item', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await expect(picker.clickItem('nope')).rejects.toThrow('No item named "nope"');
+    });
+
+    it('navigates into a folder', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await picker.navigateToItem('Documents');
+      expect(await picker.getBreadcrumbSegments()).toEqual(['mnt', 'Documents']);
+    });
+
+    it('throws when navigating to a non-navigatable item', async () => {
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await expect(picker.navigateToItem('example.txt')).rejects.toThrow('No navigatable item');
+    });
+
+    it('clears the pending selection with clickClearSelection()', async () => {
+      hostComponent.multiSelect.set(true);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.open();
+      await picker.clickItem('Documents');
+      await picker.clickClearSelection();
+      await expect(picker.clickClearSelection()).rejects.toThrow('No Clear Selection button');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.harness.spec.ts
@@ -114,6 +114,17 @@ describe('TnFilePickerHarness', () => {
       await picker.setValue('/mnt/tank/media');
       expect(hostComponent.control.value).toBeNull();
     });
+
+    it('replaces the whole multi-select selection with the single typed path', async () => {
+      // Typed input is deliberately one path even in multi-select (commas are
+      // legal in paths, never list separators) — multi-selections are built
+      // through the popup with clickItem + clickSelect instead.
+      hostComponent.multiSelect.set(true);
+      hostComponent.control.setValue(['/mnt/a', '/mnt/b']);
+      const picker = await loader.getHarness(TnFilePickerHarness);
+      await picker.setValue('/mnt/tank/media');
+      expect(hostComponent.control.value).toEqual(['/mnt/tank/media']);
+    });
   });
 
   describe('getPlaceholder', () => {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.harness.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.harness.ts
@@ -7,11 +7,14 @@ import { TnButtonHarness } from '../button/button.harness';
  *
  * The core API (`getValue` / `setValue` / `isDisabled`) mirrors webui's
  * `IxExplorerHarness` so tests migrate with minimal changes: `setValue`
- * accepts a string or string array (joined with commas) and commits it the
- * way a user would — by typing into the path input and triggering its
- * `change` event. Unlike ix-explorer the component renders no label of its
- * own (labels come from a wrapping `tn-form-field`), so instances are
- * filtered by `testId` or `placeholder` instead.
+ * commits a path the way a user would — by typing into the path input and
+ * triggering its `change` event. Two deliberate divergences from ix-explorer:
+ * the component renders no label of its own (labels come from a wrapping
+ * `tn-form-field`), so instances are filtered by `testId` or `placeholder`
+ * instead; and `setValue` takes a single path only — tn-file-picker does not
+ * split typed input on commas in multi-select mode (a comma is part of the
+ * path), so build multi-selections through the popup with
+ * `clickItem` + `clickSelect`.
  *
  * Popup helpers (`open`, `getItemNames`, `clickItem`, …) drive the browse
  * flow. The popup renders in a CDK overlay outside the component, so these
@@ -48,6 +51,11 @@ export class TnFilePickerHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a file picker
    * with specific attributes.
+   *
+   * The `testId` filter (like {@link getTestId}) reads the default test
+   * attributes (`data-testid`, falling back to `data-test`); an app that
+   * overrides `TN_TEST_ATTR` to a custom attribute name will silently
+   * match nothing.
    *
    * @param options Options for filtering which file picker instances are considered a match.
    * @returns A `HarnessPredicate` configured with the given options.
@@ -90,9 +98,16 @@ export class TnFilePickerHarness extends ComponentHarness {
   }
 
   /**
-   * Sets the picker's value by typing into the path input and committing it
-   * via the input's `change` event, exactly as a user pressing Enter would.
-   * Arrays are joined with commas, matching `IxExplorerHarness.setValue`.
+   * Sets the picker's value by typing a single path into the path input and
+   * committing it via the input's `change` event, exactly as a user pressing
+   * Enter would.
+   *
+   * Unlike `IxExplorerHarness.setValue` there is no `string[]` overload:
+   * tn-file-picker treats typed input as ONE path even in multi-select mode
+   * (commas are legal in paths, so they are never list separators). In
+   * multi-select, committing a typed path REPLACES the whole selection with
+   * that single path; build a real multi-selection through the popup with
+   * {@link clickItem} + {@link clickSelect}.
    *
    * Commits go through the component's normal validation: paths outside
    * `rootPath` are rejected (the value stays unchanged and an `error` is
@@ -100,18 +115,14 @@ export class TnFilePickerHarness extends ComponentHarness {
    * Setting an empty string clears the selection. Has no effect when
    * `allowManualInput` is false (the input is readonly).
    *
-   * @param value The path (or paths) to set.
+   * @param value The path to set.
    *
    * @example
    * ```typescript
    * await picker.setValue('/mnt/tank/media');
-   * await picker.setValue(['/mnt/a', '/mnt/b']);
    * ```
    */
-  async setValue(value: string | string[]): Promise<void> {
-    if (Array.isArray(value)) {
-      value = value.join(',');
-    }
+  async setValue(value: string): Promise<void> {
     const input = await this._input();
     await input.clear();
     if (value) {
@@ -169,6 +180,10 @@ export class TnFilePickerHarness extends ComponentHarness {
 
   /**
    * Gets the test-id attribute value from the container.
+   *
+   * Reads the default test attributes (`data-testid`, falling back to
+   * `data-test`). A custom `TN_TEST_ATTR` attribute name is not visible to
+   * the harness and resolves to null here.
    *
    * @returns Promise resolving to the test-id, or null when unset.
    *

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.harness.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.harness.ts
@@ -1,0 +1,361 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { TnButtonHarness } from '../button/button.harness';
+
+/**
+ * Harness for interacting with tn-file-picker in tests.
+ *
+ * The core API (`getValue` / `setValue` / `isDisabled`) mirrors webui's
+ * `IxExplorerHarness` so tests migrate with minimal changes: `setValue`
+ * accepts a string or string array (joined with commas) and commits it the
+ * way a user would — by typing into the path input and triggering its
+ * `change` event. Unlike ix-explorer the component renders no label of its
+ * own (labels come from a wrapping `tn-form-field`), so instances are
+ * filtered by `testId` or `placeholder` instead.
+ *
+ * Popup helpers (`open`, `getItemNames`, `clickItem`, …) drive the browse
+ * flow. The popup renders in a CDK overlay outside the component, so these
+ * find it at the document root — with several pickers on a page they address
+ * whichever popup is open (only one can be, thanks to the overlay backdrop).
+ *
+ * @example
+ * ```typescript
+ * // Type a path, ix-explorer style
+ * const picker = await loader.getHarness(TnFilePickerHarness.with({ testId: 'file-picker-source-path' }));
+ * await picker.setValue('/mnt/tank/media');
+ * expect(await picker.getValue()).toBe('/mnt/tank/media');
+ *
+ * // Browse and pick an item through the popup
+ * await picker.open();
+ * await picker.clickItem('Documents');
+ * await picker.clickSelect();
+ * ```
+ */
+export class TnFilePickerHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a `TnFilePickerComponent` instance.
+   */
+  static hostSelector = 'tn-file-picker';
+
+  private _container = this.locatorFor('.tn-file-picker-container');
+  private _input = this.locatorFor('input.tn-file-picker-input');
+  private _toggle = this.locatorFor('button.tn-file-picker-toggle');
+
+  // The popup renders in a CDK overlay (outside the host), so it is located
+  // from the document root rather than the host subtree.
+  private _popup = this.documentRootLocatorFactory().locatorForOptional('tn-file-picker-popup');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a file picker
+   * with specific attributes.
+   *
+   * @param options Options for filtering which file picker instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find by testId (the rendered attribute, i.e. including the 'file-picker-' prefix)
+   * const picker = await loader.getHarness(TnFilePickerHarness.with({ testId: 'file-picker-source-path' }));
+   *
+   * // Find by placeholder
+   * const picker = await loader.getHarness(TnFilePickerHarness.with({ placeholder: 'Select folder' }));
+   * ```
+   */
+  static with(options: FilePickerHarnessFilters = {}) {
+    return new HarnessPredicate(TnFilePickerHarness, options)
+      .addOption('placeholder', options.placeholder, async (harness, placeholder) =>
+        (await harness.getPlaceholder()) === placeholder
+      )
+      .addOption('testId', options.testId, async (harness, testId) =>
+        (await harness.getTestId()) === testId
+      );
+  }
+
+  /**
+   * Gets the current value shown in the path input.
+   *
+   * Note: with `multiSelect`, the component displays the selected paths
+   * joined with `', '` (comma-space), so that is what this resolves to.
+   *
+   * @returns Promise resolving to the input's value.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.getValue()).toBe('/mnt/tank/media');
+   * ```
+   */
+  async getValue(): Promise<string> {
+    const input = await this._input();
+    return (await input.getProperty<string>('value')) ?? '';
+  }
+
+  /**
+   * Sets the picker's value by typing into the path input and committing it
+   * via the input's `change` event, exactly as a user pressing Enter would.
+   * Arrays are joined with commas, matching `IxExplorerHarness.setValue`.
+   *
+   * Commits go through the component's normal validation: paths outside
+   * `rootPath` are rejected (the value stays unchanged and an `error` is
+   * emitted), and `callbacks.validatePath` is consulted when provided.
+   * Setting an empty string clears the selection. Has no effect when
+   * `allowManualInput` is false (the input is readonly).
+   *
+   * @param value The path (or paths) to set.
+   *
+   * @example
+   * ```typescript
+   * await picker.setValue('/mnt/tank/media');
+   * await picker.setValue(['/mnt/a', '/mnt/b']);
+   * ```
+   */
+  async setValue(value: string | string[]): Promise<void> {
+    if (Array.isArray(value)) {
+      value = value.join(',');
+    }
+    const input = await this._input();
+    await input.clear();
+    if (value) {
+      await input.sendKeys(value);
+    }
+    return input.dispatchEvent('change');
+  }
+
+  /**
+   * Gets the path input's placeholder text.
+   *
+   * @returns Promise resolving to the placeholder string, or null if unset.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.getPlaceholder()).toBe('Select file or folder');
+   * ```
+   */
+  async getPlaceholder(): Promise<string | null> {
+    const input = await this._input();
+    return input.getAttribute('placeholder');
+  }
+
+  /**
+   * Checks whether the picker is disabled (via the `disabled` input or a
+   * disabled form control).
+   *
+   * @returns Promise resolving to true if the picker is disabled.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.isDisabled()).toBe(false);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('disabled')) ?? false;
+  }
+
+  /**
+   * Checks whether manual path entry is disallowed (`allowManualInput` is
+   * false), rendering the path input readonly.
+   *
+   * @returns Promise resolving to true if the input is readonly.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.isReadonly()).toBe(false);
+   * ```
+   */
+  async isReadonly(): Promise<boolean> {
+    const input = await this._input();
+    return (await input.getProperty<boolean>('readOnly')) ?? false;
+  }
+
+  /**
+   * Gets the test-id attribute value from the container.
+   *
+   * @returns Promise resolving to the test-id, or null when unset.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.getTestId()).toBe('file-picker-source-path');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const container = await this._container();
+    return (await container.getAttribute('data-testid')) ?? (await container.getAttribute('data-test'));
+  }
+
+  /**
+   * Opens the browse popup by clicking the folder toggle button. No-op if
+   * the popup is already open.
+   *
+   * @example
+   * ```typescript
+   * await picker.open();
+   * expect(await picker.isOpen()).toBe(true);
+   * ```
+   */
+  async open(): Promise<void> {
+    if (await this.isOpen()) {
+      return;
+    }
+    await (await this._toggle()).click();
+  }
+
+  /**
+   * Closes the browse popup without applying the pending selection, by
+   * clicking the overlay backdrop (the same dismissal a user clicking
+   * outside performs). No-op if the popup is not open.
+   *
+   * @example
+   * ```typescript
+   * await picker.close();
+   * expect(await picker.isOpen()).toBe(false);
+   * ```
+   */
+  async close(): Promise<void> {
+    const backdrop = await this.documentRootLocatorFactory()
+      .locatorForOptional('.cdk-overlay-backdrop')();
+    if (backdrop) {
+      await backdrop.click();
+    }
+  }
+
+  /**
+   * Checks whether the browse popup is currently open.
+   *
+   * @returns Promise resolving to true if the popup is open.
+   *
+   * @example
+   * ```typescript
+   * expect(await picker.isOpen()).toBe(false);
+   * ```
+   */
+  async isOpen(): Promise<boolean> {
+    return (await this._popup()) !== null;
+  }
+
+  /**
+   * Gets the labels of the breadcrumb segments in the popup header. Long
+   * paths are truncated by the component, so a segment may be `'…'`.
+   *
+   * @returns Promise resolving to the breadcrumb segment labels.
+   *
+   * @example
+   * ```typescript
+   * await picker.open();
+   * expect(await picker.getBreadcrumbSegments()).toEqual(['mnt']);
+   * ```
+   */
+  async getBreadcrumbSegments(): Promise<string[]> {
+    const segments = await this.documentRootLocatorFactory()
+      .locatorForAll('tn-file-picker-popup .breadcrumb-segment')();
+    return Promise.all(segments.map(async (segment) => (await segment.text()).trim()));
+  }
+
+  /**
+   * Gets the names of the items listed in the open popup.
+   *
+   * @returns Promise resolving to the visible item names.
+   *
+   * @example
+   * ```typescript
+   * await picker.open();
+   * expect(await picker.getItemNames()).toContain('Documents');
+   * ```
+   */
+  async getItemNames(): Promise<string[]> {
+    const names = await this.documentRootLocatorFactory()
+      .locatorForAll('tn-file-picker-popup .file-name')();
+    return Promise.all(names.map(async (name) => (await name.text()).trim()));
+  }
+
+  /**
+   * Clicks the popup row with the given item name, toggling its selection
+   * (single-select replaces the pending selection; multi-select toggles the
+   * item in and out). The selection is applied with {@link clickSelect}.
+   *
+   * @param name The item name as displayed in the list.
+   *
+   * @example
+   * ```typescript
+   * await picker.open();
+   * await picker.clickItem('Documents');
+   * await picker.clickSelect();
+   * ```
+   */
+  async clickItem(name: string): Promise<void> {
+    const names = await this.documentRootLocatorFactory()
+      .locatorForAll('tn-file-picker-popup .file-name')();
+    for (const nameEl of names) {
+      if ((await nameEl.text()).trim() === name) {
+        return nameEl.click();
+      }
+    }
+    throw new Error(`No item named "${name}" found in the file picker popup.`);
+  }
+
+  /**
+   * Navigates into a directory-like item (folder, dataset, or mountpoint)
+   * by clicking its navigation chevron.
+   *
+   * @param name The item name as displayed in the list.
+   *
+   * @example
+   * ```typescript
+   * await picker.open();
+   * await picker.navigateToItem('Documents');
+   * ```
+   */
+  async navigateToItem(name: string): Promise<void> {
+    const button = await this.documentRootLocatorFactory()
+      .locatorForOptional(`tn-file-picker-popup .navigate-button[aria-label="Open ${name}"]`)();
+    if (!button) {
+      throw new Error(`No navigatable item named "${name}" found in the file picker popup.`);
+    }
+    return button.click();
+  }
+
+  /**
+   * Clicks the popup's Select button, applying the pending selection as the
+   * picker's value and closing the popup.
+   *
+   * @example
+   * ```typescript
+   * await picker.clickItem('Documents');
+   * await picker.clickSelect();
+   * expect(await picker.getValue()).toBe('/mnt/Documents');
+   * ```
+   */
+  async clickSelect(): Promise<void> {
+    const button = await this.documentRootLocatorFactory()
+      .locatorFor(TnButtonHarness.with({ label: 'Select', ancestor: '.tn-file-picker-footer' }))();
+    return button.click();
+  }
+
+  /**
+   * Clicks the popup's Clear Selection button. Only rendered while items are
+   * selected; throws otherwise.
+   *
+   * @example
+   * ```typescript
+   * await picker.clickItem('Documents');
+   * await picker.clickClearSelection();
+   * ```
+   */
+  async clickClearSelection(): Promise<void> {
+    const button = await this.documentRootLocatorFactory()
+      .locatorForOptional(TnButtonHarness.with({ label: 'Clear Selection', ancestor: '.tn-file-picker-footer' }))();
+    if (!button) {
+      throw new Error('No Clear Selection button found — nothing is selected in the file picker popup.');
+    }
+    return button.click();
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnFilePickerHarness` instances.
+ */
+export interface FilePickerHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the path input's placeholder text. */
+  placeholder?: string;
+  /** Filters by the rendered data-testid attribute (includes the `file-picker-` prefix). */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/lib/file-picker/index.ts
+++ b/projects/truenas-ui/src/lib/file-picker/index.ts
@@ -1,4 +1,5 @@
 export * from './file-picker.component';
+export * from './file-picker.harness';
 export * from './file-picker-popup.component';
 export * from './file-picker.interfaces';
 export * from './file-picker.utils';

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/angular';
 import { fireEvent, userEvent, within, screen, expect, waitFor } from 'storybook/test';
 import { TestIdInspectorComponent } from './testid-inspector.component';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnFilePickerComponent } from '../lib/file-picker/file-picker.component';
 import type { FileSystemItem, FilePickerCallbacks } from '../lib/file-picker/file-picker.interfaces';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+
+const harnessDoc = loadHarnessDoc('file-picker');
 
 const meta: Meta<TnFilePickerComponent> = {
   title: 'Components/File Picker',
@@ -1624,4 +1627,23 @@ export const TestIds: Story = {
     `,
     moduleMetadata: { imports: [TnFilePickerComponent, TestIdInspectorComponent] },
   }),
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      story: { height: 'auto' },
+      canvas: {
+        hidden: true,
+        sourceState: 'none',
+      },
+      description: {
+        story: harnessDoc || '',
+      },
+    },
+    controls: { disable: true },
+    layout: 'fullscreen',
+  },
+  render: () => ({ template: '' }),
 };

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -1612,10 +1612,29 @@ export const ErrorHandling: Story = {
 };
 
 /**
- * **Test IDs.** The file-picker **container** (the inline trigger field) emits
- * `file-picker-<base>` — shown live in the table. The browse popup renders in a
- * portaled overlay. `testId="backup-target"` → `file-picker-backup-target`,
- * under `data-testid` (default) / `data-test`.
+ * **Test IDs.** The `testId` base scopes the whole picker — and when unset it
+ * falls back to the bound control's name, so `formControlName="backupPath"`
+ * yields the same ids as `testId="backup-path"`.
+ *
+ * | Element | Emitted id (base `backup-target`) |
+ * |---|---|
+ * | container | `file-picker-backup-target` |
+ * | path input | `input-backup-target` |
+ * | browse toggle | `button-toggle-backup-target` |
+ * | popup (portaled overlay) | `file-picker-popup-backup-target` |
+ * | item row (name `docs`) | `option-backup-target-docs` |
+ * | row checkbox (multi-select) | `checkbox-backup-target-docs` |
+ * | navigate chevron | `button-navigate-backup-target-docs` |
+ * | breadcrumb segment (`mnt`) | `button-breadcrumb-backup-target-mnt` |
+ * | Select / Clear Selection | `button-select-backup-target` / `button-clear-selection-backup-target` |
+ * | create action (id `dataset`) | `button-backup-target-dataset` |
+ * | inline creation input | `input-create-backup-target` |
+ *
+ * With no base, the trigger chrome stays attribute-free (several pickers per
+ * page would collide), while popup internals fall back to bare roles
+ * (`button-select`, `option-docs`) — only one popup can be open at a time.
+ * Under `data-testid` (default) / `data-test`. Open the popup to see the
+ * derived ids in the DOM.
  */
 export const TestIds: Story = {
   render: () => ({

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -1635,23 +1635,56 @@ export const ErrorHandling: Story = {
  * (`button-select`, `option-docs`) — only one popup can be open at a time.
  * Under `data-testid` (default) / `data-test`.
  *
- * The popup is a portaled overlay, so its ids exist only while it is open:
- * **open the picker below** and the table extends live with the popup's rows,
- * checkboxes, navigate chevrons, and footer buttons, marked `(overlay)`.
+ * The live table lists the trigger's ids; the popup renders in a portaled
+ * overlay, so its ids exist only while it is open — the reference list below
+ * the table shows what to expect there (verify in devtools with the popup
+ * open).
  */
 export const TestIds: Story = {
   render: () => ({
     props: {
       createActions: [{ id: 'dataset', label: 'Create Dataset' }],
+      // Expected ids for the popup surface, per element role. Mirrors (and is
+      // kept honest by) the popup "Test IDs" cases in
+      // file-picker-popup.component.spec.ts.
+      popupIds: [
+        { element: 'popup container', id: 'file-picker-popup-backup-target' },
+        { element: 'breadcrumb segment (mnt)', id: 'button-breadcrumb-backup-target-mnt' },
+        { element: 'item row (Documents)', id: 'option-backup-target-documents' },
+        { element: 'row checkbox — multi-select (Documents)', id: 'checkbox-backup-target-documents' },
+        { element: 'navigate chevron (Documents)', id: 'button-navigate-backup-target-documents' },
+        { element: 'create action (id: dataset)', id: 'button-backup-target-dataset' },
+        { element: 'inline creation input', id: 'input-create-backup-target' },
+        { element: 'Select button', id: 'button-select-backup-target' },
+        { element: 'Clear Selection button', id: 'button-clear-selection-backup-target' },
+      ],
     },
     template: `
-      <tn-testid-inspector includeOverlay>
+      <tn-testid-inspector>
         <tn-file-picker
           testId="backup-target"
           [multiSelect]="true"
           [createActions]="createActions"
           placeholder="Choose a path" />
       </tn-testid-inspector>
+
+      <table class="tn-testid-doc" style="margin-top:16px;border-collapse:collapse;font:13px/1.5 monospace;">
+        <thead>
+          <tr>
+            <th style="text-align:left;padding:4px 12px;border-bottom:1px solid #ccc;" colspan="2">
+              in the popup (portaled overlay, while open)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of popupIds; track row.id) {
+            <tr>
+              <td style="padding:4px 12px;">{{ row.element }}</td>
+              <td style="padding:4px 12px;"><strong>{{ row.id }}</strong></td>
+            </tr>
+          }
+        </tbody>
+      </table>
     `,
     moduleMetadata: { imports: [TnFilePickerComponent, TestIdInspectorComponent] },
   }),

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -1633,15 +1633,24 @@ export const ErrorHandling: Story = {
  * With no base, the trigger chrome stays attribute-free (several pickers per
  * page would collide), while popup internals fall back to bare roles
  * (`button-select`, `option-docs`) — only one popup can be open at a time.
- * Under `data-testid` (default) / `data-test`. Open the popup to see the
- * derived ids in the DOM.
+ * Under `data-testid` (default) / `data-test`.
+ *
+ * The popup is a portaled overlay, so its ids exist only while it is open:
+ * **open the picker below** and the table extends live with the popup's rows,
+ * checkboxes, navigate chevrons, and footer buttons, marked `(overlay)`.
  */
 export const TestIds: Story = {
   render: () => ({
-    props: { callbacks: { listDirectory: () => Promise.resolve([]) } as FilePickerCallbacks },
+    props: {
+      createActions: [{ id: 'dataset', label: 'Create Dataset' }],
+    },
     template: `
-      <tn-testid-inspector>
-        <tn-file-picker testId="backup-target" [callbacks]="callbacks" placeholder="Choose a path" />
+      <tn-testid-inspector includeOverlay>
+        <tn-file-picker
+          testId="backup-target"
+          [multiSelect]="true"
+          [createActions]="createActions"
+          placeholder="Choose a path" />
       </tn-testid-inspector>
     `,
     moduleMetadata: { imports: [TnFilePickerComponent, TestIdInspectorComponent] },

--- a/projects/truenas-ui/src/stories/testid-inspector.component.ts
+++ b/projects/truenas-ui/src/stories/testid-inspector.component.ts
@@ -1,5 +1,5 @@
-import type { AfterViewInit } from '@angular/core';
-import { Component, ElementRef, inject, signal } from '@angular/core';
+import type { AfterViewInit, OnDestroy } from '@angular/core';
+import { Component, ElementRef, booleanAttribute, inject, input, signal } from '@angular/core';
 
 /**
  * Storybook docs helper for "Test IDs" stories.
@@ -15,10 +15,17 @@ import { Component, ElementRef, inject, signal } from '@angular/core';
  * </tn-testid-inspector>
  * ```
  *
- * Caveat: it only sees ids in its own DOM subtree. Ids rendered into a CDK
- * overlay (select/menu/autocomplete/dialog options & items) are portaled to
- * `document.body` and won't appear in the table until that surface is open —
- * document those in the story's prose instead, or open the overlay in a `play`.
+ * By default it only sees ids in its own DOM subtree. Ids rendered into a CDK
+ * overlay (select/menu/autocomplete/dialog/file-picker surfaces) are portaled
+ * to `document.body` and never enter that subtree. Set `includeOverlay` for
+ * stories whose ids live in such a surface:
+ * ```html
+ * <tn-testid-inspector includeOverlay>
+ * ```
+ * The table then re-scans on DOM mutations and appends whatever the overlay
+ * container currently holds — open the overlay in the story canvas and its ids
+ * appear live, marked `(overlay)`. The overlay container is shared per page,
+ * so on an autodocs page the table reflects whichever overlay is open.
  */
 @Component({
   selector: 'tn-testid-inspector',
@@ -48,20 +55,54 @@ import { Component, ElementRef, inject, signal } from '@angular/core';
     }
   `,
 })
-export class TestIdInspectorComponent implements AfterViewInit {
+export class TestIdInspectorComponent implements AfterViewInit, OnDestroy {
+  /**
+   * Also list ids currently rendered in the CDK overlay container (portaled
+   * surfaces: popups, dropdowns, dialogs), kept live via a MutationObserver.
+   */
+  readonly includeOverlay = input(false, { transform: booleanAttribute });
+
   protected readonly rows = signal<{ element: string; attribute: string; id: string }[]>([]);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private observer?: MutationObserver;
 
   ngAfterViewInit(): void {
     // Defer one tick so the directive's attribute-writing effects have flushed.
     setTimeout(() => {
-      const els = Array.from(this.host.nativeElement.querySelectorAll<HTMLElement>('[data-testid],[data-test]'));
-      this.rows.set(
-        els.map((el) => {
-          const attribute = el.hasAttribute('data-testid') ? 'data-testid' : 'data-test';
-          return { element: el.tagName.toLowerCase(), attribute, id: el.getAttribute(attribute) ?? '' };
-        }),
-      );
+      this.scan();
+      if (this.includeOverlay()) {
+        // Overlay content appears/disappears outside Angular's view of this
+        // component, so watch the document and re-scan. The scan is guarded
+        // against no-op updates, which also keeps the observer from feeding
+        // itself with the mutations of its own table re-render.
+        this.observer = new MutationObserver(() => this.scan());
+        this.observer.observe(document.body, { subtree: true, childList: true, attributes: true, attributeFilter: ['data-testid', 'data-test'] });
+      }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+  }
+
+  private scan(): void {
+    const collect = (root: ParentNode, suffix: string) =>
+      Array.from(root.querySelectorAll<HTMLElement>('[data-testid],[data-test]')).map((el) => {
+        const attribute = el.hasAttribute('data-testid') ? 'data-testid' : 'data-test';
+        return { element: el.tagName.toLowerCase() + suffix, attribute, id: el.getAttribute(attribute) ?? '' };
+      });
+
+    const rows = collect(this.host.nativeElement, '');
+    if (this.includeOverlay()) {
+      const overlay = document.querySelector('.cdk-overlay-container');
+      if (overlay) {
+        rows.push(...collect(overlay, ' (overlay)'));
+      }
+    }
+    // Update only on real changes so the observer doesn't loop on the
+    // mutations caused by rendering the table itself.
+    if (JSON.stringify(rows) !== JSON.stringify(this.rows())) {
+      this.rows.set(rows);
+    }
   }
 }

--- a/projects/truenas-ui/src/stories/testid-inspector.component.ts
+++ b/projects/truenas-ui/src/stories/testid-inspector.component.ts
@@ -1,5 +1,5 @@
-import type { AfterViewInit, OnDestroy } from '@angular/core';
-import { Component, ElementRef, booleanAttribute, inject, input, signal } from '@angular/core';
+import type { AfterViewInit } from '@angular/core';
+import { Component, ElementRef, inject, signal } from '@angular/core';
 
 /**
  * Storybook docs helper for "Test IDs" stories.
@@ -15,17 +15,10 @@ import { Component, ElementRef, booleanAttribute, inject, input, signal } from '
  * </tn-testid-inspector>
  * ```
  *
- * By default it only sees ids in its own DOM subtree. Ids rendered into a CDK
- * overlay (select/menu/autocomplete/dialog/file-picker surfaces) are portaled
- * to `document.body` and never enter that subtree. Set `includeOverlay` for
- * stories whose ids live in such a surface:
- * ```html
- * <tn-testid-inspector includeOverlay>
- * ```
- * The table then re-scans on DOM mutations and appends whatever the overlay
- * container currently holds — open the overlay in the story canvas and its ids
- * appear live, marked `(overlay)`. The overlay container is shared per page,
- * so on an autodocs page the table reflects whichever overlay is open.
+ * Caveat: it only sees ids in its own DOM subtree. Ids rendered into a CDK
+ * overlay (select/menu/autocomplete/dialog options & items) are portaled to
+ * `document.body` and won't appear in the table until that surface is open —
+ * document those in the story's prose instead, or open the overlay in a `play`.
  */
 @Component({
   selector: 'tn-testid-inspector',
@@ -55,54 +48,20 @@ import { Component, ElementRef, booleanAttribute, inject, input, signal } from '
     }
   `,
 })
-export class TestIdInspectorComponent implements AfterViewInit, OnDestroy {
-  /**
-   * Also list ids currently rendered in the CDK overlay container (portaled
-   * surfaces: popups, dropdowns, dialogs), kept live via a MutationObserver.
-   */
-  readonly includeOverlay = input(false, { transform: booleanAttribute });
-
+export class TestIdInspectorComponent implements AfterViewInit {
   protected readonly rows = signal<{ element: string; attribute: string; id: string }[]>([]);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
-  private observer?: MutationObserver;
 
   ngAfterViewInit(): void {
     // Defer one tick so the directive's attribute-writing effects have flushed.
     setTimeout(() => {
-      this.scan();
-      if (this.includeOverlay()) {
-        // Overlay content appears/disappears outside Angular's view of this
-        // component, so watch the document and re-scan. The scan is guarded
-        // against no-op updates, which also keeps the observer from feeding
-        // itself with the mutations of its own table re-render.
-        this.observer = new MutationObserver(() => this.scan());
-        this.observer.observe(document.body, { subtree: true, childList: true, attributes: true, attributeFilter: ['data-testid', 'data-test'] });
-      }
+      const els = Array.from(this.host.nativeElement.querySelectorAll<HTMLElement>('[data-testid],[data-test]'));
+      this.rows.set(
+        els.map((el) => {
+          const attribute = el.hasAttribute('data-testid') ? 'data-testid' : 'data-test';
+          return { element: el.tagName.toLowerCase(), attribute, id: el.getAttribute(attribute) ?? '' };
+        }),
+      );
     });
-  }
-
-  ngOnDestroy(): void {
-    this.observer?.disconnect();
-  }
-
-  private scan(): void {
-    const collect = (root: ParentNode, suffix: string) =>
-      Array.from(root.querySelectorAll<HTMLElement>('[data-testid],[data-test]')).map((el) => {
-        const attribute = el.hasAttribute('data-testid') ? 'data-testid' : 'data-test';
-        return { element: el.tagName.toLowerCase() + suffix, attribute, id: el.getAttribute(attribute) ?? '' };
-      });
-
-    const rows = collect(this.host.nativeElement, '');
-    if (this.includeOverlay()) {
-      const overlay = document.querySelector('.cdk-overlay-container');
-      if (overlay) {
-        rows.push(...collect(overlay, ' (overlay)'));
-      }
-    }
-    // Update only on real changes so the observer doesn't loop on the
-    // mutations caused by rendering the table itself.
-    if (JSON.stringify(rows) !== JSON.stringify(this.rows())) {
-      this.rows.set(rows);
-    }
   }
 }


### PR DESCRIPTION
* harness mimics the API surface of ix-explorer's harness
* now accepts a base test id and derives test ids for all interactive elements