### PR TITLE
NAS-142319 / 27.0.0-BETA.1 / fix(a11y): name all three progressbars by one shared rule

### DIFF
--- a/projects/truenas-ui/src/lib/a11y/accessible-name.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name.ts
@@ -1,0 +1,120 @@
+import { computed, effect, isDevMode } from '@angular/core';
+import type { Signal } from '@angular/core';
+
+/**
+ * The one place that decides how a component resolves its own accessible name
+ * from `ariaLabel` / `ariaLabelledby`, and how it complains when it has neither.
+ *
+ * WHY A SHARED FUNCTION AND NOT A COPY PER COMPONENT
+ * -------------------------------------------------
+ * Same reasoning as `live-region.ts` next door, and the same evidence. #202 and
+ * #205 gave `tn-progress-bar` and `tn-spinner` a fallback name and a dev-mode
+ * warning, written out twice, verbatim. `tn-branded-spinner` — the third
+ * `role="progressbar"` in this library — got neither, because both fixes stopped
+ * at the folder boundary: it had a fallback of its own, inline in its host
+ * binding, so it never failed `aria-progressbar-name` and nothing pointed at it.
+ * It ended up with no `ariaLabelledby` input at all and no warning, named by a
+ * third rule that nobody had decided on (#206).
+ *
+ * Duplication is not the complaint. The complaint is that the correct version is
+ * subtle enough — see the two branches below — that writing it a third time from
+ * memory produced a divergent one, and that two `computed`s cannot contradict
+ * each other loudly. Routing all three through this function is what makes the
+ * next such disagreement a compile-time edit here.
+ *
+ * WHAT THE SUBTLETY IS
+ * --------------------
+ * `aria-labelledby` wins the ARIA name calculation when it RESOLVES, which is
+ * what makes `resolvedAriaLabel`'s two branches differ:
+ *
+ * - An explicit `ariaLabel` is always emitted, `ariaLabelledby` or not.
+ *   Suppressing it would be safe only while the IDREF resolves; against a typo
+ *   or an element that has not rendered yet it would leave the element unnamed
+ *   in precisely the case where the caller supplied a name.
+ * - The generic fallback is withheld beside an `ariaLabelledby`. There it would
+ *   do the opposite of its job — masking a dangling IDREF with a name that says
+ *   nothing, clean to axe and useless to a listener, with no warning either
+ *   because the caller did name it. Unnamed at least still fails loudly.
+ *
+ * WHY THE FALLBACK IS NOT ENOUGH ON ITS OWN
+ * -----------------------------------------
+ * The fallback keeps a forgotten label from reaching assistive technology as
+ * silence; the warning keeps it from reaching the DEVELOPER as silence. Without
+ * the second half the first is a fix that satisfies axe while removing the only
+ * remaining signal that the label was missing — which is exactly the state
+ * `tn-branded-spinner` shipped in.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `live-region.ts`. It is how this library's own components agree with each
+ * other; a consumer naming its own element has `aria-label`.
+ */
+
+/** What a component needs to tell this function about itself. */
+export interface TnAccessibleNameConfig {
+  /**
+   * The element selector, used only to name the component in the dev warning —
+   * a bare "no ariaLabel was set" in a console is unactionable when three
+   * components can raise it.
+   */
+  selector: string;
+  /**
+   * The name to render when the caller supplies neither input. Per component
+   * rather than shared: a generic name is a poor one, and the least-bad generic
+   * name differs — "Progress" for a bar, "Loading" for a spinner.
+   */
+  fallback: string;
+  /**
+   * Completes "Assistive technology cannot say WHAT is …" in the warning.
+   * `'progressing'` for a progress bar, `'loading'` for a spinner.
+   */
+  activity: string;
+  /** The component's `ariaLabel` input. */
+  ariaLabel: Signal<string | null>;
+  /** The component's `ariaLabelledby` input. */
+  ariaLabelledby: Signal<string | null>;
+}
+
+/**
+ * The name to render as `aria-label`, or `null` to render no `aria-label` at
+ * all — and, in dev mode, a one-off warning when the caller named neither input.
+ *
+ * **Must be called from an injection context** — a field initializer or the
+ * constructor — because it registers an `effect`. An effect rather than a
+ * lifecycle hook, so a component that is named later stops warning; and because
+ * it re-runs only when the two inputs change, one that stays unnamed warns once
+ * rather than once per animation frame. That matters here more than it looks:
+ * every caller is a progressbar, and two of the three animate continuously.
+ *
+ * The caller keeps its own `[attr.aria-labelledby]` host binding. The IDREF is
+ * passed through untouched, so there is nothing to decide about it and nothing
+ * for a copy of it to get wrong.
+ */
+export function tnAccessibleName(config: TnAccessibleNameConfig): Signal<string | null> {
+  // Blank is not a name. A whitespace-only `ariaLabel` names the element as
+  // emptily as no `ariaLabel`, and axe agrees, so it takes the fallback and
+  // raises the warning rather than being treated as an answer.
+  const hasLabelledby = computed(() => (config.ariaLabelledby() ?? '').trim() !== '');
+  const named = computed(() => (config.ariaLabel() ?? '').trim() !== '' || hasLabelledby());
+
+  const resolved = computed(() => {
+    const label = config.ariaLabel();
+    if ((label ?? '').trim() !== '') {
+      return label;
+    }
+    return hasLabelledby() ? null : config.fallback;
+  });
+
+  if (isDevMode()) {
+    effect(() => {
+      if (!named()) {
+        console.warn(
+          `[${config.selector}] No ariaLabel or ariaLabelledby was set, so it falls back to `
+          + `"${config.fallback}". Assistive technology cannot say WHAT is ${config.activity} `
+          + `— pass ariaLabel, or ariaLabelledby pointing at visible text.`
+        );
+      }
+    });
+  }
+
+  return resolved;
+}

--- a/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/progress-bar.component.ts
@@ -1,5 +1,6 @@
 
-import { Component, input, ChangeDetectionStrategy, computed, effect, isDevMode } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy, computed } from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
 
 export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer';
 
@@ -17,8 +18,8 @@ export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer';
  * the value too.
  *
  * A generic name is still a poor one, so it is paired with the dev-mode warning
- * in the constructor. Exported so specs assert against it by name rather than
- * by a copied string literal.
+ * `tnAccessibleName` raises. Exported so specs assert against it by name rather
+ * than by a copied string literal.
  */
 export const TN_PROGRESS_BAR_DEFAULT_LABEL = 'Progress';
 
@@ -49,57 +50,26 @@ export class TnProgressBarComponent {
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
 
-  private readonly hasLabelledby = computed(() => (this.ariaLabelledby() ?? '').trim() !== '');
-
-  /** Whether the caller gave this bar a name of its own. Blank is not a name. */
-  private readonly named = computed(() => {
-    return (this.ariaLabel() ?? '').trim() !== '' || this.hasLabelledby();
-  });
-
   /**
-   * The name to render, or `null` to render no `aria-label` attribute.
+   * The name to render, or `null` to render no `aria-label` attribute — and the
+   * dev-mode warning when the caller named neither input.
    *
-   * `aria-labelledby` wins the ARIA name calculation when it RESOLVES, which is
-   * what makes the two branches below differ:
+   * Both halves live in `../a11y/accessible-name`, shared with `tn-spinner` and
+   * `tn-branded-spinner` (#206), where the reasoning for each is set out: why an
+   * explicit `ariaLabel` always survives, and why the generic fallback is
+   * withheld beside an `ariaLabelledby`.
    *
-   * - An explicit `ariaLabel` is always emitted, `ariaLabelledby` or not.
-   *   Suppressing it would be safe only while the IDREF resolves; against a typo
-   *   or an element that has not rendered yet it would leave the bar unnamed in
-   *   precisely the case where the caller supplied a name.
-   * - The generic fallback is withheld beside an `ariaLabelledby`. There it
-   *   would do the opposite of its job — masking a dangling IDREF with a name
-   *   that says nothing, clean to axe and useless to a listener, with no warning
-   *   either because the caller did name it. Unnamed at least still fails loudly.
+   * A field initializer rather than the constructor, because it registers an
+   * `effect` and so needs an injection context; this is one, and it keeps the
+   * signal beside the inputs it reads.
    */
-  resolvedAriaLabel = computed(() => {
-    const label = this.ariaLabel();
-    if ((label ?? '').trim() !== '') {
-      return label;
-    }
-    return this.hasLabelledby() ? null : TN_PROGRESS_BAR_DEFAULT_LABEL;
+  resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-progress-bar',
+    fallback: TN_PROGRESS_BAR_DEFAULT_LABEL,
+    activity: 'progressing',
+    ariaLabel: this.ariaLabel,
+    ariaLabelledby: this.ariaLabelledby
   });
-
-  constructor() {
-    // The fallback keeps a forgotten label from reaching assistive technology
-    // as silence; this keeps it from reaching the developer as silence. Without
-    // it the fix would satisfy axe while removing the only remaining signal
-    // that the label was missing.
-    //
-    // An effect rather than a lifecycle hook, so a bar that is named later
-    // stops warning — and, because it re-runs only when the two inputs change,
-    // a bar that stays unnamed warns once rather than once per animation frame.
-    if (isDevMode()) {
-      effect(() => {
-        if (!this.named()) {
-          console.warn(
-            `[tn-progress-bar] No ariaLabel or ariaLabelledby was set, so it falls back to `
-            + `"${TN_PROGRESS_BAR_DEFAULT_LABEL}". Assistive technology cannot say WHAT is `
-            + `progressing — pass ariaLabel, or ariaLabelledby pointing at visible text.`
-          );
-        }
-      });
-    }
-  }
 
   /**
    * Gets the transform value for the primary progress bar

--- a/projects/truenas-ui/src/lib/spinner/branded-spinner-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/spinner/branded-spinner-a11y.spec.ts
@@ -1,0 +1,306 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnBrandedSpinnerComponent, TN_BRANDED_SPINNER_DEFAULT_LABEL } from './branded-spinner.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * The third progressbar (#206). `tn-progress-bar` and `tn-spinner` were fixed by
+ * #202/#205; this one was missed because it never failed `aria-progressbar-name`
+ * — it had a fallback name inline in its host binding all along.
+ *
+ * So what is asserted here is NOT that a violation went away. It is that this
+ * component now names itself by the same rule as the other two: an
+ * `ariaLabelledby` input it did not have, and a dev-mode warning it did not
+ * raise. Measured before the change, under jsdom:
+ *
+ *   default markup   aria-progressbar-name -> no violation on [tn-branded-spinner]
+ *   ariaLabelledby   not an input; binding it is a template error
+ *   unnamed          console.warn not called
+ *
+ * The axe assertions below therefore guard against a regression rather than
+ * record a fix — extracting the shared helper is the change, and silently
+ * dropping the fallback while doing it is what they exist to catch.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnBrandedSpinnerComponent],
+  template: `<span id="tn-external-label">Restoring pool</span>
+    <tn-branded-spinner [ariaLabel]="ariaLabel()" [ariaLabelledby]="ariaLabelledby()" />`
+})
+class TestHostComponent {
+  ariaLabel = signal<string | null>(null);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+describe('tn-branded-spinner accessibility (#206)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // Silenced rather than merely observed: the component warns on every
+    // unnamed spinner by design, and most fixtures in this file are unnamed.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // Destroyed rather than left to the next test: this component drives a
+    // requestAnimationFrame loop from ngAfterViewInit and only cancels it in
+    // ngOnDestroy, so a fixture that is never destroyed keeps animating for the
+    // rest of the run.
+    fixture.destroy();
+    warn.mockRestore();
+  });
+
+  function spinner(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-branded-spinner') as HTMLElement;
+  }
+
+  describe('aria-progressbar-name', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing at all.
+    // It is non-vacuous here: the rule selects on `role="progressbar"`, which is
+    // the host itself and the only such node in the fixture.
+    it('names a spinner that was given no label', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabel is set', async () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabelledby is set', async () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * Positive control. Every expectation above is `toEqual([])`, which is also
+     * what axe returns when it evaluated nothing — so one fixture has to prove
+     * the rule still objects to the shape it is meant to object to.
+     *
+     * Unlike the controls in `spinner-a11y.spec.ts` and
+     * `progress-bar-a11y.spec.ts`, this is NOT the markup the component used to
+     * ship: `tn-branded-spinner` has always carried a fallback name, which is
+     * exactly why #202 did not find it. It is the markup this component would
+     * render if the extraction in #206 dropped that fallback — the regression
+     * the assertions above are guarding.
+     */
+    it('reports the violation for a branded spinner with the fallback dropped', async () => {
+      const unnamed = document.createElement('div');
+      unnamed.innerHTML = '<div role="progressbar" class="tn-branded-spinner"></div>';
+      document.body.appendChild(unnamed);
+
+      // try/finally, because `axeResult` throws rather than returning a vacuous
+      // pass — and a fixture left in `document.body` by that throw would be
+      // scanned by every later test in this file.
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          unnamed, unnamed.querySelector('[role="progressbar"]'), ['aria-progressbar-name']
+        ));
+      } finally {
+        unnamed.remove();
+      }
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+  });
+
+  describe('where the name comes from', () => {
+    it('falls back to the default label when neither input is set', () => {
+      expect(spinner().getAttribute('aria-label')).toBe(TN_BRANDED_SPINNER_DEFAULT_LABEL);
+    });
+
+    // The name this component already rendered, pinned by literal rather than by
+    // the constant, so that moving the fallback into the shared helper cannot
+    // quietly change what a caller hears.
+    it('keeps the "Loading..." default this component already shipped', () => {
+      expect(spinner().getAttribute('aria-label')).toBe('Loading...');
+    });
+
+    it('prefers an explicit ariaLabel over the fallback', () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe('Loading datasets');
+    });
+
+    it('treats a blank ariaLabel as no label at all', () => {
+      host.ariaLabel.set('   ');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe(TN_BRANDED_SPINNER_DEFAULT_LABEL);
+    });
+
+    /**
+     * `aria-labelledby` wins over `aria-label` only while its IDREF RESOLVES, so
+     * the generic fallback is withheld beside one — there it would mask a
+     * dangling reference with a name that says nothing — while an explicit
+     * `ariaLabel` is not, because it is the only name left when the reference
+     * does not resolve. These are that pair and its regression, matching
+     * `spinner-a11y.spec.ts` case for case, which is the point of the ticket.
+     */
+    it('withholds the generic fallback when only ariaLabelledby is set', () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(spinner().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('keeps an explicit ariaLabel alongside ariaLabelledby', () => {
+      host.ariaLabel.set('Loading datasets');
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(spinner().getAttribute('aria-label')).toBe('Loading datasets');
+    });
+
+    it('omits aria-labelledby when the input is not set', () => {
+      expect(spinner().hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    it('still names the spinner when ariaLabelledby points at nothing', async () => {
+      host.ariaLabel.set('Loading datasets');
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * The evidence for withholding the generic fallback beside an
+     * `ariaLabelledby` — a dangling IDREF alone is still a violation, so it is
+     * reported rather than papered over — and equally what stops the test above
+     * passing for free, by showing that axe resolves the IDREF rather than
+     * treating any `aria-labelledby` as a name.
+     */
+    it('reports a spinner whose only name is an ariaLabelledby pointing at nothing', async () => {
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, spinner(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+
+    it('reinstates the fallback if the caller clears ariaLabel again', () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+      host.ariaLabel.set(null);
+      fixture.detectChanges();
+
+      expect(spinner().getAttribute('aria-label')).toBe(TN_BRANDED_SPINNER_DEFAULT_LABEL);
+    });
+  });
+
+  /**
+   * The half this component was missing outright. Its inline fallback already
+   * kept a forgotten label from reaching assistive technology as silence; what
+   * it had no answer for was the same label reaching the DEVELOPER as silence,
+   * which is why a spinner nobody named looked correct by every check the
+   * library could run.
+   */
+  describe('the dev-mode warning', () => {
+    function messages(): string[] {
+      return warn.mock.calls.map((call) => String(call[0]));
+    }
+
+    it('warns, naming the component, when neither input is set', () => {
+      expect(messages()).toHaveLength(1);
+      expect(messages()[0]).toContain('tn-branded-spinner');
+      expect(messages()[0]).toContain('ariaLabel');
+    });
+
+    it('does not warn when ariaLabel is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabel.set('Loading datasets');
+      named.detectChanges();
+      named.destroy();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when ariaLabelledby is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabelledby.set('tn-external-label');
+      named.detectChanges();
+      named.destroy();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    // One warning per spinner that stays unnamed, not one per change detection:
+    // a per-cycle warning on a spinner that is animating by definition floods
+    // the console and trains developers to ignore it.
+    it('warns once, however many times the spinner is re-rendered', () => {
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      expect(messages()).toHaveLength(1);
+    });
+
+    it('stops warning once the spinner is named', () => {
+      host.ariaLabel.set('Loading datasets');
+      fixture.detectChanges();
+      warn.mockClear();
+      fixture.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * #206 is about the name only. This is what it must not disturb — the branded
+   * spinner is indeterminate by construction and carries no value range, so the
+   * role is the whole of the rest of its ARIA surface.
+   */
+  it('keeps the progressbar role', () => {
+    expect(spinner().getAttribute('role')).toBe('progressbar');
+  });
+});

--- a/projects/truenas-ui/src/lib/spinner/branded-spinner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/spinner/branded-spinner.component.spec.ts
@@ -5,11 +5,17 @@ import { TnBrandedSpinnerComponent } from './branded-spinner.component';
 describe('TnBrandedSpinnerComponent', () => {
   let component: TnBrandedSpinnerComponent;
   let fixture: ComponentFixture<TnBrandedSpinnerComponent>;
+  let warn: jest.SpyInstance;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TnBrandedSpinnerComponent]
     }).compileComponents();
+
+    // Almost every fixture here is unnamed, and #206 makes an unnamed spinner
+    // warn in dev mode — which Jest is. Silenced so this suite's output stays
+    // readable; the warning itself is asserted in `branded-spinner-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     fixture = TestBed.createComponent(TnBrandedSpinnerComponent);
     component = fixture.componentInstance;
@@ -18,6 +24,7 @@ describe('TnBrandedSpinnerComponent', () => {
 
   afterEach(() => {
     component.ngOnDestroy();
+    warn.mockRestore();
   });
 
   it('should create', () => {

--- a/projects/truenas-ui/src/lib/spinner/branded-spinner.component.ts
+++ b/projects/truenas-ui/src/lib/spinner/branded-spinner.component.ts
@@ -1,21 +1,58 @@
 import type { OnInit, OnDestroy, AfterViewInit} from '@angular/core';
 import { ElementRef, Component, input, ViewEncapsulation, ChangeDetectionStrategy, inject } from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
+
+/**
+ * The name this spinner falls back to when the caller names neither `ariaLabel`
+ * nor `ariaLabelledby`. Same reasoning as `TN_SPINNER_DEFAULT_LABEL` and
+ * `TN_PROGRESS_BAR_DEFAULT_LABEL`.
+ *
+ * It differs from `TN_SPINNER_DEFAULT_LABEL` — `"Loading..."` against
+ * `"Loading"` — only because this is the string the component already rendered,
+ * inline in its host binding, before #206 gave it the shared resolver. Aligning
+ * the two would change what a screen reader announces for every unnamed branded
+ * spinner already in the wild, which is a louder change than the consistency
+ * fix it would be part of. Exported so specs assert against it by name rather
+ * than by a copied string literal.
+ */
+export const TN_BRANDED_SPINNER_DEFAULT_LABEL = 'Loading...';
 
 @Component({
   selector: 'tn-branded-spinner',
   standalone: true,
   templateUrl: './branded-spinner.component.html',
-  styleUrls: ['./branded-spinner.component.scss'],  
+  styleUrls: ['./branded-spinner.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     'class': 'tn-branded-spinner',
     'role': 'progressbar',
-    '[attr.aria-label]': 'ariaLabel() || "Loading..."'
+    '[attr.aria-label]': 'resolvedAriaLabel()',
+    '[attr.aria-labelledby]': 'ariaLabelledby() || null'
   }
 })
 export class TnBrandedSpinnerComponent implements OnInit, OnDestroy, AfterViewInit {
   ariaLabel = input<string | null>(null);
+  ariaLabelledby = input<string | null>(null);
+
+  /**
+   * The name to render, or `null` to render no `aria-label` attribute — and the
+   * dev-mode warning when the caller named neither input.
+   *
+   * This component is why `../a11y/accessible-name` exists (#206). It carried a
+   * fallback inline in its host binding, so it never failed
+   * `aria-progressbar-name` and the two fixes that gave the other progressbars
+   * an `ariaLabelledby` input and a warning both passed it by. Routing it
+   * through the shared resolver is what makes it named by the same rule rather
+   * than by a third one nobody chose.
+   */
+  resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-branded-spinner',
+    fallback: TN_BRANDED_SPINNER_DEFAULT_LABEL,
+    activity: 'loading',
+    ariaLabel: this.ariaLabel,
+    ariaLabelledby: this.ariaLabelledby
+  });
 
   private paths: SVGPathElement[] = [];
   private animationId: number | null = null;

--- a/projects/truenas-ui/src/lib/spinner/spinner.component.ts
+++ b/projects/truenas-ui/src/lib/spinner/spinner.component.ts
@@ -1,5 +1,6 @@
 
-import { Component, input, ChangeDetectionStrategy, ViewEncapsulation, computed, effect, isDevMode } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy, ViewEncapsulation, computed } from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
 
 export type SpinnerMode = 'determinate' | 'indeterminate';
 
@@ -12,7 +13,9 @@ export type SpinnerMode = 'determinate' | 'indeterminate';
  *
  * `branded-spinner.component.ts` in this folder already fell back this way —
  * `ariaLabel() || "Loading..."` inline — so a fallback is the shape this
- * library had already settled on; what it lacked was the warning.
+ * library had already settled on; what it lacked was the warning. It has both
+ * since #206, through the same `tnAccessibleName` this component uses, which is
+ * why the two constants sit side by side and differ.
  */
 export const TN_SPINNER_DEFAULT_LABEL = 'Loading';
 
@@ -44,50 +47,24 @@ export class TnSpinnerComponent {
   ariaLabel = input<string | null>(null);
   ariaLabelledby = input<string | null>(null);
 
-  private readonly hasLabelledby = computed(() => (this.ariaLabelledby() ?? '').trim() !== '');
-
-  /** Whether the caller gave this spinner a name of its own. Blank is not a name. */
-  private readonly named = computed(() => {
-    return (this.ariaLabel() ?? '').trim() !== '' || this.hasLabelledby();
-  });
-
   /**
-   * The name to render, or `null` to render no `aria-label` attribute. Same two
-   * branches as `TnProgressBarComponent.resolvedAriaLabel`, where the reasoning
-   * is set out: an explicit `ariaLabel` always survives, because
-   * `aria-labelledby` only wins the name calculation while its IDREF resolves;
-   * the generic fallback is withheld beside one, because there it would mask a
-   * dangling IDREF with a name that says nothing.
+   * The name to render, or `null` to render no `aria-label` attribute — and the
+   * dev-mode warning when the caller named neither input.
+   *
+   * Both halves live in `../a11y/accessible-name`, shared with `tn-progress-bar`
+   * and `tn-branded-spinner` (#206), where the reasoning for each is set out:
+   * an explicit `ariaLabel` always survives, because `aria-labelledby` only wins
+   * the name calculation while its IDREF resolves; the generic fallback is
+   * withheld beside one, because there it would mask a dangling IDREF with a
+   * name that says nothing.
    */
-  resolvedAriaLabel = computed(() => {
-    const label = this.ariaLabel();
-    if ((label ?? '').trim() !== '') {
-      return label;
-    }
-    return this.hasLabelledby() ? null : TN_SPINNER_DEFAULT_LABEL;
+  resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-spinner',
+    fallback: TN_SPINNER_DEFAULT_LABEL,
+    activity: 'loading',
+    ariaLabel: this.ariaLabel,
+    ariaLabelledby: this.ariaLabelledby
   });
-
-  constructor() {
-    // The fallback keeps a forgotten label from reaching assistive technology
-    // as silence; this keeps it from reaching the developer as silence. Without
-    // it the fix would satisfy axe while removing the only remaining signal
-    // that the label was missing.
-    //
-    // An effect rather than a lifecycle hook, so a spinner that is named later
-    // stops warning — and, because it re-runs only when the two inputs change,
-    // one that stays unnamed warns once rather than once per animation frame.
-    if (isDevMode()) {
-      effect(() => {
-        if (!this.named()) {
-          console.warn(
-            `[tn-spinner] No ariaLabel or ariaLabelledby was set, so it falls back to `
-            + `"${TN_SPINNER_DEFAULT_LABEL}". Assistive technology cannot say WHAT is `
-            + `loading — pass ariaLabel, or ariaLabelledby pointing at visible text.`
-          );
-        }
-      });
-    }
-  }
 
   radius = computed(() => {
     return (this.diameter() - this.strokeWidth()) / 2;

--- a/projects/truenas-ui/src/stories/spinner.stories.ts
+++ b/projects/truenas-ui/src/stories/spinner.stories.ts
@@ -50,8 +50,9 @@ export const Indeterminate: Story = {
 
 // Branded Spinner Stories
 export const Branded = {
-  render: (args: { ariaLabel: string }) => ({
-    template: `<tn-branded-spinner [ariaLabel]="ariaLabel"></tn-branded-spinner>`,
+  render: (args: { ariaLabel: string; ariaLabelledby: string | null }) => ({
+    template: `<tn-branded-spinner [ariaLabel]="ariaLabel"
+      [ariaLabelledby]="ariaLabelledby"></tn-branded-spinner>`,
     props: args,
     moduleMetadata: {
       imports: [TnBrandedSpinnerComponent],
@@ -59,10 +60,16 @@ export const Branded = {
   }),
   args: {
     ariaLabel: 'Loading system...',
+    ariaLabelledby: null,
   },
   argTypes: {
-    // Only show controls relevant to branded spinner
+    // Only show controls relevant to branded spinner. `ariaLabelledby` joined
+    // them in #206, when this spinner gained the input the other two already
+    // had — it was hidden below, as a control that did not apply.
     ariaLabel: {
+      control: 'text',
+    },
+    ariaLabelledby: {
       control: 'text',
     },
     // Hide controls that don't apply to branded spinner
@@ -70,7 +77,6 @@ export const Branded = {
     value: { table: { disable: true } },
     diameter: { table: { disable: true } },
     strokeWidth: { table: { disable: true } },
-    ariaLabelledby: { table: { disable: true } },
   },
 };
 


### PR DESCRIPTION
Fixes #206.

## The defect, observed first

This is a `bug` ticket where nothing was failing, so the reproduction is worth being precise about. Measured against the unchanged component, under jsdom:

```
default markup   aria-progressbar-name -> NO violation on [tn-branded-spinner]
ariaLabelledby   not an input at all
unnamed          console.warn not called
```

That first line is the whole reason this survived #202 and #205: `tn-branded-spinner` carried a fallback name inline in its host binding (`ariaLabel() || "Loading..."`), so axe was satisfied and nothing pointed at it. What it did not carry was an `ariaLabelledby` input — so it could not be named by reference to visible text — or any signal to a developer who forgot to name it.

The new `branded-spinner-a11y.spec.ts` was written first and run against the unchanged component: **8 failed, 19 passed**, the 8 being exactly the `ariaLabelledby` cases and the warning cases. All 27 pass now.

## What was extracted, and where

`lib/a11y/accessible-name.ts` — `tnAccessibleName({selector, fallback, activity, ariaLabel, ariaLabelledby})`, returning the signal to bind to `[attr.aria-label]` and registering the dev-mode warning effect.

It sits beside `live-region.ts` for the same stated reason and is **not** exported from `public-api.ts`, matching that precedent: this is how the library's own components agree with each other, and a consumer naming its own element has `aria-label`. All three progressbars now call it; none keeps a copy.

A field initializer rather than the constructor, because it registers an `effect` and so needs an injection context — a field initializer is one, and it keeps the signal beside the inputs it reads.

## The two default labels still differ, deliberately

`TN_BRANDED_SPINNER_DEFAULT_LABEL` is `"Loading..."`; `TN_SPINNER_DEFAULT_LABEL` is `"Loading"`. Aligning them was tempting and is not done here: `"Loading..."` is what this component already rendered, so changing it would alter what a screen reader announces for every unnamed branded spinner already shipped — a louder change than the consistency fix it would be part of. The constant is exported so specs assert by name rather than by a copied literal, as the other two are.

## Also in the diff

- `branded-spinner.component.spec.ts` silences `console.warn` in `beforeEach`, exactly as #202/#205 did to the two sibling specs — most of its fixtures are unnamed and now warn by design. Its assertions are untouched, including `should use default aria-label when none provided`, which still pins the literal `"Loading..."`.
- `spinner.stories.ts`: the Branded story listed `ariaLabelledby` under "controls that don't apply to branded spinner". That comment is false as of this change, so the control moves up to the shown group and the story template binds it.
- Two doc comments that this change made stale are corrected in place: `TN_PROGRESS_BAR_DEFAULT_LABEL` no longer says its warning lives "in the constructor", and `TN_SPINNER_DEFAULT_LABEL` no longer describes the branded spinner as having a fallback but no warning.

## Tests

New `branded-spinner-a11y.spec.ts`, on the convention the other three a11y specs follow: the shared `axeResult` wrapper, `evaluated` asserted beside every empty `violated`, and a positive control.

One note on that control, because it differs from its siblings': it is **not** the markup this component used to ship. `tn-branded-spinner` always had a fallback, which is why it never violated — so a control rebuilding its old markup would be green and prove nothing. What it rebuilds instead is a branded spinner with the fallback *dropped*, which is the regression the `toEqual([])` assertions above it are guarding, and it requires axe to still object to that.

The specs from #202/#205 pass unchanged — including the pair covering a dangling `ariaLabelledby` IDREF — which is what shows the extraction preserved behaviour rather than redefined it. The same pair is now mirrored case-for-case onto the branded spinner.

Run locally: `yarn lint` (clean for every file this touches — the 4 `import/order` errors in `input.component.ts` and `menu-panel.component.ts` are pre-existing and untouched), `yarn test` (2383 passed, 101 suites), `yarn test:scripts` (42 passed), `yarn build`, and `yarn build-storybook` (run because this diff edits a story). **Not run locally:** the Storybook interaction tests, which need a Playwright/Chromium install.

## Local review, and what was left

The project's own reviewer ran here in a separate process — same rubric, severity threshold and parser as the required check — and returned **nothing at or above MEDIUM** on the first round. Two LOWs, left unfixed on purpose (each fix is a new diff, and a new diff is unreviewed), recorded here so they are not lost:

1. **The Branded story's new `ariaLabelledby` control has nothing to point at.** True: the story renders no element with an id, so a developer who types a value into that control gets a dangling IDREF, and the fallback is correctly withheld beside it — leaving the spinner unnamed in the preview. The default is `null`, so nothing is wrong out of the box. Worth a follow-up that gives the story a visible label element to reference; it is the same gap the `tn-spinner` stories have, which expose no such control at all.
2. **`tn-particle-progress-bar` is a fourth progressbar-shaped component that this rule does not reach** — it carries no role, no name and no value range, so it can never fail `aria-progressbar-name`. Pre-existing and outside this ticket, and the same shape of miss that produced this one. Proposed as its own ticket in a comment on #206.
