### PR TITLE
NAS-142299 / 27.0.0-BETA.1 / fix(a11y): declare live-region politeness once, and settle whether warning interrupts

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -417,6 +417,9 @@ assertive, `status` is polite — and an explicit `aria-live` on the same elemen
 *overrides* it. Setting both is not redundant, it is a contradiction, and it is
 the defect fixed in banner, radio, checkbox and toast (#190, #194). Prefer the
 role and leave `aria-live` off; there is then no second attribute to disagree.
+`table.component.html` still sets both. There they agree — `status` and `polite`
+say the same thing — so it is redundancy rather than a defect, and it has not
+been cleaned up.
 
 **A component whose politeness follows a severity takes it from
 `lib/a11y/live-region.ts`.** `tnLiveRegionRole(severity)` is the single place

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -410,6 +410,24 @@ Add when semantic HTML is insufficient:
 </button>
 ```
 
+### Live Regions
+
+**Declare politeness exactly once.** A live-region role implies one — `alert` is
+assertive, `status` is polite — and an explicit `aria-live` on the same element
+*overrides* it. Setting both is not redundant, it is a contradiction, and it is
+the defect fixed in banner, radio, checkbox and toast (#190, #194). Prefer the
+role and leave `aria-live` off; there is then no second attribute to disagree.
+
+**A component whose politeness follows a severity takes it from
+`lib/a11y/live-region.ts`.** `tnLiveRegionRole(severity)` is the single place
+deciding which severities interrupt — banner and toast disagreed about `warning`
+until it existed. Do not restate the mapping in a `computed`.
+
+**Assert the RESOLVED politeness, not an attribute.** A spec naming one source
+passes just as happily on markup that reintroduces the other. Use `liveSources()`
+and `politeness()` from `lib/a11y/live-region-testing.ts`; see
+`banner-a11y.spec.ts` for the shape.
+
 ### Keyboard Navigation
 Support standard keys:
 - **Tab** - Focus navigation

--- a/projects/truenas-ui/src/lib/a11y/live-region-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/live-region-testing.ts
@@ -1,0 +1,58 @@
+/**
+ * Spec helpers for asserting what a screen reader would resolve a live region's
+ * politeness to.
+ *
+ * These are the assertions that hold #190 and #194 in place, and they are
+ * shared because the defect they guard is a DISAGREEMENT between two sources.
+ * A spec that named one attribute would pass just as happily on markup that
+ * reintroduced the other, so every such spec has to resolve politeness the same
+ * way — and four private near-copies of that resolution is the shape that lets
+ * one of them quietly drift into being the lenient one.
+ *
+ * Not exported from `public-api.ts`: this is test-tree code that happens to
+ * live beside the production module it guards, the way `icon-testing.ts` does.
+ */
+
+/** Politeness each live-region role implies, per ARIA 1.2. */
+export const IMPLICIT_POLITENESS: Record<string, string> = {
+  alert: 'assertive',
+  status: 'polite',
+  log: 'polite',
+  marquee: 'off',
+  timer: 'off',
+};
+
+/**
+ * Every attribute on `el` that declares a politeness, as `attr=value` pairs.
+ *
+ * A live-region ROLE counts as one of them: that is the whole point of #190 and
+ * #194, where the second source was implicit and so easy to leave in place. A
+ * role that is not a live region (or none at all) contributes nothing.
+ */
+export function liveSources(el: HTMLElement): string[] {
+  const sources: string[] = [];
+  const role = el.getAttribute('role');
+  if (role !== null && role in IMPLICIT_POLITENESS) {
+    sources.push(`role=${role}`);
+  }
+  const live = el.getAttribute('aria-live');
+  if (live !== null) {
+    sources.push(`aria-live=${live}`);
+  }
+  return sources;
+}
+
+/**
+ * What a screen reader resolves the politeness of `el` to.
+ *
+ * An explicit `aria-live` beats the role's implicit value, which is exactly how
+ * the broken markup turned an alert into a polite one.
+ */
+export function politeness(el: HTMLElement): string {
+  const live = el.getAttribute('aria-live');
+  if (live !== null) {
+    return live;
+  }
+  const role = el.getAttribute('role');
+  return (role !== null && IMPLICIT_POLITENESS[role]) || 'off';
+}

--- a/projects/truenas-ui/src/lib/a11y/live-region-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/live-region-testing.ts
@@ -9,8 +9,11 @@
  * way — and four private near-copies of that resolution is the shape that lets
  * one of them quietly drift into being the lenient one.
  *
- * Not exported from `public-api.ts`: this is test-tree code that happens to
- * live beside the production module it guards, the way `icon-testing.ts` does.
+ * Not exported from `public-api.ts`, unlike `icon-testing.ts` and
+ * `toast-testing.ts`, which are. Those exist for consumers testing THEIR code
+ * against this library; these two functions assert an internal contract of this
+ * library's own markup, so exporting them would widen the public surface with
+ * something no consumer has a use for.
  */
 
 /** Politeness each live-region role implies, per ARIA 1.2. */

--- a/projects/truenas-ui/src/lib/a11y/live-region.ts
+++ b/projects/truenas-ui/src/lib/a11y/live-region.ts
@@ -1,0 +1,53 @@
+/**
+ * The one place that decides how urgently a severity-carrying component
+ * announces itself, and the only place the answer is written down.
+ *
+ * WHY A SHARED FUNCTION AND NOT A COMPUTED PER COMPONENT
+ * -----------------------------------------------------
+ * Banner and toast both map a severity onto a live-region role, and until #194
+ * they disagreed about `warning`: banner made it `alert`, the #190 toast fix
+ * made it `status`. Both readings are defensible, neither was written down, and
+ * nothing would have caught the drift — two `computed`s cannot contradict each
+ * other loudly. Routing both through this function is what makes the next such
+ * disagreement a compile-time edit here rather than a silent divergence.
+ *
+ * WHY `warning` INTERRUPTS
+ * -----------------------
+ * A warning names something already wrong that the user has not been told
+ * about — a pool degrading, a certificate about to expire. Politeness queues an
+ * announcement behind whatever the reader is currently saying and drops it
+ * entirely if the region's content changes again first, which for a toast is
+ * four seconds away. `info` and `success` describe what the user just did and
+ * lose nothing by waiting; `warning` and `error` describe what the user does
+ * not yet know, and a warning that arrives after the user has moved on is a
+ * warning that did not arrive.
+ *
+ * WHY THE ROLE CARRIES IT AND NOT `aria-live`
+ * -------------------------------------------
+ * A live-region role implies a politeness — `alert` is assertive, `status` is
+ * polite — and an explicit `aria-live` on the same element OVERRIDES it. Every
+ * defect this module exists for was that override: markup that set both, so the
+ * element claimed to be an alert while asking not to interrupt. Returning a
+ * role and leaving `aria-live` off keeps one source, because there is no second
+ * attribute left to disagree with it.
+ */
+
+/** The severity levels that map onto a live-region role. */
+export type TnLiveRegionSeverity = 'info' | 'success' | 'warning' | 'error';
+
+/** The severities that interrupt. See the note above for why `warning` is here. */
+export const TN_ASSERTIVE_SEVERITIES: readonly string[] = ['warning', 'error'];
+
+/**
+ * The live-region role a component of this severity should carry — which is
+ * also the only thing declaring its politeness.
+ *
+ * `severity` is typed `string` rather than `TnLiveRegionSeverity` because a
+ * TypeScript string enum member is not assignable to the literal union it
+ * spells, and `TnToastType` is one. Callers pass their own severity type; an
+ * unrecognised value resolves to the polite role, which is the safe default —
+ * it announces without interrupting.
+ */
+export function tnLiveRegionRole(severity: string): 'alert' | 'status' {
+  return TN_ASSERTIVE_SEVERITIES.includes(severity) ? 'alert' : 'status';
+}

--- a/projects/truenas-ui/src/lib/a11y/live-region.ts
+++ b/projects/truenas-ui/src/lib/a11y/live-region.ts
@@ -32,21 +32,22 @@
  * attribute left to disagree with it.
  */
 
-/** The severity levels that map onto a live-region role. */
-export type TnLiveRegionSeverity = 'info' | 'success' | 'warning' | 'error';
-
-/** The severities that interrupt. See the note above for why `warning` is here. */
+/**
+ * The severities that interrupt, out of the four this library uses — `info`,
+ * `success`, `warning`, `error`. See the note above for why `warning` is here.
+ */
 export const TN_ASSERTIVE_SEVERITIES: readonly string[] = ['warning', 'error'];
 
 /**
  * The live-region role a component of this severity should carry — which is
  * also the only thing declaring its politeness.
  *
- * `severity` is typed `string` rather than `TnLiveRegionSeverity` because a
+ * `severity` is typed `string` rather than a union of the four levels because a
  * TypeScript string enum member is not assignable to the literal union it
- * spells, and `TnToastType` is one. Callers pass their own severity type; an
- * unrecognised value resolves to the polite role, which is the safe default —
- * it announces without interrupting.
+ * spells, and `TnToastType` is one — a union here would force every toast call
+ * site through a cast. Callers pass their own severity type, which is where the
+ * spelling is checked; an unrecognised value resolves to the polite role, which
+ * is the safe default because it announces without interrupting.
  */
 export function tnLiveRegionRole(severity: string): 'alert' | 'status' {
   return TN_ASSERTIVE_SEVERITIES.includes(severity) ? 'alert' : 'status';

--- a/projects/truenas-ui/src/lib/banner/banner-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner-a11y.spec.ts
@@ -1,0 +1,82 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnBannerComponent } from './banner.component';
+import type { TnBannerType } from './banner.component';
+import { liveSources, politeness } from '../a11y/live-region-testing';
+
+/**
+ * Guards the live-region contract fixed for #194: the banner carried a static
+ * `aria-live="polite"` beside `[attr.role]="ariaRole()"`. An explicit
+ * `aria-live` overrides the role's implicit politeness, so the two types whose
+ * role is deliberately `alert` — `error` and `warning` — were downgraded to
+ * polite, and the computed that chose the role decided nothing at all.
+ *
+ * That is why these assertions are here and not in `banner.component.spec.ts`,
+ * which already asserted `ariaRole()` per type and asserted the rendered `role`
+ * attribute. Both passed against the broken markup: they read the source the
+ * screen reader was ignoring. What was missing is the RESOLVED politeness, and
+ * a count of how many attributes were claiming to set it.
+ *
+ * `liveSources()` and `politeness()` are shared with the toast, radio and
+ * checkbox specs — one resolution, so no copy can drift into being lenient.
+ */
+describe('tn-banner accessibility (#194)', () => {
+  let fixture: ComponentFixture<TnBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnBannerComponent],
+      providers: [provideHttpClient()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TnBannerComponent);
+    fixture.componentRef.setInput('heading', 'Pool degraded');
+    fixture.detectChanges();
+  });
+
+  function region(type: TnBannerType): HTMLElement {
+    fixture.componentRef.setInput('type', type);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('.tn-banner') as HTMLElement;
+  }
+
+  const ALL_TYPES: TnBannerType[] = ['info', 'success', 'warning', 'error'];
+
+  describe('exactly one source of politeness', () => {
+    // The pre-fix markup returned ['role=…', 'aria-live=polite'] here, for every
+    // type. This is the assertion that failed before the fix.
+    it.each(ALL_TYPES)('declares politeness once on a %s banner', (type) => {
+      expect(liveSources(region(type))).toHaveLength(1);
+    });
+  });
+
+  describe('politeness follows the banner type', () => {
+    // `warning` interrupts, and it is the same answer the toast gives — see
+    // `../a11y/live-region.ts` for the reason. Before the fix both of these
+    // resolved to 'polite', because the static attribute won.
+    it.each<TnBannerType>(['error', 'warning'])(
+      'interrupts for a %s banner, which is a case that needs to',
+      (type) => {
+        expect(politeness(region(type))).toBe('assertive');
+      }
+    );
+
+    it.each<TnBannerType>(['info', 'success'])(
+      'does not interrupt for a %s banner',
+      (type) => {
+        expect(politeness(region(type))).toBe('polite');
+      }
+    );
+
+    // Politeness is only honoured on something that IS a live region: drop the
+    // role and `politeness()` would still read an explicit `aria-live` no
+    // screen reader watches. Naming the two roles pins which mechanism carries
+    // it, so a later edit cannot satisfy the assertions above with an attribute
+    // alone.
+    it('carries the politeness on a live-region role', () => {
+      expect(region('error').getAttribute('role')).toBe('alert');
+      expect(region('info').getAttribute('role')).toBe('status');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/banner/banner.component.html
+++ b/projects/truenas-ui/src/lib/banner/banner.component.html
@@ -1,5 +1,10 @@
+<!--
+  `ariaRole()` is the only thing declaring how urgently the banner announces:
+  it implies the politeness, and an explicit `aria-live` here would override it
+  — which is what the static `aria-live="polite"` used to do, downgrading the
+  two types deliberately made assertive. See `../a11y/live-region.ts`.
+-->
 <div
-  aria-live="polite"
   [ngClass]="classes()"
   [attr.role]="ariaRole()"
 >

--- a/projects/truenas-ui/src/lib/banner/banner.component.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.ts
@@ -6,6 +6,7 @@ import {
   mdiAlertCircle,
   mdiCheckCircle,
 } from '@mdi/js';
+import { tnLiveRegionRole } from '../a11y/live-region';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconComponent } from '../icon/icon.component';
 
@@ -102,15 +103,15 @@ export class TnBannerComponent {
   });
 
   /**
-   * Get ARIA role based on banner type
-   * Error/warning use 'alert' for immediate attention
-   * Info/success use 'status' for polite announcements
+   * The live-region role, which is also the only thing declaring how urgently
+   * the banner is announced: `alert` implies `aria-live="assertive"` and
+   * `status` implies `polite`. The template carries no `aria-live`, because an
+   * explicit one would override this.
+   *
+   * The mapping is shared with toast rather than restated here — see
+   * `../a11y/live-region.ts` for which severities interrupt and why.
    */
-  ariaRole = computed(() => {
-    return this.type() === 'error' || this.type() === 'warning'
-      ? 'alert'
-      : 'status';
-  });
+  ariaRole = computed(() => tnLiveRegionRole(this.type()));
 
   /**
    * Generate CSS classes using BEM methodology

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-a11y.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnCheckboxComponent } from './checkbox.component';
+import { liveSources, politeness } from '../a11y/live-region-testing';
+
+/**
+ * Guards the live-region contract fixed for #194: the validation error carried
+ * `role="alert"` and `aria-live="polite"` on the same element. An explicit
+ * `aria-live` overrides the role's implicit politeness, so the element claimed
+ * to be an alert while asking not to interrupt — leaving which of the two wins
+ * to the screen reader.
+ *
+ * `role="alert"` is the right choice for a validation error and is what stayed;
+ * see `../radio/radio-a11y.spec.ts`, which guards the same shape on the same
+ * markup. The resolution helpers are shared so that no copy of them can drift.
+ */
+describe('tn-checkbox accessibility (#194)', () => {
+  let fixture: ComponentFixture<TnCheckboxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnCheckboxComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TnCheckboxComponent);
+    fixture.componentRef.setInput('label', 'Accept');
+    fixture.componentRef.setInput('error', 'You must accept');
+    fixture.detectChanges();
+  });
+
+  function errorRegion(): HTMLElement {
+    const el = fixture.nativeElement.querySelector('.tn-checkbox__error') as HTMLElement | null;
+    // The region is behind `@if (error())`, and an absent element would satisfy
+    // nothing below while failing in a way that reads like a passing suite.
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  }
+
+  // The pre-fix markup returned ['role=alert', 'aria-live=polite'] here. This is
+  // the assertion that failed before the fix.
+  it('declares politeness exactly once on the validation error', () => {
+    expect(liveSources(errorRegion())).toHaveLength(1);
+  });
+
+  it('still announces the validation error assertively', () => {
+    expect(politeness(errorRegion())).toBe('assertive');
+  });
+
+  // Politeness is only honoured on something that IS a live region: drop the
+  // role and `politeness()` would still read an explicit `aria-live` no screen
+  // reader watches. Naming the role pins which mechanism carries it.
+  it('carries the politeness on the alert role', () => {
+    expect(errorRegion().getAttribute('role')).toBe('alert');
+  });
+});

--- a/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox.component.html
@@ -30,7 +30,6 @@
     <div
       class="tn-checkbox__error"
       role="alert"
-      aria-live="polite"
       [id]="id + '-error'"
     >
       {{ error() }}

--- a/projects/truenas-ui/src/lib/radio/radio-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-a11y.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnRadioComponent } from './radio.component';
+import { liveSources, politeness } from '../a11y/live-region-testing';
+
+/**
+ * Guards the live-region contract fixed for #194: the validation error carried
+ * `role="alert"` and `aria-live="polite"` on the same element. An explicit
+ * `aria-live` overrides the role's implicit politeness, so the element claimed
+ * to be an alert while asking not to interrupt — leaving which of the two wins
+ * to the screen reader.
+ *
+ * `role="alert"` is the right choice for a validation error and is what stayed:
+ * the message appears in response to something the user just did wrong, and it
+ * has to reach them before they move on. The `aria-live` was redundant with the
+ * role at best and contradicting it at worst, so it went.
+ *
+ * `checkbox-a11y.spec.ts` guards the same shape on the same markup, and
+ * `banner-a11y.spec.ts` and `toast-a11y.spec.ts` the same defect elsewhere.
+ * The resolution helpers are shared so that no copy of them can drift.
+ */
+describe('tn-radio accessibility (#194)', () => {
+  let fixture: ComponentFixture<TnRadioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnRadioComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TnRadioComponent);
+    fixture.componentRef.setInput('label', 'Option A');
+    fixture.componentRef.setInput('error', 'Pick one');
+    fixture.detectChanges();
+  });
+
+  function errorRegion(): HTMLElement {
+    const el = fixture.nativeElement.querySelector('.tn-radio__error') as HTMLElement | null;
+    // The region is behind `@if (error())`, and an absent element would satisfy
+    // nothing below while failing in a way that reads like a passing suite.
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  }
+
+  // The pre-fix markup returned ['role=alert', 'aria-live=polite'] here. This is
+  // the assertion that failed before the fix.
+  it('declares politeness exactly once on the validation error', () => {
+    expect(liveSources(errorRegion())).toHaveLength(1);
+  });
+
+  it('still announces the validation error assertively', () => {
+    expect(politeness(errorRegion())).toBe('assertive');
+  });
+
+  // Politeness is only honoured on something that IS a live region: drop the
+  // role and `politeness()` would still read an explicit `aria-live` no screen
+  // reader watches. Naming the role pins which mechanism carries it.
+  it('carries the politeness on the alert role', () => {
+    expect(errorRegion().getAttribute('role')).toBe('alert');
+  });
+});

--- a/projects/truenas-ui/src/lib/radio/radio.component.html
+++ b/projects/truenas-ui/src/lib/radio/radio.component.html
@@ -22,7 +22,6 @@
     <div
       class="tn-radio__error"
       role="alert"
-      aria-live="polite"
       [id]="id + '-error'"
     >
       {{ error() }}

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -5,6 +5,7 @@ import axe from 'axe-core';
 import { TnToastComponent } from './toast.component';
 import { TN_TOAST_ANNOUNCE_DELAY_MS, TnToastService } from './toast.service';
 import { TnToastType } from './toast.types';
+import { liveSources, politeness } from '../a11y/live-region-testing';
 import { TnIconTesting } from '../icon/icon-testing';
 
 /**
@@ -19,10 +20,12 @@ import { TnIconTesting } from '../icon/icon-testing';
  * ---------------------------------------------------------------------
  * The defect was two sources disagreeing, so a test naming one attribute would
  * pass just as happily on markup that reintroduced the other. `politeness()`
- * below therefore resolves what a screen reader would resolve — implicit from
- * the role, explicit from `aria-live` — and `liveSources()` counts how many
- * were on offer. One assertion for what it announces, one for there being a
- * single thing saying so.
+ * therefore resolves what a screen reader would resolve — implicit from the
+ * role, explicit from `aria-live` — and `liveSources()` counts how many were on
+ * offer. One assertion for what it announces, one for there being a single
+ * thing saying so. Both come from `../a11y/live-region-testing`, shared with
+ * the banner, radio and checkbox specs (#194) so that no copy of them can drift
+ * into being the lenient one.
  *
  * WHAT AXE DOES NOT CATCH, WHICH IS WHY THE DOM TESTS COME FIRST
  * -------------------------------------------------------------
@@ -37,15 +40,6 @@ import { TnIconTesting } from '../icon/icon-testing';
  * `slide-toggle-a11y.spec.ts` (#189) does: an empty `violations` is also what
  * axe returns when it ran nothing at all.
  */
-
-/** Politeness each live-region role implies, per ARIA 1.2. */
-const IMPLICIT_POLITENESS: Record<string, string> = {
-  alert: 'assertive',
-  status: 'polite',
-  log: 'polite',
-  marquee: 'off',
-  timer: 'off',
-};
 
 describe('tn-toast accessibility (#190)', () => {
   let fixture: ComponentFixture<TnToastComponent>;
@@ -69,41 +63,6 @@ describe('tn-toast accessibility (#190)', () => {
     component.type.set(type);
     fixture.detectChanges();
     return fixture.nativeElement.querySelector('.tn-toast') as HTMLElement;
-  }
-
-  /**
-   * Every attribute on `el` that declares a politeness, as `attr=value` pairs.
-   *
-   * A live-region ROLE counts as one of them: that is the whole point of #190,
-   * where the second source was implicit and so easy to leave in place. A role
-   * that is not a live region (or none at all) contributes nothing.
-   */
-  function liveSources(el: HTMLElement): string[] {
-    const sources: string[] = [];
-    const role = el.getAttribute('role');
-    if (role !== null && role in IMPLICIT_POLITENESS) {
-      sources.push(`role=${role}`);
-    }
-    const live = el.getAttribute('aria-live');
-    if (live !== null) {
-      sources.push(`aria-live=${live}`);
-    }
-    return sources;
-  }
-
-  /**
-   * What a screen reader resolves the politeness to.
-   *
-   * An explicit `aria-live` beats the role's implicit value, which is exactly
-   * how the broken markup turned an alert into a polite one.
-   */
-  function politeness(el: HTMLElement): string {
-    const live = el.getAttribute('aria-live');
-    if (live !== null) {
-      return live;
-    }
-    const role = el.getAttribute('role');
-    return (role !== null && IMPLICIT_POLITENESS[role]) || 'off';
   }
 
   /**
@@ -147,11 +106,17 @@ describe('tn-toast accessibility (#190)', () => {
   });
 
   describe('politeness follows the toast type', () => {
-    it('interrupts for an error, which is the case that needs to', () => {
-      expect(politeness(region(TnToastType.Error))).toBe('assertive');
-    });
+    // `warning` interrupts as of #194, where it was the divergence between this
+    // component and the banner. The reason is in `../a11y/live-region.ts`; what
+    // is asserted here is only that the component obeys it.
+    it.each([TnToastType.Error, TnToastType.Warning])(
+      'interrupts for a %s toast, which is a case that needs to',
+      (type) => {
+        expect(politeness(region(type))).toBe('assertive');
+      }
+    );
 
-    it.each([TnToastType.Info, TnToastType.Success, TnToastType.Warning])(
+    it.each([TnToastType.Info, TnToastType.Success])(
       'does not interrupt for a %s toast',
       (type) => {
         expect(politeness(region(type))).toBe('polite');
@@ -199,9 +164,9 @@ describe('tn-toast accessibility (#190)', () => {
  * set `message` on the component instance and only then appended the host, so
  * the region and its text entered the DOM in one mutation and there was no
  * change to report. `role="alert"` survives that — readers special-case an
- * alert appearing already populated — but `role="status"`, which info, success
- * and warning toasts carry, is announced unreliably that way and on several
- * readers not at all.
+ * alert appearing already populated — but `role="status"`, which info and
+ * success toasts carry (warning joined the alerts in #194), is announced
+ * unreliably that way and on several readers not at all.
  *
  * WHY THESE ASSERTIONS ARE PAIRED, AND READ THE SAME ELEMENT TWICE
  * ---------------------------------------------------------------
@@ -277,7 +242,7 @@ describe('tn-toast live-region timing (#195)', () => {
   }
 
   describe('the region is inserted empty and populated afterwards', () => {
-    it.each([TnToastType.Info, TnToastType.Success, TnToastType.Warning])(
+    it.each([TnToastType.Info, TnToastType.Success])(
       'gives a polite %s toast a content change to announce',
       fakeAsync((type: TnToastType) => {
         service.open('Changes saved', { type, duration: 0 });
@@ -296,21 +261,25 @@ describe('tn-toast live-region timing (#195)', () => {
       })
     );
 
-    // Error toasts were never the broken case, and the deferral does not cost
+    // Alert toasts were never the broken case, and the deferral does not cost
     // them anything: a change to an `alert` region is announced just as its
-    // populated insertion was. Asserted because it is what #195 must not break.
-    it('keeps an error toast announcing, on the role that interrupts', fakeAsync(() => {
-      service.open('Save failed', { type: TnToastType.Error, duration: 0 });
+    // populated insertion was. Asserted because it is what #195 must not break
+    // — and re-run for `warning`, which #194 moved onto this role.
+    it.each([TnToastType.Error, TnToastType.Warning])(
+      'keeps a %s toast announcing, on the role that interrupts',
+      fakeAsync((type: TnToastType) => {
+        service.open('Save failed', { type, duration: 0 });
 
-      const el = renderedRegion();
-      expect(el.getAttribute('role')).toBe('alert');
-      expect(messageOf(el)).toBe('');
+        const el = renderedRegion();
+        expect(el.getAttribute('role')).toBe('alert');
+        expect(messageOf(el)).toBe('');
 
-      announceStep();
+        announceStep();
 
-      expect(renderedRegion()).toBe(el);
-      expect(messageOf(el)).toBe('Save failed');
-    }));
+        expect(renderedRegion()).toBe(el);
+        expect(messageOf(el)).toBe('Save failed');
+      })
+    );
 
     // An action label is set before the host is attached, so this region is
     // NOT empty at insertion — and it does not need to be. What a reader

--- a/projects/truenas-ui/src/lib/toast/toast.component.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, signal, ViewEncapsulation } from '@angular/core';
 import { TnToastPosition, TnToastType } from './toast.types';
+import { tnLiveRegionRole } from '../a11y/live-region';
 import { tnIconMarker } from '../icon/icon-marker';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective } from '../test-id';
@@ -48,8 +49,12 @@ export class TnToastComponent {
    * announced politely — including `error`, the one type that needs to interrupt.
    * Deriving the role from the type and leaving `aria-live` off keeps a single
    * source: there is no second attribute left to disagree with this one.
+   *
+   * WHICH types get `alert` is shared with banner rather than decided here
+   * (#194): #190 mapped `warning` to `status` while banner mapped it to
+   * `alert`, and `../a11y/live-region.ts` is now the one place that answers it.
    */
-  role = computed(() => (this.type() === TnToastType.Error ? 'alert' : 'status'));
+  role = computed(() => tnLiveRegionRole(this.type()));
 
   onAction: () => void = () => {};
   onDismiss: () => void = () => {};

--- a/projects/truenas-ui/src/lib/toast/toast.service.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.ts
@@ -142,8 +142,8 @@ export class TnToastService {
     // reader reports is a CHANGE to a live region's content, so the region has
     // to be present and empty before the text arrives. Inserting the region
     // already populated is special-cased for `role="alert"` and announced
-    // reliably, but the `status` regions this component uses for info, success
-    // and warning (#190) are announced unreliably that way, and on several
+    // reliably, but the `status` regions this component uses for info and
+    // success (#190, #194) are announced unreliably that way, and on several
     // readers not at all.
     this.appRef.attachView(componentRef.hostView);
     document.body.appendChild(componentRef.location.nativeElement as HTMLElement);


### PR DESCRIPTION
Fixes #194.

Banner, radio and checkbox each set an explicit `aria-live="polite"` on an element that already carried a live-region role. An explicit `aria-live` **overrides** the role's implicit politeness, so each of them announced politely whatever its role claimed to be.

Banner was the costly one. `ariaRole()` computes `alert` for `error` and `warning` and `status` otherwise — and the static attribute overrode exactly the two types that computed exists to make assertive. Its own spec asserted `ariaRole()` and the rendered `role` attribute, and both passed against the defect: they read the source the screen reader was ignoring.

Radio and checkbox use theirs on validation error text, where `role="alert"` is correct and the `aria-live` only contradicted it. The role stayed; the attribute went.

## `warning` interrupts, and now says so in one place

Banner mapped `warning` → `alert`; #190's toast fix mapped it → `status`. Both are defensible, neither was written down, and nothing would have caught the drift — two `computed`s cannot contradict each other loudly.

`projects/truenas-ui/src/lib/a11y/live-region.ts` is now the only place that answers it, and the answer is **assertive**: a warning names something already wrong that the user has not been told about, while `info` and `success` describe what the user just did. Politeness queues an announcement behind whatever the reader is saying and drops it if the region changes again first — which for a toast is four seconds away, so a warning that waits is a warning that does not arrive.

**This changes toast behaviour**: `warning` toasts now carry `role="alert"` and interrupt. That is the point of the shared decision rather than a side effect of it, and the toast specs for #190 and #195 were moved onto it.

## The tests assert what a reader resolves, not what an attribute says

The defect is two sources **disagreeing**, so a spec naming one attribute passes just as happily on markup that reintroduces the other. `liveSources()` counts how many attributes claimed to set the politeness (a live-region role counts as one); `politeness()` resolves what a screen reader would resolve. Both are shared from `lib/a11y/live-region-testing.ts` so no copy can drift into being the lenient one, and `toast-a11y.spec.ts` now imports them rather than keeping its own.

New: `banner-a11y.spec.ts`, `radio-a11y.spec.ts`, `checkbox-a11y.spec.ts`.

**Measured, not assumed:** with `aria-live="polite"` put back on all three templates, 10 of the 15 new assertions fail. The 5 that still pass are the ones pinning *which role* carries the politeness and the two banner types that are polite either way — they are there so a later edit cannot satisfy the rest with an attribute alone.

## Checks run locally

`yarn lint`, `yarn test` (95 suites, 2257 tests), `yarn test:scripts` (42) and `yarn build` all pass. Lint reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here.

**Not run:** Storybook interaction tests, which need a Playwright browser install.

## Local review

`local-review.py` ran the project's own reviewer twice — the same rubric and threshold as the required check, in a separate process — and **both rounds returned nothing at or above MEDIUM**. Round 1's four LOW findings are fixed in the second commit: a dead exported type, a docblock that cited `icon-testing.ts` as precedent for something it does not do, and a convention note that read as though nothing else in the library sets both (`table.component.html` does, where the two agree).

Round 2's four remaining LOWs are left, and are recorded here rather than silently dropped:

- `tnLiveRegionRole` takes `severity: string`, so a typo resolves to the polite role. A `TnToastType | TnBannerType` union would reject it, but it would also make the shared a11y module import from two components — the wrong direction, and `banner.component.ts` pulls in Angular and the icon component with it. The comment at the parameter says so.
- `banner-a11y.spec.ts` restates `TnBannerType` by hand, so a fifth banner type would get no coverage and no compile error.
- `radio-a11y.spec.ts` and `checkbox-a11y.spec.ts` are near-identical; a parametrized suite could also cover `form-field` and `file-picker` error regions.
- `TN_ASSERTIVE_SEVERITIES` and `IMPLICIT_POLITENESS` are exported but used only inside their own modules.

## Also

`docs/component_conventions.md` gains a **Live Regions** section: declare politeness once, take a severity mapping from `lib/a11y/live-region.ts`, and assert the resolved value rather than an attribute. Recorded because none of the three is inferable from the code, and this is the second ticket to pay for rediscovering the first.
