### PR TITLE
NAS-141985 / 27.0.0-BETA.1 / fix(file-picker,button,checkbox,table): popup rendering fixes

### DIFF
--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -11,10 +11,15 @@
 
   display: inline-block;
   cursor: pointer;
-  border: 0;
+  // Transparent border (not none) so solid and outline variants have the same
+  // rendered height and align in a shared row of actions.
+  border: 1px solid transparent;
   font-weight: 500;
   line-height: 1;
   font-family: 'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  // A button label never wraps — in a tight flex row wrapping makes buttons
+  // grow to different heights instead of the row overflowing or wrapping.
+  white-space: nowrap;
 
   &:disabled,
   &.is-disabled {

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.scss
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.scss
@@ -56,10 +56,8 @@
       }
     }
 
-    &:focus ~ .tn-checkbox__checkmark {
-      outline: 2px solid var(--tn-primary, #0095d5);
-      outline-offset: 2px;
-    }
+    // Focus ring only for keyboard focus (the :focus-visible rule below) — a
+    // plain :focus ring would persist after every mouse click.
 
     &:disabled ~ .tn-checkbox__checkmark {
       background-color: var(--tn-bg2, #f5f5f5);

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.html
@@ -37,9 +37,10 @@
     (rowClick)="onItemClick($event)"
     (rowDoubleClick)="onItemDoubleClick($event)">
 
-    <!-- Selection column -->
+    <!-- Selection column: explicit width so the auto table layout doesn't
+         hand the near-empty column a share of the spare width -->
     @if (multiSelect()) {
-      <ng-container tnColumnDef="select">
+      <ng-container tnColumnDef="select" width="20px">
       <ng-template tnHeaderCellDef>
         <!-- Select all checkbox -->
       </ng-template>

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -11,8 +11,13 @@
   // change while navigating
   width: 520px;
   max-width: calc(100vw - 32px);
-  min-height: 500px;
-  max-height: 600px;
+  // Fixed height for the same reason, but never taller than the viewport
+  // (minus the position strategy's viewport margin on both sides) — on short
+  // windows the popup shrinks and the listing scrolls instead of the popup
+  // running off-screen. Keep in sync with `withViewportMargin` in
+  // file-picker.component.ts.
+  min-height: min(500px, calc(100vh - 16px));
+  max-height: min(600px, calc(100vh - 16px));
   font-family: var(--tn-font-family-body);
   display: flex;
   flex-direction: column;
@@ -394,6 +399,9 @@ tn-table {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  // Button labels never wrap, so when the selection text and the buttons don't
+  // fit on one line the two groups stack instead of overflowing the popup.
+  flex-wrap: wrap;
   // Minimum breathing room between the selection text and the action buttons
   gap: 16px;
   padding: 16px var(--tn-content-padding, 24px);

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -399,9 +399,6 @@ tn-table {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  // Button labels never wrap, so when the selection text and the buttons don't
-  // fit on one line the two groups stack instead of overflowing the popup.
-  flex-wrap: wrap;
   // Minimum breathing room between the selection text and the action buttons
   gap: 16px;
   padding: 16px var(--tn-content-padding, 24px);

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.ts
@@ -558,7 +558,13 @@ export class TnFilePickerComponent implements ControlValueAccessor, OnInit, OnDe
       .flexibleConnectedTo(this.wrapperEl())
       .withPositions(positions)
       .withFlexibleDimensions(false)
-      .withPush(false);
+      // When no anchored position fits entirely (e.g. the input sits near the
+      // bottom of a short window), push the popup fully into the viewport
+      // instead of letting it render off-screen. The popup's own max-height
+      // caps it at viewport height minus this margin (see the popup SCSS), so
+      // a pushed popup always fits.
+      .withViewportMargin(8)
+      .withPush(true);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,

--- a/projects/truenas-ui/src/lib/table/table.component.scss
+++ b/projects/truenas-ui/src/lib/table/table.component.scss
@@ -158,6 +158,13 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    // Focus rings on embedded controls (e.g. tn-checkbox in a selection
+    // column) paint a few px outside the control's box; `overflow: hidden`
+    // clips at the padding edge, so without padding the ring is cut off at the
+    // content edge. The symmetric padding/negative-margin pair gives rings
+    // room to paint while keeping content position and cell size unchanged.
+    padding: 4px;
+    margin: -4px;
 
     > * {
       min-width: 0;


### PR DESCRIPTION
## Summary

Four rendering fixes for issues found while verifying the webui ix-explorer → tn-file-picker migration (NAS-141877):

- **fix(button):** solid and outline variants rendered at different heights (outline's 1px border was added on top of identical padding) and labels could wrap to two lines in tight flex rows, making adjacent buttons different sizes. Buttons now carry a transparent 1px border on all variants and never wrap their labels.
- **fix(checkbox, table):** the checkbox focus ring was styled on `:focus`, so every mouse click left a ring behind — and inside `tn-table` cells the ring was clipped at the left by the cell content's `overflow: hidden`, rendering checkboxes "cut off". The ring is now keyboard-only (`:focus-visible`), and table cell content uses a symmetric `padding: 4px / margin: -4px` pair so focus rings have room to paint without changing layout.
- **fix(file-picker):** the popup overlay used `withPush(false)` and a fixed 500px min-height, so near the bottom of short windows it rendered partially off-screen even when it could fit. The position strategy now pushes the popup fully into the viewport (`withPush(true)` + `withViewportMargin(8)`) and the popup's min/max height are capped at `100vh - 16px`, so the listing scrolls instead of overflowing.
- **fix(file-picker):** the multi-select checkbox column had no declared width, so the auto table layout handed the near-empty column a share of the spare width; it now uses the column def's `width` input (`20px`). Footer action buttons stay on one row (the selection count text wraps instead).

## Test plan

- `yarn test` — all suites for button, checkbox, table, and file-picker pass (480 tests).
- Verified visually in webui against a live TrueNAS box: replication wizard source picker (multi-select + create actions) and SMB path picker on a short viewport.