### PR TITLE
NAS-142319 / 27.0.0-BETA.1 / fix(a11y): give tn-progress-bar and tn-spinner an accessible name by default

### DIFF
--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar-a11y.spec.ts
@@ -1,0 +1,275 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnProgressBarComponent, TN_PROGRESS_BAR_DEFAULT_LABEL } from './progress-bar.component';
+import type { ProgressBarMode } from './progress-bar.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the naming fixed for #202: the host carried `role="progressbar"` with
+ * `aria-label` and `aria-labelledby` bound to inputs that both default to
+ * `null`, so the DEFAULT rendering was a progressbar assistive technology
+ * announces with no name — "progress bar, 40%", with nothing to say what is
+ * progressing. axe scores that serious (`aria-progressbar-name`, WCAG 4.1.2).
+ *
+ * Measured before the fix, under jsdom, with the rule reporting on the host:
+ *
+ *   default markup   aria-progressbar-name -> violations on [tn-progress-bar]
+ *
+ * So unlike `slide-toggle-a11y.spec.ts` — where the suggested rule never
+ * matched and the DOM assertions are what hold the fix — the axe assertions
+ * here are direct evidence, in the shape `chip-a11y.spec.ts` uses.
+ *
+ * WHY A DEFAULT NAME RATHER THAN DROPPING THE ROLE
+ * ------------------------------------------------
+ * The other way to satisfy the rule is to withhold `role="progressbar"` when
+ * there is nothing to name it with. That trades a badly-named progressbar for
+ * no progressbar at all: a screen reader then gets no indication that anything
+ * is loading, and on a determinate bar it also loses the value. Silence scores
+ * clean and helps nobody. So the role stays, an unnamed bar falls back to
+ * `TN_PROGRESS_BAR_DEFAULT_LABEL`, and the dev-mode warning below is what stops
+ * that fallback from being the silent default the ticket warns about.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnProgressBarComponent],
+  template: `<span id="tn-external-label">Restoring pool</span>
+    <tn-progress-bar [mode]="mode()" [value]="value()" [bufferValue]="bufferValue()"
+      [ariaLabel]="ariaLabel()" [ariaLabelledby]="ariaLabelledby()" />`
+})
+class TestHostComponent {
+  mode = signal<ProgressBarMode>('determinate');
+  value = signal(40);
+  bufferValue = signal(0);
+  ariaLabel = signal<string | null>(null);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+describe('tn-progress-bar accessibility (#202)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // Silenced rather than merely observed: the component warns on every
+    // unnamed bar by design, and most fixtures in this file are unnamed.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  function bar(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-progress-bar') as HTMLElement;
+  }
+
+  describe('aria-progressbar-name', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing at all.
+    // It is non-vacuous here: the rule selects on `role="progressbar"`, which is
+    // the host itself and the only such node in the fixture.
+    it.each<ProgressBarMode>(['determinate', 'indeterminate', 'buffer'])(
+      'names a %s bar that was given no label', async (mode) => {
+        host.mode.set(mode);
+        fixture.detectChanges();
+
+        const { violated, evaluated } = await axeResult(
+          fixture.nativeElement, bar(), ['aria-progressbar-name']
+        );
+
+        expect(violated).toEqual([]);
+        expect(evaluated).toContain('aria-progressbar-name');
+      });
+
+    it('raises no violation when ariaLabel is set', async () => {
+      host.ariaLabel.set('Copying files');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabelledby is set', async () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * Positive control, and the only assertion here that shows axe FAILING
+     * rather than passing. Every expectation above is `toEqual([])`, which is
+     * also what axe returns when it evaluates nothing — a version that narrows
+     * which nodes the rule selects, a jsdom change that makes the tree
+     * invisible to it. (A rule renamed or dropped outright is the case that does
+     * not go quiet: axe rejects with "Could not find configured rule".)
+     *
+     * This rebuilds the markup `tn-progress-bar` shipped before #202 —
+     * `role="progressbar"` with the value attributes and no name — and requires
+     * axe to still object to it. It runs through the shared `axeResult` on
+     * purpose, so it is equally the control for that wrapper: an attribution bug
+     * there would empty `violated` in every spec using it.
+     */
+    it('still reports the violation for the markup the bar used to have', async () => {
+      const previous = document.createElement('div');
+      previous.innerHTML =
+        '<div role="progressbar" class="tn-progress-bar tn-progress-bar-determinate" '
+        + 'aria-valuenow="40" aria-valuemin="0" aria-valuemax="100"></div>';
+      document.body.appendChild(previous);
+
+      // try/finally, because `axeResult` throws rather than returning a vacuous
+      // pass — and a fixture left in `document.body` by that throw would be
+      // scanned by every later test in this file.
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          previous, previous.querySelector('[role="progressbar"]'), ['aria-progressbar-name']
+        ));
+      } finally {
+        previous.remove();
+      }
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+  });
+
+  describe('where the name comes from', () => {
+    it('falls back to the default label when neither input is set', () => {
+      expect(bar().getAttribute('aria-label')).toBe(TN_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+
+    it('prefers an explicit ariaLabel over the fallback', () => {
+      host.ariaLabel.set('Copying files');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe('Copying files');
+    });
+
+    it('treats a blank ariaLabel as no label at all', () => {
+      host.ariaLabel.set('   ');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe(TN_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+
+    /**
+     * `aria-labelledby` wins over `aria-label` in the ARIA name calculation, so
+     * a fallback emitted alongside it would be dead weight that nothing
+     * announces — and reads, to anyone inspecting the element, as a name that is
+     * in force when it is not.
+     */
+    it('emits no aria-label at all when ariaLabelledby is set', () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(bar().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('reinstates the fallback if the caller clears ariaLabel again', () => {
+      host.ariaLabel.set('Copying files');
+      fixture.detectChanges();
+      host.ariaLabel.set(null);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe(TN_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+  });
+
+  /**
+   * The fallback is what keeps a forgotten label from reaching assistive
+   * technology as silence; this is what keeps it from reaching the DEVELOPER as
+   * silence. Without it the fix would satisfy axe and remove the only signal
+   * that the label was ever missing — which the ticket calls out as worse than
+   * shipping the violation.
+   */
+  describe('the dev-mode warning', () => {
+    function messages(): string[] {
+      return warn.mock.calls.map((call) => String(call[0]));
+    }
+
+    it('warns, naming the component, when neither input is set', () => {
+      expect(messages()).toHaveLength(1);
+      expect(messages()[0]).toContain('tn-progress-bar');
+      expect(messages()[0]).toContain('ariaLabel');
+    });
+
+    it('does not warn when ariaLabel is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabel.set('Copying files');
+      named.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when ariaLabelledby is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabelledby.set('tn-external-label');
+      named.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    // One warning per bar that stays unnamed, not one per change detection:
+    // a per-cycle warning on an animating progress bar floods the console and
+    // trains developers to ignore it.
+    it('warns once, however many times the bar is re-rendered', () => {
+      host.value.set(70);
+      fixture.detectChanges();
+      host.value.set(90);
+      fixture.detectChanges();
+
+      expect(messages()).toHaveLength(1);
+    });
+  });
+
+  /**
+   * #202 is about the name only. These are the attributes it must not disturb,
+   * asserted here rather than left to `progress-bar.component.spec.ts` because
+   * the regression they guard would be introduced by this fix.
+   */
+  describe('the value attributes are unchanged', () => {
+    it('keeps the role, and the value range, in determinate mode', () => {
+      expect(bar().getAttribute('role')).toBe('progressbar');
+      expect(bar().getAttribute('aria-valuenow')).toBe('40');
+      expect(bar().getAttribute('aria-valuemin')).toBe('0');
+      expect(bar().getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it.each<ProgressBarMode>(['indeterminate', 'buffer'])(
+      'keeps the role and omits the value range in %s mode', (mode) => {
+        host.mode.set(mode);
+        fixture.detectChanges();
+
+        expect(bar().getAttribute('role')).toBe('progressbar');
+        expect(bar().hasAttribute('aria-valuenow')).toBe(false);
+        expect(bar().hasAttribute('aria-valuemin')).toBe(false);
+        expect(bar().hasAttribute('aria-valuemax')).toBe(false);
+      });
+  });
+});

--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar-a11y.spec.ts
@@ -176,17 +176,67 @@ describe('tn-progress-bar accessibility (#202)', () => {
     });
 
     /**
-     * `aria-labelledby` wins over `aria-label` in the ARIA name calculation, so
-     * a fallback emitted alongside it would be dead weight that nothing
-     * announces — and reads, to anyone inspecting the element, as a name that is
-     * in force when it is not.
+     * `aria-labelledby` wins over `aria-label` only while its IDREF RESOLVES, so
+     * the generic fallback is withheld beside one — there it would mask a
+     * dangling reference with a name that says nothing — while an explicit
+     * `ariaLabel` is not, because it is the only name left when the reference
+     * does not resolve. These two tests are that pair.
      */
-    it('emits no aria-label at all when ariaLabelledby is set', () => {
+    it('withholds the generic fallback when only ariaLabelledby is set', () => {
       host.ariaLabelledby.set('tn-external-label');
       fixture.detectChanges();
 
       expect(bar().getAttribute('aria-labelledby')).toBe('tn-external-label');
       expect(bar().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('keeps an explicit ariaLabel alongside ariaLabelledby', () => {
+      host.ariaLabel.set('Copying files');
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(bar().getAttribute('aria-label')).toBe('Copying files');
+    });
+
+    /**
+     * The regression the pair above exists to prevent, and the reason this is
+     * an axe assertion rather than a DOM one: a dangling IDREF contributes
+     * nothing to the accessible name, so `aria-label` is all that stands
+     * between this bar and the very violation #202 is about.
+     */
+    it('still names the bar when ariaLabelledby points at nothing', async () => {
+      host.ariaLabel.set('Copying files');
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * The other half of that pair, and the evidence for withholding the generic
+     * fallback beside an `ariaLabelledby`: on its own, a dangling IDREF is still
+     * a violation, so it is reported rather than quietly papered over by a name
+     * that says nothing.
+     *
+     * It is also what stops the test above passing for free. Without it, that
+     * one is equally satisfied by an axe that treats ANY `aria-labelledby` as a
+     * name without resolving it — this is the assertion that shows it resolves.
+     */
+    it('reports a bar whose only name is an ariaLabelledby pointing at nothing', async () => {
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual(['aria-progressbar-name']);
     });
 
     it('reinstates the fallback if the caller clears ariaLabel again', () => {

--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.spec.ts
@@ -5,15 +5,25 @@ import { TnProgressBarComponent } from './progress-bar.component';
 describe('TnProgressBarComponent', () => {
   let component: TnProgressBarComponent;
   let fixture: ComponentFixture<TnProgressBarComponent>;
+  let warn: jest.SpyInstance;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TnProgressBarComponent]
     }).compileComponents();
 
+    // Almost every fixture here is unnamed, and #202 makes an unnamed bar warn
+    // in dev mode — which Jest is. Silenced so this suite's output stays
+    // readable; the warning itself is asserted in `progress-bar-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     fixture = TestBed.createComponent(TnProgressBarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
   });
 
   it('should create', () => {

--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
@@ -1,7 +1,26 @@
 
-import { Component, input, ChangeDetectionStrategy, computed } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy, computed, effect, isDevMode } from '@angular/core';
 
 export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer';
+
+/**
+ * The accessible name a bar falls back to when the caller names neither
+ * `ariaLabel` nor `ariaLabelledby` (#202).
+ *
+ * Deliberately generic, and deliberately not silent: the host carries
+ * `role="progressbar"` unconditionally, so without a fallback the default
+ * rendering is a progressbar assistive technology announces with no name at all
+ * — "progress bar, 40%", with nothing to say what is progressing. The
+ * alternative fix, withholding the role until there is a name for it, trades
+ * that for no announcement whatever, which is worse: a screen reader would not
+ * learn that anything is in progress, and on a determinate bar it would lose
+ * the value too.
+ *
+ * A generic name is still a poor one, so it is paired with the dev-mode warning
+ * in the constructor. Exported so specs assert against it by name rather than
+ * by a copied string literal.
+ */
+export const TN_PROGRESS_BAR_DEFAULT_LABEL = 'Progress';
 
 @Component({
   selector: 'tn-progress-bar',
@@ -19,7 +38,7 @@ export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer';
     '[attr.aria-valuenow]': 'mode() === "determinate" ? value() : null',
     '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
     '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
-    '[attr.aria-label]': 'ariaLabel() || null',
+    '[attr.aria-label]': 'resolvedAriaLabel()',
     '[attr.aria-labelledby]': 'ariaLabelledby() || null'
   }
 })
@@ -29,6 +48,49 @@ export class TnProgressBarComponent {
   bufferValue = input<number>(0);
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
+
+  /** Whether the caller gave this bar a name of its own. Blank is not a name. */
+  private readonly named = computed(() => {
+    return (this.ariaLabel() ?? '').trim() !== '' || (this.ariaLabelledby() ?? '').trim() !== '';
+  });
+
+  /**
+   * The name to render, or `null` to render no `aria-label` attribute.
+   *
+   * Null when `ariaLabelledby` is set, because `aria-labelledby` wins the ARIA
+   * name calculation outright — a fallback emitted alongside it would be a name
+   * that nothing announces, and reads to anyone inspecting the element as one
+   * that is in force when it is not.
+   */
+  resolvedAriaLabel = computed(() => {
+    if ((this.ariaLabelledby() ?? '').trim() !== '') {
+      return null;
+    }
+    const label = (this.ariaLabel() ?? '').trim();
+    return label !== '' ? this.ariaLabel() : TN_PROGRESS_BAR_DEFAULT_LABEL;
+  });
+
+  constructor() {
+    // The fallback keeps a forgotten label from reaching assistive technology
+    // as silence; this keeps it from reaching the developer as silence. Without
+    // it the fix would satisfy axe while removing the only remaining signal
+    // that the label was missing.
+    //
+    // An effect rather than a lifecycle hook, so a bar that is named later
+    // stops warning — and, because it re-runs only when the two inputs change,
+    // a bar that stays unnamed warns once rather than once per animation frame.
+    if (isDevMode()) {
+      effect(() => {
+        if (!this.named()) {
+          console.warn(
+            `[tn-progress-bar] No ariaLabel or ariaLabelledby was set, so it falls back to `
+            + `"${TN_PROGRESS_BAR_DEFAULT_LABEL}". Assistive technology cannot say WHAT is `
+            + `progressing — pass ariaLabel, or ariaLabelledby pointing at visible text.`
+          );
+        }
+      });
+    }
+  }
 
   /**
    * Gets the transform value for the primary progress bar

--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
@@ -49,25 +49,34 @@ export class TnProgressBarComponent {
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
 
+  private readonly hasLabelledby = computed(() => (this.ariaLabelledby() ?? '').trim() !== '');
+
   /** Whether the caller gave this bar a name of its own. Blank is not a name. */
   private readonly named = computed(() => {
-    return (this.ariaLabel() ?? '').trim() !== '' || (this.ariaLabelledby() ?? '').trim() !== '';
+    return (this.ariaLabel() ?? '').trim() !== '' || this.hasLabelledby();
   });
 
   /**
    * The name to render, or `null` to render no `aria-label` attribute.
    *
-   * Null when `ariaLabelledby` is set, because `aria-labelledby` wins the ARIA
-   * name calculation outright — a fallback emitted alongside it would be a name
-   * that nothing announces, and reads to anyone inspecting the element as one
-   * that is in force when it is not.
+   * `aria-labelledby` wins the ARIA name calculation when it RESOLVES, which is
+   * what makes the two branches below differ:
+   *
+   * - An explicit `ariaLabel` is always emitted, `ariaLabelledby` or not.
+   *   Suppressing it would be safe only while the IDREF resolves; against a typo
+   *   or an element that has not rendered yet it would leave the bar unnamed in
+   *   precisely the case where the caller supplied a name.
+   * - The generic fallback is withheld beside an `ariaLabelledby`. There it
+   *   would do the opposite of its job — masking a dangling IDREF with a name
+   *   that says nothing, clean to axe and useless to a listener, with no warning
+   *   either because the caller did name it. Unnamed at least still fails loudly.
    */
   resolvedAriaLabel = computed(() => {
-    if ((this.ariaLabelledby() ?? '').trim() !== '') {
-      return null;
+    const label = this.ariaLabel();
+    if ((label ?? '').trim() !== '') {
+      return label;
     }
-    const label = (this.ariaLabel() ?? '').trim();
-    return label !== '' ? this.ariaLabel() : TN_PROGRESS_BAR_DEFAULT_LABEL;
+    return this.hasLabelledby() ? null : TN_PROGRESS_BAR_DEFAULT_LABEL;
   });
 
   constructor() {

--- a/projects/truenas-ui/src/lib/spinner/spinner-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner-a11y.spec.ts
@@ -1,0 +1,256 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnSpinnerComponent, TN_SPINNER_DEFAULT_LABEL } from './spinner.component';
+import type { SpinnerMode } from './spinner.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * The spinner half of #202. Same defect as `../progress-bar/progress-bar-a11y.spec.ts`
+ * and same fix — `role="progressbar"` on the host with `aria-label` and
+ * `aria-labelledby` bound to inputs that both default to `null` — so the
+ * reasoning for a fallback name over dropping the role lives there and is not
+ * repeated here.
+ *
+ * What differs is that the spinner's default mode is `indeterminate`, so its
+ * unnamed default rendering carries no `aria-valuenow` either: assistive
+ * technology reached a progressbar with neither a name nor a value.
+ *
+ * Measured before the fix, under jsdom, with the rule reporting on the host:
+ *
+ *   default markup   aria-progressbar-name -> violations on [tn-spinner]
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSpinnerComponent],
+  template: `<span id="tn-external-label">Restoring pool</span>
+    <tn-spinner [mode]="mode()" [value]="value()"
+      [ariaLabel]="ariaLabel()" [ariaLabelledby]="ariaLabelledby()" />`
+})
+class TestHostComponent {
+  mode = signal<SpinnerMode>('indeterminate');
+  value = signal(0);
+  ariaLabel = signal<string | null>(null);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+describe('tn-spinner accessibility (#202)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // Silenced rather than merely observed: the component warns on every
+    // unnamed spinner by design, and most fixtures in this file are unnamed.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  function spinner(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-spinner') as HTMLElement;
+  }
+
+  describe('aria-progressbar-name', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing at all.
+    // It is non-vacuous here: the rule selects on `role="progressbar"`, which is
+    // the host itself and the only such node in the fixture.
+    it.each<SpinnerMode>(['indeterminate', 'determinate'])(
+      'names a %s spinner that was given no label', async (mode) => {
+        host.mode.set(mode);
+        fixture.detectChanges();
+
+        const { violated, evaluated } = await axeResult(
+          fixture.nativeElement, spinner(), ['aria-progressbar-name']
+        );
+
+        expect(violated).toEqual([]);
+        expect(evaluated).toContain('aria-progressbar-name');
+      });
+
+    it('raises no violation when ariaLabel is set', async () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabelledby is set', async () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * Positive control, for the reason set out at length in
+     * `../progress-bar/progress-bar-a11y.spec.ts`: every expectation above is
+     * `toEqual([])`, which is also what axe returns when it evaluated nothing.
+     * This rebuilds the markup `tn-spinner` shipped before #202 — an
+     * indeterminate progressbar with neither a name nor a value — and requires
+     * axe to still object to it.
+     */
+    it('still reports the violation for the markup the spinner used to have', async () => {
+      const previous = document.createElement('div');
+      previous.innerHTML =
+        '<div role="progressbar" class="tn-spinner tn-spinner-indeterminate"></div>';
+      document.body.appendChild(previous);
+
+      // try/finally, because `axeResult` throws rather than returning a vacuous
+      // pass — and a fixture left in `document.body` by that throw would be
+      // scanned by every later test in this file.
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          previous, previous.querySelector('[role="progressbar"]'), ['aria-progressbar-name']
+        ));
+      } finally {
+        previous.remove();
+      }
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+  });
+
+  describe('where the name comes from', () => {
+    it('falls back to the default label when neither input is set', () => {
+      expect(spinner().getAttribute('aria-label')).toBe(TN_SPINNER_DEFAULT_LABEL);
+    });
+
+    it('prefers an explicit ariaLabel over the fallback', () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe('Loading datasets');
+    });
+
+    it('treats a blank ariaLabel as no label at all', () => {
+      host.ariaLabel.set('   ');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe(TN_SPINNER_DEFAULT_LABEL);
+    });
+
+    /**
+     * `aria-labelledby` wins over `aria-label` in the ARIA name calculation, so
+     * a fallback emitted alongside it would be dead weight that nothing
+     * announces — and reads, to anyone inspecting the element, as a name that is
+     * in force when it is not.
+     */
+    it('emits no aria-label at all when ariaLabelledby is set', () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(spinner().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('reinstates the fallback if the caller clears ariaLabel again', () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+      host.ariaLabel.set(null);
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe(TN_SPINNER_DEFAULT_LABEL);
+    });
+  });
+
+  /**
+   * The fallback is what keeps a forgotten label from reaching assistive
+   * technology as silence; this is what keeps it from reaching the DEVELOPER as
+   * silence. Without it the fix would satisfy axe and remove the only signal
+   * that the label was ever missing.
+   */
+  describe('the dev-mode warning', () => {
+    function messages(): string[] {
+      return warn.mock.calls.map((call) => String(call[0]));
+    }
+
+    it('warns, naming the component, when neither input is set', () => {
+      expect(messages()).toHaveLength(1);
+      expect(messages()[0]).toContain('tn-spinner');
+      expect(messages()[0]).toContain('ariaLabel');
+    });
+
+    it('does not warn when ariaLabel is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabel.set('Loading datasets');
+      named.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when ariaLabelledby is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabelledby.set('tn-external-label');
+      named.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    // One warning per spinner that stays unnamed, not one per change detection:
+    // a per-cycle warning on a spinner that is animating by definition floods
+    // the console and trains developers to ignore it.
+    it('warns once, however many times the spinner is re-rendered', () => {
+      host.mode.set('determinate');
+      fixture.detectChanges();
+      host.value.set(60);
+      fixture.detectChanges();
+
+      expect(messages()).toHaveLength(1);
+    });
+  });
+
+  /**
+   * #202 is about the name only. These are the attributes it must not disturb,
+   * asserted here rather than left to `spinner.component.spec.ts` because the
+   * regression they guard would be introduced by this fix.
+   */
+  describe('the value attributes are unchanged', () => {
+    it('keeps the role, and the value range, in determinate mode', () => {
+      host.mode.set('determinate');
+      host.value.set(75);
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('role')).toBe('progressbar');
+      expect(spinner().getAttribute('aria-valuenow')).toBe('75');
+      expect(spinner().getAttribute('aria-valuemin')).toBe('0');
+      expect(spinner().getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it('keeps the role and omits the value range in indeterminate mode', () => {
+      expect(spinner().getAttribute('role')).toBe('progressbar');
+      expect(spinner().hasAttribute('aria-valuenow')).toBe(false);
+      expect(spinner().hasAttribute('aria-valuemin')).toBe(false);
+      expect(spinner().hasAttribute('aria-valuemax')).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/spinner/spinner-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner-a11y.spec.ts
@@ -158,17 +158,58 @@ describe('tn-spinner accessibility (#202)', () => {
     });
 
     /**
-     * `aria-labelledby` wins over `aria-label` in the ARIA name calculation, so
-     * a fallback emitted alongside it would be dead weight that nothing
-     * announces — and reads, to anyone inspecting the element, as a name that is
-     * in force when it is not.
+     * `aria-labelledby` wins over `aria-label` only while its IDREF RESOLVES, so
+     * the generic fallback is withheld beside one — there it would mask a
+     * dangling reference with a name that says nothing — while an explicit
+     * `ariaLabel` is not, because it is the only name left when the reference
+     * does not resolve. These three tests are that pair and its regression.
      */
-    it('emits no aria-label at all when ariaLabelledby is set', () => {
+    it('withholds the generic fallback when only ariaLabelledby is set', () => {
       host.ariaLabelledby.set('tn-external-label');
       fixture.detectChanges();
 
       expect(spinner().getAttribute('aria-labelledby')).toBe('tn-external-label');
       expect(spinner().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('keeps an explicit ariaLabel alongside ariaLabelledby', () => {
+      host.ariaLabel.set('Loading datasets');
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(spinner().getAttribute('aria-label')).toBe('Loading datasets');
+    });
+
+    it('still names the spinner when ariaLabelledby points at nothing', async () => {
+      host.ariaLabel.set('Loading datasets');
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * The evidence for withholding the generic fallback beside an
+     * `ariaLabelledby` — a dangling IDREF alone is still a violation, so it is
+     * reported rather than papered over — and equally what stops the test above
+     * passing for free, by showing that axe resolves the IDREF rather than
+     * treating any `aria-labelledby` as a name.
+     */
+    it('reports a spinner whose only name is an ariaLabelledby pointing at nothing', async () => {
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual(['aria-progressbar-name']);
     });
 
     it('reinstates the fallback if the caller clears ariaLabel again', () => {

--- a/projects/truenas-ui/src/lib/spinner/spinner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner.component.spec.ts
@@ -5,15 +5,25 @@ import { TnSpinnerComponent } from './spinner.component';
 describe('TnSpinnerComponent', () => {
   let component: TnSpinnerComponent;
   let fixture: ComponentFixture<TnSpinnerComponent>;
+  let warn: jest.SpyInstance;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TnSpinnerComponent]
     }).compileComponents();
 
+    // Almost every fixture here is unnamed, and #202 makes an unnamed spinner
+    // warn in dev mode — which Jest is. Silenced so this suite's output stays
+    // readable; the warning itself is asserted in `spinner-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     fixture = TestBed.createComponent(TnSpinnerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
   });
 
   it('should create', () => {

--- a/projects/truenas-ui/src/lib/spinner/spinner.component.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner.component.ts
@@ -44,25 +44,27 @@ export class TnSpinnerComponent {
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
 
+  private readonly hasLabelledby = computed(() => (this.ariaLabelledby() ?? '').trim() !== '');
+
   /** Whether the caller gave this spinner a name of its own. Blank is not a name. */
   private readonly named = computed(() => {
-    return (this.ariaLabel() ?? '').trim() !== '' || (this.ariaLabelledby() ?? '').trim() !== '';
+    return (this.ariaLabel() ?? '').trim() !== '' || this.hasLabelledby();
   });
 
   /**
-   * The name to render, or `null` to render no `aria-label` attribute.
-   *
-   * Null when `ariaLabelledby` is set, because `aria-labelledby` wins the ARIA
-   * name calculation outright — a fallback emitted alongside it would be a name
-   * that nothing announces, and reads to anyone inspecting the element as one
-   * that is in force when it is not.
+   * The name to render, or `null` to render no `aria-label` attribute. Same two
+   * branches as `TnProgressBarComponent.resolvedAriaLabel`, where the reasoning
+   * is set out: an explicit `ariaLabel` always survives, because
+   * `aria-labelledby` only wins the name calculation while its IDREF resolves;
+   * the generic fallback is withheld beside one, because there it would mask a
+   * dangling IDREF with a name that says nothing.
    */
   resolvedAriaLabel = computed(() => {
-    if ((this.ariaLabelledby() ?? '').trim() !== '') {
-      return null;
+    const label = this.ariaLabel();
+    if ((label ?? '').trim() !== '') {
+      return label;
     }
-    const label = (this.ariaLabel() ?? '').trim();
-    return label !== '' ? this.ariaLabel() : TN_SPINNER_DEFAULT_LABEL;
+    return this.hasLabelledby() ? null : TN_SPINNER_DEFAULT_LABEL;
   });
 
   constructor() {

--- a/projects/truenas-ui/src/lib/spinner/spinner.component.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner.component.ts
@@ -1,7 +1,20 @@
 
-import { Component, input, ChangeDetectionStrategy, ViewEncapsulation, computed } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy, ViewEncapsulation, computed, effect, isDevMode } from '@angular/core';
 
 export type SpinnerMode = 'determinate' | 'indeterminate';
+
+/**
+ * The accessible name a spinner falls back to when the caller names neither
+ * `ariaLabel` nor `ariaLabelledby` (#202). Same reasoning as
+ * `TN_PROGRESS_BAR_DEFAULT_LABEL`, and the case is sharper here: the spinner
+ * defaults to indeterminate mode, so its unnamed default rendering reached
+ * assistive technology as a progressbar with neither a name nor a value.
+ *
+ * `branded-spinner.component.ts` in this folder already fell back this way —
+ * `ariaLabel() || "Loading..."` inline — so a fallback is the shape this
+ * library had already settled on; what it lacked was the warning.
+ */
+export const TN_SPINNER_DEFAULT_LABEL = 'Loading';
 
 @Component({
   selector: 'tn-spinner',
@@ -19,7 +32,7 @@ export type SpinnerMode = 'determinate' | 'indeterminate';
     '[attr.aria-valuemin]': 'mode() === "determinate" ? 0 : null',
     '[attr.aria-valuemax]': 'mode() === "determinate" ? 100 : null',
     'role': 'progressbar',
-    '[attr.aria-label]': 'ariaLabel() || null',
+    '[attr.aria-label]': 'resolvedAriaLabel()',
     '[attr.aria-labelledby]': 'ariaLabelledby() || null'
   }
 })
@@ -30,6 +43,49 @@ export class TnSpinnerComponent {
   strokeWidth = input<number>(4);
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
+
+  /** Whether the caller gave this spinner a name of its own. Blank is not a name. */
+  private readonly named = computed(() => {
+    return (this.ariaLabel() ?? '').trim() !== '' || (this.ariaLabelledby() ?? '').trim() !== '';
+  });
+
+  /**
+   * The name to render, or `null` to render no `aria-label` attribute.
+   *
+   * Null when `ariaLabelledby` is set, because `aria-labelledby` wins the ARIA
+   * name calculation outright — a fallback emitted alongside it would be a name
+   * that nothing announces, and reads to anyone inspecting the element as one
+   * that is in force when it is not.
+   */
+  resolvedAriaLabel = computed(() => {
+    if ((this.ariaLabelledby() ?? '').trim() !== '') {
+      return null;
+    }
+    const label = (this.ariaLabel() ?? '').trim();
+    return label !== '' ? this.ariaLabel() : TN_SPINNER_DEFAULT_LABEL;
+  });
+
+  constructor() {
+    // The fallback keeps a forgotten label from reaching assistive technology
+    // as silence; this keeps it from reaching the developer as silence. Without
+    // it the fix would satisfy axe while removing the only remaining signal
+    // that the label was missing.
+    //
+    // An effect rather than a lifecycle hook, so a spinner that is named later
+    // stops warning — and, because it re-runs only when the two inputs change,
+    // one that stays unnamed warns once rather than once per animation frame.
+    if (isDevMode()) {
+      effect(() => {
+        if (!this.named()) {
+          console.warn(
+            `[tn-spinner] No ariaLabel or ariaLabelledby was set, so it falls back to `
+            + `"${TN_SPINNER_DEFAULT_LABEL}". Assistive technology cannot say WHAT is `
+            + `loading — pass ariaLabel, or ariaLabelledby pointing at visible text.`
+          );
+        }
+      });
+    }
+  }
 
   radius = computed(() => {
     return (this.diameter() - this.strokeWidth()) / 2;


### PR DESCRIPTION
Fixes #202.

`tn-progress-bar` and `tn-spinner` both put `role="progressbar"` on the host and bound `aria-label` / `aria-labelledby` to inputs defaulting to `null`, so the **default** rendering was a progressbar with no accessible name — axe scores that serious (`aria-progressbar-name`, WCAG 4.1.2).

**Reproduced before anything changed.** Running the new specs against the unfixed components, under jsdom, axe reported the violation on the host in every mode of both:

```
tn-progress-bar   determinate / indeterminate / buffer   -> violated: ["aria-progressbar-name"]
tn-spinner        indeterminate / determinate            -> violated: ["aria-progressbar-name"]
```

The positive control — the pre-fix markup rebuilt by hand — already failed at that point too, so the guard was known to be able to fail before it was ever green.

## Which of the two options, and why

The ticket asks for a decision between a default name and withholding the role.

**The role stays; an unnamed instance falls back to a generic name** (`TN_PROGRESS_BAR_DEFAULT_LABEL` = `"Progress"`, `TN_SPINNER_DEFAULT_LABEL` = `"Loading"`, both exported).

Withholding the role scores just as clean and tells a screen reader *nothing* — not that anything is loading, and on a determinate bar not the value either. It removes the violation by removing the element from the accessibility tree, which is a worse outcome for the person the rule exists to protect. `branded-spinner.component.ts`, in the same folder, already fell back this way inline (`ariaLabel() || "Loading..."`), so a fallback is the shape this library had settled on; what it lacked was any signal to the developer.

**That signal is now an `isDevMode()` warning** naming the component and both inputs, following the `autocomplete` / `form-field` convention. It is an `effect`, so it fires once per instance that stays unnamed rather than once per change detection — a per-frame warning on an animating progress bar is one developers learn to ignore.

## `aria-labelledby`

The two branches differ, and the reason is that `aria-labelledby` wins the name calculation **only while its IDREF resolves**:

- An **explicit `ariaLabel` is always emitted**, `ariaLabelledby` or not. Against a typo or an element that has not rendered yet, it is the whole name.
- The **generic fallback is withheld** beside an `ariaLabelledby`. There it would mask a dangling IDREF with a name that says nothing — clean to axe, useless to a listener. Both specs assert that a dangling IDREF on its own is still a violation, so that case fails rather than being papered over; that assertion is also what shows axe genuinely resolves the IDREF, without which the positive case would pass for free.

The first of those two was a HIGH finding on review round 1: the first round dropped `aria-label` whenever `ariaLabelledby` was set, which needed both inputs to reach and so would not have been noticed. It is fixed and guarded.

## Scope

`aria-valuenow` / `valuemin` / `valuemax` are unchanged in every mode, asserted in both new specs rather than left to the existing component specs, because that is the regression this fix could introduce.

`progress-bar-a11y.spec.ts` and `spinner-a11y.spec.ts` follow the convention set by `chip`, `slide-toggle` and `toast`: the shared `axeResult` wrapper from `lib/a11y/axe-testing.ts`, `evaluated` asserted alongside every empty `violated`, and a positive control.

The two existing component specs now silence the new warning, which their unnamed fixtures would otherwise emit 28 times across a full `yarn test`.

## Checks run locally

`yarn lint`, `yarn test` (99 suites, 2349 tests), `yarn test:scripts` (42 tests) and `yarn build` all pass. `yarn lint` reports 4 pre-existing `import/order` errors in `input/` and `menu/`, neither of which this branch touches.

**Not run:** `test-storybook`, which needs a Playwright browser download and a served Storybook. The three affected stories already pass `ariaLabel` on every variant, so no story changes behaviour and none newly warns.

## Review

Run with `local-review.py`, which executed the project's own reviewer — the same rubric, threshold and parser as the required check, in a separate process. Round 2 returned **nothing at or above MEDIUM**, which is the strong form of a clean result rather than a subagent's opinion.

Three LOW findings were left unfixed, deliberately — each fix is a new unreviewed diff and another review round:

- **The naming logic is duplicated between the two components, with `branded-spinner` keeping a third divergent variant.** Fair, and it is the better ticket: a shared helper in `lib/a11y` should also bring `branded-spinner` in, which has no `ariaLabelledby` input and no warning at all. Out of scope here, and proposed as its own ticket on #202.
- **A dangling `ariaLabelledby` suppresses the fallback *and* the warning, "despite the comment claiming it fails loudly".** The behaviour is intended and is argued above; the comment says "fails loudly" meaning the axe check, and the sentence before it states there is no warning. Worth rewording, not rewriting.
- **The default labels are hardcoded English with no injectable override.** True, and it applies equally to `branded-spinner`'s existing `"Loading..."` and to the library's other user-facing strings — a library-wide i18n question rather than something to settle inside this fix.

From round 1, also left: `resolvedAriaLabel` is public and so reaches the published types via `public-api.ts`; and the `aria-labelledby` host binding is untrimmed while the name logic trims, so a whitespace-only value renders a meaningless attribute.
