### PR TITLE
NAS-141977 / 27.0.0-BETA.1 / fix(list-item): render the gated content slots; feat(button,slide-toggle,list-item): fullWidth, dense, wrap

### DIFF
--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -8,6 +8,13 @@
 
 // `fullWidth` — the host stops shrink-wrapping and the rendered <button>/<a>
 // fills it, so consumers never have to reach in for `width: 100%`.
+//
+// Coupled to `.storybook-button`, the legacy class the template puts on all
+// three rendered forms (<button>, <a href>, <a routerLink>) — which is why one
+// selector covers them. Renaming that class silently drops the inner width and
+// leaves a stretched host wrapped around a shrink-wrapped control, so rename it
+// here and in button.component.html together. The FullWidth story's play test
+// asserts the inner control matches the host width and will catch the break.
 :host(.tn-button--full-width) {
   display: block;
   width: 100%;

--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -6,6 +6,18 @@
   justify-self: center;
 }
 
+// `fullWidth` — the host stops shrink-wrapping and the rendered <button>/<a>
+// fills it, so consumers never have to reach in for `width: 100%`.
+:host(.tn-button--full-width) {
+  display: block;
+  width: 100%;
+  justify-self: stretch;
+
+  .storybook-button {
+    width: 100%;
+  }
+}
+
 .storybook-button {
   @include label-markup.inline-code;
 

--- a/projects/truenas-ui/src/lib/button/button.component.spec.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.spec.ts
@@ -304,6 +304,19 @@ describe('TnButtonComponent', () => {
     });
   });
 
+  describe('fullWidth', () => {
+    it('shrink-wraps by default', () => {
+      expect(fixture.nativeElement.classList).not.toContain('tn-button--full-width');
+    });
+
+    it('marks the host so it and the rendered button fill the container', () => {
+      fixture.componentRef.setInput('fullWidth', true);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.classList).toContain('tn-button--full-width');
+    });
+  });
+
   describe('testId under the data-test convention (webui consumers)', () => {
     it('emits the same value under data-test when TN_TEST_ATTR is overridden', async () => {
       const { TN_TEST_ATTR } = await import('../test-id');

--- a/projects/truenas-ui/src/lib/button/button.component.ts
+++ b/projects/truenas-ui/src/lib/button/button.component.ts
@@ -12,6 +12,9 @@ import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
   imports: [CommonModule, RouterLink, TnTestIdDirective, LabelMarkupPipe, TnIconComponent],
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
+  host: {
+    '[class.tn-button--full-width]': 'fullWidth()',
+  },
 })
 export class TnButtonComponent implements AfterViewInit {
   size = 'large';
@@ -33,6 +36,11 @@ export class TnButtonComponent implements AfterViewInit {
    */
   iconPosition = input<'left' | 'right'>('left');
   disabled = input<boolean>(false);
+  /**
+   * Stretches the button to the full width of its container instead of
+   * shrink-wrapping the label. Use for buttons that head or foot a form column.
+   */
+  fullWidth = input<boolean>(false);
   /**
    * Native `type` of the rendered `<button>`. Defaults to `button` so stray
    * clicks never submit an enclosing form. Set to `submit` for a form's save

--- a/projects/truenas-ui/src/lib/list-directives/list-directives.ts
+++ b/projects/truenas-ui/src/lib/list-directives/list-directives.ts
@@ -1,5 +1,24 @@
 import { Directive } from '@angular/core';
 
+/*
+ * Content directives for `tn-list-item` / `tn-list-option`.
+ *
+ * Each of these must be imported by the component whose template writes the
+ * attribute. `tn-list-item` renders its leading, secondary and trailing slots
+ * only when a matching directive *instance* is present, and a directive applies
+ * only in the template that declares it — importing the list-item component
+ * does not bring these into scope. An attribute written without its directive
+ * imported is inert: the slot stays closed and the content silently disappears.
+ * `[tnListItemTitle]` and `[tnListItemPrimary]` are the exception; their slot is
+ * ungated, so they project either way (they still need importing for the class
+ * and styling).
+ */
+
+/**
+ * Leading icon of a list row.
+ *
+ * Requires importing `TnListIconDirective`, or the leading slot never renders.
+ */
 @Directive({
   selector: '[tnListIcon]',
   standalone: true,
@@ -9,6 +28,11 @@ import { Directive } from '@angular/core';
 })
 export class TnListIconDirective {}
 
+/**
+ * Leading avatar of a list row.
+ *
+ * Requires importing `TnListAvatarDirective`, or the leading slot never renders.
+ */
 @Directive({
   selector: '[tnListAvatar]',
   standalone: true,
@@ -18,6 +42,10 @@ export class TnListIconDirective {}
 })
 export class TnListAvatarDirective {}
 
+/**
+ * Primary text of a list row. Projects whether or not this directive is
+ * imported — the primary slot is ungated — but import it for the styling.
+ */
 @Directive({
   selector: '[tnListItemTitle]',
   standalone: true,
@@ -27,6 +55,12 @@ export class TnListAvatarDirective {}
 })
 export class TnListItemTitleDirective {}
 
+/**
+ * Secondary line of a list row. Two or more make the row three-line.
+ *
+ * Requires importing `TnListItemLineDirective`, or the secondary slot never
+ * renders and the row is not marked as multi-line.
+ */
 @Directive({
   selector: '[tnListItemLine]',
   standalone: true,
@@ -36,6 +70,10 @@ export class TnListItemTitleDirective {}
 })
 export class TnListItemLineDirective {}
 
+/**
+ * Primary text of a list row. Projects whether or not this directive is
+ * imported — the primary slot is ungated — but import it for the styling.
+ */
 @Directive({
   selector: '[tnListItemPrimary]',
   standalone: true,
@@ -45,6 +83,12 @@ export class TnListItemLineDirective {}
 })
 export class TnListItemPrimaryDirective {}
 
+/**
+ * Secondary text of a list row.
+ *
+ * Requires importing `TnListItemSecondaryDirective`, or the secondary slot
+ * never renders and the row is not marked as multi-line.
+ */
 @Directive({
   selector: '[tnListItemSecondary]',
   standalone: true,
@@ -54,6 +98,12 @@ export class TnListItemPrimaryDirective {}
 })
 export class TnListItemSecondaryDirective {}
 
+/**
+ * Trailing content of a list row — a control, a badge, a chevron.
+ *
+ * Requires importing `TnListItemTrailingDirective`, or the trailing slot never
+ * renders.
+ */
 @Directive({
   selector: '[tnListItemTrailing]',
   standalone: true,

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.html
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.html
@@ -8,16 +8,23 @@
 
   <!-- Text content -->
   <div class="tn-list-item__text">
-    <!-- Primary text -->
+    <!--
+      Primary text. The catch-all slot needs no guard: a projected node is
+      assigned to exactly one slot, so anything carrying [tnListItemTitle] or
+      [tnListItemPrimary] lands in the slot above and can never reach the
+      catch-all. Gating this on a directive query would instead key projection
+      and rendering off two different things — the slot matches the attribute,
+      a contentChildren query matches the directive instance — so an attribute
+      written without its directive imported would toggle the guard while
+      projecting exactly as before.
+    -->
     <div class="tn-list-item__primary-text">
       <ng-content select="[tnListItemTitle], [tnListItemPrimary]" />
-      @if (!hasPrimaryTextDirective()) {
-        <ng-content />
-      }
+      <ng-content />
     </div>
 
     <!-- Secondary text -->
-    @if (hasSecondaryTextContent()) {
+    @if (hasSecondaryText()) {
       <div class="tn-list-item__secondary-text">
         <ng-content select="[tnListItemLine], [tnListItemSecondary]" />
       </div>

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.html
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.html
@@ -17,6 +17,11 @@
       a contentChildren query matches the directive instance — so an attribute
       written without its directive imported would toggle the guard while
       projecting exactly as before.
+
+      The leading, secondary and trailing slots below are still gated that way,
+      deliberately: their wrappers carry gutters that would space out every row
+      if rendered empty. The cost is that they require the directive to be
+      imported, which is documented on the component and on each directive.
     -->
     <div class="tn-list-item__primary-text">
       <ng-content select="[tnListItemTitle], [tnListItemPrimary]" />

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.scss
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.scss
@@ -155,6 +155,14 @@
   }
 }
 
+// The blocks below style projected content from inside the component, which is
+// what `::ng-deep` is for here — they do not pierce into any other component.
+// They are still the deprecated shape: each of these directives already stamps
+// a host class (.tn-list-icon, .tn-list-avatar, .tn-list-item-title,
+// .tn-list-item-line), so the rules belong on the directives themselves and
+// these selectors can go away. Left as-is to keep this change reviewable;
+// moving them is a standalone cleanup.
+
 // Icon styles
 ::ng-deep [tnListIcon] {
   width: 24px;

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.scss
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.scss
@@ -120,6 +120,33 @@
     }
   }
 
+  // Compact rows
+  &--dense {
+    min-height: 32px;
+
+    .tn-list-item__content {
+      padding: 4px 16px;
+    }
+
+    .tn-list-item__leading {
+      margin-right: 8px;
+    }
+
+    .tn-list-item__trailing {
+      margin-left: 8px;
+    }
+  }
+
+  // Multi-line rows: text wraps instead of being truncated
+  &--wrap {
+    .tn-list-item__primary-text,
+    .tn-list-item__secondary-text {
+      overflow: visible;
+      text-overflow: clip;
+      white-space: normal;
+    }
+  }
+
   // Disabled state
   &--disabled {
     opacity: 0.6;
@@ -129,7 +156,7 @@
 }
 
 // Icon styles
-::ng-deep [ixListIcon] {
+::ng-deep [tnListIcon] {
   width: 24px;
   height: 24px;
   font-size: 24px;
@@ -140,7 +167,7 @@
 }
 
 // Avatar styles
-::ng-deep [ixListAvatar] {
+::ng-deep [tnListAvatar] {
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -154,12 +181,12 @@
 }
 
 // List item title directive
-::ng-deep [ixListItemTitle] {
+::ng-deep [tnListItemTitle] {
   font-weight: normal;
 }
 
 // List item line directive
-::ng-deep [ixListItemLine] {
+::ng-deep [tnListItemLine] {
   display: block;
   margin-top: 4px;
   font-size: 14px;
@@ -168,7 +195,7 @@
 }
 
 // Trailing content styles
-::ng-deep [ixListItemTrailing] {
+::ng-deep [tnListItemTrailing] {
   color: var(--tn-fg2);
   font-size: 14px;
 }

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
@@ -126,6 +126,42 @@ describe('TnListItemComponent', () => {
     });
   });
 
+  // The side slots do gate on the directive instance, so they carry the cost the
+  // primary slot avoids: the attribute alone is inert. This is a documented
+  // requirement rather than a bug — the wrappers carry gutters that would space
+  // out every row if rendered empty — but it is pinned here so the day someone
+  // makes these slots attribute-driven, this test tells them the contract moved
+  // rather than leaving the change silent.
+  describe('with side-slot attributes but no directives imported', () => {
+    it('drops the content, because the slots gate on the directive instance', async () => {
+      @Component({
+        selector: 'tn-list-item-undeclared-slots-test',
+        standalone: true,
+        imports: [TnListItemComponent],
+        template: `<tn-list-item>
+          <span tnListIcon class="icon">icon</span><span tnListItemLine>Secondary</span><span tnListItemTrailing class="trailing">trailing</span>
+        </tn-list-item>`,
+      })
+      class UndeclaredSlotsHostComponent {}
+
+      await TestBed.configureTestingModule({ imports: [UndeclaredSlotsHostComponent] }).compileComponents();
+
+      const fixture = TestBed.createComponent(UndeclaredSlotsHostComponent);
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement;
+
+      expect(element.querySelector('.tn-list-item__leading')).toBeNull();
+      expect(element.querySelector('.tn-list-item__secondary-text')).toBeNull();
+      expect(element.querySelector('.tn-list-item__trailing')).toBeNull();
+      // The content is gone entirely: it matched a select, so it never fell
+      // through to the catch-all either.
+      expect(element.querySelector('.icon')).toBeNull();
+      expect(element.querySelector('.trailing')).toBeNull();
+      expect(element.textContent).not.toContain('Secondary');
+    });
+  });
+
   describe('without projected directives', () => {
     let fixture: ComponentFixture<PlainHostComponent>;
 

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
@@ -1,0 +1,136 @@
+import { Component } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TnListItemComponent } from './list-item.component';
+import {
+  TnListIconDirective,
+  TnListItemLineDirective,
+  TnListItemTitleDirective,
+  TnListItemTrailingDirective
+} from '../list-directives/list-directives';
+
+@Component({
+  selector: 'tn-list-item-side-slots-test',
+  standalone: true,
+  imports: [TnListItemComponent, TnListIconDirective, TnListItemTrailingDirective],
+  template: `<tn-list-item>
+    <span tnListIcon class="icon">icon</span><span tnListItemTrailing class="trailing">trailing</span>
+  </tn-list-item>`,
+})
+class SideSlotsHostComponent {}
+
+@Component({
+  selector: 'tn-list-item-text-slots-test',
+  standalone: true,
+  imports: [TnListItemComponent, TnListItemTitleDirective, TnListItemLineDirective],
+  template: `<tn-list-item>
+    <span tnListItemTitle>Title</span><span tnListItemLine>Secondary</span>
+  </tn-list-item>`,
+})
+class TextSlotsHostComponent {}
+
+@Component({
+  selector: 'tn-list-item-plain-test',
+  standalone: true,
+  imports: [TnListItemComponent],
+  template: `<tn-list-item [dense]="dense" [wrap]="wrap">Just text</tn-list-item>`,
+})
+class PlainHostComponent {
+  dense = false;
+  wrap = false;
+}
+
+describe('TnListItemComponent', () => {
+  // Regression: these slots are gated behind flags that used to be set from a
+  // `querySelector` in ngAfterContentInit, which could never see content whose
+  // slot had not been rendered yet — so every gated slot stayed empty forever.
+  describe('leading and trailing slots', () => {
+    let fixture: ComponentFixture<SideSlotsHostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [SideSlotsHostComponent] }).compileComponents();
+
+      fixture = TestBed.createComponent(SideSlotsHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('renders the leading slot when a [tnListIcon] is projected', () => {
+      const leading = fixture.nativeElement.querySelector('.tn-list-item__leading');
+
+      expect(leading).not.toBeNull();
+      expect(leading.querySelector('.icon')).not.toBeNull();
+    });
+
+    it('renders the trailing slot when a [tnListItemTrailing] is projected', () => {
+      const trailing = fixture.nativeElement.querySelector('.tn-list-item__trailing');
+
+      expect(trailing).not.toBeNull();
+      expect(trailing.querySelector('.trailing')).not.toBeNull();
+    });
+  });
+
+  describe('text slots', () => {
+    let fixture: ComponentFixture<TextSlotsHostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [TextSlotsHostComponent] }).compileComponents();
+
+      fixture = TestBed.createComponent(TextSlotsHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('renders the secondary slot when a [tnListItemLine] is projected', () => {
+      const secondary = fixture.nativeElement.querySelector('.tn-list-item__secondary-text');
+
+      expect(secondary).not.toBeNull();
+      expect(secondary.textContent).toContain('Secondary');
+    });
+
+    it('marks the row as two-line when it has one secondary line', () => {
+      const host = fixture.nativeElement.querySelector('tn-list-item');
+
+      expect(host.classList).toContain('tn-list-item--two-line');
+      expect(host.classList).not.toContain('tn-list-item--three-line');
+    });
+
+    it('suppresses the default slot when a [tnListItemTitle] is projected', () => {
+      const primary = fixture.nativeElement.querySelector('.tn-list-item__primary-text');
+
+      expect(primary.textContent.trim()).toBe('Title');
+    });
+  });
+
+  describe('without projected directives', () => {
+    let fixture: ComponentFixture<PlainHostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [PlainHostComponent] }).compileComponents();
+
+      fixture = TestBed.createComponent(PlainHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('renders default content in the primary slot and hides the optional slots', () => {
+      const element = fixture.nativeElement;
+
+      expect(element.querySelector('.tn-list-item__primary-text').textContent).toContain('Just text');
+      expect(element.querySelector('.tn-list-item__leading')).toBeNull();
+      expect(element.querySelector('.tn-list-item__secondary-text')).toBeNull();
+      expect(element.querySelector('.tn-list-item__trailing')).toBeNull();
+    });
+
+    it('applies the dense and wrap modifiers from their inputs', () => {
+      const host = fixture.nativeElement.querySelector('tn-list-item');
+
+      expect(host.classList).not.toContain('tn-list-item--dense');
+      expect(host.classList).not.toContain('tn-list-item--wrap');
+
+      fixture.componentInstance.dense = true;
+      fixture.componentInstance.wrap = true;
+      fixture.detectChanges();
+
+      expect(host.classList).toContain('tn-list-item--dense');
+      expect(host.classList).toContain('tn-list-item--wrap');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
@@ -93,10 +93,36 @@ describe('TnListItemComponent', () => {
       expect(host.classList).not.toContain('tn-list-item--three-line');
     });
 
-    it('suppresses the default slot when a [tnListItemTitle] is projected', () => {
+    it('renders the primary text exactly once', () => {
       const primary = fixture.nativeElement.querySelector('.tn-list-item__primary-text');
 
       expect(primary.textContent.trim()).toBe('Title');
+    });
+  });
+
+  // Projection matches the attribute; a contentChildren query matches the
+  // directive instance. Nothing may be gated on the second while the first
+  // decides where content lands, or the two disagree for a consumer who writes
+  // the attribute without importing its directive.
+  describe('with a primary-text attribute but no directive imported', () => {
+    it('still renders the primary text exactly once', async () => {
+      @Component({
+        selector: 'tn-list-item-undeclared-title-test',
+        standalone: true,
+        imports: [TnListItemComponent],
+        template: `<tn-list-item><span tnListItemTitle>Title</span></tn-list-item>`,
+      })
+      class UndeclaredTitleHostComponent {}
+
+      await TestBed.configureTestingModule({ imports: [UndeclaredTitleHostComponent] }).compileComponents();
+
+      const fixture = TestBed.createComponent(UndeclaredTitleHostComponent);
+      fixture.detectChanges();
+
+      const primary = fixture.nativeElement.querySelector('.tn-list-item__primary-text');
+
+      expect(primary.textContent.trim()).toBe('Title');
+      expect(primary.querySelectorAll('[tnListItemTitle]')).toHaveLength(1);
     });
   });
 

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.ts
@@ -4,9 +4,7 @@ import {
   TnListAvatarDirective,
   TnListIconDirective,
   TnListItemLineDirective,
-  TnListItemPrimaryDirective,
   TnListItemSecondaryDirective,
-  TnListItemTitleDirective,
   TnListItemTrailingDirective
 } from '../list-directives/list-directives';
 
@@ -52,24 +50,16 @@ export class TnListItemComponent {
   private secondaryLines = contentChildren(TnListItemLineDirective, { descendants: true });
   private secondaryTexts = contentChildren(TnListItemSecondaryDirective, { descendants: true });
   private trailing = contentChildren(TnListItemTrailingDirective, { descendants: true });
-  private titles = contentChildren(TnListItemTitleDirective, { descendants: true });
-  private primaries = contentChildren(TnListItemPrimaryDirective, { descendants: true });
 
   protected hasLeadingContent = computed(
     () => this.leadingIcons().length > 0 || this.leadingAvatars().length > 0
   );
 
-  protected hasSecondaryTextContent = computed(
-    () => this.secondaryLines().length > 0 || this.secondaryTexts().length > 0
-  );
-
   protected hasTrailingContent = computed(() => this.trailing().length > 0);
 
-  protected hasPrimaryTextDirective = computed(
-    () => this.titles().length > 0 || this.primaries().length > 0
+  hasSecondaryText = computed(
+    () => this.secondaryLines().length > 0 || this.secondaryTexts().length > 0
   );
-
-  hasSecondaryText = computed(() => this.hasSecondaryTextContent());
 
   hasThirdText = computed(
     () => this.secondaryLines().length + this.secondaryTexts().length > 1

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.ts
@@ -8,6 +8,32 @@ import {
   TnListItemTrailingDirective
 } from '../list-directives/list-directives';
 
+/**
+ * A single row of a `tn-list`.
+ *
+ * **The content directives must be imported by the component that declares the
+ * row.** Every slot but the primary text is rendered only when a matching
+ * directive *instance* is found, and directives apply only in the template that
+ * declares them — importing `TnListItemComponent` alone does not bring them
+ * into scope. Write `<span tnListIcon>` without `TnListIconDirective` in that
+ * component's `imports` and the attribute is inert: no instance, so the leading
+ * slot never renders and the icon silently disappears. The same holds for
+ * `[tnListAvatar]`, `[tnListItemLine]`, `[tnListItemSecondary]` and
+ * `[tnListItemTrailing]`. Import them alongside the component:
+ *
+ * ```ts
+ * import {
+ *   TnListItemComponent,
+ *   TnListIconDirective,
+ *   TnListItemLineDirective,
+ *   TnListItemTrailingDirective,
+ * } from '@truenas/ui-components';
+ * ```
+ *
+ * The primary-text slot is the deliberate exception — it has no gate, so
+ * `[tnListItemTitle]` and `[tnListItemPrimary]` render either way. See the
+ * comment in `list-item.component.html` for why the asymmetry is there.
+ */
 @Component({
   selector: 'tn-list-item',
   standalone: true,
@@ -45,6 +71,18 @@ export class TnListItemComponent {
   // is still hidden behind the flag they feed. A `querySelector` cannot — the
   // element is not in the DOM until its slot renders, and its slot does not
   // render until the flag is set, so every gated slot stayed empty forever.
+  //
+  // These match directive *instances* while the slots they gate project by
+  // *attribute*, so the two disagree for a consumer who writes the attribute
+  // without importing the directive: nothing matches here, the slot stays
+  // closed, and the content vanishes. The primary-text slot avoids this by not
+  // gating at all — see the comment in the template. The side slots cannot
+  // follow it: their wrapper elements carry their own gutters, so rendering
+  // them unconditionally would leave empty ones spacing out every row, and the
+  // --two-line/--three-line host classes need the counts regardless. So the
+  // requirement is documented on the class and on each directive instead. It
+  // cannot be checked at runtime: content that never projects is never in the
+  // DOM to be found.
   private leadingIcons = contentChildren(TnListIconDirective, { descendants: true });
   private leadingAvatars = contentChildren(TnListAvatarDirective, { descendants: true });
   private secondaryLines = contentChildren(TnListItemLineDirective, { descendants: true });

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.ts
@@ -1,6 +1,14 @@
 
-import type { AfterContentInit} from '@angular/core';
-import { ElementRef, Component, input, output, computed, signal, inject } from '@angular/core';
+import { Component, input, output, computed, contentChildren } from '@angular/core';
+import {
+  TnListAvatarDirective,
+  TnListIconDirective,
+  TnListItemLineDirective,
+  TnListItemPrimaryDirective,
+  TnListItemSecondaryDirective,
+  TnListItemTitleDirective,
+  TnListItemTrailingDirective
+} from '../list-directives/list-directives';
 
 @Component({
   selector: 'tn-list-item',
@@ -12,64 +20,60 @@ import { ElementRef, Component, input, output, computed, signal, inject } from '
     'class': 'tn-list-item',
     '[class.tn-list-item--disabled]': 'disabled()',
     '[class.tn-list-item--clickable]': 'clickable()',
+    '[class.tn-list-item--dense]': 'dense()',
+    '[class.tn-list-item--wrap]': 'wrap()',
     '[class.tn-list-item--two-line]': 'hasSecondaryText()',
     '[class.tn-list-item--three-line]': 'hasThirdText()',
     'role': 'listitem',
     '(click)': 'onClick($event)'
   }
 })
-export class TnListItemComponent implements AfterContentInit {
+export class TnListItemComponent {
   disabled = input<boolean>(false);
   clickable = input<boolean>(false);
+  /** Compact row: smaller minimum height and tighter vertical padding. */
+  dense = input<boolean>(false);
+  /**
+   * Lets the primary and secondary text wrap onto multiple lines instead of
+   * being truncated with an ellipsis. Use for rows whose content is a path, a
+   * sentence, or anything else that should stay fully readable.
+   */
+  wrap = input<boolean>(false);
 
   itemClick = output<Event>();
 
-  protected hasLeadingContent = signal<boolean>(false);
-  protected hasSecondaryTextContent = signal<boolean>(false);
-  protected hasTrailingContent = signal<boolean>(false);
-  protected hasPrimaryTextDirective = signal<boolean>(false);
+  // Content queries, not a DOM query: projected content is instantiated in the
+  // *declaring* view, so these resolve even while the matching <ng-content> slot
+  // is still hidden behind the flag they feed. A `querySelector` cannot — the
+  // element is not in the DOM until its slot renders, and its slot does not
+  // render until the flag is set, so every gated slot stayed empty forever.
+  private leadingIcons = contentChildren(TnListIconDirective, { descendants: true });
+  private leadingAvatars = contentChildren(TnListAvatarDirective, { descendants: true });
+  private secondaryLines = contentChildren(TnListItemLineDirective, { descendants: true });
+  private secondaryTexts = contentChildren(TnListItemSecondaryDirective, { descendants: true });
+  private trailing = contentChildren(TnListItemTrailingDirective, { descendants: true });
+  private titles = contentChildren(TnListItemTitleDirective, { descendants: true });
+  private primaries = contentChildren(TnListItemPrimaryDirective, { descendants: true });
 
-  private elementRef = inject(ElementRef);
+  protected hasLeadingContent = computed(
+    () => this.leadingIcons().length > 0 || this.leadingAvatars().length > 0
+  );
 
-  ngAfterContentInit(): void {
-    this.checkContentProjection();
-  }
+  protected hasSecondaryTextContent = computed(
+    () => this.secondaryLines().length > 0 || this.secondaryTexts().length > 0
+  );
 
-  private checkContentProjection(): void {
-    const element = this.elementRef.nativeElement;
+  protected hasTrailingContent = computed(() => this.trailing().length > 0);
 
-    // Check for leading content (icons/avatars)
-    this.hasLeadingContent.set(!!(
-      element.querySelector('[tnListIcon]') ||
-      element.querySelector('[tnListAvatar]')
-    ));
+  protected hasPrimaryTextDirective = computed(
+    () => this.titles().length > 0 || this.primaries().length > 0
+  );
 
-    // Check for secondary text content
-    this.hasSecondaryTextContent.set(!!(
-      element.querySelector('[tnListItemLine]') ||
-      element.querySelector('[tnListItemSecondary]')
-    ));
+  hasSecondaryText = computed(() => this.hasSecondaryTextContent());
 
-    // Check for trailing content
-    this.hasTrailingContent.set(!!element.querySelector('[tnListItemTrailing]'));
-
-    // Check for primary text directive
-    this.hasPrimaryTextDirective.set(!!(
-      element.querySelector('[tnListItemTitle]') ||
-      element.querySelector('[tnListItemPrimary]')
-    ));
-  }
-
-  hasSecondaryText = computed(() => {
-    return this.hasSecondaryTextContent();
-  });
-
-  hasThirdText = computed(() => {
-    // For now, we'll consider third line as having more than one secondary line
-    const element = this.elementRef.nativeElement;
-    const secondaryElements = element.querySelectorAll('[tnListItemLine], [tnListItemSecondary]');
-    return secondaryElements.length > 1;
-  });
+  hasThirdText = computed(
+    () => this.secondaryLines().length + this.secondaryTexts().length > 1
+  );
 
   onClick(event: Event): void {
     if (!this.disabled() && this.clickable()) {

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.scss
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.scss
@@ -2,6 +2,11 @@
 // Based on Angular Material Design patterns
 @use '../pipes/label-markup/label-markup' as label-markup;
 
+:host(.tn-slide-toggle-host--full-width) {
+  display: block;
+  width: 100%;
+}
+
 .tn-slide-toggle {
   display: inline-flex;
   align-items: center;
@@ -14,6 +19,18 @@
     display: flex;
     align-items: center;
     cursor: inherit;
+  }
+
+  // `fullWidth` — fill the row and push the label away from the track, so the
+  // toggle can head a settings row without the consumer overriding internals.
+  &--full-width {
+    display: flex;
+    width: 100%;
+
+    .tn-slide-toggle__label {
+      justify-content: space-between;
+      width: 100%;
+    }
   }
 
   &__label-text {

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.spec.ts
@@ -8,11 +8,12 @@ import { TnSlideToggleComponent } from './slide-toggle.component';
   standalone: true,
   imports: [TnSlideToggleComponent],
   template: `
-    <tn-slide-toggle label="Enable" (change)="changeCount = changeCount + 1" />
+    <tn-slide-toggle label="Enable" [fullWidth]="fullWidth" (change)="changeCount = changeCount + 1" />
   `,
 })
 class TestHostComponent {
   changeCount = 0;
+  fullWidth = false;
 }
 
 describe('TnSlideToggleComponent', () => {
@@ -40,6 +41,25 @@ describe('TnSlideToggleComponent', () => {
       fixture.detectChanges();
 
       expect(host.changeCount).toBe(1);
+    });
+  });
+
+  describe('fullWidth', () => {
+    it('shrink-wraps by default', () => {
+      const toggle = fixture.nativeElement.querySelector('tn-slide-toggle') as HTMLElement;
+
+      expect(toggle.classList).not.toContain('tn-slide-toggle-host--full-width');
+      expect(toggle.querySelector('.tn-slide-toggle')!.classList).not.toContain('tn-slide-toggle--full-width');
+    });
+
+    it('stretches both the host and the inner row when set', () => {
+      host.fullWidth = true;
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('tn-slide-toggle') as HTMLElement;
+
+      expect(toggle.classList).toContain('tn-slide-toggle-host--full-width');
+      expect(toggle.querySelector('.tn-slide-toggle')!.classList).toContain('tn-slide-toggle--full-width');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.ts
@@ -15,6 +15,12 @@ export type SlideToggleColor = 'primary' | 'accent' | 'warn';
   imports: [CommonModule, FormsModule, A11yModule, TnTestIdDirective, LabelMarkupPipe],
   templateUrl: './slide-toggle.component.html',
   styleUrl: './slide-toggle.component.scss',
+  host: {
+    // The `.tn-slide-toggle` class sits on an inner <div>; the host element is
+    // inline by default, so it has to be stretched too or the inner width has
+    // nothing to fill.
+    '[class.tn-slide-toggle-host--full-width]': 'fullWidth()',
+  },
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -28,6 +34,12 @@ export class TnSlideToggleComponent implements AfterViewInit, OnDestroy, Control
 
   labelPosition = input<'before' | 'after'>('after');
   label = input<string | undefined>(undefined);
+  /**
+   * Stretches the toggle to the full width of its container and pushes the label
+   * and the track to opposite ends of the row, instead of shrink-wrapping them
+   * side by side. Use for settings rows and option lists.
+   */
+  fullWidth = input<boolean>(false);
   disabled = input<boolean>(false);
   required = input<boolean>(false);
   color = input<SlideToggleColor>('primary');
@@ -126,6 +138,10 @@ export class TnSlideToggleComponent implements AfterViewInit, OnDestroy, Control
 
     if (this.effectiveChecked()) {
       classes.push('tn-slide-toggle--checked');
+    }
+
+    if (this.fullWidth()) {
+      classes.push('tn-slide-toggle--full-width');
     }
 
     classes.push(`tn-slide-toggle--${this.color()}`);

--- a/projects/truenas-ui/src/stories/button.stories.ts
+++ b/projects/truenas-ui/src/stories/button.stories.ts
@@ -47,6 +47,10 @@ const meta: Meta<TnButtonComponent> = {
       options: ['left', 'right'],
       description: 'Side of the label the icon sits on. No effect when icon is unset.',
     },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretches the button to fill its container instead of shrink-wrapping the label.',
+    },
     href: {
       control: 'text',
       description: 'When set, renders as <a> with this href',
@@ -153,6 +157,42 @@ export const OutlineWarn: Story = {
 
     await expect(outlineWarnButton.classList.contains('button-outline-warn')).toBe(true);
     await userEvent.click(outlineWarnButton);
+  },
+};
+
+/**
+ * **Full width.** `fullWidth` stretches both the host `tn-button` and the
+ * rendered `<button>` to the container's width, so the button no longer
+ * shrink-wraps its label. Use it for buttons that head or foot a form column —
+ * previously this needed `::ng-deep` in the consuming app. The narrow container
+ * below is the story's, not the component's: the default button sizes to its
+ * label inside it, the full-width one fills it.
+ */
+export const FullWidth: Story = {
+  args: {
+    color: 'primary',
+    variant: 'filled',
+    label: 'Save changes',
+    fullWidth: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="width: 320px; display: flex; flex-direction: column; gap: 12px;">
+        <tn-button [color]="color" [variant]="variant" [label]="label" [fullWidth]="fullWidth" />
+        <tn-button color="default" variant="outline" label="Cancel" [fullWidth]="fullWidth" />
+      </div>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [save] = canvas.getAllByRole('button');
+    const host = save.closest('tn-button')!;
+
+    await expect(host.classList.contains('tn-button--full-width')).toBe(true);
+    // The rendered control fills the host, and the host fills the 320px column.
+    await expect(save.getBoundingClientRect().width).toBe(host.getBoundingClientRect().width);
+    await expect(Math.round(host.getBoundingClientRect().width)).toBe(320);
   },
 };
 

--- a/projects/truenas-ui/src/stories/list.stories.ts
+++ b/projects/truenas-ui/src/stories/list.stories.ts
@@ -75,13 +75,13 @@ export const BasicList: Story = {
     template: `
       <tn-list [dense]="dense" [disabled]="disabled">
         <tn-list-item>
-          <span ixListItemTitle>First Item</span>
+          <span tnListItemTitle>First Item</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListItemTitle>Second Item</span>
+          <span tnListItemTitle>Second Item</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListItemTitle>Third Item</span>
+          <span tnListItemTitle>Third Item</span>
         </tn-list-item>
       </tn-list>
     `
@@ -100,49 +100,117 @@ export const ListWithSections: Story = {
         <!-- Recent Files Section -->
         <tn-list-subheader>Recent Files</tn-list-subheader>
         <tn-list-item>
-          <span ixListIcon>📄</span>
-          <span ixListItemTitle>document.pdf</span>
-          <span ixListItemLine>Modified 2 hours ago</span>
+          <span tnListIcon>📄</span>
+          <span tnListItemTitle>document.pdf</span>
+          <span tnListItemLine>Modified 2 hours ago</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListIcon>📊</span>
-          <span ixListItemTitle>report.xlsx</span>
-          <span ixListItemLine>Modified yesterday</span>
+          <span tnListIcon>📊</span>
+          <span tnListItemTitle>report.xlsx</span>
+          <span tnListItemLine>Modified yesterday</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListIcon>🖼️</span>
-          <span ixListItemTitle>presentation.pptx</span>
-          <span ixListItemLine>Modified 3 days ago</span>
+          <span tnListIcon>🖼️</span>
+          <span tnListItemTitle>presentation.pptx</span>
+          <span tnListItemLine>Modified 3 days ago</span>
         </tn-list-item>
         <tn-divider [inset]="false"></tn-divider>
 
         <!-- Archived Files Section -->
         <tn-list-subheader>Archived Files</tn-list-subheader>
         <tn-list-item>
-          <span ixListIcon>📦</span>
-          <span ixListItemTitle>backup-2023.zip</span>
-          <span ixListItemLine>Modified last week</span>
+          <span tnListIcon>📦</span>
+          <span tnListItemTitle>backup-2023.zip</span>
+          <span tnListItemLine>Modified last week</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListIcon>📁</span>
-          <span ixListItemTitle>old-project.tar.gz</span>
-          <span ixListItemLine>Modified last month</span>
+          <span tnListIcon>📁</span>
+          <span tnListItemTitle>old-project.tar.gz</span>
+          <span tnListItemLine>Modified last month</span>
         </tn-list-item>
         <tn-divider [inset]="false"></tn-divider>
 
         <!-- Shared Files Section -->
         <tn-list-subheader>Shared Files</tn-list-subheader>
         <tn-list-item>
-          <span ixListIcon>🤝</span>
-          <span ixListItemTitle>team-notes.md</span>
-          <span ixListItemLine>Shared with 5 people</span>
+          <span tnListIcon>🤝</span>
+          <span tnListItemTitle>team-notes.md</span>
+          <span tnListItemLine>Shared with 5 people</span>
         </tn-list-item>
         <tn-list-item>
-          <span ixListIcon>📝</span>
-          <span ixListItemTitle>meeting-minutes.docx</span>
-          <span ixListItemLine>Shared with team</span>
+          <span tnListIcon>📝</span>
+          <span tnListItemTitle>meeting-minutes.docx</span>
+          <span tnListItemLine>Shared with team</span>
         </tn-list-item>
       </tn-list>
+    `
+  }),
+};
+
+/**
+ * **Dense rows.** `[dense]` on `tn-list-item` drops the row's minimum height to
+ * 32px and tightens the vertical padding and the leading/trailing gutters. It is
+ * per-row, so a dense row can sit next to a default one — the list below pairs
+ * each variant so the metrics are directly comparable.
+ */
+export const DenseListItems: Story = {
+  render: () => ({
+    template: `
+      <tn-list>
+        <tn-list-subheader>Default</tn-list-subheader>
+        <tn-list-item>
+          <span tnListIcon>💾</span>
+          <span tnListItemTitle>tank/apps</span>
+          <span tnListItemLine>2.4 TiB used</span>
+        </tn-list-item>
+        <tn-list-item>
+          <span tnListIcon>💾</span>
+          <span tnListItemTitle>tank/backups</span>
+          <span tnListItemLine>810 GiB used</span>
+        </tn-list-item>
+
+        <tn-list-subheader>Dense</tn-list-subheader>
+        <tn-list-item [dense]="true">
+          <span tnListIcon>💾</span>
+          <span tnListItemTitle>tank/apps</span>
+          <span tnListItemLine>2.4 TiB used</span>
+        </tn-list-item>
+        <tn-list-item [dense]="true">
+          <span tnListIcon>💾</span>
+          <span tnListItemTitle>tank/backups</span>
+          <span tnListItemLine>810 GiB used</span>
+        </tn-list-item>
+      </tn-list>
+    `
+  }),
+};
+
+/**
+ * **Wrapping rows.** By default the primary and secondary text are truncated
+ * with an ellipsis on one line. `[wrap]` lets them run onto as many lines as
+ * they need — use it for paths, sentences, and anything else that has to stay
+ * fully readable. The narrow column below forces the difference into view.
+ */
+export const WrappingListItems: Story = {
+  render: () => ({
+    template: `
+      <div style="width: 320px;">
+        <tn-list>
+          <tn-list-subheader>Truncated (default)</tn-list-subheader>
+          <tn-list-item>
+            <span tnListIcon>📁</span>
+            <span tnListItemTitle>/mnt/tank/media/shows/archive/2019/quarter-four</span>
+            <span tnListItemLine>Snapshot taken before the pool was expanded to six disks</span>
+          </tn-list-item>
+
+          <tn-list-subheader>Wrapped</tn-list-subheader>
+          <tn-list-item [wrap]="true">
+            <span tnListIcon>📁</span>
+            <span tnListItemTitle>/mnt/tank/media/shows/archive/2019/quarter-four</span>
+            <span tnListItemLine>Snapshot taken before the pool was expanded to six disks</span>
+          </tn-list-item>
+        </tn-list>
+      </div>
     `
   }),
 };
@@ -163,29 +231,29 @@ export const ListWithSelection: Story = {
     template: `
       <tn-selection-list [dense]="dense" [disabled]="disabled" (selectionChange)="onSelectionChange($event)">
         <tn-list-option [value]="'inbox'" [selected]="false">
-          <span ixListIcon>📥</span>
-          <span ixListItemTitle>Inbox</span>
-          <span ixListItemLine>25 new messages</span>
+          <span tnListIcon>📥</span>
+          <span tnListItemTitle>Inbox</span>
+          <span tnListItemLine>25 new messages</span>
         </tn-list-option>
         <tn-list-option [value]="'sent'" [selected]="true">
-          <span ixListIcon>📤</span>
-          <span ixListItemTitle>Sent</span>
-          <span ixListItemLine>Last sent 2 hours ago</span>
+          <span tnListIcon>📤</span>
+          <span tnListItemTitle>Sent</span>
+          <span tnListItemLine>Last sent 2 hours ago</span>
         </tn-list-option>
         <tn-list-option [value]="'drafts'" [selected]="false">
-          <span ixListIcon>📝</span>
-          <span ixListItemTitle>Drafts</span>
-          <span ixListItemLine>3 unsaved drafts</span>
+          <span tnListIcon>📝</span>
+          <span tnListItemTitle>Drafts</span>
+          <span tnListItemLine>3 unsaved drafts</span>
         </tn-list-option>
         <tn-list-option [value]="'spam'" [selected]="false">
-          <span ixListIcon>🚫</span>
-          <span ixListItemTitle>Spam</span>
-          <span ixListItemLine>12 filtered messages</span>
+          <span tnListIcon>🚫</span>
+          <span tnListItemTitle>Spam</span>
+          <span tnListItemLine>12 filtered messages</span>
         </tn-list-option>
         <tn-list-option [value]="'trash'" [selected]="false">
-          <span ixListIcon>🗑️</span>
-          <span ixListItemTitle>Trash</span>
-          <span ixListItemLine>Empty</span>
+          <span tnListIcon>🗑️</span>
+          <span tnListItemTitle>Trash</span>
+          <span tnListItemLine>Empty</span>
         </tn-list-option>
       </tn-selection-list>
     `

--- a/projects/truenas-ui/src/stories/slide-toggle.stories.ts
+++ b/projects/truenas-ui/src/stories/slide-toggle.stories.ts
@@ -59,6 +59,10 @@ The slide toggle can be used standalone or integrated with reactive forms. It su
       options: ['primary', 'accent', 'warn'],
       description: 'Color theme of the toggle',
     },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretches the toggle across its container, pushing the label and track to opposite ends',
+    },
     ariaLabel: {
       control: 'text',
       description: 'Accessibility label for screen readers',
@@ -167,6 +171,40 @@ export const LabelBefore: Story = {
     required: false,
     color: 'primary',
   },
+};
+
+/**
+ * **Full width.** `fullWidth` stretches the toggle across its container and
+ * pushes the label and the track to opposite ends, which is the shape settings
+ * rows and option lists want. Without it the label and track shrink-wrap side
+ * by side, whatever the container's width. The bordered 360px column below is
+ * the story's, so the difference between the two rows is visible.
+ */
+export const FullWidth: Story = {
+  args: {
+    label: 'Enable notifications',
+    labelPosition: 'after',
+    disabled: false,
+    required: false,
+    color: 'primary',
+    fullWidth: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="width: 360px; display: flex; flex-direction: column; gap: 16px;
+                  padding: 16px; border: 1px dashed var(--lines, #ccc);">
+        <tn-slide-toggle
+          [label]="label"
+          [labelPosition]="labelPosition"
+          [disabled]="disabled"
+          [color]="color"
+          [fullWidth]="fullWidth" />
+        <tn-slide-toggle label="Automatic updates" [color]="color" [fullWidth]="fullWidth" />
+        <tn-slide-toggle label="Shrink-wrapped (fullWidth off)" [color]="color" />
+      </div>
+    `,
+  }),
 };
 
 export const NoLabel: Story = {


### PR DESCRIPTION
tn-list-item gated its leading, secondary and trailing <ng-content> slots behind flags set from a querySelector in ngAfterContentInit. That query could never see the content: the element is not in the DOM until its slot renders, and its slot does not render until the flag is set. Every gated slot stayed empty forever, so [tnListIcon], [tnListAvatar], [tnListItemLine], [tnListItemSecondary] and [tnListItemTrailing] rendered nothing at all. Replaced with signal contentChildren queries, which resolve from the declaring view and so are unaffected by whether the slot has rendered. hasThirdText no longer reads the DOM from inside a computed.

Also fixes the [ix*] attribute selectors in list-item.component.scss, which never matched the tn-prefixed directives they were written for.

New inputs, so consumers stop reaching into these components with ::ng-deep:
- tn-list-item [dense]  — compact row metrics
- tn-list-item [wrap]   — primary/secondary text wraps instead of ellipsizing
- tn-button [fullWidth] — host and rendered button fill the container
- tn-slide-toggle [fullWidth] — fills the row, label and track at opposite ends
