### PR TITLE
NAS-142298 / 27.0.0-BETA.1 / fix(slide-toggle): stop making the label text a second tab stop

### DIFF
--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
@@ -68,7 +68,16 @@ describe('tn-slide-toggle accessibility (#189)', () => {
     return fixture.nativeElement.querySelector('.tn-slide-toggle__label-text');
   }
 
-  /** Every element a Tab press would stop on, in document order. */
+  /**
+   * The focusable elements this component renders, in document order.
+   *
+   * Deliberately NOT a general tab-order implementation: it does not check
+   * visibility, does not handle `contenteditable` or `<summary>`, and treats any
+   * non-negative `tabindex` alike. It is sound for the markup under test —
+   * one input and one span — and stating that is cheaper than a correct
+   * implementation nothing else would use. jsdom has no layout, so a visibility
+   * check here could not be honest anyway.
+   */
   function tabStops(): HTMLElement[] {
     const candidates = fixture.nativeElement.querySelectorAll(
       'a[href], button, input, select, textarea, [tabindex]'
@@ -178,6 +187,20 @@ describe('tn-slide-toggle accessibility (#189)', () => {
 
       expect(input().checked).toBe(false);
       expect(host.changeCount).toBe(2);
+    });
+
+    // The removed onLabelClick() opened with `if (!this.isDisabled() ...)`. That
+    // guard is now the native one — a <label> does not forward a click to a
+    // disabled control — so this covers the branch the explicit check used to.
+    it('does nothing when the toggle is disabled', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      labelText()!.click();
+      fixture.detectChanges();
+
+      expect(input().checked).toBe(false);
+      expect(host.changeCount).toBe(0);
     });
   });
 });

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
@@ -127,15 +127,21 @@ describe('tn-slide-toggle accessibility (#189)', () => {
   }
 
   describe('one tab stop per toggle', () => {
+    // `toBe` on the single element, not `toEqual` on the array: toEqual walks
+    // DOM nodes structurally, so it would accept a DIFFERENT element that
+    // happened to match the input's shape — which is exactly the confusion
+    // this assertion exists to rule out.
     it('puts the only tab stop on the input, with the label after it', () => {
-      expect(tabStops()).toEqual([input()]);
+      expect(tabStops()).toHaveLength(1);
+      expect(tabStops()[0]).toBe(input());
     });
 
     it('puts the only tab stop on the input, with the label before it', () => {
       host.labelPosition.set('before');
       fixture.detectChanges();
 
-      expect(tabStops()).toEqual([input()]);
+      expect(tabStops()).toHaveLength(1);
+      expect(tabStops()[0]).toBe(input());
     });
 
     it('leaves no tab stop at all when the toggle is disabled', () => {

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
@@ -1,6 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import axe from 'axe-core';
 import { TnSlideToggleComponent } from './slide-toggle.component';
 
@@ -40,6 +41,19 @@ class TestHostComponent {
   label = signal<string | undefined>('Enable notifications');
   labelPosition = signal<'before' | 'after'>('after');
   disabled = signal(false);
+  changeCount = 0;
+}
+
+/** The CVA half of `isDisabled()`, which the `[disabled]` input cannot reach. */
+@Component({
+  selector: 'tn-form-test-host',
+  standalone: true,
+  imports: [TnSlideToggleComponent, ReactiveFormsModule],
+  template: `<tn-slide-toggle label="Enable notifications" [formControl]="control"
+    (change)="changeCount = changeCount + 1" />`
+})
+class FormTestHostComponent {
+  control = new FormControl(false);
   changeCount = 0;
 }
 
@@ -189,10 +203,12 @@ describe('tn-slide-toggle accessibility (#189)', () => {
       expect(host.changeCount).toBe(2);
     });
 
-    // The removed onLabelClick() opened with `if (!this.isDisabled() ...)`. That
-    // guard is now the native one — a <label> does not forward a click to a
-    // disabled control — so this covers the branch the explicit check used to.
-    it('does nothing when the toggle is disabled', () => {
+    // The removed onLabelClick() opened with `if (!this.isDisabled() ...)`, and
+    // `isDisabled()` is `disabled() || formDisabled()`. The guard is now the
+    // native one — a <label> does not forward a click to a disabled control —
+    // so both halves are driven: this one, and the CVA describe below the
+    // bottom of this one.
+    it('does nothing when disabled through the [disabled] input', () => {
       host.disabled.set(true);
       fixture.detectChanges();
 
@@ -202,5 +218,55 @@ describe('tn-slide-toggle accessibility (#189)', () => {
       expect(input().checked).toBe(false);
       expect(host.changeCount).toBe(0);
     });
+  });
+
+});
+
+/**
+ * The other half of `isDisabled()`. A sibling describe rather than a nested one
+ * so it gets its own TestBed from the usual per-test reset, instead of tearing
+ * down a fixture the outer `beforeEach` has already built.
+ */
+describe('tn-slide-toggle label clicks under a disabled form control (#189)', () => {
+  let host: FormTestHostComponent;
+  let fixture: ComponentFixture<FormTestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormTestHostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormTestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('.tn-slide-toggle__input') as HTMLInputElement;
+  }
+
+  function labelText(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-slide-toggle__label-text') as HTMLElement;
+  }
+
+  it('ignores a label click once the control is disabled', () => {
+    host.control.disable();
+    fixture.detectChanges();
+
+    labelText().click();
+    fixture.detectChanges();
+
+    expect(input().disabled).toBe(true);
+    expect(input().checked).toBe(false);
+    expect(host.changeCount).toBe(0);
+    expect(host.control.value).toBe(false);
+  });
+
+  it('still toggles on a label click while the control is enabled', () => {
+    labelText().click();
+    fixture.detectChanges();
+
+    expect(host.control.value).toBe(true);
+    expect(host.changeCount).toBe(1);
   });
 });

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle-a11y.spec.ts
@@ -1,0 +1,183 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import axe from 'axe-core';
+import { TnSlideToggleComponent } from './slide-toggle.component';
+
+/**
+ * Guards the structure fixed for #189: the label text carried `tabindex="0"`,
+ * `role="button"` and its own click/keydown handlers, inside the `<label for>`
+ * that already activates the input. That gave one control two tab stops, the
+ * first of them announced as a button rather than as the switch's label — and
+ * with no focus style of its own, since the stylesheet rings the track off
+ * `.tn-slide-toggle__input:focus-visible` and never the label text.
+ *
+ * WHAT AXE DOES NOT CATCH, WHICH IS WHY THE TAB-STOP TESTS COME FIRST
+ * -------------------------------------------------------------------
+ * #189 reports this as "the same `nested-interactive` family as the chip
+ * issue". It is not. `nested-interactive` fires on a focusable descendant of an
+ * element with a WIDGET ROLE, and `<label>` has no role at all, so the rule
+ * never matched — axe-core 4.10.3 returned zero violations against the broken
+ * markup, with `nested-interactive` sitting in `passes`. Measured before any
+ * change, not assumed.
+ *
+ * So the defect is real but the suggested detector is not, and the assertions
+ * that hold this fix in place are the DOM ones below: one tab stop, and no
+ * role. Those did fail before the fix. The axe block is a forward guard only.
+ *
+ * Contrast `chip-a11y.spec.ts` (#188), where the rule genuinely fired and a
+ * positive control was the right way to keep the guard honest.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSlideToggleComponent],
+  template: `<tn-slide-toggle [label]="label()" [labelPosition]="labelPosition()"
+    [disabled]="disabled()" (change)="changeCount = changeCount + 1" />`
+})
+class TestHostComponent {
+  label = signal<string | undefined>('Enable notifications');
+  labelPosition = signal<'before' | 'after'>('after');
+  disabled = signal(false);
+  changeCount = 0;
+}
+
+describe('tn-slide-toggle accessibility (#189)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('.tn-slide-toggle__input') as HTMLInputElement;
+  }
+
+  function labelText(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.tn-slide-toggle__label-text');
+  }
+
+  /** Every element a Tab press would stop on, in document order. */
+  function tabStops(): HTMLElement[] {
+    const candidates = fixture.nativeElement.querySelectorAll(
+      'a[href], button, input, select, textarea, [tabindex]'
+    );
+    return Array.from(candidates as NodeListOf<HTMLElement>).filter((el) => {
+      const index = el.getAttribute('tabindex');
+      if (index !== null && Number(index) < 0) {
+        return false;
+      }
+      return !(el as HTMLInputElement).disabled;
+    });
+  }
+
+  /**
+   * `{violated, evaluated}` for `rules`.
+   *
+   * `evaluated` is the half that matters. An empty `violations` is also what axe
+   * returns when it looked at nothing at all — a detached tree, a renamed rule,
+   * an upgrade that drops one — so asserting only on it is a guard that can go
+   * vacuous without failing. `chip-a11y.spec.ts` (#188) pays for this with a
+   * positive control, which it can do because the rule fired there before the
+   * fix. Here it never did (see the header note), so the check is instead that
+   * axe reports having run the rule and passed it.
+   */
+  async function axeResult(rules: string[]): Promise<{ violated: string[]; evaluated: string[] }> {
+    const results = await axe.run(fixture.nativeElement as HTMLElement, {
+      runOnly: { type: 'rule', values: rules },
+    });
+    return {
+      violated: results.violations.map((v) => v.id),
+      evaluated: [...results.violations, ...results.passes, ...results.incomplete].map((v) => v.id),
+    };
+  }
+
+  describe('one tab stop per toggle', () => {
+    it('puts the only tab stop on the input, with the label after it', () => {
+      expect(tabStops()).toEqual([input()]);
+    });
+
+    it('puts the only tab stop on the input, with the label before it', () => {
+      host.labelPosition.set('before');
+      fixture.detectChanges();
+
+      expect(tabStops()).toEqual([input()]);
+    });
+
+    it('leaves no tab stop at all when the toggle is disabled', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(tabStops()).toEqual([]);
+    });
+  });
+
+  describe('the label text is a label, not a button', () => {
+    it('carries no role', () => {
+      expect(labelText()!.getAttribute('role')).toBeNull();
+    });
+
+    it('carries no tabindex', () => {
+      expect(labelText()!.getAttribute('tabindex')).toBeNull();
+    });
+  });
+
+  describe('axe', () => {
+    // Forward guards, not evidence of the fix — neither reported anything
+    // before it either; see the header note.
+    //
+    // Only rules that stay APPLICABLE after the fix can be asserted this way.
+    // `aria-allowed-role` and `tabindex` are the obvious two to want here and
+    // both had to come out: with no `role` and no `tabindex` left anywhere in
+    // the tree they match no node, so axe omits them from every bucket and
+    // `evaluated` would never contain them.
+    const RULES = ['nested-interactive', 'label'];
+
+    it('runs the named rules and passes them, label after', async () => {
+      const { violated, evaluated } = await axeResult(RULES);
+
+      expect(violated).toEqual([]);
+      expect(evaluated.sort()).toEqual([...RULES].sort());
+    });
+
+    it('runs the named rules and passes them, label before', async () => {
+      host.labelPosition.set('before');
+      fixture.detectChanges();
+      const { violated, evaluated } = await axeResult(RULES);
+
+      expect(violated).toEqual([]);
+      expect(evaluated.sort()).toEqual([...RULES].sort());
+    });
+  });
+
+  describe('clicking the label still toggles, exactly once', () => {
+    it('toggles once per click on the label text', () => {
+      labelText()!.click();
+      fixture.detectChanges();
+
+      expect(input().checked).toBe(true);
+      expect(host.changeCount).toBe(1);
+    });
+
+    it('toggles back on a second click', () => {
+      labelText()!.click();
+      fixture.detectChanges();
+      labelText()!.click();
+      fixture.detectChanges();
+
+      expect(input().checked).toBe(false);
+      expect(host.changeCount).toBe(2);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.html
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.html
@@ -3,14 +3,12 @@
 
     <!-- Label before toggle -->
     @if (label() && labelPosition() === 'before') {
+      <!-- No tabindex, role or click handler: the enclosing <label for> already
+           forwards a click to the input, and the input is the control's single
+           tab stop. See slide-toggle-a11y.spec.ts (#189). -->
       <span
         class="tn-slide-toggle__label-text tn-slide-toggle__label-text--before"
-        tabindex="0"
-        role="button"
-        [innerHTML]="label() | tnLabelMarkup"
-        (click)="onLabelClick()"
-        (keydown.enter)="onLabelClick()"
-        (keydown.space)="onLabelClick()">
+        [innerHTML]="label() | tnLabelMarkup">
       </span>
     }
 
@@ -63,14 +61,10 @@
 
     <!-- Label after toggle -->
     @if (label() && labelPosition() === 'after') {
+      <!-- Plain text, for the same reason as the `before` span above. -->
       <span
         class="tn-slide-toggle__label-text tn-slide-toggle__label-text--after"
-        tabindex="0"
-        role="button"
-        [innerHTML]="label() | tnLabelMarkup"
-        (click)="onLabelClick()"
-        (keydown.enter)="onLabelClick()"
-        (keydown.space)="onLabelClick()">
+        [innerHTML]="label() | tnLabelMarkup">
       </span>
     }
 

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.ts
@@ -122,12 +122,11 @@ export class TnSlideToggleComponent implements AfterViewInit, OnDestroy, Control
     this.toggleChange.emit(checked);
   }
 
-  onLabelClick(): void {
-    const toggleEl = this.toggleEl();
-    if (!this.isDisabled() && toggleEl) {
-      toggleEl.nativeElement.click();
-    }
-  }
+  // There is deliberately no label click handler. The label text sits inside
+  // `<label [for]="id">`, whose native activation already forwards a click to
+  // the input — including the native no-op when the input is disabled. A
+  // handler here duplicated that, and the `tabindex`/`role="button"` it was
+  // reached by gave one control two tab stops (#189).
 
   classes = computed(() => {
     const classes = ['tn-slide-toggle'];


### PR DESCRIPTION
Fixes #189.

The slide-toggle's label text carried `tabindex="0"`, `role="button"` and its own click/keydown handlers, sitting inside the `<label [for]>` that already forwards a click to the input. One control therefore had **two tab stops** — the input, plus a span announced as a button — and the first of them was styled by nothing: the stylesheet rings the track off `.tn-slide-toggle__input:focus-visible` and never the label text, so that stop was invisible. Both label positions were affected, and the span stayed focusable even when the toggle was disabled.

The span is now plain text. Native `<label for>` activation covers clicking it — including the no-op when the input is disabled — so `onLabelClick()` goes with the attributes that reached it.

## The report names a detector that does not fire

**#189 says this is "the same `nested-interactive` family as the chip issue" (#188). It is not, and I measured that before changing anything.**

`nested-interactive` fires on a focusable descendant of an element with a **widget role**. `<label>` has no role at all, so the rule never matched. Run against the *broken* markup, axe-core 4.10.3 returned **zero violations of any rule**, with `nested-interactive` sitting in `passes`.

So the defect is real — the ticket's own title describes it exactly — but the suggested reproduction would have shown nothing. What I reproduced instead was the behaviour directly: `tabStops()` returned `[input, span[role="button"][tabindex="0"]]` before the fix and `[input]` after.

This matters for how the tests are read:

- **The DOM assertions are what hold the fix in place** — one tab stop, no role, no tabindex. Those failed before the change.
- **The axe block is a forward guard only.** It was green before the fix too, so it is not evidence of anything this PR did.

That third acceptance criterion — "No `nested-interactive` violation on the Slide Toggle stories" — was already satisfied and remains satisfied. I have not claimed it as a fix.

### Keeping the axe guard from going vacuous

`chip-a11y.spec.ts` (#188) has the same hazard: `violations` is empty both when a rule passes and when axe evaluated nothing. There it was solved with a positive control, which was available because the rule genuinely fired.

Here it never did, so the guard instead asserts that axe **reports having run** each rule — `violations ∪ passes ∪ incomplete` must contain it. A renamed rule or an axe upgrade that drops one then fails the test rather than silently passing it.

Only rules that stay *applicable* after the fix can be asserted that way. `aria-allowed-role` and `tabindex` are the two you would most want, and both had to come out: with no `role` and no `tabindex` anywhere in the tree they match no node, so axe omits them from every bucket. That is a real limitation of this technique and the comment says so.

## Please decide: is the `onLabelClick()` removal worth a `!`

`onLabelClick()` was a **public method on `TnSlideToggleComponent`, which is exported from `public-api.ts`** — so removing it is source-breaking for any downstream caller. The local review raised this on every round.

There is no in-repo caller, it was an internal event handler rather than a documented API, and the library is at `27.0.0-BETA.1`. On that basis I have **not** marked this a breaking change, because a `!` would drive a major bump for a handler nobody was meant to call. **That is a maintainer's call rather than mine** — say the word and I will retitle it, or add a release note.

## Tests

`slide-toggle-a11y.spec.ts`, 12 tests. Both label positions, and both halves of `isDisabled()`:

| | |
|---|---|
| one tab stop, label `after` / `before` | asserted by **identity**, not `toEqual` — that walks DOM nodes structurally and would accept a different element of the same shape |
| no tab stop at all when disabled | the span used to remain one |
| label text carries no `role`, no `tabindex` | |
| clicking the label toggles **exactly once** | it did before too; this pins that removing the handler did not cost it, and did not double it |
| a disabled toggle ignores a label click | via `[disabled]`, and separately via `control.disable()` on a reactive form — `isDisabled()` is `disabled() \|\| formDisabled()`, and the removed guard read both |
| axe runs and passes `nested-interactive` and `label` | forward guard, per above |

## Checks run locally

| | |
|---|---|
| `yarn lint` | clean for this diff |
| `yarn test` | 2221 passed, 91 suites |
| `yarn test:scripts` | 42 passed |
| `yarn build` | ok |
| `yarn build-storybook` | ok |
| `yarn test-sb` | **not run** — needs a Storybook server plus Playwright browsers, which are not installed here |

`yarn test-sb` is the one job I could not observe. The risk is low rather than zero: **this diff touches three files, all under `lib/slide-toggle/`, and no story or play function among them.**

`local-review.py` ran the check's own reviewer (same rubric, threshold and parser as the required check) in a separate process. Four rounds, every one clean at MEDIUM and above; the LOW count went 4 → 2 → 3 → 1. Three LOWs are fixed in this branch — the untested disabled branch, a `tabStops()` comment that overstated what the helper does, and the structural `toEqual`. The one left standing is the `onLabelClick()` question above.

### Not addressed (LOW, from the review)

- `tabStops()` and `axeResult()` overlap with the helpers in `chip-a11y.spec.ts`. The review's own suggestion was to extract a shared util *when a third a11y spec lands*, and refactoring the chip spec is outside this ticket.

## Pre-existing, not from this branch

`yarn lint` reports 4 `import/order` errors on `main` — in `input.component.ts` and `menu-panel.component.ts`, neither touched here. **CI's `Run Linter` job runs the same `yarn lint` and was green on #191**, so local and CI disagree about them; I have not chased that down, and it is not this change either way.
