### PR TITLE
NAS-141906 / 27.0.0-BETA.1 / feat(file-picker): valueRoot — express the picker value relative to a root

### DIFF
--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -182,6 +182,38 @@ describe('TnFilePickerComponent', () => {
       expect(selectionSpy).toHaveBeenCalledWith('');
       expect(getInput().value).toBe('');
     });
+
+    it('canonicalizes an absolute written value into value space, keeping the display stable across submit', () => {
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.detectChanges();
+
+      component.writeValue('/mnt/tank');
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/mnt/tank']);
+      expect(getInput().value).toBe('tank');
+
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+      component.onSubmit();
+      fixture.detectChanges();
+
+      // The field shows the same text before and after submitting
+      expect(changeSpy).toHaveBeenCalledWith('tank');
+      expect(getInput().value).toBe('tank');
+    });
+
+    it('canonicalizes mixed written values in multi-select, passing outside-root paths through', () => {
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.componentRef.setInput('multiSelect', true);
+      fixture.detectChanges();
+
+      component.writeValue(['/mnt/tank/foo', 'tank/bar', '/dev/zvol/vol1']);
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/mnt/tank/foo', '/mnt/tank/bar', '/dev/zvol/vol1']);
+      expect(getInput().value).toBe('tank/foo, tank/bar, /dev/zvol/vol1');
+    });
   });
 
   describe('Programmatic API', () => {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -99,6 +99,58 @@ describe('TnFilePickerComponent', () => {
     });
   });
 
+  describe('Value Root', () => {
+    function getInput(): HTMLInputElement {
+      return fixture.nativeElement.querySelector('.tn-file-picker-input') as HTMLInputElement;
+    }
+
+    it('shows and emits value-space paths while selection state stays absolute', () => {
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.componentRef.setInput('multiSelect', true);
+      fixture.detectChanges();
+
+      component.writeValue(['tank/foo', 'tank/bar']);
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/mnt/tank/foo', '/mnt/tank/bar']);
+      expect(getInput().value).toBe('tank/foo, tank/bar');
+
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+      component.onSubmit();
+
+      expect(changeSpy).toHaveBeenCalledWith(['tank/foo', 'tank/bar']);
+    });
+
+    it('interprets typed paths in value space', () => {
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.detectChanges();
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = getInput();
+      input.value = 'tank/child';
+      input.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/mnt/tank/child']);
+      expect(getInput().value).toBe('tank/child');
+      expect(changeSpy).toHaveBeenCalledWith('tank/child');
+    });
+
+    it('maps a / value root by stripping the leading slash', () => {
+      fixture.componentRef.setInput('valueRoot', '/');
+      fixture.componentRef.setInput('rootPath', '/');
+      fixture.detectChanges();
+
+      component.writeValue('dozer/foo');
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/dozer/foo']);
+      expect(getInput().value).toBe('dozer/foo');
+    });
+  });
+
   describe('Programmatic API', () => {
     it('should re-fetch the current listing on refresh()', async () => {
       const getChildren = jest.fn().mockResolvedValue([]);

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.spec.ts
@@ -149,6 +149,39 @@ describe('TnFilePickerComponent', () => {
       expect(component.selectedItems()).toEqual(['/dozer/foo']);
       expect(getInput().value).toBe('dozer/foo');
     });
+
+    it('passes paths outside the value root through untouched', () => {
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.componentRef.setInput('rootPath', '/');
+      fixture.detectChanges();
+      const changeSpy = jest.fn();
+      component.registerOnChange(changeSpy);
+
+      const input = getInput();
+      input.value = '/dev/zvol/tank';
+      input.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(component.selectedItems()).toEqual(['/dev/zvol/tank']);
+      expect(getInput().value).toBe('/dev/zvol/tank');
+      expect(changeSpy).toHaveBeenCalledWith('/dev/zvol/tank');
+    });
+
+    it('submits the value root itself as an empty value, same as a cleared selection', () => {
+      // Documented collision: the value root is the container values are named
+      // against, not a selectable value — submitting it is indistinguishable
+      // from clearing, and writeValue('') cannot restore it.
+      fixture.componentRef.setInput('valueRoot', '/mnt');
+      fixture.componentRef.setInput('startPath', '/mnt');
+      fixture.detectChanges();
+      const selectionSpy = jest.fn();
+      component.selectionChange.subscribe(selectionSpy);
+
+      component.onSubmit();
+
+      expect(selectionSpy).toHaveBeenCalledWith('');
+      expect(getInput().value).toBe('');
+    });
   });
 
   describe('Programmatic API', () => {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -151,6 +151,9 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
       const values = Array.isArray(value) ? value : value ? [value] : [];
       const items = values.map(entry => this.fromValueSpace(entry));
       this.selectedItems.set(items);
+      // An entry equal to the value root maps to '' and leaves a stray comma
+      // in the join — accepted, per the documented "the value root is not a
+      // selectable value" caveat in toValueSpace.
       this.selectedPath.set(items.map(item => this.toValueSpace(item)).join(', '));
     } else {
       const single = typeof value === 'string' ? value : value ? value[0] : '';

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -455,21 +455,31 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
     this.selectionChange.emit(this.multiSelect() ? [value] : value);
   }
 
+  // Mirrors effectiveRootPath so both roots normalize trailing slashes once
+  private normalizedValueRoot = computed(() => {
+    const valueRoot = this.valueRoot();
+    return valueRoot ? normalizeRootPath(valueRoot) : undefined;
+  });
+
   /** Maps an internal absolute path into the `valueRoot`-relative value space. */
   private toValueSpace(path: string): string {
-    const valueRoot = this.valueRoot();
-    if (!valueRoot) {return path;}
-    const root = normalizeRootPath(valueRoot);
+    const root = this.normalizedValueRoot();
+    if (!root) {return path;}
+    // The value root itself maps to '' — the same payload as a cleared
+    // selection, and writeValue('') cannot restore it. Deliberate: a value
+    // root is the container the values are named against (e.g. /mnt for
+    // dataset names), not a selectable value itself. Revisit this mapping
+    // before pairing valueRoot with a selectable root directory.
     if (path === root) {return '';}
     if (root === '/') {return path.startsWith('/') ? path.slice(1) : path;}
+    // Paths outside the value root (e.g. typed absolute paths) pass through
     return path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path;
   }
 
   /** Maps a `valueRoot`-relative value back into an internal absolute path. */
   private fromValueSpace(value: string): string {
-    const valueRoot = this.valueRoot();
-    if (!valueRoot || !value || value.startsWith('/')) {return value;}
-    const root = normalizeRootPath(valueRoot);
+    const root = this.normalizedValueRoot();
+    if (!root || !value || value.startsWith('/')) {return value;}
     return root === '/' ? `/${value}` : `${root}/${value}`;
   }
 

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -78,6 +78,16 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
   startPath = input<string>('/mnt');
   /** Restricts navigation — users cannot navigate above this path. */
   rootPath = input<string | undefined>(undefined);
+  /**
+   * Root against which the picker's VALUE is expressed — the form value,
+   * `selectionChange` payloads, and the text shown in the input. Browsing
+   * (`rootPath`, `startPath`, `callbacks`, `selectPath`) keeps absolute paths;
+   * the mapping applies only at the value boundary. E.g. with
+   * `valueRoot="/mnt"`, selecting `/mnt/tank/child` shows and emits the
+   * dataset name `tank/child` instead of the mountpoint path. Typed input is
+   * interpreted in the same value space (absolute paths still pass through).
+   */
+  valueRoot = input<string | undefined>(undefined);
   fileExtensions = input<string[] | undefined>(undefined);
   callbacks = input<FilePickerCallbacks | undefined>(undefined);
 
@@ -132,13 +142,15 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
   // ControlValueAccessor implementation
   writeValue(value: string | string[]): void {
     if (this.multiSelect()) {
-      this.selectedItems.set(Array.isArray(value) ? value : value ? [value] : []);
-      // For multi-select, show full paths separated by commas
-      this.selectedPath.set(this.selectedItems().join(', '));
+      const values = Array.isArray(value) ? value : value ? [value] : [];
+      this.selectedItems.set(values.map(entry => this.fromValueSpace(entry)));
+      // For multi-select, show the value-space paths separated by commas
+      this.selectedPath.set(values.join(', '));
     } else {
-      // Store the full path internally
-      this.selectedPath.set(typeof value === 'string' ? value : '');
-      this.selectedItems.set(value ? [typeof value === 'string' ? value : value[0]] : []);
+      const single = typeof value === 'string' ? value : value ? value[0] : '';
+      this.selectedPath.set(single);
+      // Selection state keeps internal absolute paths
+      this.selectedItems.set(single ? [this.fromValueSpace(single)] : []);
     }
   }
 
@@ -164,7 +176,8 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
    */
   onPathCommit(event: Event): void {
     const target = event.target as HTMLInputElement;
-    const path = target.value;
+    // Typed text is expressed in value space, like the text the input displays
+    const path = this.fromValueSpace(target.value);
 
     if (this.allowManualInput()) {
       // Clearing the input clears the selection
@@ -272,14 +285,15 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
     this.hasError.set(false);
 
     if (this.multiSelect()) {
-      this.selectedPath.set(selected.join(', '));
-      this.onChange(selected);
-      this.selectionChange.emit(selected);
+      const values = selected.map(path => this.toValueSpace(path));
+      this.selectedPath.set(values.join(', '));
+      this.onChange(values);
+      this.selectionChange.emit(values);
     } else {
-      const path = selected[0];
-      this.selectedPath.set(path);
-      this.onChange(path);
-      this.selectionChange.emit(path);
+      const value = this.toValueSpace(selected[0]);
+      this.selectedPath.set(value);
+      this.onChange(value);
+      this.selectionChange.emit(value);
     }
 
     this.close();
@@ -427,18 +441,36 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
     // Clear any existing error state since popup selections are valid
     this.hasError.set(false);
 
+    const value = this.toValueSpace(path);
     if (this.multiSelect()) {
-      const selected = [path];
-      this.selectedItems.set(selected);
-      this.selectedPath.set(selected.join(', '));
-      this.onChange(selected);
-    } else {
-      this.selectedPath.set(path);
       this.selectedItems.set([path]);
-      this.onChange(path);
+      this.selectedPath.set(value);
+      this.onChange([value]);
+    } else {
+      this.selectedPath.set(value);
+      this.selectedItems.set([path]);
+      this.onChange(value);
     }
 
-    this.selectionChange.emit(this.multiSelect() ? this.selectedItems() : path);
+    this.selectionChange.emit(this.multiSelect() ? [value] : value);
+  }
+
+  /** Maps an internal absolute path into the `valueRoot`-relative value space. */
+  private toValueSpace(path: string): string {
+    const valueRoot = this.valueRoot();
+    if (!valueRoot) {return path;}
+    const root = normalizeRootPath(valueRoot);
+    if (path === root) {return '';}
+    if (root === '/') {return path.startsWith('/') ? path.slice(1) : path;}
+    return path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path;
+  }
+
+  /** Maps a `valueRoot`-relative value back into an internal absolute path. */
+  private fromValueSpace(value: string): string {
+    const valueRoot = this.valueRoot();
+    if (!valueRoot || !value || value.startsWith('/')) {return value;}
+    const root = normalizeRootPath(valueRoot);
+    return root === '/' ? `/${value}` : `${root}/${value}`;
   }
 
   private emitError(type: FilePickerError['type'], message: string, path?: string): void {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -141,16 +141,22 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
 
   // ControlValueAccessor implementation
   writeValue(value: string | string[]): void {
+    // The display is canonicalized into value space by round-tripping through
+    // the mapping: a consumer may write an absolute path while valueRoot is
+    // set (e.g. /mnt/tank with valueRoot="/mnt"), and echoing it verbatim
+    // would make the field silently flip to the canonical form (tank) on the
+    // next submit. Selection state keeps internal absolute paths either way;
+    // paths outside the value root round-trip unchanged.
     if (this.multiSelect()) {
       const values = Array.isArray(value) ? value : value ? [value] : [];
-      this.selectedItems.set(values.map(entry => this.fromValueSpace(entry)));
-      // For multi-select, show the value-space paths separated by commas
-      this.selectedPath.set(values.join(', '));
+      const items = values.map(entry => this.fromValueSpace(entry));
+      this.selectedItems.set(items);
+      this.selectedPath.set(items.map(item => this.toValueSpace(item)).join(', '));
     } else {
       const single = typeof value === 'string' ? value : value ? value[0] : '';
-      this.selectedPath.set(single);
-      // Selection state keeps internal absolute paths
-      this.selectedItems.set(single ? [this.fromValueSpace(single)] : []);
+      const item = single ? this.fromValueSpace(single) : '';
+      this.selectedItems.set(item ? [item] : []);
+      this.selectedPath.set(item ? this.toValueSpace(item) : '');
     }
   }
 

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -1408,6 +1408,73 @@ export const OpenOnClick: Story = {
   }
 };
 
+const datasetFilesystem: Record<string, FileSystemItem[]> = {
+  '/mnt': [
+    { path: '/mnt/tank', name: 'tank', type: 'dataset' },
+  ],
+  '/mnt/tank': [
+    { path: '/mnt/tank/apps', name: 'apps', type: 'dataset' },
+    { path: '/mnt/tank/media', name: 'media', type: 'dataset' },
+  ],
+};
+
+export const DatasetNames: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      callbacks: {
+        getChildren: async (path: string) => datasetFilesystem[path] || []
+      } as FilePickerCallbacks
+    },
+    template: `
+      <tn-form-field label="Source dataset">
+        <tn-file-picker
+          [mode]="mode"
+          [valueRoot]="valueRoot"
+          [rootPath]="rootPath"
+          [startPath]="startPath"
+          [callbacks]="callbacks">
+        </tn-file-picker>
+      </tn-form-field>
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, TnFilePickerComponent],
+    }
+  }),
+  args: {
+    mode: 'dataset',
+    valueRoot: '/mnt',
+    rootPath: '/mnt',
+    startPath: '/mnt/tank'
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const folderButton = canvas.getByRole('button', { name: /open file picker/i });
+    await userEvent.click(folderButton);
+
+    await waitFor(() => {
+      void expect(screen.queryByText('apps')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    await userEvent.click(screen.getByText('apps'));
+    await userEvent.click(screen.getByRole('button', { name: 'Select' }));
+
+    // The field shows the dataset name, not the mountpoint path
+    const input = canvas.getByRole('textbox');
+    await waitFor(() => {
+      void expect(input).toHaveValue('tank/apps');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'With `valueRoot="/mnt"` the picker speaks dataset names: browsing works on mountpoint paths, but the field text, form value, and `selectionChange` payloads are expressed relative to the value root — selecting `/mnt/tank/apps` yields `tank/apps`. Used by consumers whose value is a dataset id rather than a filesystem path (e.g. replication sources and targets).'
+      }
+    }
+  }
+};
+
 export const SelectionModes: Story = {
   render: (args) => ({
     props: {

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -41,6 +41,10 @@ const meta: Meta<TnFilePickerComponent> = {
     startPath: {
       control: 'text',
       description: 'Initial directory path',
+    },
+    valueRoot: {
+      control: 'text',
+      description: 'Root against which the value (form value, selectionChange, input text) is expressed, e.g. /mnt for dataset names',
     }
   }
 };
@@ -166,6 +170,11 @@ startPath = input<string>('/mnt');
 rootPath = input<string | undefined>(undefined);
 \`\`\`
 **Description:** Restrict navigation - users cannot navigate above this path. Defaults to \`/mnt\`. The confinement also applies to manually typed paths: entering a path outside the root emits a \`validation\` error instead of applying it.
+
+\`\`\`typescript
+valueRoot = input<string | undefined>(undefined);
+\`\`\`
+**Description:** Root against which the picker's VALUE is expressed — the form value, \`selectionChange\` payloads, and the text shown in the input. Browsing (\`rootPath\`, \`startPath\`, \`callbacks\`, \`selectPath\`) keeps absolute paths; the mapping applies only at the value boundary. With \`valueRoot="/mnt"\`, selecting \`/mnt/tank/child\` shows and emits the dataset name \`tank/child\`. Typed input is interpreted in the same value space (absolute paths still pass through).
 
 \`\`\`typescript
 fileExtensions = input<string[] | undefined>(undefined);


### PR DESCRIPTION
New `valueRoot` input on `tn-file-picker`: the root against which the picker's VALUE is expressed — the form value, `selectionChange` payloads, and the text shown in the input — while browsing (`rootPath`, `startPath`, `callbacks`, `selectPath`) keeps absolute paths. The mapping applies only at the value boundary.

With `valueRoot="/mnt"`, selecting `/mnt/tank/child` shows and emits the dataset name `tank/child` instead of a slash-rooted path; typed input is interpreted in the same value space (absolute paths pass through). This lets dataset-name consumers (webui replication sources/targets, `pool.filesystem_choices` pickers) display `dozer/foo, dozer/bar` in the field rather than `/dozer/foo, /dozer/bar`.

## Coverage

- Display + emission mapping (`/mnt` root, multi-select).
- Typed-input interpretation in value space.
- `/` value root (webui's relative dataset providers).
- Documented in the stories API reference and argTypes.