### PR TITLE
NAS-142092 / 27.0.0-BETA.1 / ci: require a ticket reference in PR titles

### DIFF
--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,0 +1,50 @@
+name: Check Ticket
+
+# NOTE: if this is made a required status check, remember that PRs opened with the
+# default GITHUB_TOKEN never fire pull_request events, so this workflow never runs and
+# never reports — such a PR is unmergeable with no way to unblock it from the PR side.
+# PRs opened by automation must use a PAT/app token.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-ticket-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-ticket:
+    name: Check PR references a ticket
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ticket reference in PR title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Case-sensitive on purpose: bugclerk only links the Jira ticket for uppercase NAS-.
+            const TICKET_PATTERN = /\bNAS-\d+\b/;
+            const WRONG_CASE_PATTERN = new RegExp(TICKET_PATTERN.source, 'i');
+
+            // Every pull request needs a ticket — no bot or label exemptions.
+            const title = context.payload.pull_request.title || '';
+
+            if (TICKET_PATTERN.test(title)) {
+              core.info(`Found ticket ${title.match(TICKET_PATTERN)[0]} in PR title.`);
+              return;
+            }
+
+            const wrongCase = title.match(WRONG_CASE_PATTERN);
+
+            core.setFailed(
+              (wrongCase
+                ? `This pull request references "${wrongCase[0]}", but the ticket must be uppercase (NAS-).\n\n`
+                : `This pull request does not reference a ticket.\n\n`) +
+              `Current title: "${title}"\n\n` +
+              `Add the ticket number to the pull request title, keeping the conventional ` +
+              `commit type last so Semantic Release can parse it, for example:\n` +
+              `  NAS-12345 / feat(button): add loading state\n` +
+              `  NAS-12345 / 27.0.0-BETA.1 / fix(icon): correct sprite path`
+            );

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -93,27 +93,30 @@ yarn generate-sprite  # Generate icon sprite (runs automatically on build)
 This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and [Semantic Release](https://semantic-release.gitbook.io/semantic-release/) for automated versioning and publishing. Every PR title **must** follow this format:
 
 ```
-type(scope): description
+NAS-12345 / type(scope): description
 ```
 
+- **ticket** — Required. The Jira ticket, uppercase `NAS-<number>`, followed by ` / `. Extra prefix segments are allowed (e.g. a version: `NAS-12345 / 27.0.0-BETA.1 / feat: ...`). Semantic Release strips everything before the last ` / `.
 - **type** — Required. See the table below.
 - **scope** — Optional. The area of the codebase (e.g., `button`, `icon`, `ci`).
 - **description** — Required. A short summary of the change in imperative mood.
 
 Examples:
 ```
-feat: add dropdown component
-fix(button): correct focus ring on disabled state
-refactor: simplify icon resolution logic
-docs: update contributing guide
-chore: upgrade Angular to v21
+NAS-12345 / feat: add dropdown component
+NAS-12345 / fix(button): correct focus ring on disabled state
+NAS-12345 / 27.0.0-BETA.1 / refactor: simplify icon resolution logic
+NAS-12345 / docs: update contributing guide
+NAS-12345 / chore: upgrade Angular to v21
 ```
+
+The ticket must be uppercase — bugclerk only links the Jira ticket for `NAS-`, not `nas-`.
 
 ### Why It Matters
 
 When a PR is **squash-merged**, GitHub uses the PR title as the commit message. Semantic Release analyzes these commit messages to automatically determine version bumps and generate release notes. A non-conventional PR title means the commit won't be categorized correctly.
 
-CI will reject PRs that don't have a valid conventional commit title.
+CI will reject PRs that don't have a valid conventional commit title, and separately reject PRs whose title doesn't reference a `NAS-` ticket.
 
 ### Commit Type Reference
 
@@ -147,8 +150,8 @@ Breaking changes signal to consumers that they need to update their version cons
 
 ### How Auto-Publishing Works
 
-1. You open a PR with a conventional commit-style title
-2. CI validates the PR title
+1. You open a PR with a ticket-prefixed, conventional commit-style title
+2. CI validates the PR title (conventional format + ticket reference)
 3. PR is reviewed and **squash-merged** to `main`
 4. CI runs lint, test, and build — all must pass
 5. A path check verifies that published library files actually changed (not just docs, tests, or CI config)


### PR DESCRIPTION
Mirrors the Check Ticket workflow from webui: every PR title must contain an uppercase NAS-<number>, with a distinct error when the ticket is lowercase (bugclerk only links uppercase).

This stacks with the existing conventional-commit check in pr-title.yml, so the valid title shape is "NAS-12345 / feat(button): ...". Documented that in CONTRIBUTE.md and adapted the workflow's failure examples, since webui's "NAS-12345: ..." form would fail the conventional check here.
