### PR TITLE
NAS-142297 / 27.0.0-BETA.1 / fix(chip): stop nesting the close button inside a focusable chip wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@typescript-eslint/parser": "^8.51.0",
     "@typescript-eslint/types": "^8.51.0",
     "@typescript-eslint/utils": "^8.51.0",
+    "axe-core": "4.10.3",
     "browserslist": "^4.28.1",
     "caniuse-lite": "^1.0.30001764",
     "concurrently": "^10.0.4",

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -381,8 +381,8 @@ describe('TnChipInputComponent test ids', () => {
 
     expect(getInput(fixture).getAttribute('data-testid')).toBe('chip-input-isns-servers');
 
-    // tn-chip stamps the id on its inner button element, not the host.
-    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    // tn-chip stamps the id on its inner `.tn-chip` wrapper, not the host.
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip .tn-chip');
     expect(chip?.getAttribute('data-testid')).toBe('chip-isns-servers-alpha');
 
     // Suggestions are portaled into a CDK overlay on the document root.
@@ -413,7 +413,7 @@ describe('TnChipInputComponent test ids', () => {
     const fixture = TestBed.createComponent(ObjectValueTestIdHostComponent);
     fixture.detectChanges();
 
-    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip .tn-chip');
     expect(chip?.getAttribute('data-testid')).toBe('chip-groups-admins');
   });
   // `*` and `**` both normalize to nothing, so scoping them under the base composes
@@ -428,7 +428,7 @@ describe('TnChipInputComponent test ids', () => {
     fixture.detectChanges();
 
     const chips = Array.from(
-      fixture.nativeElement.querySelectorAll('.tn-chip-input__chip [role="button"]'),
+      fixture.nativeElement.querySelectorAll('.tn-chip-input__chip .tn-chip'),
     ) as HTMLElement[];
     expect(chips.map((chip) => chip.getAttribute('data-testid')))
       .toEqual([null, null, 'chip-hosts-allow-alpha']);

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -106,6 +106,31 @@ describe('tn-chip accessibility (#188)', () => {
       expect(root().getAttribute('role')).toBeNull();
       expect(root().hasAttribute('tabindex')).toBe(false);
     });
+
+    /**
+     * Positive control. Every assertion above is `toEqual([])`, which is also
+     * what axe returns when it evaluates nothing at all — a renamed rule, an
+     * axe upgrade that drops it, a jsdom change that makes the tree invisible
+     * to it. This rebuilds the exact structure the chip had before #188 and
+     * requires axe to still object to it, so the guards above cannot quietly
+     * go vacuous without this failing first.
+     */
+    it('still reports the violation for the structure the chip used to have', async () => {
+      const previous = document.createElement('div');
+      previous.innerHTML =
+        '<div role="button" tabindex="0" aria-label="Has SSH Access">'
+        + '<span>Has SSH Access</span>'
+        + '<button type="button" aria-label="Remove Has SSH Access">x</button>'
+        + '</div>';
+      document.body.appendChild(previous);
+
+      const results = await axe.run(previous, {
+        runOnly: { type: 'rule', values: ['nested-interactive'] },
+      });
+      previous.remove();
+
+      expect(results.violations.map((v) => v.id)).toEqual(['nested-interactive']);
+    });
   });
 
   /**
@@ -236,15 +261,18 @@ describe('tn-chip accessibility (#188)', () => {
 
     it('has no other wrapper padding hiding in a nested block', () => {
       const nestedPadding = block('.tn-chip {')
+        .replace(/\/\/.*$/gm, '') // comments discuss padding; only declarations count
         .split('\n')
-        .filter((line) => /^\s+padding(-\w+)?:/.test(line) && !/padding:\s*0\s*;/.test(line));
+        .map((line) => line.trim())
+        .filter((line) => /^padding(-\w+)?:/.test(line) && !/^padding:\s*0\s*;/.test(line));
 
       // Only the two accounted for above: __body's real padding, and the
-      // closable inset. A third would be a new dead strip.
-      expect(nestedPadding.map((line) => line.trim())).toEqual([
+      // closable inset. A third would be a new dead strip. Sorted, so that
+      // reordering declarations — which changes nothing — does not fail here.
+      expect(nestedPadding.sort()).toEqual([
+        'padding-right: 6px;',
         'padding-right: 8px;',
         'padding: 6px 12px;',
-        'padding-right: 6px;',
       ]);
     });
 

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -47,16 +47,12 @@ describe('tn-chip accessibility (#188)', () => {
       imports: [TestHostComponent]
     }).compileComponents();
 
+    // TestBed attaches the fixture to the document itself, which axe needs —
+    // it walks up to the document root to decide visibility, and treats a
+    // detached tree as hidden and therefore exempt from every rule below.
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
-    // axe walks up to the document to resolve visibility and duplicate ids, so
-    // the fixture has to be attached rather than reviewed as a detached tree.
-    document.body.appendChild(fixture.nativeElement);
     fixture.detectChanges();
-  });
-
-  afterEach(() => {
-    fixture.nativeElement.remove();
   });
 
   function root(): HTMLElement {
@@ -200,8 +196,13 @@ describe('tn-chip accessibility (#188)', () => {
    * jsdom has no layout engine and Jest does not compile the component's SCSS,
    * so the hit area cannot be measured here (same constraint that made
    * `radio-error-contrast.spec.ts` read the stylesheet directly). Asserting on
-   * which rule owns the padding is the reachable form of the invariant. The
-   * values are matched loosely so retuning the chip's size does not fail this.
+   * which rule owns the padding is the reachable form of the invariant.
+   *
+   * Most of these match loosely — "the body has some non-zero padding" — so
+   * retuning the chip's size does not fail them. The last one is the
+   * exception: it enumerates every padding declaration by value, because its
+   * job is to notice a NEW one, and that cannot be done without naming the
+   * ones already accounted for. Retuning the chip means updating that list.
    */
   describe('the body button owns the padded hit area', () => {
     const scss = readFileSync(join(__dirname, './chip.component.scss'), 'utf8');

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
@@ -161,6 +163,66 @@ describe('tn-chip accessibility (#188)', () => {
       // on a button, so that half is asserted separately by the click tests
       // above; what matters here is that keydown itself contributes nothing.
       expect(host.clickCount).toBe(0);
+    });
+  });
+
+  /**
+   * Moving the click handler onto the body button moved the click TARGET with
+   * it, so the chip's padding has to move too — padding left on the wrapper is
+   * a band that looks like the chip and activates nothing.
+   *
+   * jsdom has no layout engine and Jest does not compile the component's SCSS,
+   * so the hit area cannot be measured here (same constraint that made
+   * `radio-error-contrast.spec.ts` read the stylesheet directly). Asserting on
+   * which rule owns the padding is the reachable form of the invariant. The
+   * values are matched loosely so retuning the chip's size does not fail this.
+   */
+  describe('the body button owns the padded hit area', () => {
+    const scss = readFileSync(join(__dirname, './chip.component.scss'), 'utf8');
+
+    /** Extracts a nested SCSS block's body by brace-matching from its header. */
+    function block(header: string): string {
+      const start = scss.indexOf(header);
+      expect(start).toBeGreaterThanOrEqual(0);
+      const open = scss.indexOf('{', start);
+      let depth = 0;
+      for (let i = open; i < scss.length; i++) {
+        if (scss[i] === '{') {
+          depth++;
+        } else if (scss[i] === '}' && --depth === 0) {
+          return scss.slice(open + 1, i);
+        }
+      }
+      throw new Error(`unterminated block for ${header}`);
+    }
+
+    /** Declarations of the block itself, excluding any nested rule. */
+    function ownDeclarations(blockBody: string): string {
+      let depth = 0;
+      let out = '';
+      for (const char of blockBody) {
+        if (char === '{') {
+          depth++;
+        } else if (char === '}') {
+          depth--;
+        } else if (depth === 0) {
+          out += char;
+        }
+      }
+      return out;
+    }
+
+    it('leaves the wrapper no padding of its own', () => {
+      expect(ownDeclarations(block('.tn-chip {'))).toMatch(/padding:\s*0\s*;/);
+    });
+
+    it('puts a real padding on the body button', () => {
+      expect(ownDeclarations(block('&__body {'))).toMatch(/padding:\s*[1-9]/);
+    });
+
+    it('keeps the wrapper from advertising a click it cannot deliver', () => {
+      expect(ownDeclarations(block('.tn-chip {'))).not.toMatch(/cursor:\s*pointer/);
+      expect(ownDeclarations(block('&__body {'))).toMatch(/cursor:\s*pointer/);
     });
   });
 

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -1,0 +1,200 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import axe from 'axe-core';
+import { TnChipComponent } from './chip.component';
+
+/**
+ * Guards the structure fixed for #188: the chip used to render a focusable
+ * `role="button"` wrapper with a real `<button>` inside it, which fails axe's
+ * `nested-interactive` rule — assistive technology flattens the inner control,
+ * so close could be unreachable or announced as part of the chip's own name.
+ *
+ * The Storybook a11y addon reports the same rule, but only in its panel: no
+ * CI job fails on it. Running axe here is what actually holds the fix in place.
+ *
+ * Unlike the color-contrast rule (see `radio-error-contrast.spec.ts`, which
+ * computes ratios by hand because jsdom has no layout engine),
+ * `nested-interactive` is pure DOM structure and axe evaluates it correctly
+ * under jsdom — verified by watching it report the violation before the fix.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnChipComponent],
+  template: `<tn-chip [label]="label()" [icon]="icon()" [closable]="closable()"
+    [disabled]="disabled()" (onClick)="clickCount = clickCount + 1"
+    (onClose)="closeCount = closeCount + 1" />`
+})
+class TestHostComponent {
+  label = signal('Has SSH Access');
+  icon = signal<string | undefined>(undefined);
+  closable = signal(true);
+  disabled = signal(false);
+  clickCount = 0;
+  closeCount = 0;
+}
+
+describe('tn-chip accessibility (#188)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    // axe walks up to the document to resolve visibility and duplicate ids, so
+    // the fixture has to be attached rather than reviewed as a detached tree.
+    document.body.appendChild(fixture.nativeElement);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.nativeElement.remove();
+  });
+
+  function root(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-chip') as HTMLElement;
+  }
+
+  function body(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('.tn-chip__body') as HTMLButtonElement;
+  }
+
+  function close(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector('.tn-chip__close');
+  }
+
+  async function violationIds(rules: string[]): Promise<string[]> {
+    const results = await axe.run(fixture.nativeElement as HTMLElement, {
+      runOnly: { type: 'rule', values: rules },
+    });
+    return results.violations.map((v) => v.id);
+  }
+
+  describe('nested-interactive', () => {
+    it('raises no violation on a closable chip', async () => {
+      expect(await violationIds(['nested-interactive'])).toEqual([]);
+    });
+
+    it('raises no violation on a closable chip with an icon', async () => {
+      host.icon.set('mdi:star');
+      fixture.detectChanges();
+
+      expect(await violationIds(['nested-interactive'])).toEqual([]);
+    });
+
+    it('raises no violation on a non-closable chip', async () => {
+      host.closable.set(false);
+      fixture.detectChanges();
+
+      expect(await violationIds(['nested-interactive'])).toEqual([]);
+    });
+
+    it('keeps the close button a sibling of the chip body, not a descendant', () => {
+      expect(body().contains(close())).toBe(false);
+      expect(close()!.parentElement).toBe(body().parentElement);
+    });
+
+    it('leaves the wrapper non-focusable, so the chip is a single tab stop per control', () => {
+      expect(root().getAttribute('role')).toBeNull();
+      expect(root().hasAttribute('tabindex')).toBe(false);
+    });
+  });
+
+  /**
+   * The wrapper carries no role, so ARIA state must not be parked on it —
+   * `aria-disabled` on a roleless element is an `aria-allowed-attr` violation,
+   * which would trade #188 for a different finding of the same severity.
+   */
+  it('raises no ARIA violation when disabled', async () => {
+    host.disabled.set(true);
+    fixture.detectChanges();
+
+    expect(await violationIds(['aria-allowed-attr', 'aria-valid-attr-value', 'nested-interactive'])).toEqual([]);
+    expect(body().disabled).toBe(true);
+    expect(close()!.disabled).toBe(true);
+  });
+
+  describe('the close control', () => {
+    it('keeps its accessible name', () => {
+      expect(close()!.getAttribute('aria-label')).toBe('Remove Has SSH Access');
+    });
+
+    it('stays keyboard-reachable', () => {
+      // A native, non-disabled <button> with no negative tabindex is in the tab
+      // order. Before the fix it was still a button, but nested inside the
+      // focusable wrapper, which is what flattened it for assistive technology.
+      expect(close()!.tagName).toBe('BUTTON');
+      expect(close()!.disabled).toBe(false);
+      expect(close()!.tabIndex).toBe(0);
+    });
+  });
+
+  describe('the two controls stay distinguishable', () => {
+    it('emits onClick from the body and not onClose', () => {
+      body().click();
+
+      expect(host.clickCount).toBe(1);
+      expect(host.closeCount).toBe(0);
+    });
+
+    it('emits onClose from the close button and not onClick', () => {
+      close()!.click();
+
+      expect(host.closeCount).toBe(1);
+      expect(host.clickCount).toBe(0);
+    });
+
+    /**
+     * The body is a native <button>, so Enter and Space already arrive as a
+     * click. The pre-#188 template also handled them in `handleKeyDown`, which
+     * on a real button would emit `onClick` twice per keypress.
+     */
+    it.each(['Enter', ' '])('emits onClick exactly once per %s keypress', (key) => {
+      body().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      // jsdom does not synthesise the click a browser derives from Enter/Space
+      // on a button, so that half is asserted separately by the click tests
+      // above; what matters here is that keydown itself contributes nothing.
+      expect(host.clickCount).toBe(0);
+    });
+  });
+
+  describe('the Delete/Backspace dismiss shortcut', () => {
+    it.each(['Delete', 'Backspace'])('emits onClose from the chip body on %s', (key) => {
+      body().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+
+      expect(host.closeCount).toBe(1);
+    });
+
+    it.each(['Delete', 'Backspace'])('still emits onClose on %s while close is focused', (key) => {
+      // The handler sits on the wrapper rather than the body button precisely
+      // so the shortcut survives wherever focus is inside the chip.
+      close()!.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+
+      expect(host.closeCount).toBe(1);
+    });
+
+    it('does not emit onClose on Delete when the chip is not closable', () => {
+      host.closable.set(false);
+      fixture.detectChanges();
+
+      body().dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+
+      expect(host.closeCount).toBe(0);
+    });
+
+    it('does not emit onClose on Delete when the chip is disabled', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      body().dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+
+      expect(host.closeCount).toBe(0);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -157,11 +157,12 @@ describe('tn-chip accessibility (#188)', () => {
      * click. The pre-#188 template also handled them in `handleKeyDown`, which
      * on a real button would emit `onClick` twice per keypress.
      */
-    it.each(['Enter', ' '])('emits onClick exactly once per %s keypress', (key) => {
+    it.each(['Enter', ' '])('does not emit onClick from the %s keydown itself', (key) => {
       body().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
-      // jsdom does not synthesise the click a browser derives from Enter/Space
-      // on a button, so that half is asserted separately by the click tests
-      // above; what matters here is that keydown itself contributes nothing.
+      // The browser's own Enter/Space -> click on a native button is what emits
+      // onClick, and jsdom does not synthesise it; the click tests above cover
+      // that half. What this pins down is the other half — that keydown adds
+      // nothing of its own, so the two cannot combine into a double emit.
       expect(host.clickCount).toBe(0);
     });
   });
@@ -214,6 +215,37 @@ describe('tn-chip accessibility (#188)', () => {
 
     it('leaves the wrapper no padding of its own', () => {
       expect(ownDeclarations(block('.tn-chip {'))).toMatch(/padding:\s*0\s*;/);
+    });
+
+    /**
+     * The single exception, and deliberately so. `--closable` insets the close
+     * circle from the chip's border, and that 8px sits BEYOND the circle, so
+     * no element can own it without changing what a click there means: on the
+     * body, the chip activates from outside the close button; on the close
+     * button, a click at the chip's edge deletes the chip. Dead is the safest
+     * of the three next to a destructive control.
+     *
+     * Asserted rather than merely commented because the previous version of
+     * this suite claimed the wrapper had no padding at all, which was not true
+     * of a closable chip — `ownDeclarations` strips nested blocks and could
+     * not see this one.
+     */
+    it('insets a closable chip by 8px, the only wrapper padding and the only dead strip', () => {
+      expect(ownDeclarations(block('&--closable {'))).toMatch(/padding-right:\s*8px\s*;/);
+    });
+
+    it('has no other wrapper padding hiding in a nested block', () => {
+      const nestedPadding = block('.tn-chip {')
+        .split('\n')
+        .filter((line) => /^\s+padding(-\w+)?:/.test(line) && !/padding:\s*0\s*;/.test(line));
+
+      // Only the two accounted for above: __body's real padding, and the
+      // closable inset. A third would be a new dead strip.
+      expect(nestedPadding.map((line) => line.trim())).toEqual([
+        'padding-right: 8px;',
+        'padding: 6px 12px;',
+        'padding-right: 6px;',
+      ]);
     });
 
     it('puts a real padding on the body button', () => {

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -295,8 +295,10 @@ describe('tn-chip accessibility (#188)', () => {
     });
 
     it.each(['Delete', 'Backspace'])('still emits onClose on %s while close is focused', (key) => {
-      // The handler sits on the wrapper rather than the body button precisely
-      // so the shortcut survives wherever focus is inside the chip.
+      // The handler is bound to the close button as well as the body, rather
+      // than once on the wrapper, precisely so the shortcut survives wherever
+      // focus is inside the chip — the wrapper carries no role and is not
+      // focusable, so it is not a legitimate place to hang a key handler.
       close()!.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
 
       expect(host.closeCount).toBe(1);

--- a/projects/truenas-ui/src/lib/chip/chip.component.html
+++ b/projects/truenas-ui/src/lib/chip/chip.component.html
@@ -1,19 +1,30 @@
+<!-- The chip body is a real <button>, and the close button is its SIBLING rather
+     than its descendant. A focusable wrapper containing a focusable control fails
+     axe's nested-interactive rule: assistive technology flattens the inner control,
+     so close can be unreachable or announced as part of the chip's own name.
+     The Delete/Backspace dismiss shortcut is bound to both buttons rather than
+     to the wrapper, so it works wherever focus sits inside the chip while the
+     handler still lives on genuinely focusable elements. Enter/Space need no
+     handler at all: a native button already turns them into clicks. -->
 <div
   #chipEl
-  role="button"
   tnTestIdType="chip"
   [ngClass]="classes()"
   [tnTestId]="testId()"
-  [attr.aria-label]="label() | tnLabelText"
-  [attr.aria-disabled]="disabled()"
-  [attr.tabindex]="disabled() ? -1 : 0"
-  (click)="handleClick($event)"
-  (keydown)="handleKeyDown($event)"
 >
-  @if (icon()) {
-    <tn-icon class="tn-chip__icon" size="sm" [name]="icon()!" />
-  }
-  <span class="tn-chip__label" [innerHTML]="label() | tnLabelMarkup"></span>
+  <button
+    type="button"
+    class="tn-chip__body"
+    [attr.aria-label]="label() | tnLabelText"
+    [disabled]="disabled()"
+    (click)="handleClick($event)"
+    (keydown)="handleKeyDown($event)"
+  >
+    @if (icon()) {
+      <tn-icon class="tn-chip__icon" size="sm" [name]="icon()!" />
+    }
+    <span class="tn-chip__label" [innerHTML]="label() | tnLabelMarkup"></span>
+  </button>
   @if (closable()) {
     <button
       type="button"
@@ -21,6 +32,7 @@
       [attr.aria-label]="'Remove ' + (label() | tnLabelText)"
       [disabled]="disabled()"
       (click)="handleClose($event)"
+      (keydown)="handleKeyDown($event)"
     >
       <span class="tn-chip__close-icon">×</span>
     </button>

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -72,6 +72,14 @@
     pointer-events: none;
   }
 
+  // The one piece of padding left on the wrapper, and so the one strip of a
+  // chip that does not emit onClick. It is the inset that keeps the close
+  // circle off the chip's border, and it sits BEYOND that circle, so no
+  // element can own it without changing what a click there means: give it to
+  // the body and the chip activates from outside the close button; give it to
+  // the close button and a click at the chip's edge deletes the chip. Dead is
+  // the safest of the three next to a destructive control. Asserted, with this
+  // reasoning, in chip-a11y.spec.ts.
   &--closable {
     padding-right: 8px;
   }

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -13,10 +13,13 @@
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   border: 1px solid transparent;
-  outline: none;
   user-select: none;
 
-  &:focus-visible {
+  // The wrapper is no longer focusable — the body button inside it is — so the
+  // ring is drawn here from the button's state, keeping it around the whole
+  // chip as before. :focus-within would be wrong: it would also fire for the
+  // close button, which draws its own ring.
+  &:has(> .tn-chip__body:focus-visible) {
     outline: 2px solid var(--tn-primary);
     outline-offset: 2px;
   }
@@ -67,6 +70,26 @@
 
   &--closable {
     padding-right: 8px;
+  }
+
+  // Reset to a plain span-like box: the wrapper above owns the chip's
+  // background, border, padding and focus ring, so the body button contributes
+  // only the icon/label row. `gap` is repeated here because the wrapper's own
+  // gap now separates the body from the close button, not the icon from the label.
+  &__body {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+    cursor: inherit;
+    outline: none;
   }
 
   &__icon {
@@ -141,8 +164,8 @@
 // High contrast theme adjustments
 .high-contrast .tn-chip {
   border-width: 2px;
-  
-  &:focus-visible {
+
+  &:has(> .tn-chip__body:focus-visible) {
     outline-width: 3px;
   }
 }

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -3,14 +3,18 @@
 .tn-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+
+  // Padding and the gap to the close button both live on .tn-chip__body, not
+  // here. The body button is what emits onClick now, so any space owned by this
+  // wrapper is space that looks like the chip but does not activate it. Keeping
+  // the geometry identical to the pre-#188 chip is handled by __body's padding.
+  gap: 0;
+  padding: 0;
   border-radius: 16px;
   font-family: var(--tn-font-family-body);
   font-size: 14px;
   font-weight: 500;
   line-height: 1.2;
-  cursor: pointer;
   transition: all 0.2s ease-in-out;
   border: 1px solid transparent;
   user-select: none;
@@ -72,24 +76,33 @@
     padding-right: 8px;
   }
 
-  // Reset to a plain span-like box: the wrapper above owns the chip's
-  // background, border, padding and focus ring, so the body button contributes
-  // only the icon/label row. `gap` is repeated here because the wrapper's own
-  // gap now separates the body from the close button, not the icon from the label.
+  // Reset to a plain span-like box: the wrapper owns the chip's background,
+  // border and focus ring, while this button owns the padding. The padding is
+  // here rather than on the wrapper so the whole padded area is part of the
+  // control that emits onClick — on the wrapper it would be a band that looks
+  // like the chip but activates nothing.
   &__body {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     min-width: 0;
     margin: 0;
-    padding: 0;
+    padding: 6px 12px;
     border: none;
     background: none;
     color: inherit;
     font: inherit;
     text-align: inherit;
-    cursor: inherit;
+    cursor: pointer;
     outline: none;
+
+    // Closable: the 6px that used to be the wrapper's flex gap becomes this
+    // button's right padding, so that strip still activates the chip. Total
+    // geometry is unchanged — 12px left, 6px to the close button, and the
+    // wrapper's 8px beyond it.
+    .tn-chip--closable & {
+      padding-right: 6px;
+    }
   }
 
   &__icon {

--- a/projects/truenas-ui/src/lib/chip/chip.component.ts
+++ b/projects/truenas-ui/src/lib/chip/chip.component.ts
@@ -32,7 +32,11 @@ export class TnChipComponent implements AfterViewInit, OnDestroy {
   private focusMonitor = inject(FocusMonitor);
 
   ngAfterViewInit() {
-    this.focusMonitor.monitor(this.chipEl());
+    // checkChildren, because since #188 the wrapper this points at is not
+    // itself focusable — the body and close buttons inside it are. Monitoring
+    // it alone would never fire, silently dropping the cdk-focused /
+    // cdk-keyboard-focused classes the chip applied before.
+    this.focusMonitor.monitor(this.chipEl(), true);
   }
 
   ngOnDestroy() {

--- a/projects/truenas-ui/src/lib/chip/chip.component.ts
+++ b/projects/truenas-ui/src/lib/chip/chip.component.ts
@@ -68,14 +68,19 @@ export class TnChipComponent implements AfterViewInit, OnDestroy {
     this.onClose.emit();
   }
 
+  /**
+   * Handles the chip's Delete/Backspace dismiss shortcut. Bound to both the
+   * body and the close button so the shortcut works wherever focus sits inside
+   * the chip; the wrapper between them carries no role and is not focusable,
+   * so it is not a legitimate place to hang a key handler.
+   *
+   * Enter and Space are deliberately absent: the body is a native `<button>`,
+   * which already turns both into a `click`. Handling them here as well would
+   * emit `onClick` twice per keypress.
+   */
   handleKeyDown(event: KeyboardEvent): void {
     if (this.disabled()) {
       return;
-    }
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      this.onClick.emit(event as unknown as MouseEvent);
     }
 
     if (this.closable() && (event.key === 'Delete' || event.key === 'Backspace')) {

--- a/projects/truenas-ui/src/lib/chip/chip.harness.ts
+++ b/projects/truenas-ui/src/lib/chip/chip.harness.ts
@@ -27,6 +27,7 @@ export class TnChipHarness extends ComponentHarness {
   static hostSelector = 'tn-chip';
 
   private _chip = this.locatorFor('.tn-chip');
+  private _body = this.locatorFor('.tn-chip__body');
   private _label = this.locatorFor('.tn-chip__label');
   private _icon = this.locatorForOptional('.tn-chip__icon');
   private _closeButton = this.locatorForOptional('.tn-chip__close');
@@ -100,8 +101,8 @@ export class TnChipHarness extends ComponentHarness {
    * ```
    */
   async isDisabled(): Promise<boolean> {
-    const chip = await this._chip();
-    return (await chip.getAttribute('aria-disabled')) === 'true';
+    const body = await this._body();
+    return body.getProperty<boolean>('disabled');
   }
 
   /**
@@ -146,8 +147,8 @@ export class TnChipHarness extends ComponentHarness {
    * ```
    */
   async click(): Promise<void> {
-    const chip = await this._chip();
-    return chip.click();
+    const body = await this._body();
+    return body.click();
   }
 
   /**

--- a/projects/truenas-ui/src/stories/chip.stories.ts
+++ b/projects/truenas-ui/src/stories/chip.stories.ts
@@ -57,7 +57,7 @@ export const Default: Story = {
 
     await expect(chip).toBeInTheDocument();
     await expect(chip).toHaveClass('tn-chip--primary');
-    await userEvent.click(chip);
+    await userEvent.click(chip.querySelector('.tn-chip__body') as HTMLElement);
   },
 };
 
@@ -115,7 +115,11 @@ export const Disabled: Story = {
 
     await expect(chip).toBeInTheDocument();
     await expect(chip).toHaveClass('tn-chip--disabled');
-    await expect(chip).toHaveAttribute('aria-disabled', 'true');
+    // Disabled state lives on the body button, not the wrapper: the wrapper has
+    // no role, and aria-disabled on a roleless element is itself an axe
+    // violation (aria-allowed-attr).
+    await expect(chip.querySelector('.tn-chip__body')).toBeDisabled();
+    await expect(chip.querySelector('.tn-chip__close')).toBeDisabled();
   },
 };
 
@@ -222,19 +226,29 @@ export const KeyboardNavigation: Story = {
     const canvas = within(canvasElement);
     const chip = canvas.getByTestId(`chip-${args.testId as string}`);
 
-    await expect(chip).toHaveAttribute('tabindex', '0');
-    await expect(chip).toHaveAttribute('role', 'button');
+    // The chip body is a real <button>, so it is focusable natively — the
+    // wrapper carries no role or tabindex, which is what keeps the close
+    // button from being a nested interactive control (#188).
+    const body = chip.querySelector('.tn-chip__body') as HTMLButtonElement;
+    await expect(body.tagName).toBe('BUTTON');
+    await expect(chip).not.toHaveAttribute('role');
+    await expect(chip).not.toHaveAttribute('tabindex');
 
     // Test keyboard interaction
-    chip.focus();
+    body.focus();
+    await expect(body).toHaveFocus();
     await userEvent.keyboard('{Enter}');
     await userEvent.keyboard('{Delete}');
+
+    // Close is a sibling of the body, and its own tab stop.
+    await userEvent.tab();
+    await expect(chip.querySelector('.tn-chip__close')).toHaveFocus();
   },
 };
 
 /**
  * **Test IDs (default).** `tn-chip` emits the `chip-` prefix on its
- * `role="button"` host, under `data-testid` (default) / `data-test`.
+ * `.tn-chip` wrapper, under `data-testid` (default) / `data-test`.
  * `testId="production"` → `chip-production`. With no `testId`, nothing is
  * emitted. Table read live.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -8369,7 +8369,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.2.0":
+"axe-core@npm:4.10.3, axe-core@npm:^4.2.0":
   version: 4.10.3
   resolution: "axe-core@npm:4.10.3"
   checksum: 10c0/1b1c24f435b2ffe89d76eca0001cbfff42dbf012ad9bd37398b70b11f0d614281a38a28bc3069e8972e3c90ec929a8937994bd24b0ebcbaab87b8d1e241ab0c7
@@ -21524,6 +21524,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.51.0"
     "@typescript-eslint/types": "npm:^8.51.0"
     "@typescript-eslint/utils": "npm:^8.51.0"
+    axe-core: "npm:4.10.3"
     browserslist: "npm:^4.28.1"
     caniuse-lite: "npm:^1.0.30001764"
     cheerio: "npm:~1.0.0"


### PR DESCRIPTION
Fixes #188.

The chip rendered a focusable `role="button"` wrapper and placed the real close `<button>` inside it. That fails axe's `nested-interactive` rule: assistive technology flattens the inner control, so close could be unreachable or announced as part of the chip's own accessible name, and it produced two tab stops for what reads as one control.

**Reproduced before fixing.** Running axe's `nested-interactive` rule over the rendered chip reported a `serious` violation — *"Element has focusable descendants"*, targeting `.tn-chip` and naming `button.tn-chip__close` as the related node. That observation is now a test, and it still fails against the old markup (see the positive control below).

## The change

The chip body is a real `<button>` and the close button is its **sibling**, under a wrapper that carries no role and no tabindex. Consequences worth calling out:

- **Enter/Space are no longer handled in `handleKeyDown`.** A native button already turns both into a `click`, so keeping the old branch would have emitted `onClick` twice per keypress. (It also stopped casting a `KeyboardEvent` to `MouseEvent`.)
- **Delete/Backspace is bound to both buttons** rather than once on the wrapper, so the dismiss shortcut still works wherever focus sits inside the chip, while the handler stays on genuinely focusable elements. Binding it to the roleless wrapper is what `@angular-eslint/template/interactive-supports-focus` objects to, correctly.
- **Disabled state moved from `aria-disabled` on the wrapper to `disabled` on the two buttons.** `aria-disabled` on a roleless element is itself an `aria-allowed-attr` violation, so leaving it there would have traded one finding for another of the same severity.
- **The focus ring is drawn on the wrapper** via `:has(> .tn-chip__body:focus-visible)`, so it still surrounds the whole chip. This matches the existing pattern in `slider.component.scss` and `form-field.component.scss`. `:focus-within` would be wrong — it would also fire for the close button, which draws its own ring.
- **Padding moved to the body button.** The click target moved with the handler, so the padding had to move too; left on the wrapper it would have been a 12px/6px band that looks like the chip and activates nothing. Rendered geometry is unchanged.

`TnChipHarness.click()` and `.isDisabled()` retarget to the body button. The public method contracts are unchanged, so callers are unaffected.

### One deliberate dead strip

`--closable` keeps `padding-right: 8px` on the wrapper, and that 8px no longer emits `onClick`. It insets the close circle from the chip's border and sits **beyond** that circle, so no element can own it without changing what a click there means: give it to the body and the chip activates from outside the close button; give it to the close button and a click at the chip's edge deletes the chip. Dead is the safest of the three next to a destructive control. It is asserted with that reasoning rather than left implicit, and a test enumerates every padding declaration so a *new* dead strip cannot appear unnoticed.

## Tests

`chip-a11y.spec.ts` runs the real axe rule rather than an approximation of it. The Storybook a11y addon reports `nested-interactive` too, but only in its panel — no CI job fails on it — so this spec is what actually holds the fix in place.

It carries a **positive control**: every other assertion is `toEqual([])`, which is also what axe returns if it evaluates nothing, so the suite rebuilds the pre-fix structure and requires axe to still object to it. Without that, a renamed rule or an axe upgrade could have made the whole guard vacuous while still passing.

The hit-area invariant is asserted against the stylesheet rather than the rendered box, because jsdom has no layout engine and Jest does not compile the component's SCSS — the same constraint that made `radio-error-contrast.spec.ts` read `themes.css` directly.

`axe-core` becomes an explicit devDependency, pinned to the `4.10.3` already in the tree via `@storybook/addon-a11y`, so it merges into the existing lockfile entry rather than adding a second copy.

Three story `play` functions and three `chip-input.harness.spec.ts` selectors were reaching the chip root through `role="button"`, `tabindex` or `aria-disabled`; they now use `.tn-chip` / `.tn-chip__body`.

## Checks run locally

| | |
|---|---|
| `yarn lint` | clean for this diff |
| `yarn test` | 2209 passed, 90 suites |
| `yarn test:scripts` | 42 passed |
| `yarn build` | ok |
| `yarn build-storybook` | ok |
| `yarn test-sb` | **not run** — Playwright's browsers are not installed in this environment, and the download did not finish in time |

`local-review.py` returned the check's own reviewer (exit 0/1, same rubric and threshold as the required check), and the last three rounds each found nothing at or above MEDIUM. The two blocking findings it did raise — the padding band, and `FocusMonitor` monitoring a no-longer-focusable element with `checkChildren` defaulted to false — are fixed in this branch.

### Two things to know

**`yarn test-sb` is unverified here.** Three story `play` functions changed, including a `userEvent.tab()` assertion that close is its own tab stop. That is the one job in this PR whose result I could not observe locally.

**`yarn lint` fails on `main` already**, independently of this branch: four `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, which this PR does not touch. Confirmed by stashing this diff and re-running against a clean tree. If the lint job is red here, that is why, and it is not this change. I have left them alone rather than widening the diff — happy to fix them here or in a separate ticket, whichever you prefer.

### Not addressed (LOW, from the review)

- `tn-icon` renders a root `div`, so it is now flow content inside a `<button>`, whose content model is phrasing-only. Browsers accept it and axe does not flag it; changing `tn-icon`'s root element is another component's concern.
- The wrapper could take `role="group"` with an `aria-label` to announce the body and close as one control rather than two unrelated buttons. That is a deliberate design choice rather than a defect, so I left it for a maintainer.
