### PR TITLE
NAS-142127 / 27.0.0-BETA.1 / feat(test-id): derive dropdown option ids from the label

### DIFF
--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -747,27 +747,7 @@ describe('TnAutocompleteComponent', () => {
       expect(getTInput().getAttribute('data-testid')).toBe('autocomplete-country');
     });
 
-    it('scopes each option with the base: option-<base>-<value>', () => {
-      expect(openAndGetOptionTestIds()).toEqual([
-        'option-country-us',
-        'option-country-ca',
-        'option-country-mx',
-        'option-country-gb',
-        'option-country-de',
-      ]);
-    });
-
-    it('falls back to option-<value> when there is no base', () => {
-      tHost.testId.set('');
-      tFixture.detectChanges();
-      expect(openAndGetOptionTestIds()).toEqual([
-        'option-us', 'option-ca', 'option-mx', 'option-gb', 'option-de',
-      ]);
-    });
-
-    it('uses optionTestIdKey to pick the discriminator (e.g. label over value)', () => {
-      tHost.keyFn.set((o) => o.label);
-      tFixture.detectChanges();
+    it('scopes each option with the base: option-<base>-<label>', () => {
       expect(openAndGetOptionTestIds()).toEqual([
         'option-country-united-states',
         'option-country-canada',
@@ -777,7 +757,27 @@ describe('TnAutocompleteComponent', () => {
       ]);
     });
 
-    it('falls back to the label for object-valued options', () => {
+    it('falls back to option-<label> when there is no base', () => {
+      tHost.testId.set('');
+      tFixture.detectChanges();
+      expect(openAndGetOptionTestIds()).toEqual([
+        'option-united-states', 'option-canada', 'option-mexico', 'option-united-kingdom', 'option-germany',
+      ]);
+    });
+
+    it('uses optionTestIdKey to pick the discriminator (e.g. the value over the label)', () => {
+      tHost.keyFn.set((o) => o.value);
+      tFixture.detectChanges();
+      expect(openAndGetOptionTestIds()).toEqual([
+        'option-country-us',
+        'option-country-ca',
+        'option-country-mx',
+        'option-country-gb',
+        'option-country-de',
+      ]);
+    });
+
+    it('uses the label for object-valued options too', () => {
       const oFixture = TestBed.createComponent(ObjectValueHostComponent);
       oFixture.detectChanges();
       const input = oFixture.nativeElement.querySelector('.tn-autocomplete__input') as HTMLInputElement;
@@ -821,7 +821,7 @@ describe('TnAutocompleteComponent', () => {
       input.dispatchEvent(new Event('focus'));
       cFixture.detectChanges();
       const first = overlayEl.querySelector('.tn-autocomplete__option');
-      expect(first?.getAttribute('data-testid')).toBe('option-country-us');
+      expect(first?.getAttribute('data-testid')).toBe('option-country-united-states');
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -139,9 +139,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   protected resolvedTestId = controlTestId(this.testId);
 
   /**
-   * Optional extractor for the per-option test-id discriminator. Defaults to
-   * the option's `value` (when a string/number) or its `label`. Provide this
-   * when option values are objects, or to pick a more stable/unique key —
+   * Optional extractor for the per-option test-id discriminator. Defaults to the
+   * option's `label`, the text actually on screen — provide this to key off a
+   * locale-independent field instead, or where an id per record is wanted —
    * mirrors `tn-select`'s input of the same name.
    *
    * @example

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -426,21 +426,25 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   /**
    * Scopes a per-chip test id beneath the component's base.
    *
-   * The discriminator is the value itself when primitive, else the matching
-   * option's label — `String(value)` on an object is `[object Object]`, which
-   * would stamp an identical id on every chip. Duplicates are worse than
-   * absence for automation, so an object value with no option to name it yet
-   * (options still loading) stays attribute-free rather than colliding. A primitive
-   * that normalizes away is dropped for the same reason — see
-   * {@link discriminatedTestId}.
+   * The discriminator is the chip's own text — {@link displayLabel}, the matching
+   * option's label — so a chip and the suggestion row that created it carry the
+   * same discriminator rather than one naming the label and the other the value.
+   * A free-text chip has no option to name it and is its own text, so its value
+   * stands in; an object value with no match cannot be, because `String(value)`
+   * on an object is `[object Object]` and would stamp an identical id on every
+   * chip. Duplicates are worse than absence for automation, so that chip stays
+   * attribute-free rather than colliding. A primitive that normalizes away is
+   * dropped for the same reason — see {@link discriminatedTestId}.
    */
   protected chipTestId(value: T): TnTestIdValue {
     const base = this.resolvedTestId();
-    if (typeof value === 'string' || typeof value === 'number') {
-      return this.discriminatedTestId(scopeTestId(base, value));
-    }
     const match = this.optionList().find((option) => this.valueMatches(option.value, value));
-    return match ? this.discriminatedTestId(scopeTestId(base, match.label)) : undefined;
+    if (match) {
+      return this.discriminatedTestId(scopeTestId(base, match.label));
+    }
+    return typeof value === 'string' || typeof value === 'number'
+      ? this.discriminatedTestId(scopeTestId(base, value))
+      : undefined;
   }
 
   /**

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -178,6 +178,21 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   /** Test-id base, falling back to the bound control name when `testId` is unset. */
   protected resolvedTestId = controlTestId(this.testId);
 
+  /**
+   * Optional extractor for the per-option test-id discriminator, applied to both
+   * a suggestion row and the chip it becomes. Defaults to the option's `label`,
+   * the text actually on screen — provide this to key off a locale-independent
+   * field instead, or where two options share a display name and the derived ids
+   * would otherwise collide. Free-text chips have no option to extract from and
+   * stay named by their own value.
+   *
+   * @example
+   * ```html
+   * <tn-chip-input testId="users" [optionTestIdKey]="(o) => o.value.id" ... />
+   * ```
+   */
+  optionTestIdKey = input<(option: TnChipInputOption<T>) => string | number | null | undefined>();
+
   /** Emits the committed value whenever a chip is added. */
   chipAdded = output<T>();
 
@@ -419,7 +434,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
 
   /** The label shown on a chip for a committed value. */
   protected displayLabel(value: T): string {
-    const match = this.optionList().find((option) => this.valueMatches(option.value, value));
+    const match = this.optionFor(value);
     return match ? match.label : String(value);
   }
 
@@ -429,19 +444,24 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
    * A chip backed by an option goes through the same {@link optionTestId}
    * derivation as the suggestion row that created it, so the two carry the same
    * discriminator by construction rather than one naming the label and the other
-   * the value — including whatever fallback that shared rule settles on.
-   * A free-text chip has no option to name it and is its own text, so its value
-   * stands in; an object value with no match cannot be, because `String(value)`
-   * on an object is `[object Object]` and would stamp an identical id on every
-   * chip. Duplicates are worse than absence for automation, so that chip stays
+   * the value — including whatever fallback that shared rule settles on, and any
+   * `optionTestIdKey` override.
+   *
+   * A value with no matching option is named by itself when it is a primitive:
+   * either a free-text chip, which is its own text, or an option-backed value
+   * whose options have not arrived yet — an async `[options]` load moves such a
+   * chip's id from the value to the resolved label once it does. An object value
+   * with no match cannot stand in for itself, because `String(value)` on an
+   * object is `[object Object]` and would stamp an identical id on every chip.
+   * Duplicates are worse than absence for automation, so that chip stays
    * attribute-free rather than colliding. A primitive that normalizes away is
    * dropped for the same reason — see {@link discriminatedTestId}.
    */
   protected chipTestId(value: T): TnTestIdValue {
     const base = this.resolvedTestId();
-    const match = this.optionList().find((option) => this.valueMatches(option.value, value));
+    const match = this.optionFor(value);
     if (match) {
-      return this.discriminatedTestId(optionTestId(base, match));
+      return this.discriminatedTestId(optionTestId(base, match, this.optionTestIdKey()));
     }
     return typeof value === 'string' || typeof value === 'number'
       ? this.discriminatedTestId(scopeTestId(base, value))
@@ -456,7 +476,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
    * emitting one would invite collisions between inputs.
    */
   protected suggestionTestId(option: TnChipInputOption<T>): TnTestIdValue {
-    return this.discriminatedTestId(optionTestId(this.resolvedTestId(), option));
+    return this.discriminatedTestId(optionTestId(this.resolvedTestId(), option, this.optionTestIdKey()));
   }
 
   /**
@@ -517,6 +537,40 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     this.chipAdded.emit(value);
     this.clearInput();
   }
+
+  /**
+   * The option a committed value came from, or `undefined` for a free-text chip.
+   *
+   * Both the chip's label and its test id need this lookup, and both are called
+   * from the template — once per chip per change-detection cycle — so a linear
+   * scan of the options would be quadratic in (chips × options) on every cycle.
+   * With the default identity comparator, {@link optionIndex} answers in constant
+   * time; a custom `compareWith` can't be indexed (only it knows what equality
+   * means for the value), so that path keeps the scan.
+   */
+  private optionFor(value: T): TnChipInputOption<T> | undefined {
+    const comparator = this.compareWith();
+    if (comparator) {
+      return this.optionList().find((option) => comparator(option.value, value));
+    }
+    return this.optionIndex().get(value);
+  }
+
+  /**
+   * Value → option, rebuilt only when the option list changes. First entry wins,
+   * matching the `find` it replaces where a value is repeated across options.
+   * Keys compare by `Map` identity, which agrees with the `===` this stands in
+   * for on every value a form control can hold.
+   */
+  private optionIndex = computed<Map<T, TnChipInputOption<T>>>(() => {
+    const index = new Map<T, TnChipInputOption<T>>();
+    for (const option of this.optionList()) {
+      if (!index.has(option.value)) {
+        index.set(option.value, option);
+      }
+    }
+    return index;
+  });
 
   private valuesIncludes(value: T): boolean {
     return this.values().some((existing) => this.valueMatches(existing, value));

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -426,9 +426,10 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   /**
    * Scopes a per-chip test id beneath the component's base.
    *
-   * The discriminator is the chip's own text — {@link displayLabel}, the matching
-   * option's label — so a chip and the suggestion row that created it carry the
-   * same discriminator rather than one naming the label and the other the value.
+   * A chip backed by an option goes through the same {@link optionTestId}
+   * derivation as the suggestion row that created it, so the two carry the same
+   * discriminator by construction rather than one naming the label and the other
+   * the value — including whatever fallback that shared rule settles on.
    * A free-text chip has no option to name it and is its own text, so its value
    * stands in; an object value with no match cannot be, because `String(value)`
    * on an object is `[object Object]` and would stamp an identical id on every
@@ -440,7 +441,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     const base = this.resolvedTestId();
     const match = this.optionList().find((option) => this.valueMatches(option.value, value));
     if (match) {
-      return this.discriminatedTestId(scopeTestId(base, match.label));
+      return this.discriminatedTestId(optionTestId(base, match));
     }
     return typeof value === 'string' || typeof value === 'number'
       ? this.discriminatedTestId(scopeTestId(base, value))
@@ -450,7 +451,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   /**
    * Scopes a per-suggestion test id beneath the component's base, via the shared
    * dropdown-option derivation. Unlike `tn-select` / `tn-autocomplete`, which
-   * emit an unscoped `option-<value>` when they have no base, an unidentified
+   * emit an unscoped `option-<label>` when they have no base, an unidentified
    * chip-input stays attribute-free — its rows carry no page-unique id, so
    * emitting one would invite collisions between inputs.
    */

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -349,6 +349,24 @@ class ObjectValueTestIdHostComponent {
 }
 
 @Component({
+  selector: 'tn-labelled-primitive-value-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <tn-chip-input testId="tags" formControlName="regions" [options]="options" />
+    </form>
+  `,
+})
+class LabelledPrimitiveValueHostComponent {
+  options: TnChipInputOption<string>[] = [
+    { label: 'United States', value: 'us' },
+    { label: 'Canada', value: 'ca' },
+  ];
+  form = new FormGroup({ regions: new FormControl<string[]>(['us']) });
+}
+
+@Component({
   selector: 'tn-unnormalizable-value-host',
   standalone: true,
   imports: [TnChipInputComponent, ReactiveFormsModule],
@@ -416,6 +434,26 @@ describe('TnChipInputComponent test ids', () => {
     const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
     expect(chip?.getAttribute('data-testid')).toBe('chip-groups-admins');
   });
+  // A chip and the suggestion row that created it show the same text, so they carry the
+  // same discriminator — naming one by the label and the other by the value would leave
+  // automation unable to assert that the row it clicked is the chip it got.
+  it('names a chip and its suggestion by the option label, not the value behind it', async () => {
+    await TestBed.configureTestingModule({
+      imports: [LabelledPrimitiveValueHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(LabelledPrimitiveValueHostComponent);
+    fixture.detectChanges();
+
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    expect(chip?.getAttribute('data-testid')).toBe('chip-tags-united-states');
+
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    await (await loader.getHarness(TnChipInputHarness)).typeText('can');
+    const suggestion = document.querySelector('.tn-chip-input__option');
+    expect(suggestion?.getAttribute('data-testid')).toBe('option-tags-canada');
+  });
+
   // `*` and `**` both normalize to nothing, so scoping them under the base composes
   // the bare `chip-hosts-allow` twice — duplicate ids, the failure the object-value
   // path already guards against, reached through a primitive value instead.

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -367,6 +367,24 @@ class LabelledPrimitiveValueHostComponent {
 }
 
 @Component({
+  selector: 'tn-unnormalizable-label-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <tn-chip-input testId="tags" formControlName="langs" [options]="options" />
+    </form>
+  `,
+})
+class UnnormalizableLabelHostComponent {
+  options: TnChipInputOption<string>[] = [
+    { label: '日本語', value: 'ja' },
+    { label: '한국어', value: 'ko' },
+  ];
+  form = new FormGroup({ langs: new FormControl<string[]>(['ja']) });
+}
+
+@Component({
   selector: 'tn-unnormalizable-value-host',
   standalone: true,
   imports: [TnChipInputComponent, ReactiveFormsModule],
@@ -452,6 +470,26 @@ describe('TnChipInputComponent test ids', () => {
     await (await loader.getHarness(TnChipInputHarness)).typeText('can');
     const suggestion = document.querySelector('.tn-chip-input__option');
     expect(suggestion?.getAttribute('data-testid')).toBe('option-tags-canada');
+  });
+
+  // A localized label normalizes to nothing, so keying off it would collapse every such
+  // row onto the bare base — the value behind it stands in, and the chip still agrees
+  // with its suggestion row.
+  it('falls back to the value when the option label normalizes away', async () => {
+    await TestBed.configureTestingModule({
+      imports: [UnnormalizableLabelHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(UnnormalizableLabelHostComponent);
+    fixture.detectChanges();
+
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    expect(chip?.getAttribute('data-testid')).toBe('chip-tags-ja');
+
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    await (await loader.getHarness(TnChipInputHarness)).typeText('한국');
+    const suggestion = document.querySelector('.tn-chip-input__option');
+    expect(suggestion?.getAttribute('data-testid')).toBe('option-tags-ko');
   });
 
   // `*` and `**` both normalize to nothing, so scoping them under the base composes

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -367,6 +367,45 @@ class LabelledPrimitiveValueHostComponent {
 }
 
 @Component({
+  selector: 'tn-async-options-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <tn-chip-input testId="tags" formControlName="regions" [options]="options" />
+    </form>
+  `,
+})
+class AsyncOptionsHostComponent {
+  options: TnChipInputOption<string>[] = [];
+  form = new FormGroup({ regions: new FormControl<string[]>(['us']) });
+}
+
+@Component({
+  selector: 'tn-option-key-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <form [formGroup]="form">
+      <tn-chip-input
+        testId="users"
+        formControlName="members"
+        [options]="options"
+        [optionTestIdKey]="keyFn" />
+    </form>
+  `,
+})
+class OptionTestIdKeyHostComponent {
+  options: TnChipInputOption<string>[] = [
+    { label: 'Jane Doe', value: 'u-1' },
+    { label: 'Jane Doe', value: 'u-2' },
+  ];
+  keyFn = (option: TnChipInputOption<string>): string => option.value;
+  form = new FormGroup({ members: new FormControl<string[]>(['u-1']) });
+}
+
+@Component({
   selector: 'tn-unnormalizable-label-host',
   standalone: true,
   imports: [TnChipInputComponent, ReactiveFormsModule],
@@ -470,6 +509,46 @@ describe('TnChipInputComponent test ids', () => {
     await (await loader.getHarness(TnChipInputHarness)).typeText('can');
     const suggestion = document.querySelector('.tn-chip-input__option');
     expect(suggestion?.getAttribute('data-testid')).toBe('option-tags-canada');
+  });
+
+  // A pre-populated control renders its chips before an async `[options]` load resolves,
+  // so the chip is named by its own value until the option that explains it arrives.
+  it('names an option-backed chip by its value until the options load', async () => {
+    await TestBed.configureTestingModule({
+      imports: [AsyncOptionsHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(AsyncOptionsHostComponent);
+    fixture.detectChanges();
+
+    const chipId = (): string | null | undefined => fixture.nativeElement
+      .querySelector('.tn-chip-input__chip [role="button"]')
+      ?.getAttribute('data-testid');
+    expect(chipId()).toBe('chip-tags-us');
+
+    fixture.componentInstance.options = [{ label: 'United States', value: 'us' }];
+    fixture.detectChanges();
+    expect(chipId()).toBe('chip-tags-united-states');
+  });
+
+  // Two records can share a display name, and the label default then stamps one id on
+  // both; the extractor is the way out, and it has to reach the chip as well as the row
+  // or the pair stops agreeing.
+  it('lets optionTestIdKey pick the discriminator for both a chip and its suggestion', async () => {
+    await TestBed.configureTestingModule({
+      imports: [OptionTestIdKeyHostComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OptionTestIdKeyHostComponent);
+    fixture.detectChanges();
+
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    expect(chip?.getAttribute('data-testid')).toBe('chip-users-u-1');
+
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    await (await loader.getHarness(TnChipInputHarness)).typeText('Jane');
+    const suggestion = document.querySelector('.tn-chip-input__option');
+    expect(suggestion?.getAttribute('data-testid')).toBe('option-users-u-2');
   });
 
   // A localized label normalizes to nothing, so keying off it would collapse every such

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -112,9 +112,9 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
   multiple = input<boolean>(false);
 
   /**
-   * Optional extractor for the per-option test-id discriminator. Defaults to
-   * the option's `value` (when a string/number) or its `label`. Provide this
-   * when option values are objects, or to pick a more stable/unique key —
+   * Optional extractor for the per-option test-id discriminator. Defaults to the
+   * option's `label`, the text actually on screen — provide this to key off a
+   * locale-independent field instead, or where an id per record is wanted —
    * mirrors webui's `[ixTest]="[controlName, option.<field>]"` discriminator.
    *
    * @example

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -1126,6 +1126,18 @@ describe('TnSelectComponent — per-option test ids', () => {
     expect(openAndGetOptionTestIds()).toEqual(['option-quick-filters-ssd', 'option-quick-filters-hdd']);
   });
 
+  // A label with no alphanumerics normalizes to nothing, so keying off it would give
+  // every such option the bare `option-quick-filters` — the trap the synthetic empty
+  // option is hard-coded around. The value behind the label stands in instead.
+  it('falls back to the value for labels that normalize away', () => {
+    host.options.set([
+      { value: 'ja', label: '日本語' },
+      { value: 'ko', label: '한국어' },
+    ]);
+    fixture.detectChanges();
+    expect(openAndGetOptionTestIds()).toEqual(['option-quick-filters-ja', 'option-quick-filters-ko']);
+  });
+
   it('scopes grouped options the same way', () => {
     host.options.set([]);
     host.groups.set([

--- a/projects/truenas-ui/src/lib/select/select.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select.harness.spec.ts
@@ -1107,23 +1107,23 @@ describe('TnSelectComponent — per-option test ids', () => {
     expect(container.hasAttribute('data-testid')).toBe(false);
   });
 
-  it('scopes each option with the select base: option-<base>-<value>', () => {
-    expect(openAndGetOptionTestIds()).toEqual(['option-quick-filters-ssd', 'option-quick-filters-hdd']);
-  });
-
-  it('falls back to option-<value> when the select has no base', () => {
-    host.testId.set('');
-    fixture.detectChanges();
-    expect(openAndGetOptionTestIds()).toEqual(['option-ssd', 'option-hdd']);
-  });
-
-  it('uses optionTestIdKey to pick the discriminator (e.g. label over value)', () => {
-    host.keyFn.set((o) => o.label);
-    fixture.detectChanges();
+  it('scopes each option with the select base: option-<base>-<label>', () => {
     expect(openAndGetOptionTestIds()).toEqual([
       'option-quick-filters-ssd',
       'option-quick-filters-spinning-disk',
     ]);
+  });
+
+  it('falls back to option-<label> when the select has no base', () => {
+    host.testId.set('');
+    fixture.detectChanges();
+    expect(openAndGetOptionTestIds()).toEqual(['option-ssd', 'option-spinning-disk']);
+  });
+
+  it('uses optionTestIdKey to pick the discriminator (e.g. the value over the label)', () => {
+    host.keyFn.set((o) => o.value);
+    fixture.detectChanges();
+    expect(openAndGetOptionTestIds()).toEqual(['option-quick-filters-ssd', 'option-quick-filters-hdd']);
   });
 
   it('scopes grouped options the same way', () => {
@@ -1178,7 +1178,7 @@ describe('TnSelectComponent — control-name test-id fallback', () => {
     fixture.detectChanges();
     const optionTestIds = Array.from(document.querySelectorAll<HTMLElement>('.tn-select-option'))
       .map((el) => el.getAttribute('data-testid'));
-    expect(optionTestIds).toEqual(['option-disk-ssd', 'option-disk-hdd']);
+    expect(optionTestIds).toEqual(['option-disk-ssd', 'option-disk-spinning-disk']);
   });
 
   it('derives the DOM-id namespace from the control name (not the instance counter)', () => {

--- a/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/compose-test-id.ts
@@ -13,9 +13,16 @@ export type TnTestIdValue = string | number | (string | number | null | undefine
  * collapse any run of non-alphanumeric characters to a single hyphen, and trim
  * leading/trailing hyphens.
  *
- * Mirrors the normalization webui's legacy `ixTest` directive applied via
- * lodash `kebabCase`, so migrated values stay stable (`sshPort` → `ssh-port`,
- * `addr_trtype` → `addr-trtype`, `'My Label'` → `my-label`).
+ * Follows webui's legacy `ixTest` directive (lodash `kebabCase`) for the cases
+ * that matter to migrated values — `sshPort` → `ssh-port`, `addr_trtype` →
+ * `addr-trtype`, `'My Label'` → `my-label` — but deliberately not for the
+ * letter↔digit boundary, which lodash splits and this does not: `nvme0n1` stays
+ * `nvme0n1` rather than becoming `nvme-0-n-1`, and `ipv4` stays `ipv4`. Device
+ * and protocol names read better whole, and they are exactly the strings that
+ * end up in ids. A consumer that must reproduce a legacy lodash-derived id
+ * byte-for-byte pre-normalizes the dynamic part itself before handing it over
+ * (webui's `normalizeTestIdString` does this); the result then passes through
+ * here unchanged.
  */
 export function kebabTestSegment(part: string | number): string {
   return String(part)

--- a/projects/truenas-ui/src/lib/test-id/option-test-id.spec.ts
+++ b/projects/truenas-ui/src/lib/test-id/option-test-id.spec.ts
@@ -2,23 +2,36 @@ import { composeTestId } from './compose-test-id';
 import { optionTestId } from './option-test-id';
 
 describe('optionTestId', () => {
-  it('uses a primitive value as the discriminator', () => {
+  it('uses the label as the discriminator', () => {
     expect(optionTestId('country', { label: 'United States', value: 'US' }))
-      .toEqual(['country', 'US']);
-    expect(optionTestId('port', { label: 'SSH', value: 22 }))
-      .toEqual(['port', 22]);
+      .toEqual(['country', 'United States']);
   });
 
-  it('falls back to the label for object values', () => {
+  it('prefers the label over a primitive value, so opaque values never reach the id', () => {
+    expect(optionTestId('mode', { label: 'SSH Keyscan', value: 0 }))
+      .toEqual(['mode', 'SSH Keyscan']);
+    expect(optionTestId('encryption', { label: 'Plain (No Encryption)', value: 'PLAIN' }))
+      .toEqual(['encryption', 'Plain (No Encryption)']);
+  });
+
+  it('uses the label for object values', () => {
     expect(optionTestId('city', { label: 'Lisbon', value: { id: 'lis' } }))
       .toEqual(['city', 'Lisbon']);
   });
 
-  it('falls back to the label when there is no value', () => {
+  it('uses the label when there is no value', () => {
     expect(optionTestId('city', { label: 'Porto' })).toEqual(['city', 'Porto']);
   });
 
-  it('prefers the extractor over value and label', () => {
+  it('falls back to a primitive value when the label is empty', () => {
+    expect(optionTestId('city', { label: '', value: 'porto' })).toEqual(['city', 'porto']);
+  });
+
+  it('yields no discriminator when neither half is usable', () => {
+    expect(composeTestId('option', optionTestId('city', { label: '', value: { id: 'lis' } }))).toBe('option-city');
+  });
+
+  it('prefers the extractor over label and value', () => {
     const option = { label: 'Lisbon', value: { id: 'lis' } };
     expect(optionTestId('city', option, (o) => o.value.id)).toEqual(['city', 'lis']);
   });

--- a/projects/truenas-ui/src/lib/test-id/option-test-id.spec.ts
+++ b/projects/truenas-ui/src/lib/test-id/option-test-id.spec.ts
@@ -27,8 +27,24 @@ describe('optionTestId', () => {
     expect(optionTestId('city', { label: '', value: 'porto' })).toEqual(['city', 'porto']);
   });
 
+  it('falls back to a primitive value when the label normalizes away', () => {
+    // Truthy labels that `kebabTestSegment` strips to nothing would otherwise
+    // collapse every such option onto the bare base.
+    expect(optionTestId('lang', { label: '日本語', value: 'ja' })).toEqual(['lang', 'ja']);
+    expect(optionTestId('lang', { label: '--', value: 'none' })).toEqual(['lang', 'none']);
+  });
+
+  it('keeps such options distinct once composed', () => {
+    const ids = [
+      { label: '日本語', value: 'ja' },
+      { label: '한국어', value: 'ko' },
+    ].map((option) => composeTestId('option', optionTestId('lang', option)));
+    expect(ids).toEqual(['option-lang-ja', 'option-lang-ko']);
+  });
+
   it('yields no discriminator when neither half is usable', () => {
     expect(composeTestId('option', optionTestId('city', { label: '', value: { id: 'lis' } }))).toBe('option-city');
+    expect(composeTestId('option', optionTestId('city', { label: '***', value: { id: 'lis' } }))).toBe('option-city');
   });
 
   it('prefers the extractor over label and value', () => {

--- a/projects/truenas-ui/src/lib/test-id/option-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/option-test-id.ts
@@ -1,4 +1,4 @@
-import { scopeTestId, type TnTestIdValue } from './compose-test-id';
+import { kebabTestSegment, scopeTestId, type TnTestIdValue } from './compose-test-id';
 
 /**
  * Minimal structural shape of a dropdown option for test-id derivation.
@@ -31,8 +31,12 @@ export interface TnOptionTestIdSource {
  * `option-user-1734`: not unique in any way a test author can predict, and
  * silently renumbered whenever the enum or the records change. The label is the
  * one part of an option that both the person writing the test and the person
- * reading the page can see, so it is the useful default. Where an id must be
- * stable across locales or an id-per-record is genuinely wanted, `extractor`
+ * reading the page can see, so it is the useful default. What it trades away is
+ * uniqueness by construction: a value is unique within a control (it is the
+ * model value the control round-trips) where a label is not, so an option set
+ * with a repeated display name now produces repeated ids, silently — nothing
+ * validates label uniqueness. Where that happens, or an id must be stable
+ * across locales, or an id-per-record is genuinely wanted, `extractor`
  * (`[optionTestIdKey]`) still overrides it — that is what the input is for.
  */
 export function optionTestId<O extends TnOptionTestIdSource>(
@@ -43,10 +47,15 @@ export function optionTestId<O extends TnOptionTestIdSource>(
   if (extractor) {
     return scopeTestId(base, extractor(option));
   }
-  // A labelless option is the only case left with anything to salvage: a primitive
-  // value at least discriminates the row, where an object value has nothing usable.
+  // An option whose label contributes no segment is the only case left with
+  // anything to salvage: a primitive value at least discriminates the row, where an
+  // object value has nothing usable. The test is what survives normalization rather
+  // than mere truthiness — `kebabTestSegment` strips every run of non-alphanumerics,
+  // so a label like `--` or a CJK-only string is as unusable as an empty one and
+  // would collapse every such row onto the bare base.
   const primitiveValue = typeof option.value === 'string' || typeof option.value === 'number'
     ? option.value
     : undefined;
-  return scopeTestId(base, option.label || primitiveValue);
+  const usableLabel = option.label && kebabTestSegment(option.label);
+  return scopeTestId(base, usableLabel ? option.label : primitiveValue);
 }

--- a/projects/truenas-ui/src/lib/test-id/option-test-id.ts
+++ b/projects/truenas-ui/src/lib/test-id/option-test-id.ts
@@ -15,27 +15,38 @@ export interface TnOptionTestIdSource {
  * `[tnTestId]` with `tnTestIdType="option"`. The component's resolved base
  * (explicit `testId`, else the bound control name) scopes a per-option
  * discriminator so ids stay unique across instances: base `user` + option
- * value `jane-doe` → `option-user-jane-doe`; with no base → `option-jane-doe`.
+ * label `Jane Doe` → `option-user-jane-doe`; with no base → `option-jane-doe`.
  *
  * The discriminator comes from `extractor` when provided (a component's
- * `optionTestIdKey` input), else the option's primitive `value`, else its
- * `label`. Shared by `tn-select` and `tn-autocomplete` so the derivation
- * rules can't drift between dropdown components; synthetic rows with fixed
- * discriminators (e.g. select's `allowEmpty` option) are handled by the
+ * `optionTestIdKey` input), else the option's **`label`** — the text actually
+ * on screen — falling back to a primitive `value` only for the labelless
+ * option. Shared by `tn-select`, `tn-autocomplete` and `tn-chip-input` so the
+ * derivation rules can't drift between dropdown components; synthetic rows with
+ * fixed discriminators (e.g. select's `allowEmpty` option) are handled by the
  * caller before delegating here.
+ *
+ * **Why the label and not the value.** An option's value is frequently opaque
+ * to everyone but the code that owns it — an enum ordinal, a record id, a
+ * protocol constant — so keying ids off it yields `option-sshconnectmode-0` or
+ * `option-user-1734`: not unique in any way a test author can predict, and
+ * silently renumbered whenever the enum or the records change. The label is the
+ * one part of an option that both the person writing the test and the person
+ * reading the page can see, so it is the useful default. Where an id must be
+ * stable across locales or an id-per-record is genuinely wanted, `extractor`
+ * (`[optionTestIdKey]`) still overrides it — that is what the input is for.
  */
 export function optionTestId<O extends TnOptionTestIdSource>(
   base: TnTestIdValue,
   option: O,
   extractor?: (option: O) => string | number | null | undefined,
 ): (string | number | null | undefined)[] {
-  let key: string | number | null | undefined;
   if (extractor) {
-    key = extractor(option);
-  } else if (typeof option.value === 'string' || typeof option.value === 'number') {
-    key = option.value;
-  } else {
-    key = option.label;
+    return scopeTestId(base, extractor(option));
   }
-  return scopeTestId(base, key);
+  // A labelless option is the only case left with anything to salvage: a primitive
+  // value at least discriminates the row, where an object value has nothing usable.
+  const primitiveValue = typeof option.value === 'string' || typeof option.value === 'number'
+    ? option.value
+    : undefined;
+  return scopeTestId(base, option.label || primitiveValue);
 }

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -500,20 +500,21 @@ export const ComponentHarness: Story = {
  * **Test IDs.** The autocomplete **input** (`role="combobox"`) emits
  * `autocomplete-<base>` — shown live in the table below. Each **suggestion
  * option** lives in a portaled overlay (so it's not in the table until the
- * dropdown is open) and emits `option-<base>-<value>`; the loading and
+ * dropdown is open) and emits `option-<base>-<label>`; the loading and
  * no-results status rows are stamped under the input's id:
  *
  * | Element | Emitted id (base `country`) |
  * |---|---|
  * | input | `autocomplete-country` |
- * | option (value `us`) | `option-country-us` |
- * | option (value `ca`) | `option-country-ca` |
+ * | option (label `United States`) | `option-country-united-states` |
+ * | option (label `Canada`) | `option-country-canada` |
  * | loading row | `autocomplete-country-loading` |
  * | no-results row | `autocomplete-country-no-results` |
  *
  * The base falls back to the bound control name (`formControlName="country"`)
  * when `testId` is unset. The option discriminator defaults to the option's
- * `value` (else `label`); override it with `[optionTestIdKey]="(o) => o.value.id"`.
+ * `label` — the text on screen, rather than a value that is often an enum ordinal
+ * or a record id. Override it with `[optionTestIdKey]="(o) => o.value.id"`.
  * Under `data-testid` by default / `data-test`. Focus the input to see the
  * option ids in the DOM; type a non-match to see the no-results row.
  */

--- a/projects/truenas-ui/src/stories/chip-input.stories.ts
+++ b/projects/truenas-ui/src/stories/chip-input.stories.ts
@@ -273,8 +273,9 @@ export const ComponentHarness: Story = {
 };
 
 /**
- * **Test IDs.** The field emits `chip-input-<base>`; chips are scoped beneath it
- * as `chip-<base>-<value>` and suggestion rows as `option-<base>-<value>`.
+ * **Test IDs.** The field emits `chip-input-<base>`; chips and suggestion rows are
+ * scoped beneath it by the text they show — `chip-<base>-<label>` and
+ * `option-<base>-<label>`, falling back to the value for a free-text chip.
  * `testId="tags"` → `chip-input-tags`, under `data-testid` (default) /
  * `data-test`. With no `testId`, the base falls back to the bound control name,
  * so `formControlName="isnsServers"` → `chip-input-isns-servers`; a control-less

--- a/projects/truenas-ui/src/stories/chip-input.stories.ts
+++ b/projects/truenas-ui/src/stories/chip-input.stories.ts
@@ -283,8 +283,13 @@ export const ComponentHarness: Story = {
  * its field, chips and suggestion rows are all named from the control.
  *
  * A discriminator that normalizes to nothing (`*`, `**`, a CJK-only tag) would
- * collapse a chip's id back to the bare base, so those chips stay attribute-free
- * rather than sharing one id.
+ * collapse a chip's id back to the bare base. An option-backed chip falls back to
+ * the value behind the label there; a chip with nothing else to be named by stays
+ * attribute-free rather than sharing one id.
+ *
+ * Where two options share a display name, or ids must survive a locale change,
+ * `[optionTestIdKey]="(o) => o.value.id"` picks the discriminator instead — for
+ * the chip and its suggestion row alike.
  */
 export const TestIds: Story = {
   render: () => ({

--- a/projects/truenas-ui/src/stories/select.stories.ts
+++ b/projects/truenas-ui/src/stories/select.stories.ts
@@ -580,16 +580,17 @@ export const ComponentHarness: Story = {
  * **Test IDs.** The select **trigger** (the `role="combobox"` element) emits
  * `select-<base>` — shown live in the table below. Each **option** lives in a
  * portaled overlay (so it's not in the table until the dropdown is open) and
- * emits `option-<base>-<value>`:
+ * emits `option-<base>-<label>`:
  *
  * | Element | Emitted id (base `disk-type`) |
  * |---|---|
  * | trigger | `select-disk-type` |
- * | option (value `ssd`) | `option-disk-type-ssd` |
- * | option (value `hdd`) | `option-disk-type-hdd` |
+ * | option (label `SSD`) | `option-disk-type-ssd` |
+ * | option (label `Spinning Disk`) | `option-disk-type-spinning-disk` |
  *
- * The option discriminator defaults to the option's `value` (else `label`);
- * override it with `[optionTestIdKey]="(o) => o.value.id"`. Under `data-testid`
+ * The option discriminator defaults to the option's `label` — the text on screen,
+ * rather than a value that is often an enum ordinal or a record id. Override it
+ * with `[optionTestIdKey]="(o) => o.value.id"`. Under `data-testid`
  * by default / `data-test`. Open the dropdown to see the option ids in the DOM.
  */
 export const TestIds: Story = {


### PR DESCRIPTION
## What

`tn-select`, `tn-autocomplete` and `tn-chip-input` now derive an option's test id from its **`label`** instead of a primitive **`value`**.

| | before | after |
|---|---|---|
| `{ label: 'SSH Keyscan', value: 0 }` | `option-mode-0` | `option-mode-ssh-keyscan` |
| `{ label: 'Plain (No Encryption)', value: 'PLAIN' }` | `option-encryption-plain` | `option-encryption-plain-no-encryption` |
| `{ label: 'Spinning Disk', value: 'hdd' }` | `option-disk-type-hdd` | `option-disk-type-spinning-disk` |

`[optionTestIdKey]` is unchanged and still wins — it goes back to being the escape hatch it was meant to be (`(o) => o.value` restores the old id on any one control).

## Why

An option's value is frequently opaque to everything but the code that owns it — an enum ordinal, a record id, a protocol constant. Keying ids off it produced `option-sshconnectmode-0` and `option-user-1734`: not predictable to a test author, and silently renumbered whenever the enum or the record set changes. The label is the one part of an option that both the person writing the test and the person reading the page can see.

This came out of review on [truenas/webui#13920](https://github.com/truenas/webui/pull/13920), which had to pin `[optionTestIdKey]` back to the label on **294** selects — every single one in webui — plus 127 duplicated `optionTestIdByLabel` component fields. When every consumer overrides the default, the default is wrong. The reviewer's question was the right one: fix it here rather than work around it there.

## chip-input

Chips follow the same rule, so a chip and the suggestion row that created it carry the same discriminator instead of one naming the label and the other the value. Two guards are kept:

- a **free-text** chip has no option to name it, so its value still stands in;
- an **object** value with no matching option stays attribute-free rather than collapsing to `[object Object]` on every chip.

## Also

Corrects the `kebabTestSegment` docblock, which claimed parity with lodash `kebabCase`. It deliberately does *not* split the letter↔digit boundary — `nvme0n1` stays whole where lodash gives `nvme-0-n-1`, and `ipv4` stays `ipv4`. That divergence is intentional and worth stating, since it is why a consumer chasing byte-identical legacy ids pre-normalizes the dynamic part itself.

## Breaking

Any assertion pinned to a value-derived option id changes. Both consumers are in-house and mid-migration; webui's selects all pass an explicit key today and are therefore unaffected until they drop it.

## Testing

- `yarn test` — 88 suites / 2151 tests green; `test-id/` stays at 100% coverage
- `yarn lint`, `yarn build` clean
- new coverage: label-over-primitive-value, empty-label fallback, neither-half-usable, and a chip-input case asserting a chip and its suggestion row agree

https://claude.ai/code/session_015DNgeeCxxzRm7YJwr2uVvv
