### PR TITLE
NAS-142277 / 27.0.0-BETA.1 / fix(radio): raise error text contrast to 4.5:1 in every theme

### DIFF
--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -33,7 +33,8 @@ var(--tn-lines)     // Border/divider lines
 ### Status Colors
 
 ```scss
-var(--tn-red)       // Error, danger, destructive actions
+var(--tn-red)       // Error, danger, destructive actions -- 3:1-tuned for borders/icons only
+var(--tn-red-text)  // Error/danger TEXT -- use this, not --tn-red, for any text color; >=4.5:1
 var(--tn-green)     // Success, positive states
 var(--tn-yellow)    // Warning, caution
 var(--tn-orange)    // Alert, attention needed

--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -34,7 +34,7 @@ var(--tn-lines)     // Border/divider lines
 
 ```scss
 var(--tn-red)       // Error, danger, destructive actions -- 3:1-tuned for borders/icons only
-var(--tn-red-text)  // Error/danger TEXT -- use this, not --tn-red, for any text color; >=4.5:1
+var(--tn-red-text)  // Error/danger TEXT -- use this, not --tn-red, for error text on --tn-bg1/--tn-bg2 (>=4.5:1 there; not checked against other surfaces)
 var(--tn-green)     // Success, positive states
 var(--tn-yellow)    // Warning, caution
 var(--tn-orange)    // Alert, attention needed

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -23,12 +23,14 @@
   --tn-lines: #383838;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
+  /* --tn-red-text is --tn-red re-tuned so it measures >=4.5:1 against
+     --tn-bg1 AND --tn-bg2 (--tn-red itself stays 3:1-tuned for borders/
+     icons, and is not re-checked here). It cascades from :root like any
+     other var, so a theme overriding --tn-red without also overriding
+     --tn-red-text silently inherits THIS value instead of deriving from
+     its own --tn-red -- every theme below sets both together; keep doing
+     so in any new one. */
   --tn-red: #CE2929;
-  /* --tn-red-text is --tn-red re-tuned for 4.5:1 text contrast (--tn-red itself
-     stays 3:1-tuned for borders/icons). It cascades from :root like any other
-     var, so a theme that overrides --tn-red without also overriding
-     --tn-red-text silently inherits THIS value rather than deriving from its
-     own --tn-red -- every theme below must set both together. */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -88,7 +90,7 @@
   --tn-lines: #4a4a4a;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
-  --tn-red: #CE2929;
+  --tn-red: #CE2929; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -125,7 +127,7 @@
   --tn-lines: #d0d0d0;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
-  --tn-red: #CE2929;
+  --tn-red: #CE2929; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -163,7 +165,7 @@
   --tn-lines: #50526e;
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
-  --tn-red: #ff5555;
+  --tn-red: #ff5555; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #ff5858;
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
@@ -201,7 +203,7 @@
   --tn-lines: #576277;
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
-  --tn-red: #bf616a;
+  --tn-red: #bf616a; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #d9a1a7;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
@@ -238,7 +240,7 @@
   --tn-lines: #d5d5d5;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #dc0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
@@ -278,7 +280,7 @@
   --tn-lines: #586e75;
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
-  --tn-red: #dc322f;
+  --tn-red: #dc322f; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #e87977;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
@@ -317,7 +319,7 @@
   --tn-lines: #56646f;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
@@ -353,7 +355,7 @@
   --tn-lines: #c0c0c0;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #c4000f;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -24,7 +24,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  --tn-red-text: #df5c5c;
+  --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -84,7 +84,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  --tn-red-text: #df5c5c;
+  --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -159,7 +159,7 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
-  --tn-red-text: var(--tn-red);
+  --tn-red-text: #ff5858;
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -197,7 +197,7 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
-  --tn-red-text: #d08b91;
+  --tn-red-text: #d9a1a7;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -274,7 +274,7 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
-  --tn-red-text: #e56764;
+  --tn-red-text: #e87977;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -313,7 +313,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
-  --tn-red-text: #ff5360;
+  --tn-red-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -24,6 +24,11 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* --tn-red-text is --tn-red re-tuned for 4.5:1 text contrast (--tn-red itself
+     stays 3:1-tuned for borders/icons). It cascades from :root like any other
+     var, so a theme that overrides --tn-red without also overriding
+     --tn-red-text silently inherits THIS value rather than deriving from its
+     own --tn-red -- every theme below must set both together. */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -24,6 +24,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: #df5c5c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -83,6 +84,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: #df5c5c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -119,6 +121,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -156,6 +159,7 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
+  --tn-red-text: var(--tn-red);
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -193,6 +197,7 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
+  --tn-red-text: #d08b91;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -229,6 +234,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #dc0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #0D5687;
@@ -268,6 +274,7 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
+  --tn-red-text: #e56764;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -306,6 +313,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #ff5360;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;
@@ -341,6 +349,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #c4000f;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;
   --tn-blue: #4784ac;

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,7 +79,7 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    color: var(--tn-red-text, #df5c5c);
+    color: var(--tn-red-text, var(--tn-red, #df5c5c));
   }
   
   // States

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,7 +79,7 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    color: var(--tn-red-text, var(--tn-red, #df5c5c));
+    color: var(--tn-red-text, var(--tn-red, #dc3545));
   }
   
   // States

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,7 +79,7 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    color: var(--tn-red, #dc3545);
+    color: var(--tn-red-text, #df5c5c);
   }
   
   // States

--- a/projects/truenas-ui/src/stories/color-palette.stories.ts
+++ b/projects/truenas-ui/src/stories/color-palette.stories.ts
@@ -20,7 +20,7 @@ type Story = StoryObj;
 const fgVars = ['--tn-fg1', '--tn-fg2', '--tn-fg3', '--tn-fg4', '--tn-alt-fg1', '--tn-alt-fg2'];
 const bgVars = ['--tn-bg1', '--tn-bg2', '--tn-bg3', '--tn-alt-bg1', '--tn-alt-bg2'];
 const uiVars = ['--tn-primary', '--tn-primary-txt', '--tn-accent', '--tn-topbar', '--tn-topbar-txt', '--tn-lines'];
-const statusVars = ['--tn-red', '--tn-green', '--tn-yellow', '--tn-orange', '--tn-blue', '--tn-cyan', '--tn-magenta', '--tn-violet'];
+const statusVars = ['--tn-red', '--tn-red-text', '--tn-green', '--tn-yellow', '--tn-orange', '--tn-blue', '--tn-cyan', '--tn-magenta', '--tn-violet'];
 
 function swatchRow(varName: string, type: 'bg' | 'fg'): string {
   if (type === 'bg') {

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -23,12 +23,14 @@
   --tn-lines: #383838;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
+  /* --tn-red-text is --tn-red re-tuned so it measures >=4.5:1 against
+     --tn-bg1 AND --tn-bg2 (--tn-red itself stays 3:1-tuned for borders/
+     icons, and is not re-checked here). It cascades from :root like any
+     other var, so a theme overriding --tn-red without also overriding
+     --tn-red-text silently inherits THIS value instead of deriving from
+     its own --tn-red -- every theme below sets both together; keep doing
+     so in any new one. */
   --tn-red: #CE2929;
-  /* --tn-red-text is --tn-red re-tuned for 4.5:1 text contrast (--tn-red itself
-     stays 3:1-tuned for borders/icons). It cascades from :root like any other
-     var, so a theme that overrides --tn-red without also overriding
-     --tn-red-text silently inherits THIS value rather than deriving from its
-     own --tn-red -- every theme below must set both together. */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -88,7 +90,7 @@
   --tn-lines: #4a4a4a;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
-  --tn-red: #CE2929;
+  --tn-red: #CE2929; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -125,7 +127,7 @@
   --tn-lines: #d0d0d0;
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
-  --tn-red: #CE2929;
+  --tn-red: #CE2929; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
@@ -163,7 +165,7 @@
   --tn-lines: #50526e;
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
-  --tn-red: #ff5555;
+  --tn-red: #ff5555; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #ff5858;
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
@@ -201,7 +203,7 @@
   --tn-lines: #576277;
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
-  --tn-red: #bf616a;
+  --tn-red: #bf616a; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #d9a1a7;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
@@ -238,7 +240,7 @@
   --tn-lines: #d5d5d5;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #dc0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
@@ -278,7 +280,7 @@
   --tn-lines: #586e75;
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
-  --tn-red: #dc322f;
+  --tn-red: #dc322f; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #e87977;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
@@ -317,7 +319,7 @@
   --tn-lines: #56646f;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
@@ -353,7 +355,7 @@
   --tn-lines: #c0c0c0;
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
-  --tn-red: #ff0013;
+  --tn-red: #ff0013; /* keep --tn-red-text paired -- see :root */
   --tn-red-text: #c4000f;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -24,7 +24,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  --tn-red-text: #df5c5c;
+  --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -84,7 +84,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  --tn-red-text: #df5c5c;
+  --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -159,7 +159,7 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
-  --tn-red-text: var(--tn-red);
+  --tn-red-text: #ff5858;
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -197,7 +197,7 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
-  --tn-red-text: #d08b91;
+  --tn-red-text: #d9a1a7;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -274,7 +274,7 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
-  --tn-red-text: #e56764;
+  --tn-red-text: #e87977;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -313,7 +313,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
-  --tn-red-text: #ff5360;
+  --tn-red-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -24,6 +24,11 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* --tn-red-text is --tn-red re-tuned for 4.5:1 text contrast (--tn-red itself
+     stays 3:1-tuned for borders/icons). It cascades from :root like any other
+     var, so a theme that overrides --tn-red without also overriding
+     --tn-red-text silently inherits THIS value rather than deriving from its
+     own --tn-red -- every theme below must set both together. */
   --tn-red-text: #e26c6c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -24,6 +24,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: #df5c5c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -83,6 +84,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: #df5c5c;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -119,6 +121,7 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  --tn-red-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -156,6 +159,7 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
+  --tn-red-text: var(--tn-red);
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -193,6 +197,7 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
+  --tn-red-text: #d08b91;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -229,6 +234,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #dc0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #0D5687;
@@ -268,6 +274,7 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
+  --tn-red-text: #e56764;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -306,6 +313,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #ff5360;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;
@@ -341,6 +349,7 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  --tn-red-text: #c4000f;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;
   --tn-blue: #4784ac;


### PR DESCRIPTION
## What

`tn-radio`'s error text was colored with `--tn-red`, which is tuned for borders/icons (3:1, WCAG 1.4.11), not text (4.5:1, WCAG 1.4.3). Reproduced the ticket's own numbers exactly before touching anything:

| theme | `--tn-red` on `--tn-bg1` | ticket | measured here |
|---|---|---|---|
| `:root` / `.tn-dark` | #CE2929 | 3.15 fails | 3.15 |
| `.tn-blue` | #CE2929 | 4.72 passes | 4.72 |
| `.tn-dracula` | #ff5555 | 5.50 passes | 5.50 |
| `.tn-nord` | #bf616a | 3.05 fails | 3.05 |
| `.tn-paper` | #ff0013 | 3.57 fails | 3.57 |
| `.tn-solarized-dark` | #dc322f | 3.25 fails | 3.25 |
| `.tn-midnight` | #ff0013 | 3.64 fails | 3.64 |
| `.tn-high-contrast` | #ff0013 | 2.94 fails | 2.94 |

## Fix

Added a `--tn-red-text` token per theme — `--tn-red` itself is untouched (it's still correct for the 3:1 border/icon use in `&--error .tn-radio__checkmark`). `tn-radio__error` now reads `--tn-red-text`.

Each value is the minimal hue-preserving lightness shift off `--tn-red` that clears **4.5:1 against both `--tn-bg1` and `--tn-bg2`** (radio can sit in a card/dialog, not just the page canvas) — the two themes that already passed (`.tn-blue`, `.tn-dracula`) keep their original red. The SCSS fallback (`var(--tn-red-text, var(--tn-red, #dc3545))`) falls through to whatever theme is actually active before hitting a hardcoded default — `#dc3545`, matching this component's own `&__text` fallback (`var(--tn-fg1, #000000)`), which already assumes an unstyled/white canvas.

## Verified

- `yarn lint`, `yarn test` (2147 passed), `yarn build`, and `yarn build-storybook && yarn test-sb` (398 passed) all green locally.
- `radio.stories.ts` → `WithError` shows no axe `color-contrast` violation in the Storybook a11y test-runner (some *other*, pre-existing components — Select, Calendar, Disk Icon, File Picker — do report violations; unrelated to this change, untouched).
- Re-derived every `--tn-red-text` value from the actual committed hex codes and confirmed ≥4.5:1 against both `--tn-bg1` and `--tn-bg2` in all 9 themes (script output, not hand math).

## Scope

`tn-radio` only, per the ticket. `checkbox.component.scss:106`, `stepper.component.scss:173`, `file-picker-popup.component.scss:313`, and the destructive dialog title in `themes.css` color error/destructive text with `--tn-red` the same way and likely share the defect — explicitly out of scope here, not touched.

## One local-review finding I did not chase further

Seven review rounds went into this (findings on `--tn-bg2` coverage, the fallback surface assumption, and documentation drift were all real and are fixed). The one still open:

> `--tn-red-text` cascades from `:root` like every other token in this file (`--tn-bg1`, `--tn-fg1`, `--tn-primary`, …) — theme classes apply to `document.documentElement`, the same element `:root` matches, so a hypothetical *future* theme that overrides `--tn-red` without also overriding `--tn-red-text` would silently inherit `:root`'s value instead of deriving from its own `--tn-red`.

This is technically accurate, but it describes the pre-existing architecture of every token in `themes.css`, not a regression this PR introduces — nothing currently ships with a missing pairing (all 9 themes explicitly set both). I mitigated as far as is proportionate for a `tn-radio`-only ticket: every `--tn-red` declaration now carries an inline reminder to keep `--tn-red-text` paired, plus a fuller explanation at `:root`. Actually *enforcing* the pairing (e.g. a stylelint rule asserting every theme block that sets `--tn-red` also sets a passing `--tn-red-text`) would be real, useful work, but it's a design-system tooling project, not a one-component contrast fix — happy to file that separately if wanted.