### PR TITLE
NAS-142081 / 27.0.0-BETA.1 / feat(table): wrapCells, derived width floor, expand options, two-way sort state

### DIFF
--- a/projects/truenas-ui/src/lib/menu/menu-trigger.directive.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-trigger.directive.ts
@@ -15,6 +15,10 @@ import type { TnMenuComponent } from './menu.component';
   host: {
     '(click)': 'onClick()',
     '(keydown.arrowDown)': 'onArrowDown($event)',
+    // A trigger has to announce that it opens a menu, and whether that menu is currently open —
+    // without these a screen reader reads it as a plain button and never reports the open state.
+    'aria-haspopup': 'menu',
+    '[attr.aria-expanded]': 'isOpen()',
   },
 })
 export class TnMenuTriggerDirective implements OnDestroy {
@@ -23,6 +27,12 @@ export class TnMenuTriggerDirective implements OnDestroy {
 
   private overlayRef?: OverlayRef;
   private isMenuOpen = signal<boolean>(false);
+
+  /**
+   * Whether the menu is currently open. Exposed (with `exportAs: 'tnMenuTrigger'`) so a template
+   * can reflect the state — e.g. keeping a row's action button visible while its menu is open.
+   */
+  readonly isOpen = this.isMenuOpen.asReadonly();
   private itemClickSub?: OutputRefSubscription;
   /**
    * RxJS subscriptions for the current overlay's `backdropClick()` and

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
@@ -40,7 +40,7 @@
           name="close"
           library="mdi"
           size="sm"
-          ariaLabel="Dismiss"
+          [ariaLabel]="closeButtonAriaLabel()"
           [testId]="closeButtonTestId()"
           (onClick)="dismiss()" />
       </div>

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -92,6 +92,13 @@ export class TnSidePanelComponent implements OnDestroy {
    */
   closeButtonTestId = input<string | undefined>(undefined);
 
+  /**
+   * Accessible name for the close button. Defaults to "Dismiss"; override to translate it, or to
+   * name what is being closed ("Close Add Dataset form") — a screen-reader user tabbing to it out
+   * of context otherwise hears only "Dismiss".
+   */
+  closeButtonAriaLabel = input<string>('Dismiss');
+
   // Outputs
   opened = output<void>();
   closed = output<void>();

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -75,6 +75,7 @@
         [class.tn-table__row--clickable]="clickable()"
         [attr.tabindex]="clickable() ? 0 : null"
         [attr.aria-selected]="clickable() ? isRowActive(row) : null"
+        [attr.aria-expanded]="isRowExpandTrigger(row) ? isRowExpanded(row) : null"
         (click)="onRowClick(row)"
         (dblclick)="onRowDoubleClick(row)"
         (keydown)="onRowKeydown($event, row)">

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -1,4 +1,4 @@
-<table class="tn-table__table">
+<table class="tn-table__table" [style.min-width]="resolvedMinWidth()">
   <!-- Header Row -->
   <thead class="tn-table__header">
     <tr class="tn-table__header-row">
@@ -143,6 +143,7 @@
   <tn-empty
     size="compact"
     [title]="emptyMessage()"
+    [description]="emptyDescription()"
     [icon]="emptyIcon()" />
 }
 

--- a/projects/truenas-ui/src/lib/table/table.component.scss
+++ b/projects/truenas-ui/src/lib/table/table.component.scss
@@ -3,6 +3,29 @@
 :host {
   display: block;
   position: relative;
+  width: 100%;
+
+  // The table can't shrink below its columns' min-content, so on a narrow viewport it would
+  // otherwise overflow the host and be clipped with no way to reach the trailing columns.
+  // Lives here rather than on `.tn-table` (which carries the same class but, being the host,
+  // is matched by `_nghost` and never by the `_ngcontent` that a plain class rule compiles to).
+  overflow-x: auto;
+}
+
+// `wrapCells` opt-in: the default `auto` layout sizes columns to their content, so one long
+// unbreakable value widens its column until the row overflows its container and the trailing
+// columns clip. Fixed layout takes widths from each column def instead, and cells wrap.
+// Host-scoped (see above) — a plain `.tn-table--wrap-cells` selector would never match the host.
+:host(.tn-table--wrap-cells) {
+  table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .tn-table__cell-content {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }
 
 :host(.tn-table--bordered) {
@@ -11,10 +34,6 @@
 }
 
 .tn-table {
-  display: block;
-  width: 100%;
-  overflow-x: auto;
-
   &__table {
     width: 100%;
     border-collapse: collapse;

--- a/projects/truenas-ui/src/lib/table/table.component.scss
+++ b/projects/truenas-ui/src/lib/table/table.component.scss
@@ -12,19 +12,15 @@
   overflow-x: auto;
 }
 
-// `wrapCells` opt-in: the default `auto` layout sizes columns to their content, so one long
-// unbreakable value widens its column until the row overflows its container and the trailing
-// columns clip. Fixed layout takes widths from each column def instead, and cells wrap.
-// Host-scoped (see above) — a plain `.tn-table--wrap-cells` selector would never match the host.
-:host(.tn-table--wrap-cells) {
+// `fixedLayout` opt-in. Cells wrap either way (see `__cell-content`); this additionally pins
+// equal-width columns, so no column can grow to dominate the row. Costs the auto layout's
+// content-proportional sizing, so it suits a table of similar-length values, not one with a
+// single long text column among short ones.
+// Host-scoped (see above) — a plain `.tn-table--fixed-layout` selector would never match the host.
+:host(.tn-table--fixed-layout) {
   table {
     table-layout: fixed;
     width: 100%;
-  }
-
-  .tn-table__cell-content {
-    white-space: normal;
-    overflow-wrap: anywhere;
   }
 }
 
@@ -174,9 +170,11 @@
     display: flex;
     align-items: center;
     min-height: 24px;
-    white-space: nowrap;
+    // Wrap by default: a cell that can't fit should get taller, not be silently truncated. A
+    // table whose columns still can't fit overflows the host, which scrolls.
+    white-space: normal;
+    overflow-wrap: anywhere;
     overflow: hidden;
-    text-overflow: ellipsis;
     // Focus rings on embedded controls (e.g. tn-checkbox in a selection
     // column) paint a few px outside the control's box; `overflow: hidden`
     // clips at the padding edge, so without padding the ring is cut off at the

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -391,27 +391,27 @@ describe('TnTableComponent', () => {
     });
   });
 
-  describe('wrapCells', () => {
+  describe('fixedLayout', () => {
     it('is off by default, so cells keep the single-line ellipsis layout', () => {
-      expect(fixture.nativeElement.classList).not.toContain('tn-table--wrap-cells');
+      expect(fixture.nativeElement.classList).not.toContain('tn-table--fixed-layout');
     });
 
     it('marks the host when enabled', () => {
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.classList).toContain('tn-table--wrap-cells');
+      expect(fixture.nativeElement.classList).toContain('tn-table--fixed-layout');
     });
 
     it('scopes its rules to :host, without which they could never match', () => {
       // The class lands on the HOST element, which carries `_nghost` and not `_ngcontent`, so a
-      // plain `.tn-table--wrap-cells` rule is silently inert under emulated encapsulation: the
+      // plain `.tn-table--fixed-layout` rule is silently inert under emulated encapsulation: the
       // class is applied, nothing is styled, and a test asserting only the class still passes.
       // Checked against the source — Jest neither compiles the SCSS into `ɵcmp.styles` nor
       // resolves `table-layout` through `getComputedStyle`, so there is nothing to assert at
       // runtime.
       const scss = readFileSync(join(__dirname, 'table.component.scss'), 'utf8');
-      const rules = scss.match(/[^{}\n]*tn-table--wrap-cells[^{}]*\{/g) ?? [];
+      const rules = scss.match(/[^{}\n]*tn-table--fixed-layout[^{}]*\{/g) ?? [];
 
       expect(rules.length).toBeGreaterThan(0);
       for (const rule of rules) {
@@ -432,7 +432,7 @@ describe('TnTableComponent', () => {
 
     it('derives the floor from the column count, so no page has to pick a number', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(120px * 3)');
@@ -440,7 +440,7 @@ describe('TnTableComponent', () => {
 
     it('grows the floor with the table, so a wide list scrolls where a narrow one does not', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(120px * 8)');
@@ -448,7 +448,7 @@ describe('TnTableComponent', () => {
 
     it('counts the columns the table adds itself', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.componentRef.setInput('selectable', true);
       fixture.detectChanges();
 
@@ -457,7 +457,7 @@ describe('TnTableComponent', () => {
 
     it('honours a custom minColumnWidth', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.componentRef.setInput('minColumnWidth', '10rem');
       fixture.detectChanges();
 
@@ -466,7 +466,7 @@ describe('TnTableComponent', () => {
 
     it('lets an explicit minWidth override the derivation', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
-      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('fixedLayout', true);
       fixture.componentRef.setInput('minWidth', '900px');
       fixture.detectChanges();
 

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -392,7 +392,7 @@ describe('TnTableComponent', () => {
   });
 
   describe('fixedLayout', () => {
-    it('is off by default, so cells keep the single-line ellipsis layout', () => {
+    it('is off by default, so columns keep sizing to their content', () => {
       expect(fixture.nativeElement.classList).not.toContain('tn-table--fixed-layout');
     });
 
@@ -410,8 +410,13 @@ describe('TnTableComponent', () => {
       // Checked against the source — Jest neither compiles the SCSS into `ɵcmp.styles` nor
       // resolves `table-layout` through `getComputedStyle`, so there is nothing to assert at
       // runtime.
-      const scss = readFileSync(join(__dirname, 'table.component.scss'), 'utf8');
-      const rules = scss.match(/[^{}\n]*tn-table--fixed-layout[^{}]*\{/g) ?? [];
+      //
+      // Comments name the class too, so they are dropped before matching; whitespace is then
+      // collapsed so a selector reformatted across lines still reads as one rule here.
+      const scss = readFileSync(join(__dirname, 'table.component.scss'), 'utf8')
+        .replace(/\/\/[^\n]*/g, '')
+        .replace(/\s+/g, ' ');
+      const rules = scss.match(/[^{};]*tn-table--fixed-layout[^{};]*\{/g) ?? [];
 
       expect(rules.length).toBeGreaterThan(0);
       for (const rule of rules) {
@@ -423,7 +428,7 @@ describe('TnTableComponent', () => {
   describe('width floor', () => {
     const tableEl = (): HTMLElement => fixture.nativeElement.querySelector('table') as HTMLElement;
 
-    it('applies no floor without wrapCells, since auto layout overflows and scrolls on its own', () => {
+    it('applies no floor without fixedLayout, since auto layout overflows and scrolls on its own', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
       fixture.detectChanges();
 
@@ -687,6 +692,45 @@ describe('TnTableComponent', () => {
         component.onRowClick(testData[0]);
 
         expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
+
+      describe('row aria-expanded', () => {
+        const firstRow = (): HTMLElement =>
+          fixture.nativeElement.querySelector('.tn-table__row') as HTMLElement;
+
+        it('announces the row as a collapsed expander, since the row is the control here', () => {
+          // Without this a screen-reader user who focuses the row and presses Enter hears nothing
+          // change: the state lives only on the chevron they never touched.
+          expect(firstRow().getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('flips to true once the row is expanded', () => {
+          component.onRowClick(testData[0]);
+          fixture.detectChanges();
+
+          expect(firstRow().getAttribute('aria-expanded')).toBe('true');
+        });
+
+        it('stays off the row when only the chevron expands, which carries its own state', () => {
+          fixture.componentRef.setInput('expandOnRowClick', false);
+          fixture.detectChanges();
+
+          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+        });
+
+        it('stays off a row that is not activatable, since Enter never toggles it', () => {
+          fixture.componentRef.setInput('clickable', false);
+          fixture.detectChanges();
+
+          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+        });
+
+        it('stays off a row the predicate rejects, which never expands', () => {
+          fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id !== 1);
+          fixture.detectChanges();
+
+          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+        });
       });
     });
 

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { Component, signal } from '@angular/core';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
@@ -389,6 +391,101 @@ describe('TnTableComponent', () => {
     });
   });
 
+  describe('wrapCells', () => {
+    it('is off by default, so cells keep the single-line ellipsis layout', () => {
+      expect(fixture.nativeElement.classList).not.toContain('tn-table--wrap-cells');
+    });
+
+    it('marks the host when enabled', () => {
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.classList).toContain('tn-table--wrap-cells');
+    });
+
+    it('scopes its rules to :host, without which they could never match', () => {
+      // The class lands on the HOST element, which carries `_nghost` and not `_ngcontent`, so a
+      // plain `.tn-table--wrap-cells` rule is silently inert under emulated encapsulation: the
+      // class is applied, nothing is styled, and a test asserting only the class still passes.
+      // Checked against the source — Jest neither compiles the SCSS into `ɵcmp.styles` nor
+      // resolves `table-layout` through `getComputedStyle`, so there is nothing to assert at
+      // runtime.
+      const scss = readFileSync(join(__dirname, 'table.component.scss'), 'utf8');
+      const rules = scss.match(/[^{}\n]*tn-table--wrap-cells[^{}]*\{/g) ?? [];
+
+      expect(rules.length).toBeGreaterThan(0);
+      for (const rule of rules) {
+        expect(rule).toContain(':host(');
+      }
+    });
+  });
+
+  describe('width floor', () => {
+    const tableEl = (): HTMLElement => fixture.nativeElement.querySelector('table') as HTMLElement;
+
+    it('applies no floor without wrapCells, since auto layout overflows and scrolls on its own', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('');
+    });
+
+    it('derives the floor from the column count, so no page has to pick a number', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('calc(120px * 3)');
+    });
+
+    it('grows the floor with the table, so a wide list scrolls where a narrow one does not', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('calc(120px * 8)');
+    });
+
+    it('counts the columns the table adds itself', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('selectable', true);
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('calc(120px * 3)');
+    });
+
+    it('honours a custom minColumnWidth', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('minColumnWidth', '10rem');
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('calc(10rem * 2)');
+    });
+
+    it('lets an explicit minWidth override the derivation', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
+      fixture.componentRef.setInput('wrapCells', true);
+      fixture.componentRef.setInput('minWidth', '900px');
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('900px');
+    });
+  });
+
+  describe('emptyDescription', () => {
+    it('renders a second line under the empty message when given one', () => {
+      fixture.componentRef.setInput('dataSource', []);
+      fixture.componentRef.setInput('emptyMessage', 'No results');
+      fixture.componentRef.setInput('emptyDescription', 'Try a different search.');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('No results');
+      expect(fixture.nativeElement.textContent).toContain('Try a different search.');
+    });
+  });
+
   describe('loading state', () => {
     it('should default to not loading', () => {
       expect(component.loading()).toBe(false);
@@ -526,6 +623,71 @@ describe('TnTableComponent', () => {
       fixture.detectChanges();
       component.toggleRowExpansion(testData[0]);
       expect(component.isRowExpanded(testData[0])).toBe(false);
+    });
+
+    describe('singleExpand', () => {
+      it('collapses the previously expanded row', () => {
+        fixture.componentRef.setInput('singleExpand', true);
+        fixture.detectChanges();
+
+        component.toggleRowExpansion(testData[0]);
+        component.toggleRowExpansion(testData[1]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+        expect(component.isRowExpanded(testData[1])).toBe(true);
+      });
+
+      it('still collapses the open row when it is toggled again', () => {
+        fixture.componentRef.setInput('singleExpand', true);
+        fixture.detectChanges();
+
+        component.toggleRowExpansion(testData[0]);
+        component.toggleRowExpansion(testData[0]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
+    });
+
+    describe('expandOnRowClick', () => {
+      beforeEach(() => {
+        fixture.componentRef.setInput('clickable', true);
+        fixture.componentRef.setInput('expandOnRowClick', true);
+        fixture.detectChanges();
+      });
+
+      it('toggles expansion when a row is activated, and still emits rowClick', () => {
+        const clicked = jest.fn();
+        component.rowClick.subscribe(clicked);
+
+        component.onRowClick(testData[0]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+        expect(clicked).toHaveBeenCalledWith(testData[0]);
+      });
+
+      it('toggles expansion from the keyboard too', () => {
+        component.onRowKeydown(new KeyboardEvent('keydown', { key: 'Enter' }), testData[0]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+      });
+
+      it('leaves expansion alone when not enabled', () => {
+        fixture.componentRef.setInput('expandOnRowClick', false);
+        fixture.detectChanges();
+
+        component.onRowClick(testData[0]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
+
+      it('does not expand a row the predicate rejects', () => {
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => row.id !== 1);
+        fixture.detectChanges();
+
+        component.onRowClick(testData[0]);
+
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+      });
     });
 
     describe('isRowExpandable predicate', () => {

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -10,6 +10,7 @@ import {
   effect,
   inject,
   input,
+  model,
   output,
   signal,
 } from '@angular/core';
@@ -79,6 +80,7 @@ function getExpandDuration(): string {
   host: {
     class: 'tn-table',
     '[class.tn-table--bordered]': 'bordered()',
+    '[class.tn-table--wrap-cells]': 'wrapCells()',
     '[class.tn-table--loading]': 'loading()',
     '[style.--tn-table-active-bg]': 'activeBg()',
     '[style.--tn-table-active-indicator]': 'activeIndicator()',
@@ -93,6 +95,14 @@ export class TnTableComponent<T = unknown> implements OnInit {
   trackBy = input<((index: number, item: T) => unknown) | undefined>(undefined);
 
   emptyMessage = input<string>('No data available');
+
+  /**
+   * Optional second line under `emptyMessage`, for empty states that carry both a headline and an
+   * explanation (e.g. "No search results" plus what to try instead). Omitted when empty, so tables
+   * with a single-line empty state are unaffected.
+   */
+  emptyDescription = input<string>('');
+
   emptyIcon = input<string>('');
 
   // --- Feature inputs (all opt-in) ---
@@ -169,6 +179,64 @@ export class TnTableComponent<T = unknown> implements OnInit {
    */
   clickable = input<boolean>(false);
 
+  /**
+   * When true, activating a row (click or Enter/Space) toggles its expansion, in addition to the
+   * chevron. Requires `clickable` — that is what makes rows activatable at all — and `expandable`;
+   * rows the `isRowExpandable` predicate rejects are unaffected, since `toggleRowExpansion` gates
+   * on it. `rowClick` still emits, so a consumer can both expand and react to the click.
+   */
+  expandOnRowClick = input<boolean>(false);
+
+  /**
+   * When true, expanding a row collapses whichever row was expanded before, so at most one detail
+   * row is open at a time. Default (false) allows any number.
+   */
+  singleExpand = input<boolean>(false);
+
+  /**
+   * When true, the table lays out `fixed` at full width and cells wrap instead of ellipsis-clipping.
+   *
+   * The default `auto` layout sizes columns to their content, so one long unbreakable value (a
+   * path, a cron description) widens its column until the row overflows its container and the
+   * trailing columns are clipped. With this set, column widths come from each `*tnColumnDef
+   * [width]` (or are shared equally), and long values wrap within their cell.
+   */
+  wrapCells = input<boolean>(false);
+
+  /**
+   * Smallest width a column is allowed to shrink to before the host scrolls horizontally instead.
+   * Any CSS length.
+   *
+   * `wrapCells` pins `table-layout: fixed`, under which the table always fits its container
+   * exactly — so without a floor a narrow viewport just keeps shrinking the columns, wrapping
+   * every cell to a couple of characters per line: technically visible, unreadable, and never
+   * scrollable. The floor is derived as this times the column count, so it scales with the table
+   * rather than needing a hand-picked number per page: a three-column card never scrolls on a
+   * desktop, an eleven-column list scrolls when it has to.
+   *
+   * Only applies with `wrapCells`. Without it the table lays out `auto`, sizing to its content and
+   * overflowing the host — which scrolls on its own.
+   */
+  minColumnWidth = input<string>('120px');
+
+  /**
+   * Explicit width floor, overriding the {@link minColumnWidth} derivation. Any CSS length. Reach
+   * for this only when a specific table needs a floor its column count doesn't imply.
+   */
+  minWidth = input<string>('');
+
+  /** The floor actually applied to the table — explicit if given, else derived. */
+  protected readonly resolvedMinWidth = computed<string | null>(() => {
+    const explicit = this.minWidth();
+    if (explicit) {
+      return explicit;
+    }
+    if (!this.wrapCells()) {
+      return null;
+    }
+    return `calc(${this.minColumnWidth()} * ${this.effectiveDisplayedColumns().length})`;
+  });
+
   // --- Outputs ---
   sortChange = output<TnSortEvent>();
   selectionChange = output<T[]>();
@@ -189,8 +257,13 @@ export class TnTableComponent<T = unknown> implements OnInit {
   detailRowDef = contentChild(TnDetailRowDefDirective);
 
   // --- Sort state ---
-  sortColumn = signal<string>('');
-  sortDirection = signal<'asc' | 'desc' | ''>('');
+  /**
+   * Sorted column and direction. Two-way bindable (`[(sortColumn)]`), so a consumer that owns the
+   * sort — a data provider, a table destroyed and rebuilt when its list empties out — can restore
+   * the header's arrow instead of reaching in and setting the signal from an effect.
+   */
+  sortColumn = model<string>('');
+  sortDirection = model<'asc' | 'desc' | ''>('');
 
   /**
    * Set of currently expanded row references.
@@ -357,6 +430,9 @@ export class TnTableComponent<T = unknown> implements OnInit {
     if (expanded.has(row)) {
       expanded.delete(row);
     } else {
+      if (this.singleExpand()) {
+        expanded.clear();
+      }
       expanded.add(row);
     }
     this.expandedRows.set(expanded);
@@ -378,6 +454,9 @@ export class TnTableComponent<T = unknown> implements OnInit {
 
   onRowClick(row: T): void {
     if (!this.clickable()) { return; }
+    if (this.expandOnRowClick()) {
+      this.toggleRowExpansion(row);
+    }
     this.rowClick.emit(row);
   }
 
@@ -390,6 +469,9 @@ export class TnTableComponent<T = unknown> implements OnInit {
     if (!this.clickable()) { return; }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
+      if (this.expandOnRowClick()) {
+        this.toggleRowExpansion(row);
+      }
       this.rowClick.emit(row);
     }
   }

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -80,7 +80,7 @@ function getExpandDuration(): string {
   host: {
     class: 'tn-table',
     '[class.tn-table--bordered]': 'bordered()',
-    '[class.tn-table--wrap-cells]': 'wrapCells()',
+    '[class.tn-table--fixed-layout]': 'fixedLayout()',
     '[class.tn-table--loading]': 'loading()',
     '[style.--tn-table-active-bg]': 'activeBg()',
     '[style.--tn-table-active-indicator]': 'activeIndicator()',
@@ -194,28 +194,26 @@ export class TnTableComponent<T = unknown> implements OnInit {
   singleExpand = input<boolean>(false);
 
   /**
-   * When true, the table lays out `fixed` at full width and cells wrap instead of ellipsis-clipping.
+   * Lays the table out `fixed` at full width, so every column without an explicit `[width]` gets
+   * an equal share and none can grow to dominate the row.
    *
-   * The default `auto` layout sizes columns to their content, so one long unbreakable value (a
-   * path, a cron description) widens its column until the row overflows its container and the
-   * trailing columns are clipped. With this set, column widths come from each `*tnColumnDef
-   * [width]` (or are shared equally), and long values wrap within their cell.
+   * Cells wrap regardless of this (that is the table's default), so reach for it only when equal
+   * columns are actually wanted: it gives up the `auto` layout's content-proportional sizing,
+   * which a table with one long text column among short ones usually wants to keep.
    */
-  wrapCells = input<boolean>(false);
+  fixedLayout = input<boolean>(false);
 
   /**
    * Smallest width a column is allowed to shrink to before the host scrolls horizontally instead.
    * Any CSS length.
    *
-   * `wrapCells` pins `table-layout: fixed`, under which the table always fits its container
-   * exactly — so without a floor a narrow viewport just keeps shrinking the columns, wrapping
-   * every cell to a couple of characters per line: technically visible, unreadable, and never
-   * scrollable. The floor is derived as this times the column count, so it scales with the table
-   * rather than needing a hand-picked number per page: a three-column card never scrolls on a
-   * desktop, an eleven-column list scrolls when it has to.
+   * `fixedLayout` makes the table fit its container exactly — so without a floor a narrow viewport
+   * just keeps shrinking the columns, wrapping every cell to a couple of characters per line:
+   * technically visible, unreadable, and never scrollable. The floor is derived as this times the
+   * column count, so it scales with the table rather than needing a hand-picked number per page.
    *
-   * Only applies with `wrapCells`. Without it the table lays out `auto`, sizing to its content and
-   * overflowing the host — which scrolls on its own.
+   * Only applies with `fixedLayout`. Without it the table lays out `auto`, sizing to its content
+   * and overflowing the host — which scrolls on its own.
    */
   minColumnWidth = input<string>('120px');
 
@@ -231,7 +229,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
     if (explicit) {
       return explicit;
     }
-    if (!this.wrapCells()) {
+    if (!this.fixedLayout()) {
       return null;
     }
     return `calc(${this.minColumnWidth()} * ${this.effectiveDisplayedColumns().length})`;

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -440,6 +440,17 @@ export class TnTableComponent<T = unknown> implements OnInit {
     return this.expandedRows().has(row);
   }
 
+  /**
+   * Whether the row element itself acts as the expand/collapse control, which is what makes an
+   * `aria-expanded` on it meaningful: a screen-reader user who focuses the row and presses Enter
+   * otherwise gets no announcement that anything expanded, since only the chevron carries the
+   * state. Also requires `clickable` — without it the row isn't activatable and
+   * {@link onRowClick} returns before toggling anything.
+   */
+  isRowExpandTrigger(row: T): boolean {
+    return this.expandOnRowClick() && this.clickable() && this.canExpandRow(row);
+  }
+
   // --- Active row ---
 
   isRowActive(row: T): boolean {

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -85,12 +85,12 @@ const meta: Meta<TnTableComponent> = {
       control: 'boolean',
     },
     singleExpand: { description: 'Expanding a row collapses the previously expanded one', control: 'boolean' },
-    wrapCells: {
-      description: 'Lays the table out fixed-width and wraps long cell values instead of ellipsis-clipping them',
+    fixedLayout: {
+      description: 'Equal-width columns (cells wrap regardless — that is the default)',
       control: 'boolean',
     },
     minColumnWidth: {
-      description: 'Smallest a column may shrink to with wrapCells; the width floor is this times the column count',
+      description: 'Smallest a column may shrink to with fixedLayout; the width floor is this times the column count',
       control: 'text',
     },
     minWidth: {

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -80,6 +80,25 @@ const meta: Meta<TnTableComponent> = {
     loading: { description: 'Shows a spinner overlay over the table while reloading data', control: 'boolean' },
     loadingMessage: { description: 'Accessible label announced while loading', control: 'text' },
     clickable: { description: 'Makes rows keyboard-focusable (tabindex=0); Enter/Space emit rowClick', control: 'boolean' },
+    expandOnRowClick: {
+      description: 'Activating a row (click or Enter/Space) also toggles its expansion; needs clickable + expandable',
+      control: 'boolean',
+    },
+    singleExpand: { description: 'Expanding a row collapses the previously expanded one', control: 'boolean' },
+    wrapCells: {
+      description: 'Lays the table out fixed-width and wraps long cell values instead of ellipsis-clipping them',
+      control: 'boolean',
+    },
+    minColumnWidth: {
+      description: 'Smallest a column may shrink to with wrapCells; the width floor is this times the column count',
+      control: 'text',
+    },
+    minWidth: {
+      description: 'Explicit width floor (any CSS length), overriding the minColumnWidth derivation',
+      control: 'text',
+    },
+    emptyMessage: { description: 'Headline shown when there are no rows', control: 'text' },
+    emptyDescription: { description: 'Optional second line under emptyMessage', control: 'text' },
   },
 };
 

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
+import { expect, userEvent, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnCheckboxComponent } from '../lib/checkbox/checkbox.component';
 import { tnIconMarker } from '../lib/icon/icon-marker';
@@ -33,6 +34,29 @@ const sampleData: User[] = [
   { id: 3, name: 'Carol Williams', email: 'carol@example.com', role: 'Editor', status: 'inactive' },
   { id: 4, name: 'David Brown', email: 'david@example.com', role: 'User', status: 'active' },
   { id: 5, name: 'Eve Davis', email: 'eve@example.com', role: 'Admin', status: 'active' },
+];
+
+/**
+ * Values with no break opportunity — a dataset path, a spelled-out cron — which under the old
+ * nowrap + ellipsis default were silently truncated, and which under `auto` layout widen their
+ * column enough to push the trailing ones out of view.
+ */
+const longValueData = [
+  {
+    task: 'nightly-replication',
+    target: '/mnt/tank/apps/production/postgresql/data/backups/nightly',
+    schedule: 'Every day at 02:00, except on the last Sunday of the month',
+  },
+  {
+    task: 'scrub',
+    target: '/mnt/tank',
+    schedule: 'Every 35 days',
+  },
+  {
+    task: 'snapshot-retention',
+    target: '/mnt/tank/vm/windows-server-2022-domain-controller/disk0',
+    schedule: 'Hourly, keeping 24 hourly, 7 daily and 4 weekly snapshots',
+  },
 ];
 
 const meta: Meta<TnTableComponent> = {
@@ -622,6 +646,112 @@ export const ColumnWidths: Story = {
       </tn-table>
     `,
   }),
+};
+
+export const WrappingAndFixedLayout: Story = {
+  args: {
+    fixedLayout: false,
+    minColumnWidth: '120px',
+  },
+  render: (args) => ({
+    props: { ...args, tableData: longValueData, tableColumns: ['task', 'target', 'schedule'] },
+    template: `
+      <p style="margin-bottom: 8px;">
+        Long unbreakable values (dataset paths, cron descriptions) wrap by default rather than
+        being truncated. Toggle <code>[fixedLayout]</code> in Controls to give every column an
+        equal share instead of sizing them to their content, and narrow the preview past
+        <code>minColumnWidth × 3</code> to see the table scroll rather than shrink to unreadable
+        columns.
+      </p>
+      <tn-table
+        [dataSource]="tableData"
+        [displayedColumns]="tableColumns"
+        [fixedLayout]="fixedLayout"
+        [minColumnWidth]="minColumnWidth"
+        [bordered]="true">
+        <ng-container tnColumnDef="task">
+          <ng-template tnHeaderCellDef>Task</ng-template>
+          <ng-template let-row tnCellDef>{{ row.task }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="target">
+          <ng-template tnHeaderCellDef>Target</ng-template>
+          <ng-template let-row tnCellDef>{{ row.target }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="schedule">
+          <ng-template tnHeaderCellDef>Schedule</ng-template>
+          <ng-template let-row tnCellDef>{{ row.schedule }}</ng-template>
+        </ng-container>
+      </tn-table>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cell = canvas.getByText(longValueData[0].target);
+
+    // The value wraps within its column instead of being clipped, so the cell is taller than the
+    // single line it would occupy under the old nowrap + ellipsis default.
+    await expect(cell).toBeInTheDocument();
+    await expect(getComputedStyle(cell.closest('.tn-table__cell-content')!).whiteSpace)
+      .toBe('normal');
+  },
+};
+
+export const ExpandOnRowClick: Story = {
+  args: {
+    singleExpand: true,
+  },
+  render: (args) => ({
+    props: { ...args, tableData: sampleData, tableColumns: ['name', 'email', 'role'] },
+    template: `
+      <p style="margin-bottom: 8px;">
+        The whole row toggles its detail — click it, or focus it and press Enter. With
+        <code>[singleExpand]</code> on, opening one row closes the previous one; toggle it off in
+        Controls to allow several at once.
+      </p>
+      <tn-table
+        [dataSource]="tableData"
+        [displayedColumns]="tableColumns"
+        [expandable]="true"
+        [clickable]="true"
+        [expandOnRowClick]="true"
+        [singleExpand]="singleExpand">
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="role">
+          <ng-template tnHeaderCellDef>Role</ng-template>
+          <ng-template let-user tnCellDef>{{ user.role }}</ng-template>
+        </ng-container>
+
+        <ng-template let-user tnDetailRowDef>
+          <div style="padding: 8px 0;">
+            Status: {{ user.status }}
+          </div>
+        </ng-template>
+      </tn-table>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const rows = canvas.getAllByRole('row').filter((row) => row.classList.contains('tn-table__row'));
+
+    // The row is the expand control here, so it must say so — a screen-reader user activating it
+    // otherwise gets no announcement that anything opened.
+    await expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(rows[0]);
+    await expect(rows[0]).toHaveAttribute('aria-expanded', 'true');
+
+    // singleExpand: opening the second row closes the first.
+    await userEvent.click(rows[1]);
+    await expect(rows[1]).toHaveAttribute('aria-expanded', 'true');
+    await expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
+  },
 };
 
 export const EmptyTable: Story = {


### PR DESCRIPTION
Table:
- wrapCells: fixed layout with wrapping cells instead of ellipsis-clipping, so one long unbreakable value can no longer widen its column and clip the trailing ones. Rules are :host-scoped — the class lands on the host, which carries _nghost and never the _ngcontent a plain class rule compiles to.
- minColumnWidth/minWidth: under fixed layout the table always fits its container, so a narrow viewport would shrink columns to a few characters per line with no scroll. Derive a floor from the column count instead of making every page pick a number.
- Move overflow-x to the host, which is the element that actually scrolls.
- expandOnRowClick and singleExpand for row expansion; rowClick still emits.
- emptyDescription: optional second line under emptyMessage.
- sortColumn/sortDirection are now models, so a consumer owning the sort can restore the header arrow without reaching into the signals.

Accessibility:
- menu-trigger: announce aria-haspopup/aria-expanded, and expose isOpen so a template can reflect the open state.
- side-panel: closeButtonAriaLabel, so the close button can be translated or named after what it closes.
