### PR TITLE
NAS-142299 / 27.0.0-BETA.1 / fix(toast): carry politeness on the role alone, so errors interrupt

### DIFF
--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -1,0 +1,164 @@
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import axe from 'axe-core';
+import { TnToastComponent } from './toast.component';
+import { TnToastType } from './toast.types';
+
+/**
+ * Guards the live-region contract fixed for #190: the toast carried
+ * `role="alert"` and `aria-live="polite"` on the same element. `alert` implies
+ * `aria-live="assertive"`, so the explicit attribute overrode it and the
+ * element claimed to be an alert while asking not to interrupt — with which of
+ * the two wins left to the screen reader. The cost landed on the `error` toast,
+ * the one case that most needs to interrupt.
+ *
+ * WHY THE POLITENESS IS READ THROUGH THE ROLE, AND NOT ASSERTED DIRECTLY
+ * ---------------------------------------------------------------------
+ * The defect was two sources disagreeing, so a test naming one attribute would
+ * pass just as happily on markup that reintroduced the other. `politeness()`
+ * below therefore resolves what a screen reader would resolve — implicit from
+ * the role, explicit from `aria-live` — and `liveSources()` counts how many
+ * were on offer. One assertion for what it announces, one for there being a
+ * single thing saying so.
+ *
+ * WHAT AXE DOES NOT CATCH, WHICH IS WHY THE DOM TESTS COME FIRST
+ * -------------------------------------------------------------
+ * `aria-live` is a global ARIA attribute, so it is *allowed* on `role="alert"`
+ * — `aria-allowed-attr` passes on the broken markup and no other axe-core
+ * 4.10.3 rule fires either. Measured against the pre-fix template, not assumed:
+ * the conflict is a contradiction between two valid attributes, which is not a
+ * shape a rule-per-attribute linter can see.
+ *
+ * So the assertions that hold this fix in place are the DOM ones. The axe block
+ * is a forward guard, and it asserts `evaluated` for the reason
+ * `slide-toggle-a11y.spec.ts` (#189) does: an empty `violations` is also what
+ * axe returns when it ran nothing at all.
+ */
+
+/** Politeness each live-region role implies, per ARIA 1.2. */
+const IMPLICIT_POLITENESS: Record<string, string> = {
+  alert: 'assertive',
+  status: 'polite',
+  log: 'polite',
+  marquee: 'off',
+  timer: 'off',
+};
+
+describe('tn-toast accessibility (#190)', () => {
+  let fixture: ComponentFixture<TnToastComponent>;
+  let component: TnToastComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnToastComponent]
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TnToastComponent);
+    component = fixture.componentInstance;
+    component.message.set('Changes saved');
+    fixture.detectChanges();
+  });
+
+  function region(type: TnToastType): HTMLElement {
+    component.type.set(type);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('.tn-toast') as HTMLElement;
+  }
+
+  /**
+   * Every attribute on `el` that declares a politeness, as `attr=value` pairs.
+   *
+   * A live-region ROLE counts as one of them: that is the whole point of #190,
+   * where the second source was implicit and so easy to leave in place. A role
+   * that is not a live region (or none at all) contributes nothing.
+   */
+  function liveSources(el: HTMLElement): string[] {
+    const sources: string[] = [];
+    const role = el.getAttribute('role');
+    if (role !== null && role in IMPLICIT_POLITENESS) {
+      sources.push(`role=${role}`);
+    }
+    const live = el.getAttribute('aria-live');
+    if (live !== null) {
+      sources.push(`aria-live=${live}`);
+    }
+    return sources;
+  }
+
+  /**
+   * What a screen reader resolves the politeness to.
+   *
+   * An explicit `aria-live` beats the role's implicit value, which is exactly
+   * how the broken markup turned an alert into a polite one.
+   */
+  function politeness(el: HTMLElement): string {
+    const live = el.getAttribute('aria-live');
+    if (live !== null) {
+      return live;
+    }
+    const role = el.getAttribute('role');
+    return (role !== null && IMPLICIT_POLITENESS[role]) || 'off';
+  }
+
+  /**
+   * `{violated, evaluated}` for `rules`.
+   *
+   * `evaluated` is the half that matters — see the header note.
+   */
+  async function axeResult(rules: string[]): Promise<{ violated: string[]; evaluated: string[] }> {
+    const results = await axe.run(fixture.nativeElement as HTMLElement, {
+      runOnly: { type: 'rule', values: rules },
+    });
+    return {
+      violated: results.violations.map((v) => v.id),
+      evaluated: [...results.violations, ...results.passes, ...results.incomplete].map((v) => v.id),
+    };
+  }
+
+  describe('exactly one source of politeness', () => {
+    // The pre-fix markup returned ['role=alert', 'aria-live=polite'] here, for
+    // every type. This is the assertion that failed before the fix.
+    it.each(Object.values(TnToastType))('declares politeness once on a %s toast', (type) => {
+      expect(liveSources(region(type))).toHaveLength(1);
+    });
+  });
+
+  describe('politeness follows the toast type', () => {
+    it('interrupts for an error, which is the case that needs to', () => {
+      expect(politeness(region(TnToastType.Error))).toBe('assertive');
+    });
+
+    it.each([TnToastType.Info, TnToastType.Success, TnToastType.Warning])(
+      'does not interrupt for a %s toast',
+      (type) => {
+        expect(politeness(region(type))).toBe('polite');
+      }
+    );
+
+    // Politeness is only honoured on something that IS a live region: drop the
+    // role and `politeness()` above would still read an explicit `aria-live`
+    // that no screen reader watches. Naming the two roles pins which mechanism
+    // carries it, so a later edit cannot satisfy the assertions above with an
+    // attribute alone.
+    it('carries the politeness on a live-region role', () => {
+      expect(region(TnToastType.Error).getAttribute('role')).toBe('alert');
+      expect(region(TnToastType.Info).getAttribute('role')).toBe('status');
+    });
+  });
+
+  describe('axe', () => {
+    it.each(Object.values(TnToastType))('raises no ARIA violation on a %s toast', async (type) => {
+      region(type);
+
+      const { violated, evaluated } = await axeResult([
+        'aria-allowed-attr', 'aria-valid-attr-value', 'aria-roles'
+      ]);
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-allowed-attr');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -104,17 +104,34 @@ describe('tn-toast accessibility (#190)', () => {
   }
 
   /**
-   * `{violated, evaluated}` for `rules`.
+   * `{violated, evaluated}` for `rules`, counting only what axe said about `el`
+   * ITSELF.
    *
-   * `evaluated` is the half that matters — see the header note.
+   * The per-element filter is the point. A rule lands in `passes` if it matched
+   * anywhere in the tree, and `tn-icon` renders `aria-label` and `aria-hidden`
+   * — so a tree-wide `evaluated` reports `aria-allowed-attr` as run whether or
+   * not it ever looked at the toast. That is not a hypothetical: this spec
+   * asserted exactly that, and the assertion was satisfied by the icon, because
+   * removing `aria-live` left the toast with no `aria-*` attribute for the rule
+   * to match. A guard on the wrong element is the vacuous guard the header note
+   * warns about, wearing the costume of a fix.
+   *
+   * `elementRef` is what makes the filter identity-based; without it a node
+   * result carries only a CSS selector, and comparing those compares strings.
    */
-  async function axeResult(rules: string[]): Promise<{ violated: string[]; evaluated: string[] }> {
+  async function axeResult(
+    el: HTMLElement, rules: string[]
+  ): Promise<{ violated: string[]; evaluated: string[] }> {
     const results = await axe.run(fixture.nativeElement as HTMLElement, {
       runOnly: { type: 'rule', values: rules },
+      elementRef: true,
     });
+    const touches = (rule: axe.Result): boolean =>
+      rule.nodes.some((node) => (node as { element?: Element }).element === el);
     return {
-      violated: results.violations.map((v) => v.id),
-      evaluated: [...results.violations, ...results.passes, ...results.incomplete].map((v) => v.id),
+      violated: results.violations.filter(touches).map((v) => v.id),
+      evaluated: [...results.violations, ...results.passes, ...results.incomplete]
+        .filter(touches).map((v) => v.id),
     };
   }
 
@@ -150,15 +167,22 @@ describe('tn-toast accessibility (#190)', () => {
   });
 
   describe('axe', () => {
+    // `aria-roles` is the rule asserted as evaluated because it is the one that
+    // still MATCHES the toast after the fix: it selects on the `role` attribute,
+    // which is now the element's only ARIA marking. The attribute-value rules
+    // are worth running — a typo'd role would be caught by neither of the DOM
+    // suites above, which compare against the two expected spellings — but they
+    // match no node here, so requiring them in `evaluated` would fail on
+    // correct markup.
     it.each(Object.values(TnToastType))('raises no ARIA violation on a %s toast', async (type) => {
-      region(type);
+      const el = region(type);
 
-      const { violated, evaluated } = await axeResult([
+      const { violated, evaluated } = await axeResult(el, [
         'aria-allowed-attr', 'aria-valid-attr-value', 'aria-roles'
       ]);
 
       expect(violated).toEqual([]);
-      expect(evaluated).toContain('aria-allowed-attr');
+      expect(evaluated).toContain('aria-roles');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/toast/toast.component.html
+++ b/projects/truenas-ui/src/lib/toast/toast.component.html
@@ -1,7 +1,6 @@
 <div
   class="tn-toast"
-  role="alert"
-  aria-live="polite"
+  [attr.role]="role()"
   [class.tn-toast--visible]="visible()"
   [class.tn-toast--info]="type() === 'info'"
   [class.tn-toast--success]="type() === 'success'"

--- a/projects/truenas-ui/src/lib/toast/toast.component.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.component.ts
@@ -38,6 +38,19 @@ export class TnToastComponent {
 
   icon = computed(() => TOAST_ICONS[this.type()]);
 
+  /**
+   * The live-region role, which is also the only thing declaring how urgently the
+   * toast is announced: `alert` implies `aria-live="assertive"` and `status`
+   * implies `polite`.
+   *
+   * The template carried `role="alert"` and `aria-live="polite"` together (#190).
+   * An explicit `aria-live` overrides the role's implicit one, so every toast was
+   * announced politely — including `error`, the one type that needs to interrupt.
+   * Deriving the role from the type and leaving `aria-live` off keeps a single
+   * source: there is no second attribute left to disagree with this one.
+   */
+  role = computed(() => (this.type() === TnToastType.Error ? 'alert' : 'status'));
+
   onAction: () => void = () => {};
   onDismiss: () => void = () => {};
 }


### PR DESCRIPTION
Fixes #190.

The toast set `role="alert"` and `aria-live="polite"` on the same element. `alert` implies `aria-live="assertive"`, and an explicit `aria-live` overrides that implicit value — so **every toast was announced politely, including `error`**, the one type that most needs to interrupt.

The role is now derived from the type — `alert` for `error`, `status` otherwise — and `aria-live` is gone. That leaves exactly one attribute declaring urgency, so there is nothing left to disagree with it. It follows `form-field.component.html`, which already carries the comment *"`role="alert"` is implicitly assertive+atomic, so no aria-live here."*

## Reproduced before changing anything

Measured on the pre-fix template, not inferred:

| | before | after |
|---|---|---|
| sources of politeness on the element | `["role=alert", "aria-live=polite"]` | `["role=status"]` / `["role=alert"]` |
| what an `error` toast resolves to | `polite` | `assertive` |
| what an `info` toast resolves to | `polite` | `polite` |

The `info` row is the control: it was already correct, and this PR does not claim it as a fix.

## No axe rule catches this, which shapes the third acceptance criterion

`aria-live` is a **global** ARIA attribute, so it is *allowed* on `role="alert"`. Run against the broken markup, axe-core 4.10.3 reported **zero violations** — `aria-allowed-attr` sat in `passes`. The conflict is a contradiction between two individually-valid attributes, which is not a shape a rule-per-attribute linter can see.

So AC 3 — *"The Toast stories raise no a11y violation for conflicting live-region attributes"* — was already satisfied before the change and remains satisfied. **The DOM assertions are what hold this fix in place**; the axe block is a forward guard only.

### The first version of that guard was vacuous, and the review caught it

Worth stating plainly because it is the failure mode `slide-toggle-a11y.spec.ts` (#189) explicitly warns about, and I walked into it anyway.

Round 1 asserted `aria-allowed-attr` appeared in axe's evaluated set. It did — but because **`tn-icon` renders `aria-label` and `aria-hidden`**, not because axe looked at the toast. Removing `aria-live` left the toast with no `aria-*` attribute at all, so that rule stopped matching the element the test was about.

Round 2 filters axe's node results **to the toast element by identity** (`elementRef: true`), and asserts `aria-roles` — which selects on the `role` attribute, the toast's only remaining ARIA marking, and so the one rule that still matches it. The guard passing now *is* the positive control: if the rule were satisfied by a descendant, the identity filter would exclude it and the test would fail.

## Two things I deliberately did not do

**1. `warning` stays polite, which diverges from `TnBannerComponent`.** Banner maps `error` *and* `warning` to `alert`; this maps only `error`. The ticket is explicit — *"assertive for `error`, polite otherwise"* — and its acceptance criteria name only those two cases, so that is what I implemented. **If library-wide consistency should win here, say so and it is a one-line change.** Flagging it rather than quietly picking either way.

**2. I have not unified the mapping with banner's `ariaRole()`.** Doing so means editing `banner.component.html`, which carries this same defect in a worse form — a static `aria-live="polite"` beside a *dynamic* `[attr.role]`, so its `warning` and `error` banners are the ones silently downgraded. That is a fix, not a refactor, and it belongs to its own ticket rather than riding in on this one. Proposed on #190, along with `radio.component.html:24` and `checkbox.component.html:32`, which have it too.

## What this fix does not buy

Raised by the review, and I would rather state it than let the PR imply more than it delivers: **`TnToastService` inserts the live region and its text in a single DOM mutation.** Screen readers reliably announce a `role="alert"` inserted that way, so the `error` path — the ticket's stated priority — genuinely improves. A `role="status"` region inserted already-populated is **less** reliably announced.

So polite toasts are no worse than before and no better. That is pre-existing and needs a service change (mount the empty region first, then set the text), which is outside this ticket. Proposed as a follow-up on #190.

## Tests

`toast-a11y.spec.ts`, 13 tests, all four types:

| | |
|---|---|
| exactly one source of politeness | counts **implicit** sources too — a live-region role is one. The pre-fix markup returned two, and this is the assertion that failed |
| `error` resolves to `assertive` | the reported cost of the defect |
| `info` / `success` / `warning` resolve to `polite` | |
| politeness sits on a live-region role | pins the *mechanism*, so a later edit cannot satisfy the rows above with an `aria-live` on a non-live element |
| axe raises no ARIA violation, and ran `aria-roles` **on the toast** | forward guard, per above |

## Checks run locally

| | |
|---|---|
| `yarn lint` | clean for this diff |
| `yarn test` | 2234 passed, 92 suites |
| `yarn test:scripts` | 42 passed |
| `yarn build` | ok |
| `yarn build-storybook` | **not run** |
| `yarn test-sb` | **not run** — needs a Storybook server plus Playwright browsers, not installed here |

The two Storybook jobs are the ones I could not observe. Risk is low rather than zero: the diff touches three files, all under `lib/toast/`, `yarn build` already AOT-compiled the changed template, and **`toast.stories.ts` contains no play function** — nothing in the interaction suite asserts on the toast's role.

`local-review.py` ran the check's own reviewer — same rubric, threshold and parser as the required check — in a separate process. Two rounds: one MEDIUM in round 1 (the vacuous guard, fixed), then clean at MEDIUM and above.

### Not addressed (LOW)

- **`axeResult()` is now the third near-copy across a11y specs**, and the only one with the per-element filter — `chip-a11y.spec.ts` and `slide-toggle-a11y.spec.ts` keep the tree-wide form, which is vacuous in the same way round 1 was here. #189 deferred extraction until "a third a11y spec lands"; this is that third, so the trigger has fired. It is a change to two other components' specs, so it is proposed on #190 rather than done here.

## Pre-existing, not from this branch

`yarn lint` reports 4 `import/order` errors — in `input.component.ts` and `menu-panel.component.ts`, neither touched here. CI's `Run Linter` job runs the same `yarn lint` and was green on #192, so local and CI disagree about them. Not chased down, and not this change either way.
