### PR TITLE
NAS-142281 / 27.0.0-BETA.1 / fix(radio): give tn-radio error text a theme-aware, text-safe contrast token

### DIFF
--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -40,7 +40,7 @@ var(--tn-orange)    // Alert, attention needed
 var(--tn-blue)      // Info, neutral information
 ```
 
-**These status colors are tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and none are tuned for the 4.5:1 text minimum (WCAG 1.4.3).** In several themes `--tn-red` on `--tn-bg1` clears 3:1 but not 4.5:1. For text — validation messages, inline errors — use the text-safe counterpart instead:
+**`--tn-red` is tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and it is not tuned for the 4.5:1 text minimum (WCAG 1.4.3). The other status colors are not tuned toward either threshold.** In several themes `--tn-red` on `--tn-bg1` clears 3:1 but not 4.5:1. For text — validation messages, inline errors — use the text-safe counterpart instead:
 
 ```scss
 var(--tn-error-text)  // Error/validation text, 4.5:1 against --tn-bg1 in every theme

--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -40,7 +40,7 @@ var(--tn-orange)    // Alert, attention needed
 var(--tn-blue)      // Info, neutral information
 ```
 
-**These status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), not the 4.5:1 text minimum (WCAG 1.4.3).** In several themes `--tn-red` on `--tn-bg1` clears 3:1 but not 4.5:1. For text — validation messages, inline errors — use the text-safe counterpart instead:
+**These status colors are tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and none are tuned for the 4.5:1 text minimum (WCAG 1.4.3).** In several themes `--tn-red` on `--tn-bg1` clears 3:1 but not 4.5:1. For text — validation messages, inline errors — use the text-safe counterpart instead:
 
 ```scss
 var(--tn-error-text)  // Error/validation text, 4.5:1 against --tn-bg1 in every theme

--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -40,6 +40,14 @@ var(--tn-orange)    // Alert, attention needed
 var(--tn-blue)      // Info, neutral information
 ```
 
+**These status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), not the 4.5:1 text minimum (WCAG 1.4.3).** In several themes `--tn-red` on `--tn-bg1` clears 3:1 but not 4.5:1. For text — validation messages, inline errors — use the text-safe counterpart instead:
+
+```scss
+var(--tn-error-text)  // Error/validation text, 4.5:1 against --tn-bg1 in every theme
+```
+
+Defined per theme in `themes.css`, alongside the status colors it pairs with. Where `--tn-green`/`--tn-yellow`/etc. get a text use, give them the same `-text` counterpart rather than reusing the raw status color for text.
+
 ### Icon Sizes
 
 ```scss

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -24,6 +24,9 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* >=4.5:1 against both --tn-bg1 (5.17:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.15:1 on --tn-bg1, tuned for the 3:1 border/icon minimum. */
+  --tn-error-text: #de6d6d;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -83,6 +86,9 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* >=4.5:1 against both --tn-bg1 (5.17:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.15:1 on --tn-bg1. */
+  --tn-error-text: #de6d6d;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -119,6 +125,8 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* --tn-red already clears 4.5:1 against --tn-bg1 here (measured 4.72:1). */
+  --tn-error-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -156,6 +164,8 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
+  /* --tn-red already clears 4.5:1 against --tn-bg1 here (measured 5.50:1). */
+  --tn-error-text: var(--tn-red);
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -193,6 +203,9 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
+  /* >=4.5:1 against both --tn-bg1 (5.67:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.05:1 on --tn-bg1. */
+  --tn-error-text: #d9a0a6;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -229,6 +242,8 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* 4.5:1 against --tn-bg1 (measured 4.67:1); --tn-red itself is only 3.57:1. */
+  --tn-error-text: #db0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #0D5687;
@@ -268,6 +283,9 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
+  /* >=4.5:1 against both --tn-bg1 (5.28:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.25:1 on --tn-bg1. */
+  --tn-error-text: #e87876;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -306,6 +324,9 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* >=4.5:1 against both --tn-bg1 (6.01:1) and --tn-bg2 (4.61:1); --tn-red itself
+     is only 3.64:1 on --tn-bg1. */
+  --tn-error-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;
@@ -341,6 +362,8 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 2.94:1 — the worst of the nine. */
+  --tn-error-text: #c2000e;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;
   --tn-blue: #4784ac;

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
  * tn-radio's error text (`.tn-radio__error`) reads `--tn-error-text`, a
@@ -111,8 +112,20 @@ describe('tn-radio error text contrast (#186)', () => {
   const css = readFileSync(THEMES_CSS_PATH, 'utf8');
   const themeBlocks = extractThemeBlocks(css);
 
-  it('found all nine themed surfaces in themes.css', () => {
-    expect(themeBlocks.size).toBe(9);
+  // Derived from the theme registry rather than hardcoded: extractThemeBlocks
+  // silently drops a block whose --tn-bg1 isn't a hex literal (e.g. rgb()),
+  // so a fixed expected count could stay coincidentally correct while a
+  // themed surface goes unmeasured. Tying it to TN_THEME_DEFINITIONS plus
+  // :root, and naming every registered selector below, fails on exactly
+  // which surface went missing instead.
+  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(themeBlocks.size).toBe(expectedSelectors.length);
+  });
+
+  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
+    expect(themeBlocks.has(selector)).toBe(true);
   });
 
   const cases = Array.from(themeBlocks.entries()).map(([selector, body]) => buildCase(selector, body));

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -137,9 +137,13 @@ describe('tn-radio error text contrast (#186)', () => {
 
   it('the SCSS fallback chains through --tn-red before a literal, and the literal is accessible where it is actually reachable', () => {
     const scss = readFileSync(RADIO_SCSS_PATH, 'utf8');
-    // A theme that predates --tn-error-text may still define --tn-red, so the
-    // chain must try that before a hardcoded literal — otherwise a theme
-    // author's own tuning is silently discarded.
+    // A consumer stylesheet that predates --tn-error-text entirely (no :root
+    // rule declaring it) may still define --tn-red, so the chain tries that
+    // before a hardcoded literal — otherwise that stylesheet's own tuning is
+    // silently discarded. This does not help a theme added within this
+    // repo's own themes.css: :root already declares --tn-error-text there,
+    // and wins the cascade regardless of what the new theme's own class
+    // declares, so such a theme must set --tn-error-text itself.
     const chainMatch = /--tn-error-text,\s*var\(--tn-red,\s*(#[0-9a-fA-F]{3,6})\)\)/.exec(scss);
     expect(chainMatch).not.toBeNull();
     const literal = chainMatch![1];

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * tn-radio's error text (`.tn-radio__error`) reads `--tn-error-text`, a
+ * theme-aware token added to fix #186 (`--tn-red` itself is only tuned for
+ * the 3:1 border/icon minimum, not the 4.5:1 text minimum). This measures
+ * the real WCAG contrast ratio of that token, per theme, against the actual
+ * values shipped in themes.css — rather than asserting the fix, it reports
+ * the numbers acceptance criteria asked for and guards against regression.
+ *
+ * jsdom has no layout engine, so axe-core's color-contrast rule (which needs
+ * real rendering) can't produce a meaningful pass/fail here — it reports
+ * "incomplete" rather than checking anything. Computing the ratio directly
+ * from the shipped values is the more honest check.
+ */
+
+const THEMES_CSS_PATH = join(__dirname, '../../styles/themes.css');
+const RADIO_SCSS_PATH = join(__dirname, './radio.component.scss');
+
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean;
+  const num = parseInt(full, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const [rl, gl, bl] = [r, g, b].map(channel);
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrastRatio(hexA: string, hexB: string): number {
+  const lA = relativeLuminance(hexToRgb(hexA));
+  const lB = relativeLuminance(hexToRgb(hexB));
+  const [lighter, darker] = lA > lB ? [lA, lB] : [lB, lA];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function extractThemeBlocks(css: string): Map<string, string> {
+  const blocks = new Map<string, string>();
+  const blockPattern = /(:root|\.tn-[\w-]+)\s*{([^}]*)}/g;
+  let match: RegExpExecArray | null;
+  while ((match = blockPattern.exec(css)) !== null) {
+    const [, selector, body] = match;
+    if (/--tn-bg1:\s*#/.test(body)) {
+      blocks.set(selector, body);
+    }
+  }
+  return blocks;
+}
+
+function extractVar(body: string, name: string): string | undefined {
+  const match = new RegExp(`${name}:\\s*([^;]+);`).exec(body);
+  return match?.[1].trim();
+}
+
+function resolveColor(rawValue: string, body: string): string {
+  const varRef = /^var\((--[\w-]+)\)$/.exec(rawValue);
+  if (varRef) {
+    const resolved = extractVar(body, varRef[1]);
+    if (!resolved) {
+      throw new Error(`Could not resolve ${rawValue} within block`);
+    }
+    return resolveColor(resolved, body);
+  }
+  return rawValue;
+}
+
+describe('tn-radio error text contrast (#186)', () => {
+  const css = readFileSync(THEMES_CSS_PATH, 'utf8');
+  const themeBlocks = extractThemeBlocks(css);
+
+  it('found all nine themed surfaces in themes.css', () => {
+    expect(themeBlocks.size).toBe(9);
+  });
+
+  const cases = Array.from(themeBlocks.entries()).map(([selector, body]) => {
+    const bg1 = extractVar(body, '--tn-bg1');
+    const errorTextRaw = extractVar(body, '--tn-error-text');
+    if (!bg1 || !errorTextRaw) {
+      throw new Error(`${selector} is missing --tn-bg1 or --tn-error-text`);
+    }
+    const errorText = resolveColor(errorTextRaw, body);
+    const ratio = contrastRatio(errorText, bg1);
+    return { selector, bg1, errorText, ratio, ratioLabel: ratio.toFixed(2) };
+  });
+
+  it.each(cases)(
+    '$selector: $errorText on $bg1 measures $ratioLabel : 1',
+    ({ ratio }) => {
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+
+  it('the SCSS fallback is itself accessible on a dark surface', () => {
+    const scss = readFileSync(RADIO_SCSS_PATH, 'utf8');
+    const fallbackMatch = /--tn-error-text,\s*(#[0-9a-fA-F]{3,6})\)/.exec(scss);
+    expect(fallbackMatch).not.toBeNull();
+    const fallback = fallbackMatch![1];
+    const darkSurface = '#1E1E1E'; // this theme's --tn-bg1, representative of the dark surfaces
+    const ratio = contrastRatio(fallback, darkSurface);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -6,8 +6,10 @@ import { join } from 'path';
  * theme-aware token added to fix #186 (`--tn-red` itself is only tuned for
  * the 3:1 border/icon minimum, not the 4.5:1 text minimum). This measures
  * the real WCAG contrast ratio of that token, per theme, against the actual
- * values shipped in themes.css — rather than asserting the fix, it reports
- * the numbers acceptance criteria asked for and guards against regression.
+ * values shipped in themes.css — both `--tn-bg1` (the page canvas) and
+ * `--tn-bg2` (cards, panels — tn-radio renders on both) — rather than
+ * asserting the fix, it reports the numbers acceptance criteria asked for
+ * and guards against regression.
  *
  * jsdom has no layout engine, so axe-core's color-contrast rule (which needs
  * real rendering) can't produce a meaningful pass/fail here — it reports
@@ -59,16 +61,50 @@ function extractVar(body: string, name: string): string | undefined {
   return match?.[1].trim();
 }
 
-function resolveColor(rawValue: string, body: string): string {
+function resolveColor(rawValue: string, body: string): string | undefined {
   const varRef = /^var\((--[\w-]+)\)$/.exec(rawValue);
   if (varRef) {
     const resolved = extractVar(body, varRef[1]);
-    if (!resolved) {
-      throw new Error(`Could not resolve ${rawValue} within block`);
-    }
-    return resolveColor(resolved, body);
+    return resolved ? resolveColor(resolved, body) : undefined;
   }
   return rawValue;
+}
+
+interface ThemeCase {
+  selector: string;
+  error?: string;
+  bg1?: string;
+  bg2?: string;
+  errorText?: string;
+  bg1Ratio?: number;
+  bg2Ratio?: number;
+  bg1RatioLabel?: string;
+  bg2RatioLabel?: string;
+}
+
+function buildCase(selector: string, body: string): ThemeCase {
+  const bg1 = extractVar(body, '--tn-bg1');
+  const bg2 = extractVar(body, '--tn-bg2');
+  const errorTextRaw = extractVar(body, '--tn-error-text');
+  if (!bg1 || !bg2 || !errorTextRaw) {
+    return { selector, error: `${selector} is missing --tn-bg1, --tn-bg2 or --tn-error-text` };
+  }
+  const errorText = resolveColor(errorTextRaw, body);
+  if (!errorText) {
+    return { selector, error: `${selector}'s --tn-error-text (${errorTextRaw}) could not be resolved` };
+  }
+  const bg1Ratio = contrastRatio(errorText, bg1);
+  const bg2Ratio = contrastRatio(errorText, bg2);
+  return {
+    selector,
+    bg1,
+    bg2,
+    errorText,
+    bg1Ratio,
+    bg2Ratio,
+    bg1RatioLabel: bg1Ratio.toFixed(2),
+    bg2RatioLabel: bg2Ratio.toFixed(2),
+  };
 }
 
 describe('tn-radio error text contrast (#186)', () => {
@@ -79,31 +115,41 @@ describe('tn-radio error text contrast (#186)', () => {
     expect(themeBlocks.size).toBe(9);
   });
 
-  const cases = Array.from(themeBlocks.entries()).map(([selector, body]) => {
-    const bg1 = extractVar(body, '--tn-bg1');
-    const errorTextRaw = extractVar(body, '--tn-error-text');
-    if (!bg1 || !errorTextRaw) {
-      throw new Error(`${selector} is missing --tn-bg1 or --tn-error-text`);
-    }
-    const errorText = resolveColor(errorTextRaw, body);
-    const ratio = contrastRatio(errorText, bg1);
-    return { selector, bg1, errorText, ratio, ratioLabel: ratio.toFixed(2) };
+  const cases = Array.from(themeBlocks.entries()).map(([selector, body]) => buildCase(selector, body));
+
+  it.each(cases)('$selector defines --tn-bg1, --tn-bg2 and --tn-error-text', (c) => {
+    expect(c.error).toBeUndefined();
   });
 
-  it.each(cases)(
-    '$selector: $errorText on $bg1 measures $ratioLabel : 1',
-    ({ ratio }) => {
-      expect(ratio).toBeGreaterThanOrEqual(4.5);
+  it.each(cases.filter((c) => !c.error))(
+    '$selector: $errorText on --tn-bg1 ($bg1) measures $bg1RatioLabel : 1',
+    ({ bg1Ratio }) => {
+      expect(bg1Ratio).toBeGreaterThanOrEqual(4.5);
     }
   );
 
-  it('the SCSS fallback is itself accessible on a dark surface', () => {
+  it.each(cases.filter((c) => !c.error))(
+    '$selector: $errorText on --tn-bg2 ($bg2) measures $bg2RatioLabel : 1',
+    ({ bg2Ratio }) => {
+      expect(bg2Ratio).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+
+  it('the SCSS fallback matches the default theme and is accessible on it', () => {
     const scss = readFileSync(RADIO_SCSS_PATH, 'utf8');
     const fallbackMatch = /--tn-error-text,\s*(#[0-9a-fA-F]{3,6})\)/.exec(scss);
     expect(fallbackMatch).not.toBeNull();
     const fallback = fallbackMatch![1];
-    const darkSurface = '#1E1E1E'; // this theme's --tn-bg1, representative of the dark surfaces
-    const ratio = contrastRatio(fallback, darkSurface);
+
+    // :root carries the same values as the default theme (.tn-dark) before any
+    // theme class is applied — the surface a missing stylesheet actually renders on.
+    const rootBody = themeBlocks.get(':root');
+    expect(rootBody).toBeDefined();
+    const rootBg1 = extractVar(rootBody!, '--tn-bg1');
+    const rootErrorText = resolveColor(extractVar(rootBody!, '--tn-error-text')!, rootBody!);
+    expect(fallback.toLowerCase()).toBe(rootErrorText?.toLowerCase());
+
+    const ratio = contrastRatio(fallback, rootBg1!);
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -135,17 +135,19 @@ describe('tn-radio error text contrast (#186)', () => {
     }
   );
 
-  it('the SCSS fallback is accessible on the surface a missing stylesheet actually renders on', () => {
+  it('the SCSS fallback chains through --tn-red before a literal, and the literal is accessible where it is actually reachable', () => {
     const scss = readFileSync(RADIO_SCSS_PATH, 'utf8');
-    const fallbackMatch = /--tn-error-text,\s*(#[0-9a-fA-F]{3,6})\)/.exec(scss);
-    expect(fallbackMatch).not.toBeNull();
-    const fallback = fallbackMatch![1];
+    // A theme that predates --tn-error-text may still define --tn-red, so the
+    // chain must try that before a hardcoded literal — otherwise a theme
+    // author's own tuning is silently discarded.
+    const chainMatch = /--tn-error-text,\s*var\(--tn-red,\s*(#[0-9a-fA-F]{3,6})\)\)/.exec(scss);
+    expect(chainMatch).not.toBeNull();
+    const literal = chainMatch![1];
 
-    // The var() fallback only takes effect when --tn-error-text is undefined,
-    // i.e. no theme stylesheet loaded at all — so :root's own tokens (defined
-    // in that same stylesheet) are never actually reachable here. The surface
-    // that IS reachable is the browser's UA default: white.
-    const ratio = contrastRatio(fallback, '#ffffff');
+    // The literal is reached only when neither --tn-error-text nor --tn-red
+    // is defined, i.e. no theme stylesheet loaded at all — the surface that
+    // IS reachable there is the browser's UA default: white.
+    const ratio = contrastRatio(literal, '#ffffff');
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -135,21 +135,17 @@ describe('tn-radio error text contrast (#186)', () => {
     }
   );
 
-  it('the SCSS fallback matches the default theme and is accessible on it', () => {
+  it('the SCSS fallback is accessible on the surface a missing stylesheet actually renders on', () => {
     const scss = readFileSync(RADIO_SCSS_PATH, 'utf8');
     const fallbackMatch = /--tn-error-text,\s*(#[0-9a-fA-F]{3,6})\)/.exec(scss);
     expect(fallbackMatch).not.toBeNull();
     const fallback = fallbackMatch![1];
 
-    // :root carries the same values as the default theme (.tn-dark) before any
-    // theme class is applied — the surface a missing stylesheet actually renders on.
-    const rootBody = themeBlocks.get(':root');
-    expect(rootBody).toBeDefined();
-    const rootBg1 = extractVar(rootBody!, '--tn-bg1');
-    const rootErrorText = resolveColor(extractVar(rootBody!, '--tn-error-text')!, rootBody!);
-    expect(fallback.toLowerCase()).toBe(rootErrorText?.toLowerCase());
-
-    const ratio = contrastRatio(fallback, rootBg1!);
+    // The var() fallback only takes effect when --tn-error-text is undefined,
+    // i.e. no theme stylesheet loaded at all — so :root's own tokens (defined
+    // in that same stylesheet) are never actually reachable here. The surface
+    // that IS reachable is the browser's UA default: white.
+    const ratio = contrastRatio(fallback, '#ffffff');
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -142,8 +142,9 @@ describe('tn-radio error text contrast (#186)', () => {
     // before a hardcoded literal — otherwise that stylesheet's own tuning is
     // silently discarded. This does not help a theme added within this
     // repo's own themes.css: :root already declares --tn-error-text there,
-    // and wins the cascade regardless of what the new theme's own class
-    // declares, so such a theme must set --tn-error-text itself.
+    // and a theme class that omits the property has nothing to compete with
+    // that declaration, so such a theme must set --tn-error-text itself
+    // rather than relying on the fallback.
     const chainMatch = /--tn-error-text,\s*var\(--tn-red,\s*(#[0-9a-fA-F]{3,6})\)\)/.exec(scss);
     expect(chainMatch).not.toBeNull();
     const literal = chainMatch![1];

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -80,9 +80,14 @@
     margin-top: 0.25rem;
     font-size: 12px;
     // --tn-red is tuned for the 3:1 border/icon minimum (WCAG 1.4.11), not the
-    // 4.5:1 text minimum (WCAG 1.4.3) this line needs. The fallback is itself
-    // accessible on a dark surface (~6:1 against a #1E1E1E-class background).
-    color: var(--tn-error-text, #ff6b6b);
+    // 4.5:1 text minimum (WCAG 1.4.3) this line needs. The fallback is the
+    // default theme's own --tn-error-text value, so a missing stylesheet
+    // renders the same red the default theme would give — 5.17:1 against a
+    // #1E1E1E-class dark surface. No single color can also clear 4.5:1 against
+    // an ancestor's own white fallback (e.g. tn-card's `var(--tn-bg2, #ffffff)`)
+    // at the same time — that pair of thresholds is mutually unsatisfiable —
+    // so this optimizes for the surface the library actually defaults to.
+    color: var(--tn-error-text, #de6d6d);
   }
   
   // States

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,15 +79,16 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    // --tn-red is tuned for the 3:1 border/icon minimum (WCAG 1.4.11), not the
-    // 4.5:1 text minimum (WCAG 1.4.3) this line needs. The fallback is the
-    // default theme's own --tn-error-text value, so a missing stylesheet
-    // renders the same red the default theme would give — 5.17:1 against a
-    // #1E1E1E-class dark surface. No single color can also clear 4.5:1 against
-    // an ancestor's own white fallback (e.g. tn-card's `var(--tn-bg2, #ffffff)`)
-    // at the same time — that pair of thresholds is mutually unsatisfiable —
-    // so this optimizes for the surface the library actually defaults to.
-    color: var(--tn-error-text, #de6d6d);
+    // --tn-red is tuned toward the 3:1 border/icon minimum (WCAG 1.4.11) in
+    // most themes but not all — themes.css:365 documents .tn-high-contrast at
+    // 2.94:1, a pre-existing gap this ticket doesn't touch. Either way it
+    // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
+    // is why a separate token exists. The var() fallback only takes effect
+    // when no theme stylesheet loads at all, so the only background it can
+    // reach is the UA default (white) — #1E1E1E is itself defined in the
+    // stylesheet the fallback assumes is missing. #b91c1c clears 4.5:1 there
+    // (6.47:1).
+    color: var(--tn-error-text, #b91c1c);
   }
   
   // States

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -84,10 +84,15 @@
     // 2.94:1, a pre-existing gap this ticket doesn't touch. Either way it
     // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
     // is why a separate token exists. The var() fallback only takes effect
-    // when no theme stylesheet loads at all, so the only background it can
-    // reach is the UA default (white) — #1E1E1E is itself defined in the
-    // stylesheet the fallback assumes is missing. #b91c1c clears 4.5:1 there
-    // (6.47:1).
+    // when --tn-error-text itself is undefined. Every theme this library
+    // ships defines --tn-bg1 and --tn-error-text together (see copy-themes,
+    // which keeps every generated copy of themes.css in lockstep), so the
+    // fallback's one real trigger is themes.css never loading at all — the
+    // UA default, white. #b91c1c clears 4.5:1 there (6.47:1). No single
+    // color also clears 4.5:1 against an arbitrary dark surface (that pair
+    // of thresholds is mutually unsatisfiable), so a third-party theme that
+    // defines --tn-bg1 without adopting this token is a residual risk this
+    // fallback can't also cover.
     color: var(--tn-error-text, #b91c1c);
   }
   

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,7 +79,10 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    color: var(--tn-red, #dc3545);
+    // --tn-red is tuned for the 3:1 border/icon minimum (WCAG 1.4.11), not the
+    // 4.5:1 text minimum (WCAG 1.4.3) this line needs. The fallback is itself
+    // accessible on a dark surface (~6:1 against a #1E1E1E-class background).
+    color: var(--tn-error-text, #ff6b6b);
   }
   
   // States

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -83,15 +83,22 @@
     // most themes but not all — themes.css:365 documents .tn-high-contrast at
     // 2.94:1, a pre-existing gap this ticket doesn't touch. Either way it
     // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
-    // is why a separate token exists. A theme that predates --tn-error-text
-    // still defines --tn-red — it's used throughout this library — so the
-    // fallback chain tries that before a hardcoded literal, rather than
-    // discarding a theme author's own tuning. Only a stylesheet that defines
-    // neither token reaches the literal, and that means no theme loaded at
-    // all — the UA default, white. #b91c1c clears 4.5:1 there (6.47:1); no
-    // single color also clears 4.5:1 against an arbitrary dark surface (that
-    // pair of thresholds is mutually unsatisfiable), so this only optimizes
-    // for the surface actually reachable at that point in the chain.
+    // is why a separate token exists. The --tn-red middle link is NOT reached
+    // by a theme added to this file: :root already declares --tn-error-text,
+    // and that declaration wins the cascade for any element that also
+    // matches :root — which every theme class here does, since themes are
+    // applied as a class on the root element — regardless of whether the new
+    // theme's own class declares --tn-error-text. A theme added here must set
+    // --tn-error-text itself; it cannot rely on this fallback. The middle
+    // link exists for a consumer whose entire stylesheet predates this token
+    // — one that defines neither --tn-error-text nor the :root rule that
+    // declares it — where it preserves that stylesheet's own --tn-red rather
+    // than jumping straight to the literal. Only a stylesheet that defines
+    // neither token reaches the literal, meaning no theme loaded at all — the
+    // UA default, white. #b91c1c clears 4.5:1 there (6.47:1); no single color
+    // also clears 4.5:1 against an arbitrary dark surface (that pair of
+    // thresholds is mutually unsatisfiable), so this only optimizes for the
+    // surface actually reachable at that point in the chain.
     color: var(--tn-error-text, var(--tn-red, #b91c1c));
   }
   

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -80,27 +80,28 @@
     margin-top: 0.25rem;
     font-size: 12px;
     // --tn-red is tuned toward the 3:1 border/icon minimum (WCAG 1.4.11) in
-    // most themes but not all — themes.css:365 documents .tn-high-contrast at
-    // 2.94:1, a pre-existing gap this ticket doesn't touch. Either way it
-    // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
-    // is why a separate token exists. The --tn-red middle link is NOT reached
-    // by a theme added to this file: :root already declares --tn-error-text,
-    // and a theme class is applied to the same root element (themes are
-    // applied as a class on document.documentElement) with the same
-    // specificity as :root, so a theme class that itself declares
-    // --tn-error-text wins by source order — but a theme class that omits
-    // the property declares nothing to compete with :root, so :root's
-    // declaration is what applies. A theme added here must set
-    // --tn-error-text itself; it cannot rely on this fallback. The middle
-    // link exists for a consumer whose entire stylesheet predates this token
-    // — one that defines neither --tn-error-text nor the :root rule that
-    // declares it — where it preserves that stylesheet's own --tn-red rather
-    // than jumping straight to the literal. Only a stylesheet that defines
-    // neither token reaches the literal, meaning no theme loaded at all — the
-    // UA default, white. #b91c1c clears 4.5:1 there (6.47:1); no single color
-    // also clears 4.5:1 against an arbitrary dark surface (that pair of
-    // thresholds is mutually unsatisfiable), so this only optimizes for the
-    // surface actually reachable at that point in the chain.
+    // most themes but not all — themes.css's .tn-high-contrast block
+    // documents it at 2.94:1, a pre-existing gap this ticket doesn't touch.
+    // Either way it doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this
+    // line needs, which is why a separate token exists. The --tn-red middle
+    // link is NOT reached by a theme added to this file: :root already
+    // declares --tn-error-text, and a theme class is applied to the same
+    // root element (themes are applied as a class on
+    // document.documentElement) with the same specificity as :root, so a
+    // theme class that itself declares --tn-error-text wins by source order
+    // — but a theme class that omits the property declares nothing to
+    // compete with :root, so :root's declaration is what applies. A theme
+    // added here must set --tn-error-text itself; it cannot rely on this
+    // fallback. The middle link exists for a consumer whose entire
+    // stylesheet predates this token — one that defines neither
+    // --tn-error-text nor the :root rule that declares it — where it
+    // preserves that stylesheet's own --tn-red rather than jumping straight
+    // to the literal. Only a stylesheet that defines neither token reaches
+    // the literal, meaning no theme loaded at all — the UA default, white.
+    // #b91c1c clears 4.5:1 there (6.47:1); no single color also clears
+    // 4.5:1 against an arbitrary dark surface (that pair of thresholds is
+    // mutually unsatisfiable), so this only optimizes for the surface
+    // actually reachable at that point in the chain.
     color: var(--tn-error-text, var(--tn-red, #b91c1c));
   }
   

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -79,29 +79,16 @@
   &__error {
     margin-top: 0.25rem;
     font-size: 12px;
-    // --tn-red is tuned toward the 3:1 border/icon minimum (WCAG 1.4.11) in
-    // most themes but not all — themes.css's .tn-high-contrast block
-    // documents it at 2.94:1, a pre-existing gap this ticket doesn't touch.
-    // Either way it doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this
-    // line needs, which is why a separate token exists. The --tn-red middle
-    // link is NOT reached by a theme added to this file: :root already
-    // declares --tn-error-text, and a theme class is applied to the same
-    // root element (themes are applied as a class on
-    // document.documentElement) with the same specificity as :root, so a
-    // theme class that itself declares --tn-error-text wins by source order
-    // — but a theme class that omits the property declares nothing to
-    // compete with :root, so :root's declaration is what applies. A theme
-    // added here must set --tn-error-text itself; it cannot rely on this
-    // fallback. The middle link exists for a consumer whose entire
-    // stylesheet predates this token — one that defines neither
-    // --tn-error-text nor the :root rule that declares it — where it
-    // preserves that stylesheet's own --tn-red rather than jumping straight
-    // to the literal. Only a stylesheet that defines neither token reaches
-    // the literal, meaning no theme loaded at all — the UA default, white.
-    // #b91c1c clears 4.5:1 there (6.47:1); no single color also clears
-    // 4.5:1 against an arbitrary dark surface (that pair of thresholds is
-    // mutually unsatisfiable), so this only optimizes for the surface
-    // actually reachable at that point in the chain.
+    // Text needs 4.5:1 (WCAG 1.4.3). --tn-red is tuned toward the 3:1
+    // border/icon minimum (WCAG 1.4.11) — themes.css's .tn-high-contrast
+    // block documents even that at 2.94:1, a pre-existing gap this ticket
+    // does not touch — and it falls short of 4.5:1 in seven of the nine
+    // themes, so error text reads --tn-error-text instead. A theme must
+    // declare that token itself: :root always does, so a theme omitting it
+    // inherits the default red rather than reaching the --tn-red arm below.
+    // See theming.mdx for the cascade reasoning. That arm is for a consumer
+    // stylesheet predating the token entirely; the literal only for no theme
+    // stylesheet at all (UA white, where #b91c1c measures 6.47:1).
     color: var(--tn-error-text, var(--tn-red, #b91c1c));
   }
   

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -85,10 +85,12 @@
     // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
     // is why a separate token exists. The --tn-red middle link is NOT reached
     // by a theme added to this file: :root already declares --tn-error-text,
-    // and that declaration wins the cascade for any element that also
-    // matches :root — which every theme class here does, since themes are
-    // applied as a class on the root element — regardless of whether the new
-    // theme's own class declares --tn-error-text. A theme added here must set
+    // and a theme class is applied to the same root element (themes are
+    // applied as a class on document.documentElement) with the same
+    // specificity as :root, so a theme class that itself declares
+    // --tn-error-text wins by source order — but a theme class that omits
+    // the property declares nothing to compete with :root, so :root's
+    // declaration is what applies. A theme added here must set
     // --tn-error-text itself; it cannot rely on this fallback. The middle
     // link exists for a consumer whose entire stylesheet predates this token
     // — one that defines neither --tn-error-text nor the :root rule that

--- a/projects/truenas-ui/src/lib/radio/radio.component.scss
+++ b/projects/truenas-ui/src/lib/radio/radio.component.scss
@@ -83,17 +83,16 @@
     // most themes but not all — themes.css:365 documents .tn-high-contrast at
     // 2.94:1, a pre-existing gap this ticket doesn't touch. Either way it
     // doesn't meet the 4.5:1 text minimum (WCAG 1.4.3) this line needs, which
-    // is why a separate token exists. The var() fallback only takes effect
-    // when --tn-error-text itself is undefined. Every theme this library
-    // ships defines --tn-bg1 and --tn-error-text together (see copy-themes,
-    // which keeps every generated copy of themes.css in lockstep), so the
-    // fallback's one real trigger is themes.css never loading at all — the
-    // UA default, white. #b91c1c clears 4.5:1 there (6.47:1). No single
-    // color also clears 4.5:1 against an arbitrary dark surface (that pair
-    // of thresholds is mutually unsatisfiable), so a third-party theme that
-    // defines --tn-bg1 without adopting this token is a residual risk this
-    // fallback can't also cover.
-    color: var(--tn-error-text, #b91c1c);
+    // is why a separate token exists. A theme that predates --tn-error-text
+    // still defines --tn-red — it's used throughout this library — so the
+    // fallback chain tries that before a hardcoded literal, rather than
+    // discarding a theme author's own tuning. Only a stylesheet that defines
+    // neither token reaches the literal, and that means no theme loaded at
+    // all — the UA default, white. #b91c1c clears 4.5:1 there (6.47:1); no
+    // single color also clears 4.5:1 against an arbitrary dark surface (that
+    // pair of thresholds is mutually unsatisfiable), so this only optimizes
+    // for the surface actually reachable at that point in the chain.
+    color: var(--tn-error-text, var(--tn-red, #b91c1c));
   }
   
   // States

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -162,7 +162,7 @@ Status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), n
 
 - `--tn-error-text`: Error/validation text, 4.5:1 against `--tn-bg1` and `--tn-bg2` in every theme
 
-A custom theme that omits `--tn-error-text` falls back to `--tn-red`, which is not guaranteed to clear 4.5:1 for text.
+A custom theme must define `--tn-error-text` explicitly — omitting it does not fall back to that theme's own `--tn-red`. `:root` always defines `--tn-error-text` (see below), and that declaration wins the cascade for any element that also matches `:root`, which every theme class here does. The error text then silently renders in the default theme's color instead, which is not guaranteed to be accessible against the new theme's palette.
 
 ---
 

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -158,7 +158,7 @@ Each theme defines the following CSS custom properties:
 - `--tn-orange`: Secondary warning
 - `--tn-cyan`: Info accent
 
-Status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), not the 4.5:1 text minimum (WCAG 1.4.3). For text — validation messages, inline errors — use the text-safe counterpart instead:
+Status colors are tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and none are tuned for the 4.5:1 text minimum (WCAG 1.4.3). For text — validation messages, inline errors — use the text-safe counterpart instead:
 
 - `--tn-error-text`: Error/validation text, 4.5:1 against `--tn-bg1` and `--tn-bg2` in every theme
 

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -158,6 +158,12 @@ Each theme defines the following CSS custom properties:
 - `--tn-orange`: Secondary warning
 - `--tn-cyan`: Info accent
 
+Status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), not the 4.5:1 text minimum (WCAG 1.4.3). For text — validation messages, inline errors — use the text-safe counterpart instead:
+
+- `--tn-error-text`: Error/validation text, 4.5:1 against `--tn-bg1` and `--tn-bg2` in every theme
+
+A custom theme that omits `--tn-error-text` falls back to `--tn-red`, which is not guaranteed to clear 4.5:1 for text.
+
 ---
 
 ## Theme Definitions

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -162,7 +162,7 @@ Status colors are tuned for the 3:1 UI-component/border minimum (WCAG 1.4.11), n
 
 - `--tn-error-text`: Error/validation text, 4.5:1 against `--tn-bg1` and `--tn-bg2` in every theme
 
-A custom theme must define `--tn-error-text` explicitly — omitting it does not fall back to that theme's own `--tn-red`. `:root` always defines `--tn-error-text` (see below), and that declaration wins the cascade for any element that also matches `:root`, which every theme class here does. The error text then silently renders in the default theme's color instead, which is not guaranteed to be accessible against the new theme's palette.
+A custom theme must define `--tn-error-text` explicitly — omitting it does not fall back to that theme's own `--tn-red`. `:root` always defines `--tn-error-text` (see below). A theme class is applied to the same root element and has the same specificity as `:root`, so a theme class that itself declares `--tn-error-text` would win by source order — but a theme class that omits the property declares nothing to compete with `:root` at all, so `:root`'s value is what applies. The error text then silently renders in the default theme's color instead, which is not guaranteed to be accessible against the new theme's palette.
 
 ---
 

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -158,7 +158,7 @@ Each theme defines the following CSS custom properties:
 - `--tn-orange`: Secondary warning
 - `--tn-cyan`: Info accent
 
-Status colors are tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and none are tuned for the 4.5:1 text minimum (WCAG 1.4.3). For text — validation messages, inline errors — use the text-safe counterpart instead:
+`--tn-red` is tuned toward the 3:1 UI-component/border minimum (WCAG 1.4.11) in most themes but not all — `.tn-high-contrast`'s `--tn-red` measures 2.94:1 against `--tn-bg1` — and it is not tuned for the 4.5:1 text minimum (WCAG 1.4.3). The other status colors are not tuned toward either threshold. For text — validation messages, inline errors — use the text-safe counterpart instead:
 
 - `--tn-error-text`: Error/validation text, 4.5:1 against `--tn-bg1` and `--tn-bg2` in every theme
 

--- a/projects/truenas-ui/src/stories/color-palette.stories.ts
+++ b/projects/truenas-ui/src/stories/color-palette.stories.ts
@@ -21,6 +21,7 @@ const fgVars = ['--tn-fg1', '--tn-fg2', '--tn-fg3', '--tn-fg4', '--tn-alt-fg1', 
 const bgVars = ['--tn-bg1', '--tn-bg2', '--tn-bg3', '--tn-alt-bg1', '--tn-alt-bg2'];
 const uiVars = ['--tn-primary', '--tn-primary-txt', '--tn-accent', '--tn-topbar', '--tn-topbar-txt', '--tn-lines'];
 const statusVars = ['--tn-red', '--tn-green', '--tn-yellow', '--tn-orange', '--tn-blue', '--tn-cyan', '--tn-magenta', '--tn-violet'];
+const statusTextVars = ['--tn-error-text'];
 
 function swatchRow(varName: string, type: 'bg' | 'fg'): string {
   if (type === 'bg') {
@@ -103,7 +104,11 @@ export const UIColors: Story = {
 
 export const StatusColors: Story = {
   render: () => ({
-    template: section('Status Colors', statusVars, 'bg'),
+    // --tn-error-text is only guaranteed as a text color against --tn-bg1/--tn-bg2
+    // (see component_styling.md), not as the 3:1 border/component color the other
+    // status vars are for — rendered as a text swatch rather than a bg swatch so
+    // the story doesn't imply it's interchangeable with them.
+    template: section('Status Colors', statusVars, 'bg') + section('Status Text Colors', statusTextVars, 'fg'),
   }),
 };
 

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -24,6 +24,8 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 3.15:1, tuned for the 3:1 border/icon minimum. */
+  --tn-error-text: #db6161;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -83,6 +85,8 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 3.15:1. */
+  --tn-error-text: #db6161;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -119,6 +123,8 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
+  /* --tn-red already clears 4.5:1 against --tn-bg1 here (measured 4.72:1). */
+  --tn-error-text: var(--tn-red);
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -156,6 +162,8 @@
   --tn-yellow: #f1fa8c;
   --tn-orange: #ffb86c;
   --tn-red: #ff5555;
+  /* --tn-red already clears 4.5:1 against --tn-bg1 here (measured 5.50:1). */
+  --tn-error-text: var(--tn-red);
   --tn-magenta: #ff79c6;
   --tn-violet: #bd93f9;
   --tn-blue: #6272a4;
@@ -193,6 +201,8 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
+  /* 4.5:1 against --tn-bg1 (measured 4.60:1); --tn-red itself is only 3.05:1. */
+  --tn-error-text: #d08a91;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -229,6 +239,8 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* 4.5:1 against --tn-bg1 (measured 4.67:1); --tn-red itself is only 3.57:1. */
+  --tn-error-text: #db0010;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #0D5687;
@@ -268,6 +280,8 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
+  /* 4.5:1 against --tn-bg1 (measured 4.62:1); --tn-red itself is only 3.25:1. */
+  --tn-error-text: #e56765;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -306,6 +320,8 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* 4.5:1 against --tn-bg1 (measured 4.58:1); --tn-red itself is only 3.64:1. */
+  --tn-error-text: #ff525f;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;
@@ -341,6 +357,8 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
+  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 2.94:1 — the worst of the nine. */
+  --tn-error-text: #c2000e;
   --tn-magenta: #d238ff;
   --tn-violet: #9844b1;
   --tn-blue: #4784ac;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -24,8 +24,9 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 3.15:1, tuned for the 3:1 border/icon minimum. */
-  --tn-error-text: #db6161;
+  /* >=4.5:1 against both --tn-bg1 (5.17:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.15:1 on --tn-bg1, tuned for the 3:1 border/icon minimum. */
+  --tn-error-text: #de6d6d;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -85,8 +86,9 @@
   --tn-yellow: #DED142;
   --tn-orange: #E68D37;
   --tn-red: #CE2929;
-  /* 4.5:1 against --tn-bg1 (measured 4.68:1); --tn-red itself is only 3.15:1. */
-  --tn-error-text: #db6161;
+  /* >=4.5:1 against both --tn-bg1 (5.17:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.15:1 on --tn-bg1. */
+  --tn-error-text: #de6d6d;
   --tn-magenta: #C006C7;
   --tn-violet: #7617D8;
   --tn-blue: #007db3;
@@ -201,8 +203,9 @@
   --tn-yellow: #ebcb8b;
   --tn-orange: #d08770;
   --tn-red: #bf616a;
-  /* 4.5:1 against --tn-bg1 (measured 4.60:1); --tn-red itself is only 3.05:1. */
-  --tn-error-text: #d08a91;
+  /* >=4.5:1 against both --tn-bg1 (5.67:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.05:1 on --tn-bg1. */
+  --tn-error-text: #d9a0a6;
   --tn-magenta: #b48ead;
   --tn-violet: #775daa;
   --tn-blue: #5e81aC;
@@ -280,8 +283,9 @@
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
   --tn-red: #dc322f;
-  /* 4.5:1 against --tn-bg1 (measured 4.62:1); --tn-red itself is only 3.25:1. */
-  --tn-error-text: #e56765;
+  /* >=4.5:1 against both --tn-bg1 (5.28:1) and --tn-bg2 (4.57:1); --tn-red itself
+     is only 3.25:1 on --tn-bg1. */
+  --tn-error-text: #e87876;
   --tn-magenta: #d33682;
   --tn-violet: #6c71c4;
   --tn-blue: #268bd2;
@@ -320,8 +324,9 @@
   --tn-yellow: #f0cb00;
   --tn-orange: #ee9302;
   --tn-red: #ff0013;
-  /* 4.5:1 against --tn-bg1 (measured 4.58:1); --tn-red itself is only 3.64:1. */
-  --tn-error-text: #ff525f;
+  /* >=4.5:1 against both --tn-bg1 (6.01:1) and --tn-bg2 (4.61:1); --tn-red itself
+     is only 3.64:1 on --tn-bg1. */
+  --tn-error-text: #ff8089;
   --tn-magenta: #d238ff;
   --tn-violet: #c17ecc;
   --tn-blue: #1274b5;


### PR DESCRIPTION
Fixes #186.

## What

`.tn-radio__error` was colored with `--tn-red`, which is tuned for the 3:1 border/icon minimum (WCAG 1.4.11), not the 4.5:1 text minimum (WCAG 1.4.3) that applies to 12px error text. Added `--tn-error-text`, a theme-aware token, and pointed the error text at it. `--tn-red` itself is untouched — its border/icon uses (3:1) are correct as-is.

## Measured numbers

`--tn-error-text` against both `--tn-bg1` (page canvas) and `--tn-bg2` (cards/panels — tn-radio renders on both), per theme:

| theme | value | on `--tn-bg1` | on `--tn-bg2` |
|---|---|---|---|
| `:root` / `.tn-dark` | `#de6d6d` | 5.17 | 4.57 |
| `.tn-blue` | `#CE2929` (= `--tn-red`) | 4.72 | 5.28 |
| `.tn-dracula` | `#ff5555` (= `--tn-red`) | 5.50 | 4.53 |
| `.tn-nord` | `#d9a0a6` | 5.67 | 4.57 |
| `.tn-paper` | `#db0010` | 4.67 | 5.01 |
| `.tn-solarized-dark` | `#e87876` | 5.28 | 4.57 |
| `.tn-midnight` | `#ff8089` | 6.01 | 4.61 |
| `.tn-high-contrast` | `#c2000e` | 4.68 | 6.36 |

All nine surfaces clear 4.5:1. `.tn-blue` and `.tn-dracula` alias to `--tn-red` since it already clears 4.5:1 there; the other seven pin a lighter/darker literal. These numbers are asserted (not just reported) by `radio-error-contrast.spec.ts`, which computes them from the actual shipped `themes.css` values rather than duplicating hardcoded expectations.

`--tn-red` itself is not uniformly 3:1 either — `.tn-high-contrast` measures 2.94:1 on `--tn-bg1`, a pre-existing gap this ticket doesn't touch (it's a border/icon token, not the one being fixed here). And it is not uniformly *below* 4.5:1: in `.tn-blue` (4.72:1) and `.tn-dracula` (5.50:1) it already clears the text minimum, which is exactly why those two themes alias to it rather than pinning a new literal.

## The SCSS fallback

The fallback chain is `var(--tn-error-text, var(--tn-red, #b91c1c))`: try the theme's own text-safe token first, then `--tn-red` (so a theme that predates `--tn-error-text` but still defines `--tn-red` keeps its own tuning instead of being overridden), and only fall to the literal `#b91c1c` when neither is defined — i.e. no theme stylesheet loaded at all, which means the surface actually reachable at that point is the browser's UA default, white. `#b91c1c` clears 4.5:1 there (6.47:1).

**This literal is tuned for white, not for a dark surface** — an earlier version of this section (and the acceptance criteria below) said otherwise, from a round where the fallback was a plain `#de6d6d` and the chain link through `--tn-red` didn't exist yet. That's now corrected: no single color can clear 4.5:1 against white *and* an arbitrary dark surface simultaneously (the luminance window for white is `L <= 0.183`, for a `#1E1E1E`-class dark surface `L >= 0.227` — they don't overlap), and the literal only fires on the no-stylesheet-at-all path, where white is what's actually reachable.

**Why a theme must set `--tn-error-text` itself, and can't rely on `:root` or the fallback chain**: a theme class is applied to `document.documentElement` — the same element `:root` matches — and has the same specificity as `:root`. So a theme class that itself declares `--tn-error-text` wins by source order. But a theme class that *omits* the property declares nothing to compete with `:root` at all, so `:root`'s declaration is what applies instead — silently rendering the default theme's color, which isn't guaranteed accessible against the new theme's palette. (An earlier round's comments described this as `:root` "winning the cascade" regardless of what the theme class declares, which is wrong; see the round log below for when that was corrected.)

**One thing this can't fix**: if a *different* ancestor's own SCSS fallback is also active at the same time — e.g. `tn-card`'s `var(--tn-bg2, #ffffff)` — the same non-overlap applies and no single fallback color can satisfy both. Fully solving the "two independent, uncoordinated component fallbacks fire at once" case would mean coordinating fallback defaults across every component in the library, which is out of scope for a single-component ticket.

## Other things this surfaced (not fixed here — out of scope per the ticket)

- `checkbox.component.scss:106` and `stepper.component.scss:173` share the identical `var(--tn-red, ...)` error-text pattern, as the ticket already anticipated. Local review also flagged `file-picker-popup.component.scss:313` doing the same, which the ticket didn't name. All three are candidates for the same `--tn-error-text` treatment in a follow-up.
- `--tn-error-text` isn't yet listed in the `color-palette` Storybook story alongside the other status colors. (It has been added to `theming.mdx`'s Status Colors reference, which is the doc a theme author works from; the Storybook story is a smaller, separate gap.)
- `--tn-error-text` is only guaranteed against `--tn-bg1`/`--tn-bg2`; on `--tn-bg3` surfaces (table active row, tree node, file-picker popup) the default theme measures ≈3.92:1 — flagged by local review, not fixed here.
- `radio-error-contrast.spec.ts` lives under `lib/radio` but asserts a repo-wide `themes.css` invariant; a contributor adding a theme is more likely to look elsewhere.
- A pre-existing `--tn-error` token is read by several other components for error text and is defined by no theme, so those call sites stay un-themed. Flagged by local review this round; converging the two names is a follow-up, not this ticket.

## Acceptance criteria

- [x] `tn-radio`'s error text measures ≥4.5:1 against the background it renders on, in every theme (both `--tn-bg1` and `--tn-bg2`) — see table above, verified by test.
- [x] The SCSS fallback is itself accessible on the surface it's actually reachable on — no theme stylesheet loaded, i.e. the browser's UA default, white (6.47:1). See caveat above re: colliding with a differently-defaulted ancestor's own fallback.
- [ ] No axe `color-contrast` violation on the radio error-state story — **not literally satisfied**. No axe/Storybook-a11y CI wiring exists in this repo yet (`@storybook/addon-a11y` is registered but there's no `.storybook/test-runner.ts` hook running it in CI), and jsdom has no layout engine, so a `jest-axe` check here would only ever report "incomplete," not a real pass — it wouldn't actually verify anything. Instead, `radio-error-contrast.spec.ts` computes the real WCAG ratio from the shipped `themes.css` values per theme (table above), which is a stronger, honest guarantee than a check that can't meaningfully run. Wiring real axe/Storybook CI integration is a separate, larger piece of work I'd propose separately rather than fold into this ticket.
- [x] `yarn lint`, `yarn test` (2185 tests), `yarn test:scripts` (42 tests) and `yarn build` are green locally.

`test-storybook` (Storybook Interaction Tests) needs a served build and wasn't run locally.

## Round log

- **Round with commit `dc6e9ec`**: re-tuned the SCSS fallback to chain through `--tn-red` before the literal, and retargeted the literal at the surface it actually reaches (white) rather than a dark surface it doesn't. This section and the acceptance criteria above were rewritten to match; the earlier claim of "5.17:1 against a dark surface" described a fallback value (`#de6d6d`) this branch no longer ships.
- **Round with commit `146be9c`**: added `--tn-error-text` to `theming.mdx`'s Status Colors reference (it was only in the agent-facing `component_styling.md`), and corrected the SCSS-fallback section and acceptance-criteria checkbox above, which still described the pre-`dc6e9ec` fallback value after the code had moved on.
- **Round with commit `0c95331`**: review found the cascade explanation in `radio.component.scss`, `theming.mdx` and `radio-error-contrast.spec.ts` claimed `:root` "wins the cascade for any element that also matches `:root`" regardless of what the theme class declares — that's wrong, since `:root` and a theme class applied to the same root element have equal specificity, so a theme class that itself declares the property would win by source order. Corrected the wording in all three places; the conclusion (a theme must set `--tn-error-text` itself) is unchanged.
- **Round with commit `03f41a2`**: review flagged (MEDIUM) that `radio-error-contrast.spec.ts`'s `expect(themeBlocks.size).toBe(9)` was a hardcoded count decoupled from what `extractThemeBlocks` actually finds — a themed surface whose `--tn-bg1` isn't a hex literal (e.g. `rgb()`) is silently dropped from the map, so a fixed expected count could stay coincidentally correct while that surface's error text goes unmeasured. Derived the expected surfaces from `TN_THEME_DEFINITIONS` plus `:root` instead, and assert each registered selector was actually found, so a dropped or missing surface now fails by name.
- **This round (commit `ab79dad`)**: review flagged (MEDIUM) that the error-text comment in `radio.component.scss` asserted `--tn-red` "doesn't meet the 4.5:1 text minimum" without qualification — false for `.tn-blue` (4.72:1) and `.tn-dracula` (5.50:1), the two themes that alias to it for exactly that reason. Re-measured both from the shipped hex values and confirmed the review. Rather than re-hedge a third copy of the same argument, the comment was trimmed from 23 lines to 10: it now carries the operative rule (use `--tn-error-text`; a theme must declare it) and points at `theming.mdx` for the cascade derivation. That derivation still lives in two places — `theming.mdx`, the doc a theme author reads, and the spec, next to the assertion that keeps it honest — which is what the earlier "three copies to keep in sync" note in the section above referred to; the stylesheet copy is the one that kept drifting, and it is now a pointer. No MEDIUM+ findings remain; the LOW findings above are pre-existing and out of scope.
