### PR TITLE
NAS-142082 / 27.0.0-BETA.1 / fix(card): add fillHeight input so a card can size to its content

### DIFF
--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -1,3 +1,15 @@
+// The host is a custom element, so without this it lays out inline and consumers have to set
+// `display: block` themselves before any height rule here behaves predictably.
+:host {
+  display: block;
+}
+
+// `.tn-card`'s `height: 100%` resolves against the host, so opting out of fill-height has to
+// release both. Driven by the `fillHeight` input via a host class binding.
+:host(.tn-card--content-height) {
+  height: auto;
+}
+
 .tn-card {
   height: 100%;
   display: flex;
@@ -5,6 +17,11 @@
   border-radius: 8px;
   transition: box-shadow 0.3s ease;
   overflow: hidden;
+
+  // Opt out of fill-height (see the `fillHeight` input) for cards that size to their content.
+  &--content-height {
+    height: auto;
+  }
 
   &--elevation-none {
     box-shadow: none;

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -4,10 +4,17 @@
   display: block;
 }
 
-// `.tn-card`'s `height: 100%` resolves against the host, so opting out of fill-height has to
-// release both. Driven by the `fillHeight` input via a host class binding.
-:host(.tn-card--content-height) {
+// Opt out of fill-height (see the `fillHeight` input) for cards that size to their content.
+// `.tn-card`'s `height: 100%` resolves against the host, so releasing the host alone isn't
+// enough — the inner element has to release its own height too. The modifier lives on the
+// host only (a `tn-card-host--` name, since the host is not itself a `.tn-card`) so there is
+// one source of truth for the opt-out.
+:host(.tn-card-host--content-height) {
   height: auto;
+
+  .tn-card {
+    height: auto;
+  }
 }
 
 .tn-card {
@@ -17,11 +24,6 @@
   border-radius: 8px;
   transition: box-shadow 0.3s ease;
   overflow: hidden;
-
-  // Opt out of fill-height (see the `fillHeight` input) for cards that size to their content.
-  &--content-height {
-    height: auto;
-  }
 
   &--elevation-none {
     box-shadow: none;

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -301,3 +301,41 @@ describe('TnCardComponent title router link & tooltip', () => {
     expect(tooltipButton?.getAttribute('aria-label')).toBe('More information');
   });
 });
+
+@Component({
+  standalone: true,
+  imports: [TnCardComponent],
+  template: `<tn-card [fillHeight]="fillHeight()">Content</tn-card>`,
+})
+class HeightHostComponent {
+  fillHeight = signal(true);
+}
+
+describe('TnCardComponent fillHeight', () => {
+  function createHeightHost() {
+    TestBed.configureTestingModule({ imports: [HeightHostComponent] });
+    const fixture = TestBed.createComponent(HeightHostComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  // `.tn-card` sets `height: 100%`, which resolves against the host — so opting out has to mark
+  // both the inner element and the host, or the card still fills its container.
+  it('fills its container by default, marking neither the host nor the card', () => {
+    const fixture = createHeightHost();
+
+    const host = fixture.nativeElement.querySelector('tn-card') as HTMLElement;
+    expect(host.classList.contains('tn-card--content-height')).toBe(false);
+    expect(host.querySelector('.tn-card--content-height')).toBeNull();
+  });
+
+  it('marks host and card for content height when fillHeight is false', () => {
+    const fixture = createHeightHost();
+    fixture.componentInstance.fillHeight.set(false);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('tn-card') as HTMLElement;
+    expect(host.classList.contains('tn-card--content-height')).toBe(true);
+    expect(host.querySelector('.tn-card--content-height')).toBeTruthy();
+  });
+});

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -319,23 +319,21 @@ describe('TnCardComponent fillHeight', () => {
     return fixture;
   }
 
-  // `.tn-card` sets `height: 100%`, which resolves against the host — so opting out has to mark
-  // both the inner element and the host, or the card still fills its container.
-  it('fills its container by default, marking neither the host nor the card', () => {
+  // `.tn-card` sets `height: 100%`, which resolves against the host — so the opt-out lives on
+  // the host and releases both from there (`:host(.tn-card-host--content-height) .tn-card`).
+  it('fills its container by default, leaving the host unmarked', () => {
     const fixture = createHeightHost();
 
     const host = fixture.nativeElement.querySelector('tn-card') as HTMLElement;
-    expect(host.classList.contains('tn-card--content-height')).toBe(false);
-    expect(host.querySelector('.tn-card--content-height')).toBeNull();
+    expect(host.classList.contains('tn-card-host--content-height')).toBe(false);
   });
 
-  it('marks host and card for content height when fillHeight is false', () => {
+  it('marks the host for content height when fillHeight is false', () => {
     const fixture = createHeightHost();
     fixture.componentInstance.fillHeight.set(false);
     fixture.detectChanges();
 
     const host = fixture.nativeElement.querySelector('tn-card') as HTMLElement;
-    expect(host.classList.contains('tn-card--content-height')).toBe(true);
-    expect(host.querySelector('.tn-card--content-height')).toBeTruthy();
+    expect(host.classList.contains('tn-card-host--content-height')).toBe(true);
   });
 });

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -39,7 +39,7 @@ import { TnTooltipDirective } from '../tooltip/tooltip.directive';
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
   host: {
-    '[class.tn-card--content-height]': '!fillHeight()',
+    '[class.tn-card-host--content-height]': '!fillHeight()',
   },
 })
 export class TnCardComponent {
@@ -136,10 +136,11 @@ export class TnCardComponent {
     const contentPaddingClass = this.padContent() ? `tn-card--content-padding-${this.padding()}` : 'tn-card--content-padding-none';
     const borderedClass = this.bordered() ? 'tn-card--bordered' : '';
     const backgroundClass = this.background() ? 'tn-card--background' : '';
-    const heightClass = this.fillHeight() ? '' : 'tn-card--content-height';
 
+    // Note: fill-height has no class here — the opt-out is a host modifier
+    // (`tn-card-host--content-height`) that releases the host and this element together.
     return [
-      'tn-card', elevationClass, paddingClass, contentPaddingClass, borderedClass, backgroundClass, heightClass,
+      'tn-card', elevationClass, paddingClass, contentPaddingClass, borderedClass, backgroundClass,
     ].filter(Boolean);
   });
 

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -38,6 +38,9 @@ import { TnTooltipDirective } from '../tooltip/tooltip.directive';
   ],
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
+  host: {
+    '[class.tn-card--content-height]': '!fillHeight()',
+  },
 })
 export class TnCardComponent {
   private iconRegistry = inject(TnIconRegistryService);
@@ -74,6 +77,16 @@ export class TnCardComponent {
   elevation = input<'none' | 'low' | 'medium' | 'high'>('medium');
   padding = input<'small' | 'medium' | 'large'>('medium');
   padContent = input<boolean>(true);
+
+  /**
+   * Whether the card stretches to fill its container's height.
+   *
+   * Defaults to `true`, which is what an equal-height dashboard grid wants: every card in a row
+   * matches the tallest. Set it to `false` for a card that should size to its content instead —
+   * typically a full-page card wrapping a table, which otherwise leaves a large empty area below
+   * the content when the page is taller than the table.
+   */
+  fillHeight = input<boolean>(true);
   bordered = input<boolean>(false);
   background = input<boolean>(true);
 
@@ -123,8 +136,11 @@ export class TnCardComponent {
     const contentPaddingClass = this.padContent() ? `tn-card--content-padding-${this.padding()}` : 'tn-card--content-padding-none';
     const borderedClass = this.bordered() ? 'tn-card--bordered' : '';
     const backgroundClass = this.background() ? 'tn-card--background' : '';
+    const heightClass = this.fillHeight() ? '' : 'tn-card--content-height';
 
-    return ['tn-card', elevationClass, paddingClass, contentPaddingClass, borderedClass, backgroundClass].filter(Boolean);
+    return [
+      'tn-card', elevationClass, paddingClass, contentPaddingClass, borderedClass, backgroundClass, heightClass,
+    ].filter(Boolean);
   });
 
   hasHeader = computed(() => {

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -30,6 +30,10 @@ const meta: Meta<TnCardComponent> = {
       control: 'boolean',
       description: 'Enable content area padding. Set to false ONLY for full-width content like tables, images, or charts.',
     },
+    fillHeight: {
+      control: 'boolean',
+      description: 'Stretch the card to fill its container height (default). Set to false for a card that sizes to its content, e.g. a full-page card wrapping a table.',
+    },
     bordered: {
       control: 'boolean',
       description: 'Show border around card',
@@ -89,6 +93,7 @@ const meta: Meta<TnCardComponent> = {
         [padContent]="padContent"
         [bordered]="bordered"
         [background]="background"
+        [fillHeight]="fillHeight ?? true"
       >
         <p>This is the card content. You can put any content here including other components, text, images, etc.</p>
         <p>The card provides a clean container with customizable elevation, padding, and optional borders.</p>
@@ -254,6 +259,72 @@ export const FullWidthContent: Story = {
       </tn-card>
     `,
   }),
+};
+
+/**
+ * Cards fill their container's height by default — what an equal-height dashboard grid wants,
+ * where every card in a row matches the tallest.
+ *
+ * Set `[fillHeight]="false"` for a card that should size to its content instead. The typical
+ * case is a full-page card wrapping a table: in a container taller than the content, the
+ * default leaves a large empty area below the last row.
+ *
+ * Both cards below sit in the same 320px-tall container.
+ */
+export const ContentHeight: Story = {
+  args: {
+    elevation: 'medium',
+    padding: 'medium',
+    padContent: false,
+    bordered: true,
+    background: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; height: 320px;">
+        <tn-card
+          title="fillHeight (default)"
+          [elevation]="elevation"
+          [padding]="padding"
+          [padContent]="padContent"
+          [bordered]="bordered"
+          [background]="background">
+          <table style="width: 100%; border-collapse: collapse;">
+            <tr><td style="padding: 8px 16px;">Pool A</td><td style="padding: 8px 16px;">Online</td></tr>
+            <tr><td style="padding: 8px 16px;">Pool B</td><td style="padding: 8px 16px;">Online</td></tr>
+          </table>
+        </tn-card>
+
+        <tn-card
+          title="fillHeight = false"
+          [fillHeight]="false"
+          [elevation]="elevation"
+          [padding]="padding"
+          [padContent]="padContent"
+          [bordered]="bordered"
+          [background]="background">
+          <table style="width: 100%; border-collapse: collapse;">
+            <tr><td style="padding: 8px 16px;">Pool A</td><td style="padding: 8px 16px;">Online</td></tr>
+            <tr><td style="padding: 8px 16px;">Pool B</td><td style="padding: 8px 16px;">Online</td></tr>
+          </table>
+        </tn-card>
+      </div>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    // Measure the visible `.tn-card` box, not the host: as a grid item the host is stretched
+    // by `align-self: stretch` either way (which applies exactly when its height is `auto`).
+    // Releasing the inner element is what removes the visible empty area below the content.
+    const [filled, contentSized] = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('tn-card')
+    ).map((host) => ({
+      host: host.getBoundingClientRect().height,
+      card: host.querySelector('.tn-card')!.getBoundingClientRect().height,
+    }));
+    await expect(filled.card).toBeGreaterThanOrEqual(filled.host);
+    await expect(contentSized.card).toBeLessThan(contentSized.host);
+  },
 };
 
 export const BorderedLowElevation: Story = {


### PR DESCRIPTION
tn-card hardcoded `height: 100%` on its inner element and set no `display` on the host, so a full-page card wrapping a table filled the viewport and left a large empty area below the content. Consumers worked around it by overriding both `display` and `height` from outside (webui has this in a shared mixin used by ~15 list pages, plus a reach-in to `.tn-card__content` in master-detail-view).

Fill-height stays the default — it is what the equal-height dashboard grid needs — and `[fillHeight]="false"` opts out. The host gets `display: block`, which it needed regardless: as a custom element it laid out inline, so any height rule behaved unpredictably until a consumer set it.

