### PR TITLE
NAS-142079 / 27.0.0-BETA.1 / fix(table): make the derived width floor opt-in

### DIFF
--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -435,9 +435,20 @@ describe('TnTableComponent', () => {
       expect(tableEl().style.minWidth).toBe('');
     });
 
+    it('applies no floor with fixedLayout alone, so a table in a card or split pane still fits it', () => {
+      // A derived floor cannot know the container, so it is opt-in: defaulting it on scrolled every
+      // table that shares its row with something else at ordinary window sizes.
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
+      fixture.componentRef.setInput('fixedLayout', true);
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('');
+    });
+
     it('derives the floor from the column count, so no page has to pick a number', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c']);
       fixture.componentRef.setInput('fixedLayout', true);
+      fixture.componentRef.setInput('minColumnWidth', '120px');
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(120px * 3)');
@@ -446,6 +457,7 @@ describe('TnTableComponent', () => {
     it('grows the floor with the table, so a wide list scrolls where a narrow one does not', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
       fixture.componentRef.setInput('fixedLayout', true);
+      fixture.componentRef.setInput('minColumnWidth', '120px');
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(120px * 8)');
@@ -454,19 +466,28 @@ describe('TnTableComponent', () => {
     it('counts the columns the table adds itself', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
       fixture.componentRef.setInput('fixedLayout', true);
+      fixture.componentRef.setInput('minColumnWidth', '120px');
       fixture.componentRef.setInput('selectable', true);
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(120px * 3)');
     });
 
-    it('honours a custom minColumnWidth', () => {
+    it('honours any CSS length as the per-column floor', () => {
       fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
       fixture.componentRef.setInput('fixedLayout', true);
       fixture.componentRef.setInput('minColumnWidth', '10rem');
       fixture.detectChanges();
 
       expect(tableEl().style.minWidth).toBe('calc(10rem * 2)');
+    });
+
+    it('ignores minColumnWidth without fixedLayout, where auto layout already scrolls', () => {
+      fixture.componentRef.setInput('displayedColumns', ['a', 'b']);
+      fixture.componentRef.setInput('minColumnWidth', '120px');
+      fixture.detectChanges();
+
+      expect(tableEl().style.minWidth).toBe('');
     });
 
     it('lets an explicit minWidth override the derivation', () => {

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -200,22 +200,32 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * Cells wrap regardless of this (that is the table's default), so reach for it only when equal
    * columns are actually wanted: it gives up the `auto` layout's content-proportional sizing,
    * which a table with one long text column among short ones usually wants to keep.
+   *
+   * Changes the layout algorithm only — the table still shrinks with its container, with no floor
+   * unless {@link minColumnWidth} or {@link minWidth} sets one.
    */
   fixedLayout = input<boolean>(false);
 
   /**
    * Smallest width a column is allowed to shrink to before the host scrolls horizontally instead.
-   * Any CSS length.
+   * Any CSS length. Empty (the default) applies no floor.
    *
-   * `fixedLayout` makes the table fit its container exactly — so without a floor a narrow viewport
-   * just keeps shrinking the columns, wrapping every cell to a couple of characters per line:
-   * technically visible, unreadable, and never scrollable. The floor is derived as this times the
-   * column count, so it scales with the table rather than needing a hand-picked number per page.
+   * `fixedLayout` makes the table fit its container exactly, so past a certain width the columns
+   * keep shrinking and wrap every cell to a couple of characters per line: technically visible,
+   * unreadable, and never scrollable. Set this to scroll instead once a column would go below it.
+   * The floor is derived as this times the column count, so it scales with the table rather than
+   * needing a hand-picked number per page.
+   *
+   * Opt-in rather than on by default, because a derived floor cannot know the table's container: a
+   * full-width page table has room for one, while the same table in a dashboard card or beside a
+   * details pane would just scroll at every ordinary window size. Only the consumer knows which it
+   * is — reach for it when the table can actually get narrow enough to matter, typically a
+   * full-width table on a phone.
    *
    * Only applies with `fixedLayout`. Without it the table lays out `auto`, sizing to its content
    * and overflowing the host — which scrolls on its own.
    */
-  minColumnWidth = input<string>('120px');
+  minColumnWidth = input<string>('');
 
   /**
    * Explicit width floor, overriding the {@link minColumnWidth} derivation. Any CSS length. Reach
@@ -223,16 +233,17 @@ export class TnTableComponent<T = unknown> implements OnInit {
    */
   minWidth = input<string>('');
 
-  /** The floor actually applied to the table — explicit if given, else derived. */
+  /** The floor actually applied to the table — explicit if given, else derived, else none. */
   protected readonly resolvedMinWidth = computed<string | null>(() => {
     const explicit = this.minWidth();
     if (explicit) {
       return explicit;
     }
-    if (!this.fixedLayout()) {
+    const perColumn = this.minColumnWidth();
+    if (!perColumn || !this.fixedLayout()) {
       return null;
     }
-    return `calc(${this.minColumnWidth()} * ${this.effectiveDisplayedColumns().length})`;
+    return `calc(${perColumn} * ${this.effectiveDisplayedColumns().length})`;
   });
 
   // --- Outputs ---

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -114,7 +114,8 @@ const meta: Meta<TnTableComponent> = {
       control: 'boolean',
     },
     minColumnWidth: {
-      description: 'Smallest a column may shrink to with fixedLayout; the width floor is this times the column count',
+      description: 'Opt-in: smallest a column may shrink to with fixedLayout, before the host scrolls instead. '
+        + 'The width floor is this times the column count; empty (the default) applies no floor',
       control: 'text',
     },
     minWidth: {
@@ -661,7 +662,8 @@ export const WrappingAndFixedLayout: Story = {
         being truncated. Toggle <code>[fixedLayout]</code> in Controls to give every column an
         equal share instead of sizing them to their content, and narrow the preview past
         <code>minColumnWidth × 3</code> to see the table scroll rather than shrink to unreadable
-        columns.
+        columns. That floor is opt-in — this story sets <code>[minColumnWidth]</code> to get it;
+        clear the control and the table keeps shrinking with its container instead.
       </p>
       <tn-table
         [dataSource]="tableData"


### PR DESCRIPTION
A derived floor cannot know the table's container. A full-width page table has room for `minColumnWidth * columns`, but the same table in a dashboard card or beside a details pane hits that floor and scrolls at ordinary window sizes. Defaulting `minColumnWidth` to `120px` therefore made `fixedLayout` alone start scrolling tables that used to fit.

Default it to empty instead: `fixedLayout` now only changes the layout algorithm, and a floor applies only when the consumer — who knows the container — asks for one.
