### PR TITLE
NAS-141487 / 27.0.0-BETA.1 / feat(card): allow a translated aria-label on the header menu trigger

### DIFF
--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -79,7 +79,8 @@
                 name="dots-vertical"
                 library="mdi"
                 size="md"
-                ariaLabel="Card menu"
+                [ariaLabel]="headerMenuAriaLabel()"
+                [tnTooltip]="resolvedHeaderMenuTooltip()"
                 [testId]="headerMenuTriggerTestId()"
                 [tnMenuTriggerFor]="cardMenu" />
               <tn-menu

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -80,7 +80,7 @@
                 library="mdi"
                 size="md"
                 [ariaLabel]="headerMenuAriaLabel()"
-                [tnTooltip]="resolvedHeaderMenuTooltip()"
+                [tooltip]="resolvedHeaderMenuTooltip()"
                 [testId]="headerMenuTriggerTestId()"
                 [tnMenuTriggerFor]="cardMenu" />
               <tn-menu

--- a/projects/truenas-ui/src/lib/card/card.component.html
+++ b/projects/truenas-ui/src/lib/card/card.component.html
@@ -33,7 +33,7 @@
               <button
                 type="button"
                 class="tn-card__title-tooltip"
-                aria-label="More information"
+                [attr.aria-label]="resolvedTitleTooltipAriaLabel()"
                 [tnTooltip]="tooltip">
                 <tn-icon name="help-circle" library="mdi" size="sm" [attr.aria-hidden]="true" />
               </button>
@@ -79,7 +79,7 @@
                 name="dots-vertical"
                 library="mdi"
                 size="md"
-                [ariaLabel]="headerMenuAriaLabel()"
+                [ariaLabel]="resolvedHeaderMenuAriaLabel()"
                 [tooltip]="resolvedHeaderMenuTooltip()"
                 [testId]="headerMenuTriggerTestId()"
                 [tnMenuTriggerFor]="cardMenu" />

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -23,7 +23,7 @@ class HostComponent {
   control = signal<TnCardControl | undefined>(undefined);
   menu = signal<TnMenuItem[] | undefined>(undefined);
   menuTriggerTestId = signal<string | undefined>(undefined);
-  menuAriaLabel = signal<string>('Card menu');
+  menuAriaLabel = signal<string | undefined>(undefined);
   menuTooltip = signal<string | undefined>(undefined);
   primary = signal<TnCardAction | undefined>(undefined);
   secondary = signal<TnCardAction | undefined>(undefined);
@@ -132,6 +132,18 @@ describe('TnCardComponent testId support', () => {
 
     const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
     expect(trigger.getAttribute('aria-label')).toBe('Card menu');
+  });
+
+  it('leaves the kebab trigger without a tooltip until one is asked for', async () => {
+    const fixture = createHost();
+    fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
+    fixture.detectChanges();
+
+    // The built-in name is deliberately not a tooltip fallback: existing consumers would all
+    // gain a hover hint that only repeats the button's accessible name.
+    const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+    expect(await showTooltip(fixture, trigger)).toBeUndefined();
   });
 
   it('lets a consumer supply a translated accessible name for the kebab trigger', () => {
@@ -297,12 +309,13 @@ describe('TnCardComponent projected action templates', () => {
 @Component({
   standalone: true,
   imports: [TnCardComponent],
-  template: `<tn-card [title]="title()" [titleRouterLink]="routerLink()" [titleTooltip]="tooltip()">Content</tn-card>`,
+  template: `<tn-card [title]="title()" [titleRouterLink]="routerLink()" [titleTooltip]="tooltip()" [titleTooltipAriaLabel]="tooltipAriaLabel()">Content</tn-card>`,
 })
 class TitleHostComponent {
   title = signal<string | undefined>('Recent Orders');
   routerLink = signal<string | unknown[] | undefined>(undefined);
   tooltip = signal<string | undefined>(undefined);
+  tooltipAriaLabel = signal<string | undefined>(undefined);
 }
 
 describe('TnCardComponent title router link & tooltip', () => {
@@ -357,6 +370,18 @@ describe('TnCardComponent title router link & tooltip', () => {
     // The button's accessible name is generic; the tooltip text is exposed as the
     // description (aria-describedby) so a screen reader doesn't read it twice.
     expect(tooltipButton?.getAttribute('aria-label')).toBe('More information');
+  });
+
+  it('lets a consumer supply a translated accessible name for the title help button', () => {
+    const fixture = createTitleHost();
+    fixture.componentInstance.tooltip.set('Open the full orders page');
+    // Same untranslatable-default problem as the kebab trigger: the library ships English, so
+    // an app with an i18n layer has to be able to pass its own string.
+    fixture.componentInstance.tooltipAriaLabel.set('Weitere Informationen');
+    fixture.detectChanges();
+
+    const tooltipButton = fixture.nativeElement.querySelector('.tn-card__title-tooltip') as HTMLElement | null;
+    expect(tooltipButton?.getAttribute('aria-label')).toBe('Weitere Informationen');
   });
 });
 

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -16,7 +16,7 @@ import type { TnMenuItem } from '../menu/menu.component';
 @Component({
   standalone: true,
   imports: [TnCardComponent],
-  template: `<tn-card [headerStatus]="status()" [headerControl]="control()" [headerMenu]="menu()" [headerMenuTriggerTestId]="menuTriggerTestId()" [headerMenuAriaLabel]="menuAriaLabel()" [headerMenuTriggerTooltip]="menuTooltip()" [primaryAction]="primary()" [secondaryAction]="secondary()" [footerLink]="footerLink()">Content</tn-card>`,
+  template: `<tn-card [headerStatus]="status()" [headerControl]="control()" [headerMenu]="menu()" [headerMenuTriggerTestId]="menuTriggerTestId()" [headerMenuTriggerAriaLabel]="menuAriaLabel()" [headerMenuTriggerTooltip]="menuTooltip()" [primaryAction]="primary()" [secondaryAction]="secondary()" [footerLink]="footerLink()">Content</tn-card>`,
 })
 class HostComponent {
   status = signal<TnCardHeaderStatus | undefined>(undefined);
@@ -158,7 +158,7 @@ describe('TnCardComponent testId support', () => {
     expect(trigger.getAttribute('aria-label')).toBe('Weitere Aktionen');
   });
 
-  it('falls back to headerMenuAriaLabel for the trigger tooltip, and prefers an explicit one', async () => {
+  it('falls back to headerMenuTriggerAriaLabel for the trigger tooltip, and prefers an explicit one', async () => {
     const fixture = createHost();
     fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
     fixture.componentInstance.menuAriaLabel.set('More Actions');

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { TN_TEST_ATTR } from '../test-id';
 import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
@@ -38,6 +38,23 @@ function createHost(providers: unknown[] = []) {
   const fixture = TestBed.createComponent(HostComponent);
   fixture.detectChanges();
   return fixture;
+}
+
+/** Hovers `element`, reads the text of the tooltip that pops up, then hovers away again. */
+async function showTooltip(
+  fixture: ComponentFixture<HostComponent>,
+  element: HTMLElement,
+): Promise<string | undefined> {
+  element.dispatchEvent(new MouseEvent('mouseenter'));
+  await new Promise((resolve) => setTimeout(resolve));
+  fixture.detectChanges();
+
+  const text = document.querySelector('.tn-tooltip')?.textContent ?? undefined;
+
+  element.dispatchEvent(new MouseEvent('mouseleave'));
+  await new Promise((resolve) => setTimeout(resolve));
+  fixture.detectChanges();
+  return text;
 }
 
 describe('TnCardComponent testId support', () => {
@@ -129,21 +146,21 @@ describe('TnCardComponent testId support', () => {
     expect(trigger.getAttribute('aria-label')).toBe('Weitere Aktionen');
   });
 
-  it('falls back to headerMenuAriaLabel for the trigger tooltip, and prefers an explicit one', () => {
+  it('falls back to headerMenuAriaLabel for the trigger tooltip, and prefers an explicit one', async () => {
     const fixture = createHost();
     fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
     fixture.componentInstance.menuAriaLabel.set('More Actions');
     fixture.detectChanges();
 
-    const card = fixture.debugElement.query(By.directive(TnCardComponent));
-    const cardInstance = card.componentInstance as TnCardComponent & {
-      resolvedHeaderMenuTooltip: () => string;
-    };
-    expect(cardInstance.resolvedHeaderMenuTooltip()).toBe('More Actions');
+    const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
+    // The tooltip has to hang off the focusable button rather than the tn-icon-button host, or
+    // neither the aria-describedby link nor the focus trigger reaches a keyboard user.
+    expect(trigger.getAttribute('aria-describedby')).toBeTruthy();
+    expect(await showTooltip(fixture, trigger)).toBe('More Actions');
 
     fixture.componentInstance.menuTooltip.set('Show more');
     fixture.detectChanges();
-    expect(cardInstance.resolvedHeaderMenuTooltip()).toBe('Show more');
+    expect(await showTooltip(fixture, trigger)).toBe('Show more');
   });
 
   it('honors TN_TEST_ATTR override for every slot', () => {

--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { TN_TEST_ATTR } from '../test-id';
 import { TnCardFooterActionsDirective, TnCardHeaderActionsDirective } from './card-action.directive';
@@ -15,13 +16,15 @@ import type { TnMenuItem } from '../menu/menu.component';
 @Component({
   standalone: true,
   imports: [TnCardComponent],
-  template: `<tn-card [headerStatus]="status()" [headerControl]="control()" [headerMenu]="menu()" [headerMenuTriggerTestId]="menuTriggerTestId()" [primaryAction]="primary()" [secondaryAction]="secondary()" [footerLink]="footerLink()">Content</tn-card>`,
+  template: `<tn-card [headerStatus]="status()" [headerControl]="control()" [headerMenu]="menu()" [headerMenuTriggerTestId]="menuTriggerTestId()" [headerMenuAriaLabel]="menuAriaLabel()" [headerMenuTriggerTooltip]="menuTooltip()" [primaryAction]="primary()" [secondaryAction]="secondary()" [footerLink]="footerLink()">Content</tn-card>`,
 })
 class HostComponent {
   status = signal<TnCardHeaderStatus | undefined>(undefined);
   control = signal<TnCardControl | undefined>(undefined);
   menu = signal<TnMenuItem[] | undefined>(undefined);
   menuTriggerTestId = signal<string | undefined>(undefined);
+  menuAriaLabel = signal<string>('Card menu');
+  menuTooltip = signal<string | undefined>(undefined);
   primary = signal<TnCardAction | undefined>(undefined);
   secondary = signal<TnCardAction | undefined>(undefined);
   footerLink = signal<TnCardFooterLink | undefined>(undefined);
@@ -103,6 +106,44 @@ describe('TnCardComponent testId support', () => {
     const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
     expect(trigger).toBeTruthy();
     expect(trigger.getAttribute('data-testid')).toBe('button-4-actions-menu');
+  });
+
+  it('names the kebab trigger "Card menu" by default', () => {
+    const fixture = createHost();
+    fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
+    expect(trigger.getAttribute('aria-label')).toBe('Card menu');
+  });
+
+  it('lets a consumer supply a translated accessible name for the kebab trigger', () => {
+    const fixture = createHost();
+    fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
+    // A consumer with an i18n layer passes an already-translated string; the library cannot
+    // translate its own default.
+    fixture.componentInstance.menuAriaLabel.set('Weitere Aktionen');
+    fixture.detectChanges();
+
+    const trigger = fixture.nativeElement.querySelector('.tn-card__menu button') as HTMLElement;
+    expect(trigger.getAttribute('aria-label')).toBe('Weitere Aktionen');
+  });
+
+  it('falls back to headerMenuAriaLabel for the trigger tooltip, and prefers an explicit one', () => {
+    const fixture = createHost();
+    fixture.componentInstance.menu.set([{ id: 'a', label: 'Action A' }]);
+    fixture.componentInstance.menuAriaLabel.set('More Actions');
+    fixture.detectChanges();
+
+    const card = fixture.debugElement.query(By.directive(TnCardComponent));
+    const cardInstance = card.componentInstance as TnCardComponent & {
+      resolvedHeaderMenuTooltip: () => string;
+    };
+    expect(cardInstance.resolvedHeaderMenuTooltip()).toBe('More Actions');
+
+    fixture.componentInstance.menuTooltip.set('Show more');
+    fixture.detectChanges();
+    expect(cardInstance.resolvedHeaderMenuTooltip()).toBe('Show more');
   });
 
   it('honors TN_TEST_ATTR override for every slot', () => {

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -100,6 +100,24 @@ export class TnCardComponent {
    * (default `data-testid`).
    */
   headerMenuTriggerTestId = input<string | undefined>(undefined);
+  /**
+   * Accessible name for the kebab-menu trigger rendered when `headerMenu` is set.
+   *
+   * The library cannot translate its own default, so a consumer with an i18n layer must be able to
+   * supply an already-translated string here — otherwise the trigger's only accessible name is the
+   * English fallback below. Also used as the trigger's tooltip when `headerMenuTriggerTooltip` is
+   * not set.
+   */
+  headerMenuAriaLabel = input<string>('Card menu');
+  /**
+   * Hover tooltip for the kebab-menu trigger. Defaults to `headerMenuAriaLabel`, so setting a
+   * single translated string covers both the accessible name and the visible hint.
+   */
+  headerMenuTriggerTooltip = input<string | undefined>(undefined);
+
+  protected readonly resolvedHeaderMenuTooltip = computed(
+    () => this.headerMenuTriggerTooltip() ?? this.headerMenuAriaLabel(),
+  );
 
   // Footer elements (bottom-right) - Always render in footer
   primaryAction = input<TnCardAction | undefined>(undefined);

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -76,8 +76,8 @@ export class TnCardComponent {
   titleTooltip = input<string | undefined>(undefined);
   /**
    * Accessible name for the help button that carries `titleTooltip`. Same reason as
-   * `headerMenuAriaLabel`: the library cannot translate its own `'More information'` default, so a
-   * consumer with an i18n layer passes an already-translated string here.
+   * `headerMenuTriggerAriaLabel`: the library cannot translate its own `'More information'`
+   * default, so a consumer with an i18n layer passes an already-translated string here.
    */
   titleTooltipAriaLabel = input<string | undefined>(undefined);
 
@@ -119,15 +119,15 @@ export class TnCardComponent {
    * English `'Card menu'` fallback. Also used as the trigger's tooltip when
    * `headerMenuTriggerTooltip` is not set.
    */
-  headerMenuAriaLabel = input<string | undefined>(undefined);
+  headerMenuTriggerAriaLabel = input<string | undefined>(undefined);
   /**
-   * Hover tooltip for the kebab-menu trigger. Defaults to `headerMenuAriaLabel`, so setting a
-   * single translated string covers both the accessible name and the visible hint.
+   * Hover tooltip for the kebab-menu trigger. Defaults to `headerMenuTriggerAriaLabel`, so setting
+   * a single translated string covers both the accessible name and the visible hint.
    */
   headerMenuTriggerTooltip = input<string | undefined>(undefined);
 
   protected readonly resolvedHeaderMenuAriaLabel = computed(
-    () => this.headerMenuAriaLabel() ?? 'Card menu',
+    () => this.headerMenuTriggerAriaLabel() ?? 'Card menu',
   );
 
   /**
@@ -137,7 +137,7 @@ export class TnCardComponent {
    * only repeats the button's accessible name.
    */
   protected readonly resolvedHeaderMenuTooltip = computed(
-    () => this.headerMenuTriggerTooltip() ?? this.headerMenuAriaLabel(),
+    () => this.headerMenuTriggerTooltip() ?? this.headerMenuTriggerAriaLabel(),
   );
 
   // Footer elements (bottom-right) - Always render in footer

--- a/projects/truenas-ui/src/lib/card/card.component.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.ts
@@ -74,6 +74,17 @@ export class TnCardComponent {
 
   /** Help/hover text shown on the title via the tooltip directive. */
   titleTooltip = input<string | undefined>(undefined);
+  /**
+   * Accessible name for the help button that carries `titleTooltip`. Same reason as
+   * `headerMenuAriaLabel`: the library cannot translate its own `'More information'` default, so a
+   * consumer with an i18n layer passes an already-translated string here.
+   */
+  titleTooltipAriaLabel = input<string | undefined>(undefined);
+
+  protected readonly resolvedTitleTooltipAriaLabel = computed(
+    () => this.titleTooltipAriaLabel() ?? 'More information',
+  );
+
   elevation = input<'none' | 'low' | 'medium' | 'high'>('medium');
   padding = input<'small' | 'medium' | 'large'>('medium');
   padContent = input<boolean>(true);
@@ -105,16 +116,26 @@ export class TnCardComponent {
    *
    * The library cannot translate its own default, so a consumer with an i18n layer must be able to
    * supply an already-translated string here — otherwise the trigger's only accessible name is the
-   * English fallback below. Also used as the trigger's tooltip when `headerMenuTriggerTooltip` is
-   * not set.
+   * English `'Card menu'` fallback. Also used as the trigger's tooltip when
+   * `headerMenuTriggerTooltip` is not set.
    */
-  headerMenuAriaLabel = input<string>('Card menu');
+  headerMenuAriaLabel = input<string | undefined>(undefined);
   /**
    * Hover tooltip for the kebab-menu trigger. Defaults to `headerMenuAriaLabel`, so setting a
    * single translated string covers both the accessible name and the visible hint.
    */
   headerMenuTriggerTooltip = input<string | undefined>(undefined);
 
+  protected readonly resolvedHeaderMenuAriaLabel = computed(
+    () => this.headerMenuAriaLabel() ?? 'Card menu',
+  );
+
+  /**
+   * The trigger has no tooltip unless the consumer asks for one — either explicitly, or by naming
+   * the trigger and letting that one string drive both. Falling back to the built-in `'Card menu'`
+   * default instead would put a new hover hint on every existing `[headerMenu]` consumer, one that
+   * only repeats the button's accessible name.
+   */
   protected readonly resolvedHeaderMenuTooltip = computed(
     () => this.headerMenuTriggerTooltip() ?? this.headerMenuAriaLabel(),
   );

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
@@ -1,0 +1,89 @@
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { Component } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TnTooltipDirective } from './tooltip.directive';
+
+@Component({
+  standalone: true,
+  imports: [TnTooltipDirective],
+  template: `<button tnTooltip="Card menu">Trigger</button>`,
+})
+class HostComponent {}
+
+function createHost(): ComponentFixture<HostComponent> {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+/** Lets the directive's show/hide timeouts run, then syncs the view. */
+async function settle(fixture: ComponentFixture<HostComponent>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve));
+  fixture.detectChanges();
+}
+
+function visibleTooltip(): string | undefined {
+  return document.querySelector('.tn-tooltip')?.textContent?.trim();
+}
+
+describe('TnTooltipDirective focus handling', () => {
+  it('shows on hover', async () => {
+    const fixture = createHost();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLElement;
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    await settle(fixture);
+
+    expect(visibleTooltip()).toBe('Card menu');
+  });
+
+  it('shows on keyboard focus', async () => {
+    const fixture = createHost();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLElement;
+
+    TestBed.inject(FocusMonitor).focusVia(trigger, 'keyboard');
+    await settle(fixture);
+
+    expect(visibleTooltip()).toBe('Card menu');
+  });
+
+  it('stays hidden when focus is restored programmatically', async () => {
+    const fixture = createHost();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLElement;
+
+    // A menu trigger returning focus to itself after its menu closes focuses the button with no
+    // user gesture behind it. Showing a tooltip there parks it over the button with the pointer
+    // nowhere near, and nothing hides it until the user clicks or tabs away.
+    TestBed.inject(FocusMonitor).focusVia(trigger, 'program');
+    await settle(fixture);
+
+    expect(visibleTooltip()).toBeUndefined();
+  });
+
+  it('stays hidden when the button is focused by a mouse click', async () => {
+    const fixture = createHost();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLElement;
+
+    // Hover already covers this interaction — `mouseenter` fired before the click.
+    TestBed.inject(FocusMonitor).focusVia(trigger, 'mouse');
+    await settle(fixture);
+
+    expect(visibleTooltip()).toBeUndefined();
+  });
+
+  it('hides again on blur', async () => {
+    const fixture = createHost();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLElement;
+
+    TestBed.inject(FocusMonitor).focusVia(trigger, 'keyboard');
+    await settle(fixture);
+    expect(visibleTooltip()).toBe('Card menu');
+
+    trigger.blur();
+    await settle(fixture);
+
+    expect(visibleTooltip()).toBeUndefined();
+  });
+});

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.directive.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @angular-eslint/no-input-rename */
 // Input aliasing is intentional for directive API consistency (e.g., ixTooltip, ixTooltipPosition)
 // This follows the standard Angular pattern used by Material and other directive-based components
+import { FocusMonitor } from '@angular/cdk/a11y';
 import {
   Overlay,
   type OverlayRef,
@@ -19,6 +20,7 @@ import {
   input,
   HostListener,
   ElementRef,
+  NgZone,
   ViewContainerRef,
   inject
 } from '@angular/core';
@@ -48,6 +50,7 @@ export class TnTooltipDirective implements OnInit, OnDestroy {
   private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
   private _isTooltipVisible = false;
   private _positionSub: Subscription | null = null;
+  private _focusSub: Subscription | null = null;
   private _tooltipId = '';
 
   /**
@@ -63,16 +66,35 @@ export class TnTooltipDirective implements OnInit, OnDestroy {
   private _elementRef = inject(ElementRef<HTMLElement>);
   private _viewContainerRef = inject(ViewContainerRef);
   private _overlayPositionBuilder = inject(OverlayPositionBuilder);
+  private _focusMonitor = inject(FocusMonitor);
+  private _ngZone = inject(NgZone);
 
   ngOnInit() {
     // Generate unique ID for aria-describedby
     this._tooltipId = `tn-tooltip-${Math.random().toString(36).substr(2, 9)}`;
+
+    // Focus opens the tooltip only when the focus actually came from the keyboard. A plain
+    // `focus` listener also fires for programmatic `.focus()` — e.g. TnMenuTriggerDirective
+    // restoring focus to its trigger after the menu closes — which popped a tooltip back up
+    // next to a button the pointer was nowhere near, and left it there until the user clicked
+    // or tabbed away. Routing through FocusMonitor (same approach as MatTooltip) also skips
+    // mouse/touch focus, where the hover handlers already cover the interaction.
+    this._focusSub = this._focusMonitor.monitor(this._elementRef).subscribe((origin) => {
+      // FocusMonitor emits outside the Angular zone, so re-enter before touching the overlay.
+      if (!origin) {
+        this._ngZone.run(() => this.hide(this.hideDelay()));
+      } else if (origin === 'keyboard') {
+        this._ngZone.run(() => this.show(this.showDelay()));
+      }
+    });
   }
 
   ngOnDestroy() {
     this._clearTimeouts();
     this.hide(0);
     this._positionSub?.unsubscribe();
+    this._focusSub?.unsubscribe();
+    this._focusMonitor.stopMonitoring(this._elementRef);
 
     if (this._overlayRef) {
       this._overlayRef.dispose();
@@ -89,18 +111,6 @@ export class TnTooltipDirective implements OnInit, OnDestroy {
 
   @HostListener('mouseleave')
   _onMouseLeave(): void {
-    this.hide(this.hideDelay());
-  }
-
-  @HostListener('focus')
-  _onFocus(): void {
-    if (!this.disabled() && this.message()) {
-      this.show(this.showDelay());
-    }
-  }
-
-  @HostListener('blur')
-  _onBlur(): void {
     this.hide(this.hideDelay());
   }
 

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -76,7 +76,7 @@ const meta: Meta<TnCardComponent> = {
       control: 'object',
       description: 'Array of TnMenuItem objects for header menu',
     },
-    headerMenuAriaLabel: {
+    headerMenuTriggerAriaLabel: {
       control: 'text',
       description:
         'Accessible name for the header menu trigger. Defaults to "Card menu"; pass an '
@@ -85,7 +85,7 @@ const meta: Meta<TnCardComponent> = {
     headerMenuTriggerTooltip: {
       control: 'text',
       description:
-        'Hover tooltip for the header menu trigger. Falls back to headerMenuAriaLabel; with '
+        'Hover tooltip for the header menu trigger. Falls back to headerMenuTriggerAriaLabel; with '
         + 'neither set the trigger has no tooltip.',
     },
     primaryAction: {
@@ -457,7 +457,7 @@ export const WithHeaderMenu: Story = {
       { id: 'sep1', label: '', separator: true },
       { id: '3', label: 'Delete', action: () => {}, icon: 'delete' },
     ],
-    headerMenuAriaLabel: 'More Actions',
+    headerMenuTriggerAriaLabel: 'More Actions',
     headerMenuTriggerTooltip: 'Show more actions',
   },
   render: (args) => ({
@@ -470,11 +470,11 @@ export const WithHeaderMenu: Story = {
         [padContent]="padContent"
         [bordered]="bordered"
         [background]="background"
-        [headerMenuAriaLabel]="headerMenuAriaLabel"
+        [headerMenuTriggerAriaLabel]="headerMenuTriggerAriaLabel"
         [headerMenuTriggerTooltip]="headerMenuTriggerTooltip"
         [headerMenu]="headerMenu">
         <p>This card includes a three-dot menu icon in the header with common actions. Click the dots to open the menu.</p>
-        <p>The trigger's accessible name comes from <code>headerMenuAriaLabel</code>, so an app with an i18n layer can pass a translated string. <code>headerMenuTriggerTooltip</code> overrides the visible hover hint — clear it in the Controls panel and the tooltip falls back to the accessible name.</p>
+        <p>The trigger's accessible name comes from <code>headerMenuTriggerAriaLabel</code>, so an app with an i18n layer can pass a translated string. <code>headerMenuTriggerTooltip</code> overrides the visible hover hint — clear it in the Controls panel and the tooltip falls back to the accessible name.</p>
       </tn-card>
     `,
   }),

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -58,6 +58,12 @@ const meta: Meta<TnCardComponent> = {
       control: 'text',
       description: 'Help/hover text shown on the title',
     },
+    titleTooltipAriaLabel: {
+      control: 'text',
+      description:
+        'Accessible name for the title help button. Defaults to "More information"; pass an '
+        + 'already-translated string from an app with an i18n layer.',
+    },
     headerStatus: {
       control: 'object',
       description: 'Status badge configuration (label, type)',
@@ -78,7 +84,9 @@ const meta: Meta<TnCardComponent> = {
     },
     headerMenuTriggerTooltip: {
       control: 'text',
-      description: 'Hover tooltip for the header menu trigger. Defaults to headerMenuAriaLabel.',
+      description:
+        'Hover tooltip for the header menu trigger. Falls back to headerMenuAriaLabel; with '
+        + 'neither set the trigger has no tooltip.',
     },
     primaryAction: {
       control: 'object',
@@ -137,6 +145,7 @@ export const TitleRouterLinkAndTooltip: Story = {
     title: 'Recent Orders',
     titleRouterLink: '/orders',
     titleTooltip: 'Open the full orders page',
+    titleTooltipAriaLabel: 'More information',
     elevation: 'medium',
     padding: 'medium',
     padContent: true,
@@ -148,6 +157,7 @@ export const TitleRouterLinkAndTooltip: Story = {
         [title]="title"
         [titleRouterLink]="titleRouterLink"
         [titleTooltip]="titleTooltip"
+        [titleTooltipAriaLabel]="titleTooltipAriaLabel"
         [elevation]="elevation"
         [padding]="padding"
         [padContent]="padContent"

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -70,6 +70,16 @@ const meta: Meta<TnCardComponent> = {
       control: 'object',
       description: 'Array of TnMenuItem objects for header menu',
     },
+    headerMenuAriaLabel: {
+      control: 'text',
+      description:
+        'Accessible name for the header menu trigger. Defaults to "Card menu"; pass an '
+        + 'already-translated string from an app with an i18n layer.',
+    },
+    headerMenuTriggerTooltip: {
+      control: 'text',
+      description: 'Hover tooltip for the header menu trigger. Defaults to headerMenuAriaLabel.',
+    },
     primaryAction: {
       control: 'object',
       description: 'Primary footer action button (label, handler, icon)',
@@ -437,6 +447,7 @@ export const WithHeaderMenu: Story = {
       { id: 'sep1', label: '', separator: true },
       { id: '3', label: 'Delete', action: () => {}, icon: 'delete' },
     ],
+    headerMenuAriaLabel: 'More Actions',
   },
   render: (args) => ({
     props: args,
@@ -448,8 +459,10 @@ export const WithHeaderMenu: Story = {
         [padContent]="padContent"
         [bordered]="bordered"
         [background]="background"
+        [headerMenuAriaLabel]="headerMenuAriaLabel"
         [headerMenu]="headerMenu">
         <p>This card includes a three-dot menu icon in the header with common actions. Click the dots to open the menu.</p>
+        <p>The trigger's accessible name and tooltip come from <code>headerMenuAriaLabel</code>, so an app with an i18n layer can pass a translated string.</p>
       </tn-card>
     `,
   }),

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -448,6 +448,7 @@ export const WithHeaderMenu: Story = {
       { id: '3', label: 'Delete', action: () => {}, icon: 'delete' },
     ],
     headerMenuAriaLabel: 'More Actions',
+    headerMenuTriggerTooltip: 'Show more actions',
   },
   render: (args) => ({
     props: args,
@@ -460,9 +461,10 @@ export const WithHeaderMenu: Story = {
         [bordered]="bordered"
         [background]="background"
         [headerMenuAriaLabel]="headerMenuAriaLabel"
+        [headerMenuTriggerTooltip]="headerMenuTriggerTooltip"
         [headerMenu]="headerMenu">
         <p>This card includes a three-dot menu icon in the header with common actions. Click the dots to open the menu.</p>
-        <p>The trigger's accessible name and tooltip come from <code>headerMenuAriaLabel</code>, so an app with an i18n layer can pass a translated string.</p>
+        <p>The trigger's accessible name comes from <code>headerMenuAriaLabel</code>, so an app with an i18n layer can pass a translated string. <code>headerMenuTriggerTooltip</code> overrides the visible hover hint — clear it in the Controls panel and the tooltip falls back to the accessible name.</p>
       </tn-card>
     `,
   }),


### PR DESCRIPTION
The kebab trigger rendered for `headerMenu` hardcoded `ariaLabel="Card menu"`, so a consumer with an i18n layer could not translate the only accessible name that trigger has — and the trigger had no tooltip at all.

Add `headerMenuAriaLabel` (defaulting to the previous "Card menu", so existing consumers are unaffected) and `headerMenuTriggerTooltip`, which falls back to `headerMenuAriaLabel` so one translated string covers both the accessible name and the visible hover hint.

Without this, consumers have to abandon `[headerMenu]` and rebuild the trigger by projecting `tnCardHeaderActions` just to translate one string.