### PR TITLE
NAS-142299 / 27.0.0-BETA.1 / fix(toast): announce polite toasts by populating the live region after it is attached

### DIFF
--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -1,8 +1,11 @@
-import { TestBed } from '@angular/core/testing';
+import { ApplicationRef } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import axe from 'axe-core';
 import { TnToastComponent } from './toast.component';
+import { TnToastService } from './toast.service';
 import { TnToastType } from './toast.types';
+import { TnIconTesting } from '../icon/icon-testing';
 
 /**
  * Guards the live-region contract fixed for #190: the toast carried
@@ -184,5 +187,144 @@ describe('tn-toast accessibility (#190)', () => {
       expect(violated).toEqual([]);
       expect(evaluated).toContain('aria-roles');
     });
+  });
+});
+
+/**
+ * Guards the live-region TIMING fixed for #195, which is the other half of
+ * making a toast announce: #190 settled WHAT the region says it is, this
+ * settles WHEN its content arrives.
+ *
+ * A screen reader reports a *change* to a live region's content. The service
+ * set `message` on the component instance and only then appended the host, so
+ * the region and its text entered the DOM in one mutation and there was no
+ * change to report. `role="alert"` survives that — readers special-case an
+ * alert appearing already populated — but `role="status"`, which info, success
+ * and warning toasts carry, is announced unreliably that way and on several
+ * readers not at all.
+ *
+ * WHY THESE ASSERTIONS ARE PAIRED, AND READ THE SAME ELEMENT TWICE
+ * ---------------------------------------------------------------
+ * Neither sample means anything alone. "Empty at insertion" is satisfied by a
+ * toast that never populates, and "populated afterwards" by the pre-fix code.
+ * The contract is the transition between them, so each test asserts both ends
+ * and that `region()` returns the SAME node at each — a service that replaced
+ * the element instead of mutating it would satisfy both samples while giving a
+ * reader a fresh region it was never watching.
+ *
+ * WHY THIS SUITE DRIVES THE SERVICE AND NOT A FIXTURE
+ * --------------------------------------------------
+ * The defect is in the order of the service's own steps — set, attach, render
+ * — and a component fixture is attached before a test can observe anything.
+ * There is nothing here a `TnToastComponent` fixture could fail on.
+ */
+describe('tn-toast live-region timing (#195)', () => {
+  let service: TnToastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [TnIconTesting.jest.providers()],
+    });
+    service = TestBed.inject(TnToastService);
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('tn-toast').forEach((el) => el.remove());
+  });
+
+  /**
+   * The live region in the document, asserted to be RENDERED — its bindings
+   * applied, not merely created.
+   *
+   * That distinction is the difference between these tests and vacuous ones.
+   * `createComponent` runs the template's create pass, so `.tn-toast` is in the
+   * DOM before any change detection has applied a binding: no `role`, and
+   * `{{ message() }}` still empty. A region carrying no role is not one a
+   * screen reader watches, and "empty at insertion" is satisfied by it — so
+   * three of the tests below passed against the pre-fix service until this
+   * helper read `role`. Measured, not assumed.
+   *
+   * Read from `document` rather than a fixture because when the element gets
+   * there, and in what state, is the whole subject.
+   */
+  function renderedRegion(): HTMLElement {
+    const el = document.querySelector('.tn-toast');
+    expect(el).not.toBeNull();
+    expect((el as HTMLElement).getAttribute('role')).not.toBeNull();
+    return el as HTMLElement;
+  }
+
+  /** The message text a screen reader would announce out of `el`. */
+  function messageOf(el: HTMLElement): string {
+    return (el.querySelector('.tn-toast__message')?.textContent ?? '').trim();
+  }
+
+  /**
+   * Run the frame the service defers the message to, then render it.
+   *
+   * `tick(16)` is what fires the `requestAnimationFrame`: zone.js schedules one
+   * as a macrotask a frame out. The explicit `ApplicationRef.tick()` is because
+   * setting a signal only marks the view dirty — nothing in a TestBed zone test
+   * renders it on its own.
+   */
+  function nextFrame(): void {
+    tick(16);
+    TestBed.inject(ApplicationRef).tick();
+  }
+
+  describe('the region is inserted empty and populated afterwards', () => {
+    it.each([TnToastType.Info, TnToastType.Success, TnToastType.Warning])(
+      'gives a polite %s toast a content change to announce',
+      fakeAsync((type: TnToastType) => {
+        service.open('Changes saved', { type, duration: 0 });
+
+        const el = renderedRegion();
+        // In the document — an unattached region is one no reader is watching,
+        // so populating it later would announce nothing either.
+        expect(document.body.contains(el)).toBe(true);
+        expect(el.getAttribute('role')).toBe('status');
+        expect(messageOf(el)).toBe('');
+
+        nextFrame();
+
+        expect(renderedRegion()).toBe(el);
+        expect(messageOf(el)).toBe('Changes saved');
+      })
+    );
+
+    // Error toasts were never the broken case, and the deferral does not cost
+    // them anything: a change to an `alert` region is announced just as its
+    // populated insertion was. Asserted because it is what #195 must not break.
+    it('keeps an error toast announcing, on the role that interrupts', fakeAsync(() => {
+      service.open('Save failed', { type: TnToastType.Error, duration: 0 });
+
+      const el = renderedRegion();
+      expect(el.getAttribute('role')).toBe('alert');
+      expect(messageOf(el)).toBe('');
+
+      nextFrame();
+
+      expect(renderedRegion()).toBe(el);
+      expect(messageOf(el)).toBe('Save failed');
+    }));
+  });
+
+  describe('the visible behaviour is unchanged', () => {
+    it('never shows the empty region, and still runs the enter transition', fakeAsync(() => {
+      service.open('Changes saved', { duration: 0 });
+
+      const el = renderedRegion();
+      // `.tn-toast` is `opacity: 0` until `--visible`, so this is the empty
+      // region being invisible rather than merely off-screen.
+      expect(messageOf(el)).toBe('');
+      expect(el.classList.contains('tn-toast--visible')).toBe(false);
+
+      nextFrame();
+
+      // Both land in the one frame: the toast becomes visible in the same
+      // render that gives it something to say, so there is no empty flash.
+      expect(messageOf(el)).toBe('Changes saved');
+      expect(el.classList.contains('tn-toast--visible')).toBe(true);
+    }));
   });
 });

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -307,6 +307,44 @@ describe('tn-toast live-region timing (#195)', () => {
       expect(renderedRegion()).toBe(el);
       expect(messageOf(el)).toBe('Save failed');
     }));
+
+    // An action label is set before the host is attached, so this region is
+    // NOT empty at insertion — and it does not need to be. What a reader
+    // reports is the mutation, and the message still arrives as one.
+    it('announces a toast whose region already carries an action label', fakeAsync(() => {
+      service.open('Item deleted', 'Undo', { duration: 0 });
+
+      const el = renderedRegion();
+      expect(el.querySelector('.tn-toast__action')?.textContent?.trim()).toBe('Undo');
+      expect(messageOf(el)).toBe('');
+
+      nextFrame();
+
+      expect(renderedRegion()).toBe(el);
+      expect(messageOf(el)).toBe('Item deleted');
+    }));
+  });
+
+  describe('a toast dismissed before its frame never announces', () => {
+    it('leaves a superseded toast silent, and announces the one that replaced it', fakeAsync(() => {
+      service.open('First', { duration: 0 });
+      const first = renderedRegion();
+
+      // Dismisses the first synchronously, while its frame is still pending.
+      service.open('Second', { duration: 0 });
+
+      nextFrame();
+
+      const regions = document.querySelectorAll('.tn-toast');
+      expect(regions).toHaveLength(2);
+      // The first is still attached — it is removed 200ms later — so a reader
+      // is still watching it. Populating it now would announce a message the
+      // user was never shown.
+      expect(messageOf(first)).toBe('');
+      expect(messageOf(regions[1] as HTMLElement)).toBe('Second');
+
+      tick(200);
+    }));
   });
 
   describe('the visible behaviour is unchanged', () => {

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -3,7 +3,7 @@ import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import axe from 'axe-core';
 import { TnToastComponent } from './toast.component';
-import { TnToastService } from './toast.service';
+import { TN_TOAST_ANNOUNCE_DELAY_MS, TnToastService } from './toast.service';
 import { TnToastType } from './toast.types';
 import { TnIconTesting } from '../icon/icon-testing';
 
@@ -260,15 +260,13 @@ describe('tn-toast live-region timing (#195)', () => {
   }
 
   /**
-   * Run the frame the service defers the message to, then render it.
+   * Reach the step the service defers the message to, then render it.
    *
-   * `tick(16)` is what fires the `requestAnimationFrame`: zone.js schedules one
-   * as a macrotask a frame out. The explicit `ApplicationRef.tick()` is because
-   * setting a signal only marks the view dirty — nothing in a TestBed zone test
-   * renders it on its own.
+   * The explicit `ApplicationRef.tick()` is because setting a signal only marks
+   * the view dirty — nothing in a TestBed zone test renders it on its own.
    */
-  function nextFrame(): void {
-    tick(16);
+  function announceStep(): void {
+    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
     TestBed.inject(ApplicationRef).tick();
   }
 
@@ -285,7 +283,7 @@ describe('tn-toast live-region timing (#195)', () => {
         expect(el.getAttribute('role')).toBe('status');
         expect(messageOf(el)).toBe('');
 
-        nextFrame();
+        announceStep();
 
         expect(renderedRegion()).toBe(el);
         expect(messageOf(el)).toBe('Changes saved');
@@ -302,7 +300,7 @@ describe('tn-toast live-region timing (#195)', () => {
       expect(el.getAttribute('role')).toBe('alert');
       expect(messageOf(el)).toBe('');
 
-      nextFrame();
+      announceStep();
 
       expect(renderedRegion()).toBe(el);
       expect(messageOf(el)).toBe('Save failed');
@@ -318,7 +316,7 @@ describe('tn-toast live-region timing (#195)', () => {
       expect(el.querySelector('.tn-toast__action')?.textContent?.trim()).toBe('Undo');
       expect(messageOf(el)).toBe('');
 
-      nextFrame();
+      announceStep();
 
       expect(renderedRegion()).toBe(el);
       expect(messageOf(el)).toBe('Item deleted');
@@ -333,7 +331,7 @@ describe('tn-toast live-region timing (#195)', () => {
       // Dismisses the first synchronously, while its frame is still pending.
       service.open('Second', { duration: 0 });
 
-      nextFrame();
+      announceStep();
 
       const regions = document.querySelectorAll('.tn-toast');
       expect(regions).toHaveLength(2);
@@ -357,7 +355,7 @@ describe('tn-toast live-region timing (#195)', () => {
       expect(messageOf(el)).toBe('');
       expect(el.classList.contains('tn-toast--visible')).toBe(false);
 
-      nextFrame();
+      announceStep();
 
       // Both land in the one frame: the toast becomes visible in the same
       // render that gives it something to say, so there is no empty flash.

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -246,12 +246,18 @@ describe('tn-toast live-region timing (#195)', () => {
    *
    * Read from `document` rather than a fixture because when the element gets
    * there, and in what state, is the whole subject.
+   *
+   * `index` is which region, in document order. A dismissed toast stays
+   * attached for the 200ms of its exit, so "the toast" is not always the only
+   * one present and defaulting to the first would quietly read the wrong
+   * element in any test that opens two.
    */
-  function renderedRegion(): HTMLElement {
-    const el = document.querySelector('.tn-toast');
-    expect(el).not.toBeNull();
-    expect((el as HTMLElement).getAttribute('role')).not.toBeNull();
-    return el as HTMLElement;
+  function renderedRegion(index = 0): HTMLElement {
+    const regions = document.querySelectorAll('.tn-toast');
+    expect(regions.length).toBeGreaterThan(index);
+    const el = regions[index] as HTMLElement;
+    expect(el.getAttribute('role')).not.toBeNull();
+    return el;
   }
 
   /** The message text a screen reader would announce out of `el`. */
@@ -333,13 +339,13 @@ describe('tn-toast live-region timing (#195)', () => {
 
       announceStep();
 
-      const regions = document.querySelectorAll('.tn-toast');
-      expect(regions).toHaveLength(2);
+      expect(document.querySelectorAll('.tn-toast')).toHaveLength(2);
       // The first is still attached — it is removed 200ms later — so a reader
       // is still watching it. Populating it now would announce a message the
       // user was never shown.
+      expect(renderedRegion(0)).toBe(first);
       expect(messageOf(first)).toBe('');
-      expect(messageOf(regions[1] as HTMLElement)).toBe('Second');
+      expect(messageOf(renderedRegion(1))).toBe('Second');
 
       tick(200);
     }));

--- a/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
@@ -62,17 +62,35 @@ describe('TnToastService', () => {
     tick(200);
   }));
 
+  // `duration` is time on screen, so it is counted from the announcement and
+  // not from the call (#195).
   it('should auto-dismiss after duration', fakeAsync(() => {
     const ref = service.open('Test', { duration: 1000 });
     let dismissed = false;
     ref.afterDismissed().subscribe(() => { dismissed = true; });
 
-    tick(999);
+    tick(TN_TOAST_ANNOUNCE_DELAY_MS + 999);
     expect(dismissed).toBe(false);
 
     tick(1);
     expect(dismissed).toBe(true);
 
+    tick(200);
+  }));
+
+  // Counted from the call, this duration would elapse before the toast was
+  // ever shown — and dismissal cancels the pending announcement, so it would
+  // appear and announce nothing at all.
+  it('should still show a toast whose duration is shorter than the announce delay', fakeAsync(() => {
+    service.open('Brief', { duration: 50 });
+
+    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
+    detectChanges();
+    const message = document.querySelector('.tn-toast__message');
+    expect(message?.textContent?.trim()).toBe('Brief');
+    expect(document.querySelector('.tn-toast')?.classList.contains('tn-toast--visible')).toBe(true);
+
+    tick(50);
     tick(200);
   }));
 
@@ -169,7 +187,7 @@ describe('TnToastService', () => {
     let dismissed = false;
     ref.afterDismissed().subscribe(() => { dismissed = true; });
 
-    tick(3999);
+    tick(TN_TOAST_ANNOUNCE_DELAY_MS + 3999);
     expect(dismissed).toBe(false);
 
     tick(1);

--- a/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
@@ -31,12 +31,16 @@ describe('TnToastService', () => {
     expect(document.querySelector('tn-toast')).not.toBeNull();
   });
 
-  it('should render the message text', () => {
-    service.open('Hello world');
+  // The message lands a frame after insertion, so that the live region changes
+  // rather than arriving already populated (#195). `toast-a11y.spec.ts` holds
+  // that contract; this only needs to reach the same frame before reading.
+  it('should render the message text', fakeAsync(() => {
+    service.open('Hello world', { duration: 0 });
+    tick(16);
     detectChanges();
     const message = document.querySelector('.tn-toast__message');
     expect(message?.textContent?.trim()).toBe('Hello world');
-  });
+  }));
 
   it('should return a TnToastRef', () => {
     const ref = service.open('Test');

--- a/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
@@ -1,6 +1,6 @@
 import { ApplicationRef } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { TnToastService } from './toast.service';
+import { TN_TOAST_ANNOUNCE_DELAY_MS, TnToastService } from './toast.service';
 import { TnToastPosition, TnToastType } from './toast.types';
 import { TnIconTesting } from '../icon/icon-testing';
 
@@ -31,12 +31,12 @@ describe('TnToastService', () => {
     expect(document.querySelector('tn-toast')).not.toBeNull();
   });
 
-  // The message lands a frame after insertion, so that the live region changes
-  // rather than arriving already populated (#195). `toast-a11y.spec.ts` holds
-  // that contract; this only needs to reach the same frame before reading.
+  // The message lands after insertion, so that the live region changes rather
+  // than arriving already populated (#195). `toast-a11y.spec.ts` holds that
+  // contract; this only needs to reach the same step before reading.
   it('should render the message text', fakeAsync(() => {
     service.open('Hello world', { duration: 0 });
-    tick(16);
+    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
     detectChanges();
     const message = document.querySelector('.tn-toast__message');
     expect(message?.textContent?.trim()).toBe('Hello world');

--- a/projects/truenas-ui/src/lib/toast/toast.service.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.ts
@@ -156,19 +156,21 @@ export class TnToastService {
     // `opacity: 0` until `visible`, so holding the enter transition back to the
     // step that populates the region is also what keeps the empty region above
     // from ever being seen. The cost is that the toast appears
-    // TN_TOAST_ANNOUNCE_DELAY_MS later than it is attached; `duration` still
-    // runs from the call, so a default toast is shown for 3900ms rather than
-    // 4000ms.
+    // TN_TOAST_ANNOUNCE_DELAY_MS later than it is attached.
+    let timeout: ReturnType<typeof setTimeout> | null = null;
     const announce = setTimeout(() => {
       instance.message.set(message);
       instance.visible.set(true);
-    }, TN_TOAST_ANNOUNCE_DELAY_MS);
 
-    // Auto-dismiss
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    if (duration > 0) {
-      timeout = setTimeout(() => ref.dismiss(), duration);
-    }
+      // The auto-dismiss clock starts here, so `duration` measures time the
+      // toast is ON SCREEN. Started at the call instead, any duration shorter
+      // than the announce delay would dismiss the toast before it was ever
+      // shown — and dismissal cancels the pending announcement, so it would
+      // never appear and never announce either.
+      if (duration > 0) {
+        timeout = setTimeout(() => ref.dismiss(), duration);
+      }
+    }, TN_TOAST_ANNOUNCE_DELAY_MS);
 
     // Cleanup on dismiss
     ref.afterDismissed().subscribe(() => {

--- a/projects/truenas-ui/src/lib/toast/toast.service.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.ts
@@ -107,19 +107,31 @@ export class TnToastService {
     ref._componentRef = componentRef;
 
     const instance = componentRef.instance;
-    instance.message.set(message);
     instance.action.set(action ?? null);
     instance.type.set(type);
     instance.position.set(position);
     instance.onAction = () => ref._triggerAction();
     instance.onDismiss = () => ref.dismiss();
 
-    // Attach to DOM
+    // Attach to DOM. `message` is deliberately still empty here: what a screen
+    // reader reports is a CHANGE to a live region's content, so the region has
+    // to be present and empty before the text arrives. Inserting the region
+    // already populated is special-cased for `role="alert"` and announced
+    // reliably, but the `status` regions this component uses for info, success
+    // and warning (#190) are announced unreliably that way, and on several
+    // readers not at all.
     this.appRef.attachView(componentRef.hostView);
     document.body.appendChild(componentRef.location.nativeElement as HTMLElement);
 
-    // Animate in
+    // Render the empty region now rather than waiting for the next scheduled
+    // tick, so the message below is a second mutation whatever schedules it.
+    componentRef.changeDetectorRef.detectChanges();
+
+    // Announce, and animate in. The message rides the same frame as the enter
+    // transition because that is the frame the toast becomes visible in: it is
+    // `opacity: 0` until `visible`, so the empty region above is never seen.
     requestAnimationFrame(() => {
+      instance.message.set(message);
       instance.visible.set(true);
     });
 

--- a/projects/truenas-ui/src/lib/toast/toast.service.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.ts
@@ -130,7 +130,7 @@ export class TnToastService {
     // Announce, and animate in. The message rides the same frame as the enter
     // transition because that is the frame the toast becomes visible in: it is
     // `opacity: 0` until `visible`, so the empty region above is never seen.
-    requestAnimationFrame(() => {
+    const frame = requestAnimationFrame(() => {
       instance.message.set(message);
       instance.visible.set(true);
     });
@@ -144,6 +144,11 @@ export class TnToastService {
     // Cleanup on dismiss
     ref.afterDismissed().subscribe(() => {
       if (timeout) { clearTimeout(timeout); }
+      // Dropping the frame is what keeps the deferral above from outliving the
+      // toast: `open()` twice in one task dismisses the first synchronously,
+      // and a pending frame would then populate a live region belonging to a
+      // toast already on its way out — announcing a message nobody was shown.
+      cancelAnimationFrame(frame);
       instance.visible.set(false);
 
       // Wait for animation to complete before removing

--- a/projects/truenas-ui/src/lib/toast/toast.service.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.ts
@@ -11,6 +11,25 @@ import { TnToastComponent } from './toast.component';
 import type { TnToastConfig } from './toast.types';
 import { TnToastPosition, TnToastType } from './toast.types';
 
+/**
+ * How long the live region is left attached and empty before the message is
+ * written into it, in milliseconds.
+ *
+ * WHY A TIMER AND NOT THE ANIMATION FRAME THE TRANSITION RIDES
+ * -----------------------------------------------------------
+ * A `requestAnimationFrame` callback runs BEFORE that frame's style, layout and
+ * accessibility-tree update. Attaching the region in one task and populating it
+ * from the next frame's callback therefore commits both mutations in a single
+ * accessibility-tree update — which is the already-populated insertion this
+ * deferral exists to avoid, still there and harder to see. The region needs a
+ * rendering pass of its own, which means yielding past one.
+ *
+ * 100ms is what `@angular/cdk`'s `LiveAnnouncer` waits before writing into its
+ * own region — a dependency of this project already, and the closest thing to a
+ * measured number available.
+ */
+export const TN_TOAST_ANNOUNCE_DELAY_MS = 100;
+
 export class TnToastRef {
   private readonly _onAction = new Subject<void>();
   private readonly _afterDismissed = new Subject<void>();
@@ -53,6 +72,12 @@ export class TnToastService {
 
   /**
    * Opens a toast notification.
+   *
+   * The toast is attached synchronously, but its message and its enter
+   * transition both land `TN_TOAST_ANNOUNCE_DELAY_MS` later — the delay is what
+   * makes the text a *change* to a live region a screen reader is already
+   * watching. A test reading `.tn-toast__message` must let that elapse; one
+   * asserting on the call rather than the DOM should use `TnToastMock`.
    *
    * @param message The message to display.
    * @param actionOrConfig Optional action button text, or config object.
@@ -127,13 +152,17 @@ export class TnToastService {
     // tick, so the message below is a second mutation whatever schedules it.
     componentRef.changeDetectorRef.detectChanges();
 
-    // Announce, and animate in. The message rides the same frame as the enter
-    // transition because that is the frame the toast becomes visible in: it is
-    // `opacity: 0` until `visible`, so the empty region above is never seen.
-    const frame = requestAnimationFrame(() => {
+    // Announce, and animate in — together, and not before. The toast is
+    // `opacity: 0` until `visible`, so holding the enter transition back to the
+    // step that populates the region is also what keeps the empty region above
+    // from ever being seen. The cost is that the toast appears
+    // TN_TOAST_ANNOUNCE_DELAY_MS later than it is attached; `duration` still
+    // runs from the call, so a default toast is shown for 3900ms rather than
+    // 4000ms.
+    const announce = setTimeout(() => {
       instance.message.set(message);
       instance.visible.set(true);
-    });
+    }, TN_TOAST_ANNOUNCE_DELAY_MS);
 
     // Auto-dismiss
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -144,11 +173,12 @@ export class TnToastService {
     // Cleanup on dismiss
     ref.afterDismissed().subscribe(() => {
       if (timeout) { clearTimeout(timeout); }
-      // Dropping the frame is what keeps the deferral above from outliving the
-      // toast: `open()` twice in one task dismisses the first synchronously,
-      // and a pending frame would then populate a live region belonging to a
-      // toast already on its way out — announcing a message nobody was shown.
-      cancelAnimationFrame(frame);
+      // Dropping the pending announcement is what keeps the deferral above from
+      // outliving the toast: `open()` twice in one task dismisses the first
+      // synchronously, and a pending timer would then populate a live region
+      // belonging to a toast already on its way out — announcing a message
+      // nobody was shown.
+      clearTimeout(announce);
       instance.visible.set(false);
 
       // Wait for animation to complete before removing

--- a/projects/truenas-ui/src/lib/toast/toast.types.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.types.ts
@@ -11,7 +11,11 @@ export enum TnToastPosition {
 }
 
 export interface TnToastConfig {
-  /** Auto-dismiss duration in milliseconds. Default: 4000. Set to 0 to disable. */
+  /**
+   * How long the toast stays on screen, in milliseconds, counted from when it
+   * appears rather than from the `open()` call. Default: 4000. Set to 0 to
+   * disable auto-dismissal.
+   */
   duration?: number;
   /** Visual style of the toast. Default: TnToastType.Info. */
   type?: TnToastType;


### PR DESCRIPTION
Fixes #195.

`TnToastService` set `message` on the component instance and only then appended the host, so the live region and its text entered the DOM in a single mutation. A screen reader reports a **change** to a live region's content: `role="alert"` is special-cased and announced on insertion, but the `role="status"` regions that info, success and warning toasts carry after #190 are announced unreliably that way, and on several readers not at all.

The region is now attached and rendered empty, and the message written into it 100ms later. The component is unchanged, as the ticket says it should be.

## Why 100ms and not the animation frame the ticket suggests

The ticket offers "a subsequent tick (or a `requestAnimationFrame`, which the service already uses)". The first version of this PR used the frame, and it does not work:

**a `requestAnimationFrame` callback runs BEFORE that frame's style, layout and accessibility-tree update.** Attaching the region in one task and populating it from the next frame's callback commits both mutations in a single accessibility-tree update — which is the already-populated insertion this deferral exists to avoid, still there and harder to see than before. The region needs a rendering pass of its own, which means yielding past one.

100ms is what `@angular/cdk`'s `LiveAnnouncer` waits before writing into its own region (`_a11y-module-chunk.mjs`, `announce()`), and `@angular/cdk` is a peer dependency of this package. It is exported as `TN_TOAST_ANNOUNCE_DELAY_MS` so the specs assert against the real number rather than a guess at it.

**No test here can tell the two versions apart.** jsdom has no rendering lifecycle, so both satisfy every DOM assertion below. The mechanism is what decides it, and that is worth knowing when reading the tests.

## Two defects the deferral introduced, and what they cost

Deferring a write gives it ways to outlive its toast. Both were found in review and both are covered:

| input | before the fix in this PR | now |
|---|---|---|
| `open('First'); open('Second')` in one task | the first is dismissed synchronously, its pending write then populates its region — announcing a message the user was never shown. Measured: the superseded region announced `"First"` | dismissal cancels the pending announcement |
| `open('Brief', { duration: 50 })` | dismissed 50ms after the call, before the 100ms announcement — and dismissal cancels it, so the toast appeared and announced nothing at all. Measured: the region rendered empty and stayed empty | the auto-dismiss clock starts where the toast becomes visible |

The second changes what `duration` means: **time on screen, counted from when the toast appears rather than from `open()`**. That is now the only reading under which every value of it works, and `TnToastConfig.duration` says so. A default toast is shown for its full 4000ms; it simply starts 100ms later.

## Acceptance criteria

| criterion | where |
|---|---|
| the toast is in the document with no message text before the message is set | `toast-a11y.spec.ts` — `the region is inserted empty and populated afterwards` |
| an `info` toast is announced, asserted by observing the region empty at insertion and populated afterwards | same, for all three polite types |
| visible behaviour unchanged: no flash of an empty toast, enter transition still runs | `the visible behaviour is unchanged`. The message and `visible` land together, and `.tn-toast` is `opacity: 0` until then, so the empty region is never painted |
| `error` toasts keep announcing as they do today | `keeps an error toast announcing, on the role that interrupts` |

## The tests assert a transition, not a sample

Neither end means anything alone: "empty at insertion" is satisfied by a toast that never populates, "populated afterwards" by the pre-fix code. Each test asserts both, and that the region is the **same node** at each — a service that replaced the element rather than mutating it would satisfy both samples while handing a reader a region it was never watching.

The helper also asserts the region is *rendered*, and that is not decoration. `createComponent` runs the template's create pass, so `.tn-toast` is in the DOM before any binding has been applied: no `role`, and an empty `{{ message() }}`. **Three of these tests passed against the pre-fix service until the helper read `role`** — an unrendered region is empty too. Measured, not assumed.

Every assertion was run against the code it is meant to catch:

- all 5 original timing tests fail on the pre-fix service
- the superseded-toast test reports `"First"` without the cancellation
- the short-duration test renders an empty region without the moved clock

## Review

`local-review.py` ran the project's own reviewer — same rubric, threshold and parser as the required check — over four rounds. It exited clean on the pushed diff. Two LOW findings were left in place deliberately:

- **"`@angular/cdk` is a devDependency, so library code cannot import `LiveAnnouncer`"** — it is a devDependency at the workspace root, but `projects/truenas-ui/package.json` declares it as a **peer** dependency, so it is available to library code and to consumers. Nothing here imports it in any case; it is cited as precedent for the delay.
- **"the `opacity: 0` toast intercepts clicks at top-centre, and that window grows from ~1 frame to 100ms"** — correct, and accepted. `.tn-toast` is `pointer-events: auto` throughout its enter transition, so the window exists today and this lengthens it by 100ms. Narrowing it means changing the component's styles, which this ticket says should not change.

## Checks run locally

`yarn lint`, `yarn test` (2242 passing), `yarn test:scripts`, `yarn build`. Lint reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here. The Storybook interaction job was not run locally; no toast story has a play function, and no other story opens a toast.
