### PR TITLE
NAS-142319 / 27.0.0-BETA.1 / fix(a11y): stop the tooltip overlay exposing a second, unnamed tooltip

### DIFF
--- a/projects/truenas-ui/src/lib/card/card.component.spec.ts
+++ b/projects/truenas-ui/src/lib/card/card.component.spec.ts
@@ -404,7 +404,12 @@ describe('TnCardComponent action tooltips', () => {
       // Assert on the overlay tooltip element specifically — AriaDescriber keeps the
       // message in a hidden description container at all times, so a body-text check
       // would pass whether or not the focus actually showed the tooltip.
-      expect(document.querySelector('[role="tooltip"]')).toBeNull();
+      //
+      // `.tn-tooltip` is what distinguishes the two, not `[role="tooltip"]`: the
+      // overlay dropped that role in #203 precisely so it stops duplicating the
+      // describer's node in the accessibility tree. The describer's container carries
+      // CDK's own classes and never this one, so the selector is still exclusive.
+      expect(document.querySelector('.tn-tooltip')).toBeNull();
 
       // The directive host is the <tn-button> wrapper; FocusMonitor monitors descendants,
       // so focusing the inner control still opens the tooltip — but only for keyboard focus.
@@ -412,8 +417,12 @@ describe('TnCardComponent action tooltips', () => {
       jest.runAllTimers();
       fixture.detectChanges();
 
-      const tooltip = document.querySelector('[role="tooltip"]');
-      expect(tooltip?.textContent).toContain('WebShare service is not running');
+      const tooltip = document.querySelector('.tn-tooltip');
+      // Asserted non-null first: `tooltip?.textContent` on a missing overlay is
+      // `undefined`, which fails `toContain` as a matcher error rather than as
+      // "the tooltip did not show" — the failure this test exists to report.
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.textContent).toContain('WebShare service is not running');
     } finally {
       jest.useRealTimers();
     }

--- a/projects/truenas-ui/src/lib/tooltip/tooltip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip-a11y.spec.ts
@@ -1,0 +1,202 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnTooltipComponent } from './tooltip.component';
+import { TnTooltipDirective } from './tooltip.directive';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the structure fixed for #203: the overlay used to render
+ * `role="tooltip"` with `aria-hidden="false"` hard-coded, which put a second
+ * tooltip in the accessibility tree alongside the one `AriaDescriber` already
+ * maintains — and left it unnamed whenever the message was empty or contributed
+ * no text, which axe scores `aria-tooltip-name` (serious, WCAG 4.1.2).
+ *
+ * The fix makes the overlay decorative. That is only correct if the accessible
+ * description still reaches the user by the other route, so the two halves are
+ * asserted together below rather than in separate files: hiding the overlay
+ * without the describer working would be silence, not a fix.
+ */
+
+@Component({
+  standalone: true,
+  imports: [TnTooltipDirective],
+  template: `<div class="wrapper" tnTooltip="Pool is degraded"><button>Details</button></div>`,
+})
+class WrapperHostComponent {}
+
+describe('tn-tooltip accessibility (#203)', () => {
+  describe('the overlay component on its own', () => {
+    let fixture: ComponentFixture<TnTooltipComponent>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({ imports: [TnTooltipComponent] });
+      // TestBed attaches the fixture to the document itself, which axe needs —
+      // it walks to the document root to decide visibility, and treats a
+      // detached tree as hidden and therefore exempt from every rule.
+      fixture = TestBed.createComponent(TnTooltipComponent);
+    });
+
+    function overlay(): HTMLElement {
+      return fixture.nativeElement.querySelector('.tn-tooltip') as HTMLElement;
+    }
+
+    /**
+     * The default inputs, which is the shape the ticket reproduced: `message`
+     * defaults to `''`, so the old markup rendered a `role="tooltip"` with no
+     * text to name it. A message-carrying overlay was named by its own content
+     * and so did NOT violate — which is exactly why the rule went unnoticed.
+     */
+    it('raises no aria-tooltip-name violation with no message', async () => {
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, overlay(), ['aria-tooltip-name']
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    it('raises no aria-tooltip-name violation with a message', async () => {
+      fixture.componentRef.setInput('message', 'Pool is degraded');
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, overlay(), ['aria-tooltip-name']
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    /**
+     * `violated` above is `toEqual([])`, which is also what axe returns when it
+     * evaluated nothing at all — and here that is not a hypothetical worry but
+     * the literal mechanism of the fix: removing `role="tooltip"` is what stops
+     * `aria-tooltip-name` selecting the node, so post-fix the rule is correctly
+     * not evaluated on it and an `evaluated` assertion would fail on right
+     * markup. This positive control is what keeps those two tests honest: it
+     * rebuilds the exact markup the ticket reproduced and requires axe to still
+     * object to it, so they cannot go vacuous for any OTHER reason — a rule
+     * narrowed by an axe upgrade, a jsdom change that hides the tree — without
+     * failing here first.
+     *
+     * It runs through the shared `axeResult` on purpose, so it is also the
+     * control for that wrapper reporting a violation at all.
+     */
+    it('still reports the violation for the markup the overlay used to render', async () => {
+      const previous = document.createElement('div');
+      previous.innerHTML =
+        '<div class="tn-tooltip" role="tooltip" id="" aria-hidden="false"></div>';
+      document.body.appendChild(previous);
+
+      // try/finally, because `axeResult` throws rather than returning a vacuous
+      // pass — and a fixture left in `document.body` by that throw would be
+      // scanned by every later test in this file.
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          previous, previous.querySelector('.tn-tooltip'), ['aria-tooltip-name']
+        ));
+      } finally {
+        previous.remove();
+      }
+
+      expect(violated).toEqual(['aria-tooltip-name']);
+    });
+
+    it('claims no tooltip role, so the describer is the only tooltip in the tree', () => {
+      fixture.componentRef.setInput('message', 'Pool is degraded');
+      fixture.detectChanges();
+
+      expect(overlay().getAttribute('role')).toBeNull();
+      expect(overlay().getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('omits the id attribute rather than rendering an empty one', () => {
+      fixture.detectChanges();
+
+      // `id=""` cannot be referenced by `aria-describedby` or any selector, so
+      // anything reaching for it resolves to nothing, silently.
+      expect(overlay().hasAttribute('id')).toBe(false);
+    });
+
+    it('still renders an id it is given', () => {
+      fixture.componentRef.setInput('id', 'tn-tooltip-abc123');
+      fixture.detectChanges();
+
+      expect(overlay().getAttribute('id')).toBe('tn-tooltip-abc123');
+    });
+  });
+
+  /**
+   * The other half of the model, and the one that makes hiding the overlay a
+   * fix rather than a regression: with the directive driving it, the message
+   * must still reach assistive technology — via the describer, on the control.
+   *
+   * `tooltip.component.spec.ts` already covers the describer's targeting rules
+   * on their own. What is asserted here is the pair holding at once, in the one
+   * state where the overlay actually exists: shown.
+   */
+  describe('with the directive driving it', () => {
+    let fixture: ComponentFixture<WrapperHostComponent>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({ imports: [WrapperHostComponent] });
+      fixture = TestBed.createComponent(WrapperHostComponent);
+      fixture.detectChanges();
+    });
+
+    /** Lets the directive's show timeout run, then syncs the view. */
+    async function settle(): Promise<void> {
+      await new Promise((resolve) => setTimeout(resolve));
+      fixture.detectChanges();
+    }
+
+    function trigger(): HTMLElement {
+      return fixture.nativeElement.querySelector('.wrapper') as HTMLElement;
+    }
+
+    function control(): HTMLElement {
+      return fixture.nativeElement.querySelector('button') as HTMLElement;
+    }
+
+    function shownOverlay(): HTMLElement | null {
+      return document.querySelector('.tn-tooltip');
+    }
+
+    it('shows a decorative overlay while the control keeps the description', async () => {
+      trigger().dispatchEvent(new MouseEvent('mouseenter'));
+      await settle();
+
+      const overlay = shownOverlay();
+      expect(overlay).not.toBeNull();
+      expect(overlay!.textContent?.trim()).toBe('Pool is degraded');
+      expect(overlay!.getAttribute('role')).toBeNull();
+      expect(overlay!.getAttribute('aria-hidden')).toBe('true');
+
+      // The describer's element, not the overlay: it is what `aria-describedby`
+      // points at, and it outlives the overlay so the reference never dangles.
+      const describedBy = control().getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      const description = document.getElementById(describedBy!.split(/\s+/)[0]);
+      expect(description).not.toBe(overlay);
+      expect(description?.textContent).toBe('Pool is degraded');
+    });
+
+    it('raises no aria-tooltip-name violation on the shown overlay', async () => {
+      trigger().dispatchEvent(new MouseEvent('mouseenter'));
+      await settle();
+
+      const overlay = shownOverlay();
+      expect(overlay).not.toBeNull();
+
+      // Scanned from the overlay's own container: the CDK attaches it outside
+      // the fixture's element, so the fixture root does not contain it.
+      const { violated } = await axeResult(
+        document.body, overlay, ['aria-tooltip-name']
+      );
+
+      expect(violated).toEqual([]);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.html
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.html
@@ -1,7 +1,6 @@
 <div
   class="tn-tooltip"
-  role="tooltip"
-  [id]="id()"
-  [attr.aria-hidden]="false"
+  aria-hidden="true"
+  [attr.id]="id() || null"
   [innerHTML]="message()">
 </div>

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.ts
@@ -1,6 +1,31 @@
 
 import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 
+/**
+ * The visual half of `tnTooltip`, and only the visual half (#203).
+ *
+ * WHY THIS NODE IS `aria-hidden` AND CARRIES NO ROLE
+ * -------------------------------------------------
+ * The accessible text is `TnTooltipDirective`'s job, and it routes it through
+ * CDK's `AriaDescriber` — a persistent visually-hidden element referenced by
+ * `aria-describedby` on the interactive control, so the reference never dangles
+ * while this overlay comes and goes. That is one tooltip, described once.
+ *
+ * This node used to ALSO claim `role="tooltip"`, which put a second tooltip in
+ * the accessibility tree for the same message: the describer's (named, and
+ * referenced by the control) and this one (named by nothing when the message is
+ * empty or markup-only). axe scores that `aria-tooltip-name`, WCAG 4.1.2.
+ * Of the two models the ticket set out — make the overlay the accessible
+ * tooltip, or make it decorative — decorative is the one the rest of the
+ * directive is already built for, and it is what `pointer-events: none` on
+ * `:host` already says: this element cannot be hovered, clicked or interacted
+ * with. Hiding it removes the duplicate rather than moving the name onto it.
+ *
+ * `aria-hidden="true"` is static rather than bound to a visibility signal on
+ * purpose. The node is exposed in no state, so there is no state for it to
+ * reflect — the previous hard-coded `aria-hidden="false"` was the bug, because
+ * that value DID depend on state it was not tracking.
+ */
 @Component({
   selector: 'tn-tooltip',
   standalone: true,
@@ -14,5 +39,10 @@ import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 })
 export class TnTooltipComponent {
   message = input('');
+  /**
+   * Optional DOM id for the rendered element. Omitted entirely when empty
+   * rather than rendered as `id=""`, which no `aria-describedby` or selector can
+   * reference — a silently dangling hook.
+   */
   id = input('');
 }


### PR DESCRIPTION
Fixes #203.

## The defect, reproduced first

`TnTooltipComponent` rendered, with default inputs:

```html
<div role="tooltip" class="tn-tooltip" id="" aria-hidden="false"></div>
```

Scanned with axe through the shared `axeResult` wrapper, before any change:

```
VIOLATED: ["aria-tooltip-name"]  EVALUATED: ["aria-tooltip-name"]
```

Worth recording precisely, because it explains how this survived: the same
overlay **with** a message is named by its own text content and raises no
violation. Only the empty — or markup-only — message exposes it. So the rule
was live but silent in the states most likely to be eyeballed.

## Which model was chosen, and why

The ticket set out two, and asked for one to be named. **This takes the
decorative model: the overlay is `aria-hidden="true"` and carries no role.**

`TnTooltipDirective` already routes the accessible text through CDK's
`AriaDescriber`, which keeps it in a persistent visually-hidden element so
`aria-describedby` never dangles while the overlay comes and goes. That is one
tooltip, described once, and the overlay was duplicating it. Two further things
point the same way:

- `:host` is `pointer-events: none`. The overlay cannot be hovered, clicked or
  interacted with — it is already, materially, decoration.
- Making the overlay the accessible tooltip instead would mean deleting the
  describer, which is the half that has the dangling-reference problem solved.

`aria-hidden="true"` is static rather than bound to a visibility signal. The
node is exposed in no state, so there is no state for it to reflect — the
previous hard-coded `aria-hidden="false"` was the bug precisely because that
value *did* depend on state it was not tracking.

## Also in the diff

- `id=""` is gone: `[attr.id]="id() || null"` omits the attribute when the input
  is empty, so nothing can hold a reference that silently resolves to nothing.
- `card.component.spec.ts` selected the overlay by `[role="tooltip"]`, to tell it
  apart from the describer's hidden container. That discriminator is now
  `.tn-tooltip`, which the describer's container never carries. Its adjacent
  assertion also changed from `tooltip?.textContent` to a non-null check first —
  the optional chain reported a missing overlay as a matcher error rather than
  as "the tooltip did not show", which is the failure the test exists to report.

## Tests

New `tooltip-a11y.spec.ts`, using the shared `axeResult` wrapper:

- No `aria-tooltip-name` violation with a message, and with no message.
- **A positive control** rebuilding the exact pre-fix markup and requiring axe to
  still object to it. This matters more than usual here: removing the role is
  what stops the rule selecting the node, so post-fix the rule is *correctly not
  evaluated* on it and an `evaluated` assertion would fail on right markup. The
  control is what keeps the empty-`violated` assertions from going vacuous for
  any other reason.
- With the directive actually driving it: the shown overlay is decorative **and**
  the description still reaches the control, asserted together — hiding the
  overlay without the describer working would be silence, not a fix.
- `id` omitted when empty; still rendered when given.

`tooltip.directive.spec.ts` and `tooltip.component.spec.ts` pass unchanged,
including the existing "forwards the description to the single interactive
descendant of a wrapper" case the acceptance criteria name.

Run locally: `yarn lint` (clean for every file this touches — 4 `import/order`
errors remain in `input.component.ts` and `menu-panel.component.ts`, untouched
by this and pre-existing), `yarn test` (2363 passed, 100 suites), `yarn
test:scripts` (42 passed), `yarn build`. **Not run locally:** Storybook
interaction tests, which need a Playwright/Chromium install.

## Local review, and what was left

The project's own reviewer ran here in a separate process — same rubric,
severity threshold and parser as the required check — and returned **nothing at
or above MEDIUM**. Four LOWs, left unfixed on purpose (each fix is a new diff,
and a new diff is unreviewed), recorded here so they are not lost:

1. **`id` is now inert.** Nothing references the rendered id, and the directive
   still generates a `_tooltipId` for it. True, and it predates this change —
   the id was never referenced, because the describer owns `aria-describedby`.
   Removing the input would be a public API break beyond this ticket's scope;
   worth its own ticket.
2. **The with-a-message `aria-tooltip-name` test** passes against both pre- and
   post-fix markup, so it guards less than its sibling. Kept deliberately: it
   documents the asymmetry that hid this bug, which is the part a future reader
   most needs.
3. **Static `aria-hidden` over an `[innerHTML]` subtree** means a message
   containing an anchor would be an `aria-hidden-focus` case. Measured before
   deciding: axe reports no violation and does not evaluate the rule there under
   jsdom, so a test asserting on it would be exactly the vacuous guard
   `a11y/axe-testing.ts` exists to prevent. Interactive content in a
   `pointer-events: none` tooltip is a misuse in its own right.
4. **Dropping `role="tooltip"` changes the published DOM contract** for any
   consumer keying on `[role="tooltip"]`. Real, and flagged here for the release
   note — one in-repo consumer did exactly that (`card.component.spec.ts`) and is
   updated in this diff.
