### PR TITLE
NAS-142316 / 27.0.0-BETA.1 / test(a11y): share one WCAG contrast helper, and migrate the radio spec onto it

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -470,6 +470,43 @@ in `chip-a11y.spec.ts`, and the unlabelled checkbox in
 `slide-toggle-a11y.spec.ts`. It is the only assertion that shows axe failing
 rather than passing, and it doubles as the control for `axeResult()` itself.
 
+### Measuring colour contrast in a spec
+
+**Use `lib/a11y/contrast-testing.ts`. Do not write the formula again.** Three
+cycles working one `tn-radio` contrast bug wrote seven throwaway implementations
+of it in a day, in two languages (#197). Nothing about the computation varies per
+ticket, and each hand-roll is another chance to get a step wrong in the direction
+that makes a failing colour look passing.
+
+**`themePalettes(css)` reads the tokens; `contrast()` measures one against the
+surface it renders on.** That pairing — a token and the background behind it — is
+the form every one of those scripts actually needed. Pass the text of
+`styles/themes.css`; the module takes CSS rather than reading the file, so the
+resolution rules can be covered against a fixture that no theme retune breaks.
+
+**`declares()` and `color()` answer different questions.** `color()` resolves the
+way the browser does, following `var()` chains and inheriting from `:root`;
+`declares()` says whether *this* block sets the token. A token tuned per theme —
+`--tn-error-text` is, since it exists to clear 4.5:1 against that theme's own
+background — is a defect when a theme inherits `:root`'s value, and only
+`declares()` sees it.
+
+**Never compare a rounded ratio.** `4.4999` formats as `"4.50"`, and a check
+built on the formatted value clears AA on a colour that fails it. `meetsAa()`
+takes the unrounded ratio; `formatRatio()` is for titles and messages only.
+
+**A translucent foreground is composited before it is measured.** Half the
+palette's foreground tokens are `rgba()` — `--tn-fg2` is
+`rgba(255,255,255,0.85)`. Measuring one as if it were opaque reports 16.67:1
+where it renders at 12.30:1. A translucent *background* throws instead: what is
+behind it decides the answer, and only the caller knows what that is.
+
+**This is not axe's `color-contrast` rule, and cannot be.** That rule needs a
+layout engine to find what is actually painted behind an element; under jsdom it
+reports `incomplete`, which `axeResult()` treats as an error. What these
+assertions measure is the palette as shipped, against the surface the spec names.
+See `radio-error-contrast.spec.ts` for the shape.
+
 ### Keyboard Navigation
 Support standard keys:
 - **Tab** - Focus navigation

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -337,6 +337,33 @@ describe('themePalettes', () => {
       .toThrow('nested inside @media (prefers-contrast: more)');
   });
 
+  it('names the innermost at-rule scoping the palette, not the outermost', () => {
+    const doublyNested = `
+      :root { --tn-bg1: #ffffff; }
+      @supports (color: color-mix(in srgb, red, blue)) {
+        @media (prefers-contrast: more) {
+          :root { --tn-bg1: #000000; }
+        }
+      }
+    `;
+
+    expect(() => themePalettes(doublyNested)).toThrow('@media (prefers-contrast: more)');
+  });
+
+  it('keeps the declarations that come before a nested rule, rather than losing the palette', () => {
+    // Native CSS nesting inside a palette block. With one shared buffer, the
+    // `{` of the nested rule discards everything above it: `--tn-bg1` goes, the
+    // block stops counting as a palette, and the surface disappears from the
+    // list with nothing to say it was ever there.
+    const nested = ':root { --tn-bg1: #ffffff; .tn-card { color: red; } --tn-fg1: #767676; }';
+
+    const [palette] = themePalettes(nested);
+
+    expect(palette.selector).toBe(':root');
+    expect(palette.color('--tn-bg1')).toBe('#ffffff');
+    expect(palette.color('--tn-fg1')).toBe('#767676');
+  });
+
   it('refuses a stylesheet whose braces do not balance, rather than mis-attributing what follows', () => {
     expect(() => themePalettes(':root { --tn-bg1: #ffffff; } }')).toThrow('unbalanced braces');
   });

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -223,19 +223,26 @@ describe('themePalettes', () => {
     return found;
   };
 
-  it('finds the blocks that declare a palette, and only those', () => {
-    // `.tn-not-a-palette` declares a token without being a themed surface, and
-    // the `:root` inside `@media` declares one that is not a colour at all —
-    // counting either would put a surface with no `--tn-bg1` in front of a spec
-    // that then measures against `undefined`.
+  it('finds the blocks that declare a palette, and only those, under the selector alone', () => {
+    // Three claims in one assertion, because each of them is a wrong entry in
+    // this exact list: `.tn-not-a-palette` declares a token without being a
+    // themed surface and must not appear; the `:root` inside `@media` declares
+    // one that is not a colour at all and must not merge into the `:root` that
+    // is here; and `.tn-dark` is introduced by the banner comment style
+    // themes.css uses, which read as part of the selector would put
+    // `/* ... */ .tn-dark` here instead — a palette no spec would ever find.
     expect(palettes.map((palette) => palette.selector)).toEqual([':root', '.tn-dark']);
   });
 
-  it('does not read a banner comment as part of the selector below it', () => {
-    // The `.tn-dark` above is introduced by exactly the comment style
-    // themes.css uses. Captured as part of the selector, it would produce a
-    // palette no `find` in any spec would ever match.
-    expect(palettes.map((palette) => palette.selector)).toContain('.tn-dark');
+  it('reads a final declaration that omits its optional semicolon', () => {
+    // Dropping it is not a syntax error in CSS. Dropped here, the block loses
+    // `--tn-bg1` and stops being a palette at all — it vanishes from this list
+    // rather than reporting a wrong colour.
+    const noTrailingSemicolon = ':root { --tn-fg1: #767676; --tn-bg1: #ffffff }';
+
+    const [palette] = themePalettes(noTrailingSemicolon);
+
+    expect(palette.color('--tn-bg1')).toBe('#ffffff');
   });
 
   it('does not read a commented-out declaration as a declaration', () => {

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -333,4 +333,14 @@ describe('themePalettes', () => {
   it('refuses a stylesheet whose braces do not balance, rather than mis-attributing what follows', () => {
     expect(() => themePalettes(':root { --tn-bg1: #ffffff; } }')).toThrow('unbalanced braces');
   });
+
+  it('refuses a block left open too, which is the quieter half of the same fault', () => {
+    // Without the closing brace on `:root`, the next selector is swallowed into
+    // its body and the palette that comes back is called
+    // `--tn-bg1: #ffffff; .tn-dark` — a surface no spec looks for, in a list
+    // that still has the right shape.
+    const unclosed = ':root { --tn-bg1: #ffffff; .tn-dark { --tn-bg1: #000000; }';
+
+    expect(() => themePalettes(unclosed)).toThrow('unbalanced braces');
+  });
 });

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -281,9 +281,14 @@ describe('themePalettes', () => {
       .toThrow('does not declare --tn-invented');
   });
 
-  it('refuses a token that resolves to something that is not a colour', () => {
+  it('refuses a token that resolves to something that is not a colour, and names it', () => {
     expect(() => bySelector(':root').color('--tn-font-family-body'))
-      .toThrow('not a colour this can read');
+      .toThrow(':root --tn-font-family-body');
+    // Through contrast() too: the message is the same one, because a font stack
+    // reaching the maths is the same mistake whichever entry point it came in
+    // by, and "not a colour" without the token name does not say which.
+    expect(() => bySelector(':root').contrast('--tn-font-family-body', '--tn-bg1'))
+      .toThrow(':root --tn-font-family-body');
   });
 
   it('refuses a var() chain that loops, rather than following it forever', () => {
@@ -303,5 +308,29 @@ describe('themePalettes', () => {
    */
   it('refuses to return no palettes at all', () => {
     expect(() => themePalettes('.tn-button { color: red; }')).toThrow('no themed surface found');
+  });
+
+  /**
+   * The fixture's `@media` block declares a token that is not a colour, so it is
+   * skipped for being no palette rather than for being conditional. A
+   * conditional block that IS a palette is the case that matters: merged into
+   * the unconditional `:root` by selector — which is what a scan that cannot see
+   * nesting does — it wins, and every spec downstream measures a surface that
+   * renders at one viewport width against tokens that render at another.
+   */
+  it('refuses a palette nested inside an at-rule, rather than merging it into the unconditional one', () => {
+    const conditional = `
+      :root { --tn-bg1: #ffffff; --tn-fg1: #767676; }
+      @media (prefers-contrast: more) {
+        :root { --tn-bg1: #000000; --tn-fg1: #ffffff; }
+      }
+    `;
+
+    expect(() => themePalettes(conditional))
+      .toThrow('nested inside @media (prefers-contrast: more)');
+  });
+
+  it('refuses a stylesheet whose braces do not balance, rather than mis-attributing what follows', () => {
+    expect(() => themePalettes(':root { --tn-bg1: #ffffff; } }')).toThrow('unbalanced braces');
   });
 });

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -350,6 +350,19 @@ describe('themePalettes', () => {
     expect(() => themePalettes(doublyNested)).toThrow('@media (prefers-contrast: more)');
   });
 
+  it('refuses a palette nested inside a plain selector too, not only inside an at-rule', () => {
+    // CSS nesting reaches the same end by a different route: `:root` inside
+    // `.tn-theme-host` applies only in that subtree, and merged by selector into
+    // the top-level `:root` it reports a background that renders on one surface
+    // against a foreground that renders on another.
+    const nestedPalette = `
+      :root { --tn-bg1: #ffffff; }
+      .tn-theme-host { :root { --tn-bg1: #000000; } }
+    `;
+
+    expect(() => themePalettes(nestedPalette)).toThrow('nested inside .tn-theme-host');
+  });
+
   it('keeps the declarations that come before a nested rule, rather than losing the palette', () => {
     // Native CSS nesting inside a palette block. With one shared buffer, the
     // `{` of the nested rule discards everything above it: `--tn-bg1` goes, the

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -263,7 +263,7 @@ describe('themePalettes', () => {
   });
 
   it('walks a fallback that is itself a var(), which is the shape the SCSS uses', () => {
-    // `radio.component.scss` reads `var(--tn-error-text, var(--tn-red, #de6d6d))`,
+    // `radio.component.scss` reads `var(--tn-error-text, var(--tn-red, #b91c1c))`,
     // so a spec measuring what that renders as needs the whole chain, not the
     // first hop.
     expect(bySelector('.tn-dark').color('--tn-nested-fallback')).toBe('#654321');

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -1,0 +1,307 @@
+import { AA_MINIMUM, contrastRatio, formatRatio, meetsAa, themePalettes } from './contrast-testing';
+import * as contrastTesting from './contrast-testing';
+import * as publicApi from '../../public-api';
+
+/**
+ * The numbers asserted here were measured, not remembered, and two of them are
+ * cross-checkable against something outside this repository: black on white is
+ * 21:1 by definition, and `#777777` on white is the widely published 4.48:1
+ * pair. `#de6d6d` on `#1E1E1E` measuring 5.17:1 matches what `themes.css` says
+ * about that token in a comment, which is a third check from a fourth source.
+ *
+ * Where an expectation exists to pin a specific step of the formula, the comment
+ * says what a wrong implementation returns instead — an assertion that both
+ * implementations satisfy is not covering the step it claims to.
+ */
+/**
+ * The docblock in `contrast-testing.ts` says this module must not be exported,
+ * and this is what holds it to that. The names are derived from the module
+ * rather than restated, for the reason `axe-testing.spec.ts` gives: a guard
+ * keyed to a string literal covers one name and not the module, and both a
+ * rename and a second export walk out from under it without breaking anything.
+ *
+ * `Object.hasOwn` rather than `in`: a public-api export named after an
+ * `Object.prototype` key would otherwise fail this test for a reason that has
+ * nothing to do with the claim.
+ */
+describe('contrast-testing is not part of the public API', () => {
+  it('exports nothing that public-api.ts also exports', () => {
+    expect(Object.keys(publicApi).filter((name) => Object.hasOwn(contrastTesting, name))).toEqual([]);
+  });
+});
+
+describe('contrastRatio', () => {
+  describe('reference pairs', () => {
+    it('measures black on white as 21:1, the maximum', () => {
+      expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 10);
+    });
+
+    it('measures white on black as 21:1 too, since the ratio does not care which is which', () => {
+      expect(contrastRatio('#ffffff', '#000000')).toBeCloseTo(21, 10);
+    });
+
+    it('measures a colour against itself as 1:1, the minimum', () => {
+      expect(contrastRatio('#71BF44', '#71BF44')).toBeCloseTo(1, 10);
+    });
+
+    it('measures the shipped --tn-error-text on --tn-bg1 at the 5.17:1 themes.css claims', () => {
+      expect(contrastRatio('#de6d6d', '#1E1E1E')).toBeCloseTo(5.1714, 4);
+    });
+  });
+
+  /**
+   * The step that gets dropped when this formula is written from memory. sRGB is
+   * gamma-encoded, so each channel is linearised before it is weighted — a
+   * straight line below the 0.03928 crossover (channel 10 of 255), a 2.4 power
+   * curve above it. Both branches are pinned, because the two implementations
+   * that get written by mistake fail on different ones.
+   */
+  describe('the sRGB gamma step', () => {
+    it('linearises mid-tones with the power curve', () => {
+      // Weighting the raw 0-255 channels instead — the formula without any
+      // gamma step at all — returns 2.0323 for this pair.
+      expect(contrastRatio('#777777', '#ffffff')).toBeCloseTo(4.4781, 4);
+    });
+
+    it('and a second mid-tone, so the first is not a coincidence', () => {
+      // 1.9023 without the gamma step.
+      expect(contrastRatio('#808080', '#ffffff')).toBeCloseTo(3.9494, 4);
+    });
+
+    it('uses the straight line below the crossover, not the power curve', () => {
+      // The two branches meet at the crossover by construction, so most dark
+      // pairs cannot tell them apart — at channel 10 they differ in the fifth
+      // decimal place. Channel 1 is where the gap is legible: applying the power
+      // curve all the way down returns 1.019674 instead.
+      expect(contrastRatio('#010101', '#000000')).toBeCloseTo(1.006071, 6);
+    });
+  });
+
+  describe('colour syntax', () => {
+    it('expands 3-digit hex by doubling each digit, not by zero-padding', () => {
+      expect(contrastRatio('#abc', '#000000')).toBeCloseTo(contrastRatio('#aabbcc', '#000000'), 10);
+      expect(contrastRatio('#abc', '#000000')).not.toBeCloseTo(contrastRatio('#0a0b0c', '#000000'), 4);
+    });
+
+    it('reads rgb() the same as the hex it denotes', () => {
+      expect(contrastRatio('rgb(119, 119, 119)', '#ffffff')).toBeCloseTo(4.4781, 4);
+    });
+
+    it('reads the space-and-slash form the same as the comma form', () => {
+      expect(contrastRatio('rgb(255 255 255 / 85%)', '#1E1E1E'))
+        .toBeCloseTo(contrastRatio('rgba(255, 255, 255, 0.85)', '#1E1E1E'), 10);
+    });
+
+    it('refuses a colour it cannot read rather than guessing at one', () => {
+      expect(() => contrastRatio('red', '#ffffff')).toThrow('not a colour this can read');
+      expect(() => contrastRatio('color-mix(in srgb, #fff, #000)', '#ffffff'))
+        .toThrow('not a colour this can read');
+      expect(() => contrastRatio('#12345', '#ffffff')).toThrow('3, 4, 6 or 8 digit hex');
+      expect(() => contrastRatio('rgb(255, 255)', '#ffffff')).toThrow('3 or 4 components');
+      expect(() => contrastRatio('rgb(255, 255, blue)', '#ffffff')).toThrow('not a number');
+    });
+  });
+
+  /**
+   * Half this library's foreground tokens are translucent — `--tn-fg2` is
+   * `rgba(255,255,255,0.85)` — so measuring one as if it were opaque is not an
+   * edge case, it is the common case, and it overstates the result by a long
+   * way.
+   */
+  describe('alpha', () => {
+    it('composites a translucent foreground over the background before measuring', () => {
+      expect(contrastRatio('rgba(255, 255, 255, 0.85)', '#1E1E1E')).toBeCloseTo(12.3034, 4);
+    });
+
+    it('and that is a different answer from ignoring the alpha, which reports 16.67:1', () => {
+      expect(contrastRatio('rgba(255, 255, 255, 0.85)', '#1E1E1E'))
+        .not.toBeCloseTo(contrastRatio('#ffffff', '#1E1E1E'), 2);
+    });
+
+    it('leaves a fully opaque foreground alone', () => {
+      expect(contrastRatio('rgba(255, 255, 255, 1)', '#1E1E1E'))
+        .toBeCloseTo(contrastRatio('#ffffff', '#1E1E1E'), 10);
+    });
+
+    it('measures fully transparent text as 1:1, which is what it renders as', () => {
+      expect(contrastRatio('rgba(255, 255, 255, 0)', '#1E1E1E')).toBeCloseTo(1, 10);
+    });
+
+    it('refuses a translucent background, whose real colour depends on what is behind it', () => {
+      expect(() => contrastRatio('#ffffff', 'rgba(0, 0, 0, 0.5)')).toThrow('is not opaque');
+      expect(() => contrastRatio('#ffffff', '#00000080')).toThrow('is not opaque');
+    });
+  });
+});
+
+describe('meetsAa', () => {
+  it('uses 4.5:1 for normal text and 3:1 for large', () => {
+    expect(AA_MINIMUM).toEqual({ normal: 4.5, large: 3 });
+  });
+
+  it('clears AA exactly at the threshold', () => {
+    expect(meetsAa(4.5, 'normal')).toBe(true);
+    expect(meetsAa(3, 'large')).toBe(true);
+  });
+
+  it('does not clear it just below', () => {
+    expect(meetsAa(4.4999, 'normal')).toBe(false);
+    expect(meetsAa(2.9999, 'large')).toBe(false);
+  });
+
+  it('applies the size, rather than one threshold for everything', () => {
+    expect(meetsAa(4, 'normal')).toBe(false);
+    expect(meetsAa(4, 'large')).toBe(true);
+  });
+
+  /**
+   * The rounding trap this module exists to close. A check that formats first
+   * and compares the formatted value clears AA on a colour that fails it — and
+   * "4.50:1" in a passing test title is exactly how that goes unnoticed.
+   */
+  it('compares the unrounded ratio, even where the formatted one reads as a pass', () => {
+    expect(formatRatio(4.4999)).toBe('4.50:1');
+    expect(meetsAa(4.4999, 'normal')).toBe(false);
+  });
+
+  it('refuses a number that is not a contrast ratio, rather than reading it as a failure', () => {
+    // `NaN >= 4.5` is `false`, so without this every arithmetic mistake upstream
+    // arrives as a contrast failure and sends the reader to the palette.
+    expect(() => meetsAa(Number.NaN, 'normal')).toThrow('is not a contrast ratio');
+    expect(() => meetsAa(0.9, 'normal')).toThrow('is not a contrast ratio');
+    expect(() => meetsAa(21.5, 'normal')).toThrow('is not a contrast ratio');
+  });
+});
+
+/**
+ * Resolution is covered against a fixture rather than against `themes.css`,
+ * because the claims here are about the rules — inheritance, `var()` chains,
+ * what counts as a palette — and pinning them to shipped colour values would
+ * make this file fail every time a theme is retuned, for a reason that is not
+ * about it. `radio-error-contrast.spec.ts` is what measures the real stylesheet.
+ */
+describe('themePalettes', () => {
+  const FIXTURE = `
+    :root {
+      --tn-bg1: #ffffff;
+      --tn-fg1: #767676;
+      --tn-red: #ce2929;
+      --tn-error-text: var(--tn-red);
+      --tn-font-family-body: "IBM Plex Sans", sans-serif;
+      /* --tn-commented-out: #000000; */
+    }
+
+    /* ================================
+       A banner comment, of the kind every theme block in themes.css carries
+       ================================ */
+    .tn-dark {
+      --tn-bg1: #1E1E1E;
+      --tn-fg1: rgba(255, 255, 255, 0.85);
+      --tn-unset-fallback: var(--tn-nowhere, #123456);
+      --tn-nested-fallback: var(--tn-nowhere, var(--tn-still-nowhere, #654321));
+      --tn-loop-a: var(--tn-loop-b);
+      --tn-loop-b: var(--tn-loop-a);
+    }
+
+    .tn-not-a-palette {
+      --tn-fg1: #000000;
+    }
+
+    @media (min-width: 768px) {
+      :root {
+        --tn-content-padding: 24px;
+      }
+    }
+  `;
+
+  const palettes = themePalettes(FIXTURE);
+  const bySelector = (selector: string) => {
+    const found = palettes.find((palette) => palette.selector === selector);
+    if (!found) {
+      throw new Error(`fixture has no ${selector} palette`);
+    }
+    return found;
+  };
+
+  it('finds the blocks that declare a palette, and only those', () => {
+    // `.tn-not-a-palette` declares a token without being a themed surface, and
+    // the `:root` inside `@media` declares one that is not a colour at all —
+    // counting either would put a surface with no `--tn-bg1` in front of a spec
+    // that then measures against `undefined`.
+    expect(palettes.map((palette) => palette.selector)).toEqual([':root', '.tn-dark']);
+  });
+
+  it('does not read a banner comment as part of the selector below it', () => {
+    // The `.tn-dark` above is introduced by exactly the comment style
+    // themes.css uses. Captured as part of the selector, it would produce a
+    // palette no `find` in any spec would ever match.
+    expect(palettes.map((palette) => palette.selector)).toContain('.tn-dark');
+  });
+
+  it('does not read a commented-out declaration as a declaration', () => {
+    expect(bySelector(':root').declares('--tn-commented-out')).toBe(false);
+  });
+
+  it('follows a var() chain within the block', () => {
+    expect(bySelector(':root').color('--tn-error-text')).toBe('#ce2929');
+  });
+
+  it('falls back to :root for a token the theme does not declare, as the cascade does', () => {
+    expect(bySelector('.tn-dark').color('--tn-error-text')).toBe('#ce2929');
+  });
+
+  it('but declares() reports what THIS block sets, which is the different question', () => {
+    // A token that is meant to be tuned per theme — `--tn-error-text` is, since
+    // it exists to clear 4.5:1 against that theme's own background — is a defect
+    // when a theme inherits it, and only `declares` can see that.
+    expect(bySelector('.tn-dark').declares('--tn-error-text')).toBe(false);
+    expect(bySelector('.tn-dark').declares('--tn-bg1')).toBe(true);
+  });
+
+  it('uses a var() fallback when the token it names is declared nowhere', () => {
+    expect(bySelector('.tn-dark').color('--tn-unset-fallback')).toBe('#123456');
+  });
+
+  it('walks a fallback that is itself a var(), which is the shape the SCSS uses', () => {
+    // `radio.component.scss` reads `var(--tn-error-text, var(--tn-red, #de6d6d))`,
+    // so a spec measuring what that renders as needs the whole chain, not the
+    // first hop.
+    expect(bySelector('.tn-dark').color('--tn-nested-fallback')).toBe('#654321');
+  });
+
+  it('measures a token against the surface it renders on, compositing its alpha', () => {
+    // The same 12.30:1 as the direct call above, reached through two token
+    // lookups: this is the form the throwaway scripts all needed.
+    expect(bySelector('.tn-dark').contrast('--tn-fg1', '--tn-bg1')).toBeCloseTo(12.3034, 4);
+  });
+
+  it('refuses a token nothing declares, rather than measuring against undefined', () => {
+    expect(() => bySelector(':root').color('--tn-invented')).toThrow('does not declare --tn-invented');
+    expect(() => bySelector(':root').contrast('--tn-invented', '--tn-bg1'))
+      .toThrow('does not declare --tn-invented');
+  });
+
+  it('refuses a token that resolves to something that is not a colour', () => {
+    expect(() => bySelector(':root').color('--tn-font-family-body'))
+      .toThrow('not a colour this can read');
+  });
+
+  it('refuses a var() chain that loops, rather than following it forever', () => {
+    expect(() => bySelector('.tn-dark').color('--tn-loop-a')).toThrow('in a loop');
+  });
+
+  it('lets a later block override an earlier one for the same selector, as the cascade does', () => {
+    const [overridden] = themePalettes(':root { --tn-bg1: #ffffff; } :root { --tn-bg1: #000000; }');
+
+    expect(overridden.color('--tn-bg1')).toBe('#000000');
+  });
+
+  /**
+   * An empty list is the vacuous shape: every `it.each` over it disappears, and
+   * a suite whose cases have all silently vanished is green. The stylesheet
+   * moving, or a rename of `--tn-bg1`, is what would produce it.
+   */
+  it('refuses to return no palettes at all', () => {
+    expect(() => themePalettes('.tn-button { color: red; }')).toThrow('no themed surface found');
+  });
+});

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -354,10 +354,17 @@ function declarationBlocks(css: string): DeclarationBlock[] {
   return blocks;
 }
 
-/** The custom properties a declaration block sets. Comments are already gone. */
+/**
+ * The custom properties a declaration block sets. Comments are already gone.
+ *
+ * The final semicolon in a block is optional in CSS, so it is optional here.
+ * Requiring it drops the last declaration — and when that declaration is
+ * `--tn-bg1`, the whole block stops counting as a palette and disappears from
+ * `themePalettes` with nothing said.
+ */
 function customProperties(body: string): Map<string, string> {
   const properties = new Map<string, string>();
-  const declaration = /(--[\w-]+)\s*:\s*([^;]+);/g;
+  const declaration = /(--[\w-]+)\s*:\s*([^;]+)(?:;|$)/g;
   let match: RegExpExecArray | null;
   while ((match = declaration.exec(body)) !== null) {
     properties.set(match[1], match[2].trim());

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -116,9 +116,16 @@ export function formatRatio(ratio: number): string {
 /**
  * The WCAG 2.1 contrast ratio between two CSS colours, from 1 to 21.
  *
- * Accepts hex (3, 4, 6 or 8 digits) and `rgb()`/`rgba()`, in comma or
- * space-with-slash form. Anything else — a named colour, `hsl()`, `color-mix()`
- * — throws rather than being guessed at.
+ * Accepts hex (3, 4, 6 or 8 digits) and `rgb()`/`rgba()`. Any colour function
+ * this cannot read — a named colour, `hsl()`, `color-mix()` — throws rather than
+ * being guessed at.
+ *
+ * Within `rgb()` the separators are read leniently: commas, whitespace and the
+ * slash are interchangeable, so the legacy and modern forms both work and so
+ * does a mixture of them that CSS itself would reject. The input here is a
+ * stylesheet the browser has already accepted, so a separator this is lenient
+ * about is not a way to get a wrong number — being wrong about the components
+ * is, and every one of those throws.
  *
  * The order of the arguments matters only for alpha: a translucent
  * `foreground` is composited over `background` first, because that is the colour
@@ -191,23 +198,23 @@ export function themePalettes(css: string): ThemePalette[] {
     if (!properties.has('--tn-bg1')) {
       continue;
     }
-    // A palette that only applies under a condition is not one this can measure:
-    // merged into the unconditional palette of the same selector it reports
-    // colours that render together at no viewport width, and kept apart it is a
+    // A palette that applies only inside something else is not one this can
+    // measure: merged into the unconditional palette of the same selector it
+    // reports colours that render together nowhere, and kept apart it is a
     // surface whose applicability only a browser can decide. Neither is worth
     // guessing at silently, so it says so.
     //
-    // The narrow reading is deliberate: this fires on a conditional *palette*.
-    // An at-rule that overrides one token without declaring `--tn-bg1` is not a
+    // The narrow reading is deliberate: this fires on a nested *palette*. A
+    // block that overrides one token without declaring `--tn-bg1` is not a
     // surface, so it is skipped like any other non-palette block — and a spec
-    // measuring that token gets the unconditional value, which is the answer for
-    // every condition but one.
+    // measuring that token gets the unconditional value, which is what renders
+    // everywhere but there.
     if (block.nestedIn !== null) {
       throw new Error(
         `themePalettes: the palette at ${block.selector} is nested inside ${block.nestedIn}. `
-        + 'A palette that applies only under a condition renders differently from the '
-        + 'unconditional one, and measuring the two as if they were one surface reports '
-        + 'colours that never appear together.'
+        + 'A palette that applies only there renders on a different surface from the '
+        + 'unconditional one, and measuring the two as if they were one reports colours '
+        + 'that never appear together.'
       );
     }
     if (!declarations.has(block.selector)) {
@@ -250,7 +257,11 @@ function palette(
     const value = declared(token);
     if (value === undefined) {
       throw new Error(
-        `themePalettes: ${selector} does not declare ${token}, and neither does :root`
+        `themePalettes: ${selector} does not declare ${token}`
+        // Saying "and neither does :root" on the `:root` palette itself reads as
+        // a bug in the message, which is a poor advertisement for the rest of
+        // what this module says.
+        + (own === root ? '' : ', and neither does :root')
       );
     }
     return resolveValue(value, [...chain, token]);
@@ -299,11 +310,18 @@ function palette(
   };
 }
 
-/** One `selector { … }` block, and the at-rule it sits inside if it sits in one. */
+/** One `selector { … }` block, and whatever it sits inside if it sits in anything. */
 interface DeclarationBlock {
   selector: string;
   body: string;
-  /** The at-rule prelude — `@media (min-width: 768px)` — or `null` at top level. */
+  /**
+   * The prelude of the innermost enclosing block — `@media (min-width: 768px)`,
+   * or a selector when CSS nesting puts one rule inside another — or `null` at
+   * top level. Any enclosure at all, because a palette inside a selector applies
+   * only within that subtree exactly as one inside `@media` applies only under
+   * that condition, and neither is the surface an unconditional palette of the
+   * same name describes.
+   */
   nestedIn: string | null;
 }
 
@@ -355,10 +373,10 @@ function declarationBlocks(css: string): DeclarationBlock[] {
         blocks.push({
           selector: closing.prelude,
           body: closing.body,
-          // The innermost at-rule, not the outermost: `@media` inside
+          // The innermost enclosure, not the outermost: `@media` inside
           // `@supports` is scoped by the `@media`, and naming the outer one in
           // the refusal would send a reader to the wrong line.
-          nestedIn: [...open].reverse().find((block) => block.prelude.startsWith('@'))?.prelude ?? null,
+          nestedIn: open[open.length - 1]?.prelude ?? null,
         });
       }
     } else {

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -74,12 +74,16 @@ interface Rgba {
 /**
  * Does `ratio` clear the AA minimum for text of this size?
  *
- * Takes a ratio rather than two colours so that a spec reports the measurement
- * it asserts on — `expect(ratio).toBeGreaterThanOrEqual(AA_MINIMUM.normal)` in a
- * titled case says which number failed, where a boolean says only "false".
+ * Takes a ratio rather than two colours so the measurement can be made once and
+ * then both asserted on and reported — `formatRatio` it into the case title, and
+ * the failure names the colour and the number as well as the theme.
  *
- * The comparison is on the unrounded ratio. A pair measuring 4.4999 does not
- * clear AA, however it prints.
+ * That is worth knowing when choosing between this and `AA_MINIMUM` directly:
+ * `expect(meetsAa(ratio, 'normal')).toBe(true)` fails with "expected true", so
+ * the number has to be in the title, while
+ * `expect(ratio).toBeGreaterThanOrEqual(AA_MINIMUM.normal)` puts it in the
+ * failure output instead. Both compare the same unrounded value; a pair
+ * measuring 4.4999 does not clear AA, however it prints.
  */
 export function meetsAa(ratio: number, size: TextSize): boolean {
   // 1:1 is identical colours and 21:1 is black on white; nothing real lands
@@ -182,32 +186,31 @@ export interface ThemePalette {
 export function themePalettes(css: string): ThemePalette[] {
   const declarations = new Map<string, Map<string, string>>();
   const order: string[] = [];
-  // Comments go first, for two reasons. `themes.css` records measured ratios
-  // next to the tokens they are about, so `/* --tn-red is only 3.15:1 */` would
-  // otherwise read as a declaration; and every theme block is introduced by a
-  // banner comment, which would otherwise be captured as part of its selector.
-  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
-  // Braces do not nest inside a declaration block, so `[^{}]*` is enough to find
-  // one. A block inside `@media` is still found, because the scan simply resumes
-  // past the `{` it could not match across — what is lost is the media query it
-  // was nested in, and a palette that only applies at one viewport width is not
-  // a thing this stylesheet has.
-  const blockPattern = /([^{}]+?)\s*\{([^{}]*)\}/g;
-  let match: RegExpExecArray | null;
-  while ((match = blockPattern.exec(withoutComments)) !== null) {
-    const [, rawSelector, body] = match;
-    const properties = customProperties(body);
+  for (const block of declarationBlocks(css)) {
+    const properties = customProperties(block.body);
     if (!properties.has('--tn-bg1')) {
       continue;
     }
-    const selector = rawSelector.trim();
-    if (!declarations.has(selector)) {
-      declarations.set(selector, new Map());
-      order.push(selector);
+    // A palette that only applies under a condition is not one this can measure:
+    // merged into the unconditional palette of the same selector it reports
+    // colours that render together at no viewport width, and kept apart it is a
+    // surface whose applicability only a browser can decide. Neither is worth
+    // guessing at silently, so it says so.
+    if (block.nestedIn !== null) {
+      throw new Error(
+        `themePalettes: the palette at ${block.selector} is nested inside ${block.nestedIn}. `
+        + 'A palette that applies only under a condition renders differently from the '
+        + 'unconditional one, and measuring the two as if they were one surface reports '
+        + 'colours that never appear together.'
+      );
+    }
+    if (!declarations.has(block.selector)) {
+      declarations.set(block.selector, new Map());
+      order.push(block.selector);
     }
     // Later declarations win, as they do in the cascade, so a palette split
     // across two blocks reads the way the browser reads it.
-    const merged = declarations.get(selector) as Map<string, string>;
+    const merged = declarations.get(block.selector) as Map<string, string>;
     properties.forEach((value, name) => merged.set(name, value));
   }
 
@@ -269,20 +272,76 @@ function palette(
     return resolve(token, chain);
   }
 
+  function color(token: string): string {
+    const value = resolve(token, []);
+    // Resolved, but resolved to what? Reaching the maths with a font stack or a
+    // length gives `NaN`, and a `NaN` ratio fails an AA assertion for a reason
+    // that has nothing to do with contrast. The context is the selector and the
+    // token, because `"IBM Plex Sans", sans-serif is not a colour` on its own
+    // does not say which of them named it.
+    parseColor(value, `${selector} ${token}`);
+    return value;
+  }
+
   return {
     selector,
     declares: (token) => own.has(token),
-    color: (token) => {
-      const value = resolve(token, []);
-      // Resolved, but resolved to what? Reaching the maths with a font stack or
-      // a length gives `NaN`, and a `NaN` ratio fails an AA assertion for a
-      // reason that has nothing to do with contrast.
-      parseColor(value, `${selector} ${token}`);
-      return value;
-    },
-    contrast: (token, surfaceToken) =>
-      contrastRatio(resolve(token, []), resolve(surfaceToken, [])),
+    color,
+    // Through `color` rather than `resolve`, so that a token resolving to a
+    // non-colour is reported the same way here as it is there.
+    contrast: (token, surfaceToken) => contrastRatio(color(token), color(surfaceToken)),
   };
+}
+
+/** One `selector { … }` block, and the at-rule it sits inside if it sits in one. */
+interface DeclarationBlock {
+  selector: string;
+  body: string;
+  /** The at-rule prelude — `@media (min-width: 768px)` — or `null` at top level. */
+  nestedIn: string | null;
+}
+
+/**
+ * Every declaration block in `css`, with its nesting recorded.
+ *
+ * A brace walk rather than a regex, because the nesting is the point: a regex
+ * for `selector { no braces here }` finds a block inside `@media` perfectly well
+ * and cannot tell you it was in one, which is how a conditional palette would
+ * come to be merged into the unconditional palette of the same selector.
+ *
+ * Comments go first, for two reasons. `themes.css` records measured ratios next
+ * to the tokens they are about, so `/* --tn-red is only 3.15:1 *\/` would
+ * otherwise read as a declaration; and every theme block is introduced by a
+ * banner comment, which would otherwise be captured as part of its selector.
+ */
+function declarationBlocks(css: string): DeclarationBlock[] {
+  const blocks: DeclarationBlock[] = [];
+  const open: string[] = [];
+  let buffer = '';
+  for (const character of css.replace(/\/\*[\s\S]*?\*\//g, '')) {
+    if (character === '{') {
+      open.push(buffer.trim());
+      buffer = '';
+    } else if (character === '}') {
+      const prelude = open.pop();
+      // A `}` with nothing open is a stylesheet this cannot read. Continuing
+      // would silently attribute everything after it to the wrong nesting.
+      if (prelude === undefined) {
+        throw new Error('themePalettes: unbalanced braces in the CSS given');
+      }
+      if (!prelude.startsWith('@')) {
+        blocks.push({
+          selector: prelude,
+          body: buffer,
+          nestedIn: open.find((enclosing) => enclosing.startsWith('@')) ?? null,
+        });
+      }
+      buffer = '';
+    } else {
+      buffer += character;
+    }
+  }
+  return blocks;
 }
 
 /** The custom properties a declaration block sets. Comments are already gone. */

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -252,7 +252,7 @@ function palette(
 
   // `var(--x)` and `var(--x, <fallback>)`, where the fallback may itself be a
   // `var()`. That nesting is not hypothetical: `radio.component.scss` reads
-  // `var(--tn-error-text, var(--tn-red, #de6d6d))`, and a spec measuring what
+  // `var(--tn-error-text, var(--tn-red, #b91c1c))`, and a spec measuring what
   // that renders as has to walk the whole chain. These two are function
   // declarations rather than `const` arrows because they call each other, and
   // one of the two references would otherwise be a forward one.

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -341,6 +341,16 @@ function declarationBlocks(css: string): DeclarationBlock[] {
       buffer += character;
     }
   }
+  // A `{` that was never closed is the other half of the same fault, and the
+  // quieter half: the block it opened is never emitted, and the NEXT selector is
+  // swallowed into its body — so `:root {` with its `}` dropped hands back a
+  // palette whose selector is `--tn-bg1: #ffffff; .tn-dark`, matching nothing a
+  // spec looks for while everything downstream still passes.
+  if (open.length > 0) {
+    throw new Error(
+      `themePalettes: unbalanced braces in the CSS given — ${open.length} block(s) left open`
+    );
+  }
   return blocks;
 }
 

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -1,0 +1,396 @@
+/**
+ * The WCAG 2.1 contrast maths the a11y specs share, and the theme-token lookup
+ * that gets a colour into it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Three cycles working one `tn-radio` contrast bug wrote seven throwaway
+ * implementations of this formula in a day, in two languages (#197). Nothing
+ * about the computation varies per ticket: given two colours, produce the ratio;
+ * given a ratio and a text size, say whether it clears AA. It was re-derived
+ * because it was not available, and each hand-roll is another chance to get the
+ * sRGB gamma step or the rounding wrong in the direction that makes a failing
+ * colour look passing.
+ *
+ * WHAT IS EASY TO GET WRONG, AND WHAT IS DONE ABOUT IT HERE
+ * ---------------------------------------------------------
+ * - **The gamma step.** Relative luminance is not a weighted sum of the 0–255
+ *   channels; each channel is linearised first, by a piecewise curve. Skipping
+ *   it turns `#777777` on white from 4.48:1 into 2.03:1 — which reads as a
+ *   failure, so it would be caught — but the same error inflates other pairs.
+ *   `contrast-testing.spec.ts` pins both branches of the curve.
+ * - **Rounding.** `toFixed(2)` on 4.4999 is `"4.50"`, and a check that compares
+ *   the rounded string clears AA on a colour that does not. Nothing here rounds
+ *   before comparing: `meetsAa` takes the unrounded ratio, and `formatRatio` is
+ *   for test titles and messages only.
+ * - **Alpha.** Half this library's foreground tokens are `rgba()` —
+ *   `--tn-fg2` is `rgba(255,255,255,0.85)`. Measuring one as if it were opaque
+ *   overstates it badly: 16.67:1 rather than the 12.30:1 it actually renders at
+ *   on `--tn-bg1`. `contrastRatio` composites a translucent foreground over the
+ *   background before measuring, and refuses a translucent *background*, whose
+ *   real colour depends on whatever is behind it.
+ * - **A token that resolves to nothing.** `undefined` reaching this maths gives
+ *   `NaN`, and `NaN >= 4.5` is `false` — a red test blaming the colour for a
+ *   typo in the token name. Every lookup here throws instead, naming the
+ *   selector and the token.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * Not axe's `color-contrast` rule. That one needs a layout engine to find what
+ * is actually rendered behind an element, which jsdom does not have — it reports
+ * `incomplete` rather than checking anything, and `axeResult` throws on that
+ * (see `axe-testing.ts`). This measures the values shipped in `themes.css`,
+ * against the surface the caller names, which is a claim about the palette
+ * rather than about a rendered page.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `axe-testing.ts` and `live-region-testing.ts`. These assertions are about this
+ * library's own palette and no consumer has a use for them.
+ */
+
+/**
+ * WCAG 2.1 AA minimum contrast ratios for text, by size.
+ *
+ * `large` is 18pt (24px), or 14pt (18.66px) bold — everything else is `normal`.
+ * That classification is the caller's: it depends on the component's own type
+ * scale, which this module cannot see.
+ */
+export const AA_MINIMUM = {
+  normal: 4.5,
+  large: 3,
+} as const;
+
+/** Which AA threshold applies. See `AA_MINIMUM` for what counts as large. */
+export type TextSize = keyof typeof AA_MINIMUM;
+
+/** A colour with its channels in 0–255 and its alpha in 0–1. */
+interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+/**
+ * Does `ratio` clear the AA minimum for text of this size?
+ *
+ * Takes a ratio rather than two colours so that a spec reports the measurement
+ * it asserts on — `expect(ratio).toBeGreaterThanOrEqual(AA_MINIMUM.normal)` in a
+ * titled case says which number failed, where a boolean says only "false".
+ *
+ * The comparison is on the unrounded ratio. A pair measuring 4.4999 does not
+ * clear AA, however it prints.
+ */
+export function meetsAa(ratio: number, size: TextSize): boolean {
+  // 1:1 is identical colours and 21:1 is black on white; nothing real lands
+  // outside that. A value that does is a caller who passed something other than
+  // a ratio — a colour string, or a `NaN` from arithmetic on `undefined` — and
+  // `NaN >= 4.5` is silently `false`, which reads as a contrast failure rather
+  // than as the mistake it is. The tolerance is for the float arithmetic that
+  // produces the ratio, not for the range: a near-white luminance can sum to a
+  // hair over 1, and throwing on 21.000000000000004 would be this guard becoming
+  // the bug it exists to catch.
+  if (!Number.isFinite(ratio) || ratio < 1 - 1e-9 || ratio > 21 + 1e-9) {
+    throw new Error(
+      `meetsAa: ${String(ratio)} is not a contrast ratio (they run from 1 to 21)`
+    );
+  }
+  return ratio >= AA_MINIMUM[size];
+}
+
+/**
+ * A contrast ratio at the precision it is conventionally quoted, for test titles
+ * and failure messages.
+ *
+ * Display only. Never compare a formatted ratio against a threshold: `4.4999`
+ * formats as `"4.50"`, and a check built on that passes a colour that fails.
+ */
+export function formatRatio(ratio: number): string {
+  return `${ratio.toFixed(2)}:1`;
+}
+
+/**
+ * The WCAG 2.1 contrast ratio between two CSS colours, from 1 to 21.
+ *
+ * Accepts hex (3, 4, 6 or 8 digits) and `rgb()`/`rgba()`, in comma or
+ * space-with-slash form. Anything else — a named colour, `hsl()`, `color-mix()`
+ * — throws rather than being guessed at.
+ *
+ * The order of the arguments matters only for alpha: a translucent
+ * `foreground` is composited over `background` first, because that is the colour
+ * that ends up on screen. A translucent `background` throws — what is behind it
+ * decides the answer, and only the caller knows what that is.
+ */
+export function contrastRatio(foreground: string, background: string): number {
+  const behind = parseColor(background, 'background');
+  if (behind.a !== 1) {
+    throw new Error(
+      `contrastRatio: the background ${background} is not opaque, so the colour it `
+      + 'renders as depends on what is behind it. Composite it against that surface '
+      + 'and pass the result.'
+    );
+  }
+  const front = parseColor(foreground, 'foreground');
+  const rendered = front.a === 1 ? front : compositeOver(front, behind);
+
+  const lighter = Math.max(relativeLuminance(rendered), relativeLuminance(behind));
+  const darker = Math.min(relativeLuminance(rendered), relativeLuminance(behind));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** One themed surface from `themes.css`: `:root`, `.tn-dark`, `.tn-nord`, … */
+export interface ThemePalette {
+  /** The selector the block was declared under. */
+  readonly selector: string;
+  /**
+   * Is `token` declared in this block itself?
+   *
+   * Deliberately not the same question as whether `color()` can resolve it: a
+   * theme that omits a token still renders, inheriting `:root`'s value. Which of
+   * the two a spec wants is a real choice — `--tn-error-text` is per-theme by
+   * design, so a theme silently falling back to `:root`'s is the defect a spec
+   * should catch, and it is `declares` that catches it.
+   */
+  declares(token: string): boolean;
+  /**
+   * The literal colour `token` resolves to on this surface, following `var()`
+   * chains and falling back to `:root` for anything this block does not declare
+   * — which is what the browser does, since custom properties inherit and a
+   * theme class sits below `:root`.
+   *
+   * Throws if the token is declared nowhere, if its chain loops, or if it ends
+   * at something that is not a colour this module can read.
+   */
+  color(token: string): string;
+  /**
+   * The contrast ratio of `token` rendered on `surfaceToken`, both resolved on
+   * this surface. The form every one of the throwaway scripts actually needed.
+   */
+  contrast(token: string, surfaceToken: string): number;
+}
+
+/**
+ * Every themed surface declared in `css`, in the order they appear.
+ *
+ * A block counts as a themed surface when it declares `--tn-bg1`, i.e. a whole
+ * palette rather than a component tweak. The caller passes the stylesheet text
+ * (`readFileSync` of `styles/themes.css`) rather than this module reading it, so
+ * that nothing here depends on Node and the same function can be pointed at a
+ * fixture — which is how `contrast-testing.spec.ts` covers the resolution rules
+ * without asserting on colours that are free to change.
+ */
+export function themePalettes(css: string): ThemePalette[] {
+  const declarations = new Map<string, Map<string, string>>();
+  const order: string[] = [];
+  // Comments go first, for two reasons. `themes.css` records measured ratios
+  // next to the tokens they are about, so `/* --tn-red is only 3.15:1 */` would
+  // otherwise read as a declaration; and every theme block is introduced by a
+  // banner comment, which would otherwise be captured as part of its selector.
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  // Braces do not nest inside a declaration block, so `[^{}]*` is enough to find
+  // one. A block inside `@media` is still found, because the scan simply resumes
+  // past the `{` it could not match across — what is lost is the media query it
+  // was nested in, and a palette that only applies at one viewport width is not
+  // a thing this stylesheet has.
+  const blockPattern = /([^{}]+?)\s*\{([^{}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = blockPattern.exec(withoutComments)) !== null) {
+    const [, rawSelector, body] = match;
+    const properties = customProperties(body);
+    if (!properties.has('--tn-bg1')) {
+      continue;
+    }
+    const selector = rawSelector.trim();
+    if (!declarations.has(selector)) {
+      declarations.set(selector, new Map());
+      order.push(selector);
+    }
+    // Later declarations win, as they do in the cascade, so a palette split
+    // across two blocks reads the way the browser reads it.
+    const merged = declarations.get(selector) as Map<string, string>;
+    properties.forEach((value, name) => merged.set(name, value));
+  }
+
+  // An empty list is the vacuous shape this module is here to refuse: every
+  // `it.each` over it disappears, and a suite with no cases left in it is green.
+  if (order.length === 0) {
+    throw new Error(
+      'themePalettes: no themed surface found — no block in this CSS declares --tn-bg1'
+    );
+  }
+
+  const root = declarations.get(':root');
+  return order.map((selector) => palette(selector, declarations.get(selector) as Map<string, string>, root));
+}
+
+function palette(
+  selector: string,
+  own: Map<string, string>,
+  root: Map<string, string> | undefined,
+): ThemePalette {
+  function declared(token: string): string | undefined {
+    return own.get(token) ?? (own === root ? undefined : root?.get(token));
+  }
+
+  function resolve(token: string, chain: readonly string[]): string {
+    if (chain.includes(token)) {
+      throw new Error(
+        `themePalettes: ${selector} resolves ${[...chain, token].join(' -> ')} in a loop`
+      );
+    }
+    const value = declared(token);
+    if (value === undefined) {
+      throw new Error(
+        `themePalettes: ${selector} does not declare ${token}, and neither does :root`
+      );
+    }
+    return resolveValue(value, [...chain, token]);
+  }
+
+  // `var(--x)` and `var(--x, <fallback>)`, where the fallback may itself be a
+  // `var()`. That nesting is not hypothetical: `radio.component.scss` reads
+  // `var(--tn-error-text, var(--tn-red, #de6d6d))`, and a spec measuring what
+  // that renders as has to walk the whole chain. These two are function
+  // declarations rather than `const` arrows because they call each other, and
+  // one of the two references would otherwise be a forward one.
+  function resolveValue(value: string, chain: readonly string[]): string {
+    const reference = /^var\(\s*(--[\w-]+)\s*(?:,([\s\S]*))?\)$/.exec(value.trim());
+    if (!reference) {
+      return value.trim();
+    }
+    const [, token, fallback] = reference;
+    // The fallback is used only when the token is declared nowhere — which is
+    // what `var()` does. A token declared as something unreadable does NOT fall
+    // back; it throws, because silently using the fallback would report a colour
+    // the browser never renders.
+    if (fallback !== undefined && declared(token) === undefined) {
+      return resolveValue(fallback, chain);
+    }
+    return resolve(token, chain);
+  }
+
+  return {
+    selector,
+    declares: (token) => own.has(token),
+    color: (token) => {
+      const value = resolve(token, []);
+      // Resolved, but resolved to what? Reaching the maths with a font stack or
+      // a length gives `NaN`, and a `NaN` ratio fails an AA assertion for a
+      // reason that has nothing to do with contrast.
+      parseColor(value, `${selector} ${token}`);
+      return value;
+    },
+    contrast: (token, surfaceToken) =>
+      contrastRatio(resolve(token, []), resolve(surfaceToken, [])),
+  };
+}
+
+/** The custom properties a declaration block sets. Comments are already gone. */
+function customProperties(body: string): Map<string, string> {
+  const properties = new Map<string, string>();
+  const declaration = /(--[\w-]+)\s*:\s*([^;]+);/g;
+  let match: RegExpExecArray | null;
+  while ((match = declaration.exec(body)) !== null) {
+    properties.set(match[1], match[2].trim());
+  }
+  return properties;
+}
+
+function parseColor(value: string, context: string): Rgba {
+  const text = value.trim();
+  const hex = /^#([0-9a-f]+)$/i.exec(text);
+  if (hex) {
+    return parseHex(hex[1], text, context);
+  }
+  const functional = /^rgba?\(([^)]*)\)$/i.exec(text);
+  if (functional) {
+    return parseRgb(functional[1], text, context);
+  }
+  throw new Error(
+    `${context}: ${text} is not a colour this can read. Hex and rgb()/rgba() only — `
+    + 'a named colour, hsl() or color-mix() would have to be converted, and guessing '
+    + 'at one is how a wrong ratio gets asserted.'
+  );
+}
+
+function parseHex(digits: string, text: string, context: string): Rgba {
+  // #rgb and #rgba are shorthand for each digit doubled, not for a zero-padded
+  // byte: #abc is #aabbcc, not #0a0b0c.
+  const full = digits.length === 3 || digits.length === 4
+    ? digits.split('').map((digit) => digit + digit).join('')
+    : digits;
+  if (full.length !== 6 && full.length !== 8) {
+    throw new Error(`${context}: ${text} is not a 3, 4, 6 or 8 digit hex colour`);
+  }
+  const byte = (at: number): number => parseInt(full.slice(at, at + 2), 16);
+  return {
+    r: byte(0),
+    g: byte(2),
+    b: byte(4),
+    a: full.length === 8 ? byte(6) / 255 : 1,
+  };
+}
+
+function parseRgb(args: string, text: string, context: string): Rgba {
+  const parts = args.split(/[\s,/]+/).filter((part) => part.length > 0);
+  if (parts.length !== 3 && parts.length !== 4) {
+    throw new Error(`${context}: ${text} does not have 3 or 4 components`);
+  }
+  const channel = (part: string): number => {
+    const percent = part.endsWith('%');
+    const magnitude = Number(percent ? part.slice(0, -1) : part);
+    if (!Number.isFinite(magnitude)) {
+      throw new Error(`${context}: ${text} has a component that is not a number (${part})`);
+    }
+    // CSS clamps out-of-range channels rather than rejecting them, and so does
+    // this: the alternative is a luminance outside 0–1 and a ratio outside 1–21,
+    // which `meetsAa` would then reject for the wrong reason.
+    return clamp(percent ? (magnitude * 255) / 100 : magnitude, 0, 255);
+  };
+  const alpha = (part: string): number => {
+    const percent = part.endsWith('%');
+    const magnitude = Number(percent ? part.slice(0, -1) : part);
+    if (!Number.isFinite(magnitude)) {
+      throw new Error(`${context}: ${text} has an alpha that is not a number (${part})`);
+    }
+    return clamp(percent ? magnitude / 100 : magnitude, 0, 1);
+  };
+  return {
+    r: channel(parts[0]),
+    g: channel(parts[1]),
+    b: channel(parts[2]),
+    a: parts.length === 4 ? alpha(parts[3]) : 1,
+  };
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), high);
+}
+
+/** Source-over compositing, the operation a browser performs to paint `front`. */
+function compositeOver(front: Rgba, opaqueBehind: Rgba): Rgba {
+  const mix = (a: number, b: number): number => a * front.a + b * (1 - front.a);
+  return {
+    r: mix(front.r, opaqueBehind.r),
+    g: mix(front.g, opaqueBehind.g),
+    b: mix(front.b, opaqueBehind.b),
+    a: 1,
+  };
+}
+
+/**
+ * WCAG 2.1 relative luminance.
+ *
+ * The piecewise step is the part that gets dropped: each channel is linearised
+ * before it is weighted — a straight line below 0.03928 (roughly channel 10 of
+ * 255) and a 2.4 power curve above it — because sRGB is gamma-encoded. Weighting
+ * the raw channels instead reports `#777777` on white as 2.03:1 rather than
+ * 4.48:1.
+ */
+function relativeLuminance({ r, g, b }: Rgba): number {
+  const linear = (value: number): number => {
+    const channel = value / 255;
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -196,6 +196,12 @@ export function themePalettes(css: string): ThemePalette[] {
     // colours that render together at no viewport width, and kept apart it is a
     // surface whose applicability only a browser can decide. Neither is worth
     // guessing at silently, so it says so.
+    //
+    // The narrow reading is deliberate: this fires on a conditional *palette*.
+    // An at-rule that overrides one token without declaring `--tn-bg1` is not a
+    // surface, so it is skipped like any other non-palette block — and a spec
+    // measuring that token gets the unconditional value, which is the answer for
+    // every condition but one.
     if (block.nestedIn !== null) {
       throw new Error(
         `themePalettes: the palette at ${block.selector} is nested inside ${block.nestedIn}. `
@@ -316,29 +322,47 @@ interface DeclarationBlock {
  */
 function declarationBlocks(css: string): DeclarationBlock[] {
   const blocks: DeclarationBlock[] = [];
-  const open: string[] = [];
-  let buffer = '';
+  const open: { prelude: string; body: string }[] = [];
+  // Text not yet attributed: the prelude being read, or the declarations of the
+  // innermost open block. Each block keeps its own body, because one shared
+  // buffer loses the declarations that came BEFORE a nested rule — a palette
+  // holding `--tn-bg1` above a nested selector would stop being a palette, and
+  // do it silently.
+  let pending = '';
   for (const character of css.replace(/\/\*[\s\S]*?\*\//g, '')) {
     if (character === '{') {
-      open.push(buffer.trim());
-      buffer = '';
+      // Everything after the last `;` is the prelude of the block opening now;
+      // everything before it belongs to the block already open. (A declaration
+      // sitting immediately before a nested rule without its semicolon is a CSS
+      // syntax error, so there is no third case to split here.)
+      const lastSemicolon = pending.lastIndexOf(';');
+      const enclosing = open[open.length - 1];
+      if (enclosing) {
+        enclosing.body += pending.slice(0, lastSemicolon + 1);
+      }
+      open.push({ prelude: pending.slice(lastSemicolon + 1).trim(), body: '' });
+      pending = '';
     } else if (character === '}') {
-      const prelude = open.pop();
+      const closing = open.pop();
       // A `}` with nothing open is a stylesheet this cannot read. Continuing
       // would silently attribute everything after it to the wrong nesting.
-      if (prelude === undefined) {
+      if (closing === undefined) {
         throw new Error('themePalettes: unbalanced braces in the CSS given');
       }
-      if (!prelude.startsWith('@')) {
+      closing.body += pending;
+      pending = '';
+      if (!closing.prelude.startsWith('@')) {
         blocks.push({
-          selector: prelude,
-          body: buffer,
-          nestedIn: open.find((enclosing) => enclosing.startsWith('@')) ?? null,
+          selector: closing.prelude,
+          body: closing.body,
+          // The innermost at-rule, not the outermost: `@media` inside
+          // `@supports` is scoped by the `@media`, and naming the outer one in
+          // the refusal would send a reader to the wrong line.
+          nestedIn: [...open].reverse().find((block) => block.prelude.startsWith('@'))?.prelude ?? null,
         });
       }
-      buffer = '';
     } else {
-      buffer += character;
+      pending += character;
     }
   }
   // A `{` that was never closed is the other half of the same fault, and the

--- a/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-error-contrast.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
 import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
@@ -16,135 +17,101 @@ import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
  * real rendering) can't produce a meaningful pass/fail here — it reports
  * "incomplete" rather than checking anything. Computing the ratio directly
  * from the shipped values is the more honest check.
+ *
+ * The maths and the token lookup come from `lib/a11y/contrast-testing.ts`
+ * (#197). They used to be hand-rolled here, which is how seven copies of this
+ * formula got written in a day — see that module for what each copy is a chance
+ * to get wrong.
  */
 
 const THEMES_CSS_PATH = join(__dirname, '../../styles/themes.css');
 const RADIO_SCSS_PATH = join(__dirname, './radio.component.scss');
 
-function hexToRgb(hex: string): [number, number, number] {
-  const clean = hex.replace('#', '');
-  const full = clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean;
-  const num = parseInt(full, 16);
-  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
-}
-
-function relativeLuminance([r, g, b]: [number, number, number]): number {
-  const channel = (c: number) => {
-    const s = c / 255;
-    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-  };
-  const [rl, gl, bl] = [r, g, b].map(channel);
-  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
-}
-
-function contrastRatio(hexA: string, hexB: string): number {
-  const lA = relativeLuminance(hexToRgb(hexA));
-  const lB = relativeLuminance(hexToRgb(hexB));
-  const [lighter, darker] = lA > lB ? [lA, lB] : [lB, lA];
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
-function extractThemeBlocks(css: string): Map<string, string> {
-  const blocks = new Map<string, string>();
-  const blockPattern = /(:root|\.tn-[\w-]+)\s*{([^}]*)}/g;
-  let match: RegExpExecArray | null;
-  while ((match = blockPattern.exec(css)) !== null) {
-    const [, selector, body] = match;
-    if (/--tn-bg1:\s*#/.test(body)) {
-      blocks.set(selector, body);
-    }
-  }
-  return blocks;
-}
-
-function extractVar(body: string, name: string): string | undefined {
-  const match = new RegExp(`${name}:\\s*([^;]+);`).exec(body);
-  return match?.[1].trim();
-}
-
-function resolveColor(rawValue: string, body: string): string | undefined {
-  const varRef = /^var\((--[\w-]+)\)$/.exec(rawValue);
-  if (varRef) {
-    const resolved = extractVar(body, varRef[1]);
-    return resolved ? resolveColor(resolved, body) : undefined;
-  }
-  return rawValue;
-}
+/**
+ * Declared by each theme itself, not inherited from `:root`. `--tn-error-text`
+ * exists to clear 4.5:1 against a particular theme's background, so a theme
+ * falling back to `:root`'s value is measuring a colour that was tuned for a
+ * different surface — `declares` is what sees that, where `color` would resolve
+ * it and report a number.
+ */
+const REQUIRED_TOKENS = ['--tn-bg1', '--tn-bg2', '--tn-error-text'];
 
 interface ThemeCase {
   selector: string;
-  error?: string;
-  bg1?: string;
-  bg2?: string;
-  errorText?: string;
-  bg1Ratio?: number;
-  bg2Ratio?: number;
-  bg1RatioLabel?: string;
-  bg2RatioLabel?: string;
-}
-
-function buildCase(selector: string, body: string): ThemeCase {
-  const bg1 = extractVar(body, '--tn-bg1');
-  const bg2 = extractVar(body, '--tn-bg2');
-  const errorTextRaw = extractVar(body, '--tn-error-text');
-  if (!bg1 || !bg2 || !errorTextRaw) {
-    return { selector, error: `${selector} is missing --tn-bg1, --tn-bg2 or --tn-error-text` };
-  }
-  const errorText = resolveColor(errorTextRaw, body);
-  if (!errorText) {
-    return { selector, error: `${selector}'s --tn-error-text (${errorTextRaw}) could not be resolved` };
-  }
-  const bg1Ratio = contrastRatio(errorText, bg1);
-  const bg2Ratio = contrastRatio(errorText, bg2);
-  return {
-    selector,
-    bg1,
-    bg2,
-    errorText,
-    bg1Ratio,
-    bg2Ratio,
-    bg1RatioLabel: bg1Ratio.toFixed(2),
-    bg2RatioLabel: bg2Ratio.toFixed(2),
-  };
+  errorText: string;
+  bg1: string;
+  bg2: string;
+  bg1Ratio: number;
+  bg2Ratio: number;
+  bg1RatioLabel: string;
+  bg2RatioLabel: string;
 }
 
 describe('tn-radio error text contrast (#186)', () => {
   const css = readFileSync(THEMES_CSS_PATH, 'utf8');
-  const themeBlocks = extractThemeBlocks(css);
+  const palettes = themePalettes(css);
 
-  // Derived from the theme registry rather than hardcoded: extractThemeBlocks
-  // silently drops a block whose --tn-bg1 isn't a hex literal (e.g. rgb()),
-  // so a fixed expected count could stay coincidentally correct while a
-  // themed surface goes unmeasured. Tying it to TN_THEME_DEFINITIONS plus
-  // :root, and naming every registered selector below, fails on exactly
-  // which surface went missing instead.
+  // Derived from the theme registry rather than hardcoded: a themed surface
+  // that stops being recognised — a renamed class, a block that drops
+  // `--tn-bg1` — would otherwise go unmeasured while every remaining case still
+  // passed. Tying the count to TN_THEME_DEFINITIONS plus :root, and naming every
+  // registered selector below, fails on exactly which surface went missing.
   const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
 
   it('found every registered themed surface in themes.css', () => {
-    expect(themeBlocks.size).toBe(expectedSelectors.length);
+    expect(palettes).toHaveLength(expectedSelectors.length);
   });
 
   it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(themeBlocks.has(selector)).toBe(true);
+    expect(palettes.map((palette) => palette.selector)).toContain(selector);
   });
 
-  const cases = Array.from(themeBlocks.entries()).map(([selector, body]) => buildCase(selector, body));
+  const declarations = palettes.map((palette) => ({
+    selector: palette.selector,
+    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
+  }));
 
-  it.each(cases)('$selector defines --tn-bg1, --tn-bg2 and --tn-error-text', (c) => {
-    expect(c.error).toBeUndefined();
+  it.each(declarations)('$selector declares --tn-bg1, --tn-bg2 and --tn-error-text itself', ({ missing }) => {
+    expect(missing).toEqual([]);
   });
 
-  it.each(cases.filter((c) => !c.error))(
-    '$selector: $errorText on --tn-bg1 ($bg1) measures $bg1RatioLabel : 1',
+  // Only the surfaces that passed the check above are measured — a palette
+  // missing a token has already failed, and measuring it would add a second
+  // failure saying the same thing in worse words. If that leaves nothing to
+  // measure, `it.each` errors on the empty array rather than reporting a suite
+  // with no contrast cases in it as green.
+  const cases: ThemeCase[] = palettes
+    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+    .map((palette) => {
+      const bg1Ratio = palette.contrast('--tn-error-text', '--tn-bg1');
+      const bg2Ratio = palette.contrast('--tn-error-text', '--tn-bg2');
+      return {
+        selector: palette.selector,
+        errorText: palette.color('--tn-error-text'),
+        bg1: palette.color('--tn-bg1'),
+        bg2: palette.color('--tn-bg2'),
+        bg1Ratio,
+        bg2Ratio,
+        bg1RatioLabel: formatRatio(bg1Ratio),
+        bg2RatioLabel: formatRatio(bg2Ratio),
+      };
+    });
+
+  // `normal`, not `large`: `.tn-radio__error` is 12px, well under the 18pt (or
+  // 14pt bold) that AA counts as large text, so 4.5:1 applies rather than 3:1.
+  // The measured ratio is in each case's title, so a failure names the colour
+  // and the number it came to as well as the theme it belongs to.
+  it.each(cases)(
+    '$selector: $errorText on --tn-bg1 ($bg1) measures $bg1RatioLabel',
     ({ bg1Ratio }) => {
-      expect(bg1Ratio).toBeGreaterThanOrEqual(4.5);
+      expect(meetsAa(bg1Ratio, 'normal')).toBe(true);
     }
   );
 
-  it.each(cases.filter((c) => !c.error))(
-    '$selector: $errorText on --tn-bg2 ($bg2) measures $bg2RatioLabel : 1',
+  it.each(cases)(
+    '$selector: $errorText on --tn-bg2 ($bg2) measures $bg2RatioLabel',
     ({ bg2Ratio }) => {
-      expect(bg2Ratio).toBeGreaterThanOrEqual(4.5);
+      expect(meetsAa(bg2Ratio, 'normal')).toBe(true);
     }
   );
 
@@ -157,7 +124,8 @@ describe('tn-radio error text contrast (#186)', () => {
     // repo's own themes.css: :root already declares --tn-error-text there,
     // and a theme class that omits the property has nothing to compete with
     // that declaration, so such a theme must set --tn-error-text itself
-    // rather than relying on the fallback.
+    // rather than relying on the fallback. That is what the `declares` cases
+    // above hold every theme to.
     const chainMatch = /--tn-error-text,\s*var\(--tn-red,\s*(#[0-9a-fA-F]{3,6})\)\)/.exec(scss);
     expect(chainMatch).not.toBeNull();
     const literal = chainMatch![1];
@@ -165,7 +133,6 @@ describe('tn-radio error text contrast (#186)', () => {
     // The literal is reached only when neither --tn-error-text nor --tn-red
     // is defined, i.e. no theme stylesheet loaded at all — the surface that
     // IS reachable there is the browser's UA default: white.
-    const ratio = contrastRatio(literal, '#ffffff');
-    expect(ratio).toBeGreaterThanOrEqual(4.5);
+    expect(meetsAa(contrastRatio(literal, '#ffffff'), 'normal')).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #197.

Three cycles working one `tn-radio` contrast bug wrote seven throwaway implementations of the WCAG contrast formula in a day, in two languages. Nothing about the computation varies per ticket — two colours in, a ratio out, and a threshold by text size — so it was re-derived because it was not available, and each hand-roll is another chance to get a step wrong in the direction that makes a failing colour look passing.

`projects/truenas-ui/src/lib/a11y/contrast-testing.ts` is now the one place it lives, alongside `axe-testing.ts` and `live-region-testing.ts` and under the same do-not-export rule.

| | |
|---|---|
| `contrastRatio(fg, bg)` | the WCAG 2.1 ratio, 1 to 21 |
| `meetsAa(ratio, size)`, `AA_MINIMUM` | 4.5:1 for normal text, 3:1 for large |
| `formatRatio(ratio)` | `"5.17:1"`, for titles and messages **only** |
| `themePalettes(css)` | every themed surface in `themes.css`, each with `declares`, `color` and `contrast` |

## What the helper refuses to do

Every one of these returns a plausible number if it is not guarded, and a plausible wrong number in a contrast test is a defect that ships.

- **Rounding before comparing.** `4.4999` formats as `"4.50"`. `meetsAa` compares the unrounded ratio; `formatRatio` exists so the number can be in the test's title without being in the comparison.
- **Measuring a translucent colour as opaque.** `--tn-fg2` is `rgba(255,255,255,0.85)`. Read as opaque it reports 16.67:1 on `--tn-bg1`; composited, as it renders, 12.30:1. A translucent *background* throws — what is behind it decides the answer.
- **Resolving a token to nothing.** `undefined` reaching the maths is `NaN`, and `NaN >= 4.5` is `false`: a red test blaming the palette for a typo in a token name. Unknown tokens, `var()` loops and values that are not colours all throw, naming the selector and the token.
- **Answering for a surface that does not render.** A palette nested in `@media`, `@supports` or a plain selector applies only there; merged into the unconditional palette of the same name it reports a background and a foreground that never appear together. It throws instead of merging.
- **Coming back empty.** No palettes found, or unbalanced braces, throw. An empty list makes every `it.each` over it vanish, which is a green suite with no cases left in it.

## What was measured, not assumed

The expectations were computed and then cross-checked against sources outside this change: black on white is 21:1 by definition, `#777777` on white is the published 4.48:1 pair, and `#de6d6d` on `#1E1E1E` comes to the 5.17:1 that `themes.css` records in a comment next to the token. The migrated spec reports the same nine ratios it reported before, each matching the comment in the stylesheet.

Where a test exists to pin one step of the formula, its comment says what a wrong implementation returns instead — an expectation both implementations satisfy is not covering the step it claims to:

| assertion | what it catches |
|---|---|
| `#777777` on white = 4.4781 | no gamma step at all (returns 2.0323) |
| `#010101` on black = 1.006071 | the power curve applied below the crossover (returns 1.019674) |
| `rgba(255,255,255,0.85)` on `#1E1E1E` = 12.3034 | alpha ignored (returns 16.6712) |

`themePalettes` is covered against a fixture rather than `themes.css`, because its claims are about the resolution rules — inheritance, `var()` chains, what counts as a palette — and pinning them to shipped colours would make the file fail every time a theme is retuned, for a reason that is not about it.

`declares()` and `color()` are deliberately different questions. `color()` resolves the way the browser does, inheriting from `:root`; `declares()` says whether *this* block sets the token. `--tn-error-text` is tuned per theme against that theme's own background, so a theme inheriting `:root`'s value is a defect, and only `declares()` sees it — that is what `radio-error-contrast.spec.ts` holds all nine surfaces to.

## Checks run locally

`yarn lint`, `yarn test` (2315 passing, up from 2309), `yarn test:scripts`, `yarn build`. Lint reports 4 errors, all pre-existing `import/order` in `input/` and `menu/`, neither touched here. The built package was checked for `contrastRatio`/`themePalettes` and contains neither, which is the do-not-export claim confirmed against `dist/` rather than only asserted in a spec.

Storybook interaction tests were not run locally — they need Playwright and a Storybook build; this change adds no story and touches no component markup.

## Review

Seven local rounds, $12.27 of a $25 ceiling. Round 7 came back clean at MEDIUM and above, which is where this stopped.

Rounds 1 to 6 each raised one MEDIUM, all in the CSS block scanner and all the same shape — a stylesheet this read wrongly while still answering:

1. A regex could find a block inside `@media` and could not tell you it was in one, so a conditional palette merged into the unconditional one. Replaced with a brace walk that records nesting.
2. A surplus `}` threw; a `{` left open did not, and swallowed the next selector into the unclosed block's body.
3. The final semicolon in a block is optional in CSS and was required here, so a block whose last declaration omitted it lost that declaration — and losing `--tn-bg1` removes the whole surface from the list.
4. One shared buffer meant the opening brace of a nested rule discarded every declaration above it.
5. Nesting was refused only inside at-rules, so CSS nesting inside a plain selector reached the same end by a different route.

Smaller corrections, each a place where prose claimed more than the code did: a comment quoted `radio.component.scss`'s fallback literal as `#de6d6d` when it is `#b91c1c`; `meetsAa`'s docblock argued for an assertion shape the migrated spec does not use; `contrast()` bypassed `color()`'s validation, so a token holding a font stack threw without naming it; the undeclared-token error told the `:root` palette that `:root` does not declare it either; and the `rgb()` docblock described the separators as stricter than the parser reads them.

**Left open, deliberately, all LOW.** Every fix is a new diff and a new diff is unreviewed, so these are recorded here rather than spent on another round:

- A palette nested in an at-rule throws for the whole stylesheet, so adding a `prefers-contrast` palette to `themes.css` would take out every contrast case rather than the one surface it is about. Loud and wrong-shaped rather than quiet and wrong, which is the right way round, but a reader would rather be told which block.
- The do-not-export guard compares export *names*, so `export { axeResult as runAxe }` from `public-api.ts` would pass it. Comparing values would close that. `axe-testing.spec.ts` (#196) has the same gap and this file inherits its shape.
- `relativeLuminance` is evaluated four times for two colours in `contrastRatio`; naming the two luminances halves the work and reads better.
- `radio-error-contrast.spec.ts` builds its cases in the `describe` body, so a token retuned to something unreadable throws at collection and fails the whole file rather than the one theme's case.
- `axe-testing.spec.ts`'s public-API guard uses `name in axeTesting`, which walks the prototype chain; this file uses `Object.hasOwn`. Worth making the two match, in whichever direction, when something else touches that file.

## Conventions

`docs/component_conventions.md` gains a **Measuring colour contrast in a spec** section next to the axe one: use the helper, never compare a rounded ratio, `declares()` and `color()` answer different questions, and this is not axe's `color-contrast` rule and cannot be — that rule needs a layout engine, reports `incomplete` under jsdom, and `axeResult()` treats `incomplete` as an error.
