### PR TITLE
NAS-142095 / 27.0.0-BETA.1 / ci: call the shared check-ticket workflow

### DIFF
--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -15,10 +15,3 @@ jobs:
     permissions:
       contents: read
     uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@master
-    with:
-      # This repo's titles carry a second rule the shared default knows nothing about:
-      # semantic-release parses the conventional-commit type, and only finds it last.
-      help-text: |
-        Add the ticket number to the pull request title, keeping the conventional commit type last so Semantic Release can parse it, for example:
-          NAS-12345 / feat(button): add loading state
-          NAS-12345 / 27.0.0-BETA.1 / fix(icon): correct sprite path

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,50 +1,19 @@
+# Reports as "check-ticket / <job name in ux-github-workflows>". Branch protection
+# matches that whole string, so the shared workflow's job name is API — renaming it
+# there silently stops this check reporting here.
 name: Check Ticket
-
-# NOTE: if this is made a required status check, remember that PRs opened with the
-# default GITHUB_TOKEN never fire pull_request events, so this workflow never runs and
-# never reports — such a PR is unmergeable with no way to unblock it from the PR side.
-# PRs opened by automation must use a PAT/app token.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-
-permissions:
-  contents: read
-
-concurrency:
-  group: check-ticket-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   check-ticket:
-    name: Check PR references a ticket
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check ticket reference in PR title
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Case-sensitive on purpose: bugclerk only links the Jira ticket for uppercase NAS-.
-            const TICKET_PATTERN = /\bNAS-\d+\b/;
-            const WRONG_CASE_PATTERN = new RegExp(TICKET_PATTERN.source, 'i');
-
-            // Every pull request needs a ticket — no bot or label exemptions.
-            const title = context.payload.pull_request.title || '';
-
-            if (TICKET_PATTERN.test(title)) {
-              core.info(`Found ticket ${title.match(TICKET_PATTERN)[0]} in PR title.`);
-              return;
-            }
-
-            const wrongCase = title.match(WRONG_CASE_PATTERN);
-
-            core.setFailed(
-              (wrongCase
-                ? `This pull request references "${wrongCase[0]}", but the ticket must be uppercase (NAS-).\n\n`
-                : `This pull request does not reference a ticket.\n\n`) +
-              `Current title: "${title}"\n\n` +
-              `Add the ticket number to the pull request title, keeping the conventional ` +
-              `commit type last so Semantic Release can parse it, for example:\n` +
-              `  NAS-12345 / feat(button): add loading state\n` +
-              `  NAS-12345 / 27.0.0-BETA.1 / fix(icon): correct sprite path`
-            );
+    permissions:
+      contents: read
+    uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@master
+    with:
+      # This repo's titles carry a second rule the shared default knows nothing about:
+      # semantic-release parses the conventional-commit type, and only finds it last.
+      help-text: |
+        Add the ticket number to the pull request title, keeping the conventional commit type last so Semantic Release can parse it, for example:
+          NAS-12345 / feat(button): add loading state
+          NAS-12345 / 27.0.0-BETA.1 / fix(icon): correct sprite path

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,3 +1,8 @@
+# The trigger lives here, so this caveat does too: PRs opened with the default
+# GITHUB_TOKEN never fire pull_request, so this would never run and never report —
+# unmergeable with no way to unblock it, if it is a required check. Automation opening
+# PRs here must use a PAT/app token.
+#
 # Reports as "check-ticket / <job name in ux-github-workflows>". Branch protection
 # matches that whole string, so the shared workflow's job name is API — renaming it
 # there silently stops this check reporting here.


### PR DESCRIPTION
The rule now lives in iXsystems/ux-github-workflows, so this repo, webui and truenas-connect/ui share one copy instead of maintaining three. 49 lines down to 18: the trigger, the token ceiling, the job, and the reference — a reusable workflow cannot declare a trigger for its caller, and a caller's permissions is a ceiling the callee can only lower.

Behaviour is unchanged. The default prefix is NAS, and this repo's failure message survives verbatim through the shared workflow's help-text input, so the conventional-commit-type-last instruction semantic-release depends on is still what authors are told.

The reported check name changes from 'Check PR references a ticket' to 'check-ticket / Check PR references a ticket'. If the old name is a required status check on main, it must be updated when this merges, or it sits as Expected forever and nothing can be merged.