### PR TITLE
NAS-141998 / 27.0.0-BETA.1 / fix(calendar): size header columns so host styles can't widen the grid

### DIFF
--- a/projects/truenas-ui/src/lib/calendar/month-view.component.scss
+++ b/projects/truenas-ui/src/lib/calendar/month-view.component.scss
@@ -33,6 +33,11 @@
 .tn-calendar-table-header {
   th {
     text-align: center;
+    // `table-layout: fixed` takes every column's width from the first row, which is this
+    // header — the width on the body cells below never gets a say. Leaving it unset means
+    // the grid is sized by whatever ambient `th` rule the host app happens to have, which
+    // can push the table clean past its container.
+    width: calc(100% / 7);
     height: var(--calendar-header-height);
     padding: 8px 0;
     font-size: var(--calendar-header-font-size);


### PR DESCRIPTION
`table-layout: fixed` takes every column's width from the first row, so the header cells decide the grid and the width on the body cells never gets a say. With no width declared on `th`, an ambient `table th { width: ... }` rule in the consuming app sizes the columns instead and pushes the table past its container.

Surfaced in webui's scheduler preview, where a global `table tr th { width: 78px }` under a max-width:1280px media query rendered the 7-column grid at 546px inside a 400px panel. The overflow was clipped with no scrollbar, so Friday and Saturday were invisible and unclickable at any viewport <= 1280px.

`min-width: min(100%, ...)` on the table doesn't help: it's a floor, not a ceiling. Declaring the width on `th` matches what the body cells already use, sums to exactly 100%, and out-specifies a bare `table tr th` selector.

jsdom performs no table layout, so this isn't reachable from a unit test.