### PR TITLE
NAS-142093 / 27.0.0-BETA.1 / fix(select): highlight an option as soon as the dropdown opens

### DIFF
--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -316,21 +316,22 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     if (this.isDisabled() || this.isOpen()) {return;}
     this.isOpen.set(true);
 
-    // Seed keyboard focus at the current selection when there is one;
-    // otherwise leave it unset so the next ArrowDown lands on the first item.
+    // Seed keyboard focus at the current selection when there is one, else at
+    // the first navigable row. Something is ALWAYS highlighted while the panel
+    // is open (matching mat-select): a freshly-opened select must be operable
+    // with Enter/Space straight away, without an ArrowDown first.
     const selected = this.selectedValue();
-    if (selected !== null && selected !== undefined) {
-      const idx = this.navigableOptions().findIndex((x) =>
-        x.kind === 'option' && this.compareValues(x.option.value, selected),
-      );
-      this.focusedIndex.set(idx);
-    } else if (this.emptyOption()) {
-      // A cleared value means the empty option (always first) is the current
-      // selection — seed keyboard focus there.
-      this.focusedIndex.set(0);
-    } else {
-      this.focusedIndex.set(-1);
-    }
+    const idx = selected === null || selected === undefined
+      ? -1
+      : this.navigableOptions().findIndex((x) =>
+          x.kind === 'option' && this.compareValues(x.option.value, selected),
+        );
+    // findIndex can also miss (e.g. the selected option is disabled, so it
+    // isn't navigable) — fall back to the first row there too. `-1` would
+    // leave the panel with nothing highlighted, which is the state we're
+    // avoiding. When `allowEmpty` is set the first row IS the empty option,
+    // so a cleared value lands on it for free.
+    this.focusedIndex.set(idx >= 0 ? idx : 0);
 
     this.attachOverlay();
   }
@@ -680,8 +681,9 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
       case 'ArrowDown':
         event.preventDefault();
         if (!this.isOpen()) {
+          // openDropdown() already seeds the highlight (selection, else first),
+          // so opening must not also advance a row.
           this.openDropdown();
-          if (this.focusedIndex() < 0) {this.moveFocus('first');}
         } else {
           this.moveFocus(1);
         }

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -840,6 +840,16 @@ describe('TnSelectComponent - keyboard navigation', () => {
     return focused ? (focused.textContent ?? '').trim() : null;
   }
 
+  /** Opens the dropdown and clicks the option with the given label. */
+  function pickOption(label: string): void {
+    trigger.click();
+    fixture.detectChanges();
+    const option = Array.from(document.querySelectorAll<HTMLElement>('.tn-select-option'))
+      .find((el) => (el.textContent ?? '').trim() === label);
+    option?.click();
+    fixture.detectChanges();
+  }
+
   it('opens the dropdown on ArrowDown when closed', () => {
     expect(document.querySelector('.tn-select-dropdown')).toBeNull();
 
@@ -956,6 +966,67 @@ describe('TnSelectComponent - keyboard navigation', () => {
 
     expect(hostComponent.selectedValue).toBe('apple');
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it('highlights the first option as soon as the dropdown opens by click', () => {
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(focusedOptionLabel()).toBe('Apple');
+  });
+
+  it('Enter picks the first option right after opening, with no ArrowDown', () => {
+    trigger.click();
+    fixture.detectChanges();
+    press('Enter');
+
+    expect(hostComponent.selectedValue).toBe('apple');
+    expect(document.querySelector('.tn-select-dropdown')).toBeNull();
+  });
+
+  it('Space picks the first option right after opening', () => {
+    press('Enter'); // opens (closed + Enter opens)
+    press(' ');
+
+    expect(hostComponent.selectedValue).toBe('apple');
+  });
+
+  it('highlights the first enabled option when the leading option is disabled', () => {
+    hostComponent.options.set([
+      { value: 'a', label: 'A', disabled: true },
+      { value: 'b', label: 'B' },
+    ]);
+    fixture.detectChanges();
+
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(focusedOptionLabel()).toBe('B');
+  });
+
+  it('highlights the current selection, not the first option, when one is set', () => {
+    pickOption('Cherry');
+
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(focusedOptionLabel()).toBe('Cherry');
+  });
+
+  it('falls back to the first option when the selection is not navigable', () => {
+    // A previously-picked option can become disabled; it's then no longer
+    // navigable, so the highlight must land somewhere rather than vanish.
+    pickOption('Banana');
+    hostComponent.options.set([
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana', disabled: true },
+    ]);
+    fixture.detectChanges();
+
+    trigger.click();
+    fixture.detectChanges();
+
+    expect(focusedOptionLabel()).toBe('Apple');
   });
 
   it('Tab closes the dropdown without refocusing the trigger', () => {


### PR DESCRIPTION
Opening the select left `focusedIndex` at -1 whenever nothing was selected, so the freshly-opened panel had no highlighted row and Enter/Space did nothing until the user pressed ArrowDown first. That diverges from mat-select, where the first option is active on open and can be submitted immediately.

openDropdown() now always seeds the highlight: at the current selection when there is one, otherwise at the first navigable row. The same fallback also covers a selection that isn't navigable (e.g. the bound option became disabled), which previously produced -1 too.

The ArrowDown-when-closed branch no longer re-seeds — opening already does it, so opening must not also advance a row.

https://github.com/user-attachments/assets/726c2b33-bca0-4f0f-895c-e32b87550f74




