### PR TITLE
NAS-142091 / 27.0.0-BETA.1 / feat(file-picker): submitOnBlur opt-out for side-effecting inline creations

### DIFF
--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
@@ -88,6 +88,28 @@
                 @if (creation.loading) {
                   <tn-icon name="mdi-loading" class="creation-loading-icon" aria-hidden="true" />
                 }
+                <!-- Blur doesn't submit for these actions, so mouse users need
+                     explicit confirm/cancel affordances -->
+                @if (creation.action.submitOnBlur === false && !creation.loading) {
+                  <button
+                    type="button"
+                    class="inline-create-button confirm"
+                    tnTestIdType="button"
+                    aria-label="Confirm creation"
+                    [tnTestId]="inlineConfirmTestId()"
+                    (click)="submitInlineCreation()">
+                    <tn-icon name="mdi-check" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    class="inline-create-button cancel"
+                    tnTestIdType="button"
+                    aria-label="Cancel creation"
+                    [tnTestId]="inlineCancelTestId()"
+                    (click)="cancelInlineCreation()">
+                    <tn-icon name="mdi-close" aria-hidden="true" />
+                  </button>
+                }
               </div>
               @if (creation.error) {
                 <div class="inline-create-error" role="alert" [id]="inlineErrorId">

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -150,6 +150,32 @@
     color: var(--tn-primary);
     flex-shrink: 0;
   }
+
+  .inline-create-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 4px;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--tn-fg2);
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      background: var(--tn-bg2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--tn-primary);
+    }
+
+    &.confirm {
+      color: var(--tn-primary);
+    }
+  }
 }
 
 .inline-create-error {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.spec.ts
@@ -763,6 +763,93 @@ describe('TnFilePickerPopupComponent', () => {
     });
   });
 
+  describe('Inline Creation – submitOnBlur: false', () => {
+    let create: jest.Mock;
+
+    beforeEach(() => {
+      create = jest.fn();
+      fixture.componentRef.setInput('createActions', [
+        {
+          id: 'dataset', label: 'Create Dataset', create, submitOnBlur: false,
+        },
+      ]);
+      fixture.detectChanges();
+
+      (fixture.debugElement.query(By.css('.footer-actions button')).nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+    });
+
+    function inlineInput(): HTMLInputElement | null {
+      const input = fixture.debugElement.query(By.css('.inline-create-input'));
+      return input ? input.nativeElement as HTMLInputElement : null;
+    }
+
+    function typeName(name: string): void {
+      const input = inlineInput()!;
+      input.value = name;
+      input.dispatchEvent(new Event('input'));
+    }
+
+    it('should keep the row open without creating when the input loses focus', async () => {
+      typeName('heavy-dataset');
+      inlineInput()!.dispatchEvent(new Event('blur'));
+      await fixture.whenStable();
+
+      expect(create).not.toHaveBeenCalled();
+      expect(inlineInput()).not.toBeNull();
+      expect(inlineInput()!.value).toBe('heavy-dataset');
+    });
+
+    it('should submit through the explicit confirm button', async () => {
+      create.mockResolvedValue('/mnt/tank/heavy-dataset');
+      const createdSpy = jest.fn();
+      component.created.subscribe(createdSpy);
+
+      typeName('heavy-dataset');
+      fixture.detectChanges();
+      (fixture.debugElement.query(By.css('.inline-create-button.confirm')).nativeElement as HTMLButtonElement).click();
+      await fixture.whenStable();
+
+      expect(create).toHaveBeenCalledWith('/mnt/tank', 'heavy-dataset');
+      expect(createdSpy).toHaveBeenCalledWith('/mnt/tank/heavy-dataset');
+    });
+
+    it('should still submit on Enter', async () => {
+      create.mockResolvedValue('/mnt/tank/heavy-dataset');
+
+      typeName('heavy-dataset');
+      inlineInput()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await fixture.whenStable();
+
+      expect(create).toHaveBeenCalledWith('/mnt/tank', 'heavy-dataset');
+    });
+
+    it('should close the row without creating through the cancel button', () => {
+      typeName('heavy-dataset');
+      fixture.detectChanges();
+      (fixture.debugElement.query(By.css('.inline-create-button.cancel')).nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(create).not.toHaveBeenCalled();
+      expect(inlineInput()).toBeNull();
+    });
+
+    it('should not render confirm/cancel buttons for default (blur-submitting) actions', () => {
+      // Close the dataset row opened in beforeEach, then open a default action's row
+      inlineInput()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      fixture.detectChanges();
+      fixture.componentRef.setInput('createActions', [
+        { id: 'folder', label: 'New Folder', create },
+      ]);
+      fixture.detectChanges();
+      (fixture.debugElement.query(By.css('.footer-actions button')).nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(inlineInput()).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.inline-create-button'))).toBeNull();
+    });
+  });
+
   describe('Current Directory Selection', () => {
     function selectButton(): HTMLButtonElement | null {
       const button = fixture.debugElement.query(By.css('.footer-actions button'));

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.ts
@@ -185,6 +185,9 @@ export class TnFilePickerPopupComponent implements AfterViewChecked {
   protected readonly clearSelectionTestId = computed(() => ['clear-selection', ...this.baseSegments()]);
   /** Role-first segments for the inline creation input: `input-create[-<base>]`. */
   protected readonly inlineCreateTestId = computed(() => ['create', ...this.baseSegments()]);
+  /** Role-first segments for the inline row's explicit confirm/cancel buttons. */
+  protected readonly inlineConfirmTestId = computed(() => ['create-confirm', ...this.baseSegments()]);
+  protected readonly inlineCancelTestId = computed(() => ['create-cancel', ...this.baseSegments()]);
 
   /**
    * Base-first segments for a listed item's row (`option[-<base>]-<name>`) and
@@ -370,8 +373,16 @@ export class TnFilePickerPopupComponent implements AfterViewChecked {
     // Escape / navigation.
     if (this.inlineCreation()?.error) {return;}
 
+    // Actions with `submitOnBlur: false` (side-effecting creations) keep the
+    // row open on focus loss; submission requires Enter or the ✓ button.
+    if (this.inlineCreation()?.action.submitOnBlur === false) {return;}
+
     // Auto-submit on blur, matching inline-rename conventions
     void this.submitInlineCreation();
+  }
+
+  cancelInlineCreation(): void {
+    this.inlineCreation.set(null);
   }
 
   onClearSelection(): void {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.interfaces.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.interfaces.ts
@@ -45,14 +45,25 @@ export interface FilePickerCreateAction {
    * the inline error and keep the row editable for retry. Name validation
    * (duplicates, invalid characters, …) belongs in this callback.
    *
-   * The row auto-submits when it loses focus with a non-empty name
-   * (matching inline-rename conventions), so this callback can also fire
-   * when the user clicks away — including on a click that navigates
+   * By default the row auto-submits when it loses focus with a non-empty
+   * name (matching inline-rename conventions), so this callback can also
+   * fire when the user clicks away — including on a click that navigates
    * elsewhere, which abandons the row and silently discards the resolved
    * path even though the item was created. Implementations should tolerate
-   * that (e.g. creation is cheap to leave behind, or idempotent).
+   * that (e.g. creation is cheap to leave behind, or idempotent) — or opt
+   * out of blur submission with `submitOnBlur: false`.
    */
   create?: (parentPath: string, name: string) => Promise<string>;
+  /**
+   * Whether losing focus with a non-empty name submits the inline row
+   * (default true). Set to false for side-effecting or hard-to-reverse
+   * creations (e.g. datasets): clicking away then keeps the row open
+   * instead of silently creating, and the row shows explicit confirm/cancel
+   * buttons so submission stays reachable by mouse (Enter and Escape work
+   * either way). Navigating to another directory still abandons the row
+   * without creating anything.
+   */
+  submitOnBlur?: boolean;
 }
 
 export interface FilePickerCreateActionEvent {

--- a/projects/truenas-ui/src/stories/file-picker.stories.ts
+++ b/projects/truenas-ui/src/stories/file-picker.stories.ts
@@ -163,6 +163,8 @@ createActions = input<FilePickerCreateAction[]>([]);
 - **Event-only** (no \`create\`): pressing the button emits \`createAction\` with \`{ actionId, parentPath }\`; run your own flow (dialog, API call) and, when it completes, call \`selectPath(newPath)\` to show the created item selected and applied as the value — or \`refresh()\` to only re-fetch the listing.
 - **Inline** (\`create\` provided): pressing the button opens an editable name row inside the popup. Submitting calls \`create(parentPath, name)\` — your implementation does the real work (e.g. a websocket API call) and owns validation. Resolve with the created path to have it listed and selected; reject with an Error to show its message inline and keep the row editable.
 
+By default the inline row auto-submits when it loses focus with a non-empty name (inline-rename convention). For side-effecting or hard-to-reverse creations (e.g. datasets), set \`submitOnBlur: false\`: clicking away then keeps the row open instead of silently creating, and explicit ✓/✕ buttons appear in the row so submission stays reachable by mouse (Enter and Escape work either way).
+
 ### Navigation Configuration
 \`\`\`typescript
 startPath = input<string>('/mnt');


### PR DESCRIPTION
The inline creation row auto-submits when it loses focus with a non-empty name — the inline-rename convention, and fine for cheap creations like folders. But for side-effecting, hard-to-reverse creations (webui's dataset action runs a real `pool.dataset.create`), a user who types a name and clicks away intending to cancel silently creates the item.

`FilePickerCreateAction` gains `submitOnBlur?: boolean` (default `true`, existing behavior unchanged):

- `submitOnBlur: false` makes blur keep the row open instead of submitting.
- Since blur no longer commits, the row renders explicit ✓ confirm / ✕ cancel buttons for such actions so submission stays reachable by mouse; Enter and Escape work either way.
- Navigating to another directory still abandons the row without creating anything.

Motivated by review feedback on truenas/webui#13849 (ix-explorer → tn-file-picker migration); webui's `ix-explorer-create-dataset` will set `submitOnBlur: false` once this releases.