### PR TITLE
NAS-142324 / 27.0.0-BETA.1 / docs: say where a Jira ticket comes from, and that a cycle must not invent or copy one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,43 @@ Look at these story files for reference:
 - `projects/truenas-ui/src/stories/card.stories.ts`
 - `projects/truenas-ui/src/stories/menu.stories.ts`
 
+## Opening a pull request: do NOT invent a Jira ticket
+
+`CONTRIBUTE.md` requires every PR title to start `NAS-<number> / ` and CI
+rejects titles without one. **You cannot mint that number and you must not
+copy one.**
+
+**What actually happens:** open the PR with a title that has *no* `NAS-`
+prefix — just `type(scope): description` — then apply the **`jira`** label.
+bugclerk files a fresh Jira issue and rewrites the PR title with its key,
+usually within seconds, and comments the Jira URL. `check-ticket` goes green
+on the rename.
+
+```
+./scripts/forge.py developer POST /issues/<pr>/labels '{"labels":["jira","no-time-tracked"]}'
+```
+
+**Why this is written down.** Every cycle that learned the title format by
+reading a recent merged PR copied the key along with the shape — because what
+is on `main` is the *post-rename* title. Six agent pull requests ended up
+attached to two Jira issues instead of six: NAS-142299 collected three, and
+NAS-142319 collected three more. Each cycle reasoned carefully and reached the
+wrong answer, because the only evidence available said the key belongs in the
+title.
+
+**Do not invent one either.** One cycle cut a branch on `NAS-142300`, thought
+better of it, and backed out; the next free id bugclerk assigned was 142316,
+so 142300 was someone else's ticket. An invented number maps to nothing or to
+a stranger's work, and bugclerk links it either way.
+
+**Branch names need no Jira key at all** — `<issue>-<slug>` is the convention
+here, e.g. `204-stepper-aria-structure`.
+
+**The one exception:** carry an existing `NAS-` key only when the work truly
+belongs to that Jira issue — a follow-up commit to a PR that already has one.
+Not "a related ticket", not "the same component". If you are choosing a key
+rather than continuing one, leave it out.
+
 ## Important Notes for Agents
 
 - **Don't read all files at once** - Load only what you need for the current task


### PR DESCRIPTION
Adds one section to `CLAUDE.md`: where a Jira ticket comes from, and that a cycle must neither invent nor copy one.

## What went wrong

`CONTRIBUTE.md` requires every PR title to start `NAS-<number> / ` and CI rejects titles without one. It does not say where that number comes from, and no ticket on the board carries one — so every cycle had to work it out, and they worked it out by reading a recently merged PR.

What is on `main` is the **post-rename** title. bugclerk rewrites a PR title with the key it mints, so the only available evidence says the key belongs in the title you write. Six agent pull requests ended up attached to two Jira issues instead of six:

| Jira issue | PRs |
|---|---|
| NAS-142299 | #193, #198, #199 |
| NAS-142319 | #205, #207, #208 |

Two cycles got it right — #197 and #202 opened with bare titles and bugclerk minted NAS-142316 and NAS-142319 for them. The difference was not skill; it was whether a merged PR happened to be visible at the moment they looked.

## Why not just tell them to pick a number

One cycle did try. It cut a branch on `NAS-142300`, thought better of it sixteen seconds later, and renamed back. The next free id bugclerk assigned was **142316** — so 142300 belongs to somebody else's ticket. Its own note on the decision was right: *"an invented number either maps to nothing or, worse, to somebody else's ticket, and bugclerk links it either way."*

## The rule

Open the PR with **no** `NAS-` prefix, then apply the **`jira`** label. bugclerk files a fresh issue, rewrites the title, comments the URL, and `check-ticket` goes green on the rename.

**This pull request follows that rule** — opened with a bare title, `jira` applied after. If the title above now starts with a `NAS-` key, that is bugclerk doing what the section describes.

Also documented: branch names need no key (`<issue>-<slug>`), and the one case where carrying an existing key is right — a follow-up to a PR that already has one, not "a related ticket" and not "the same component".

## Provenance

Found by watching the loop file six PRs across a day. Filed as a documentation change rather than a prompt change because it is this project's convention, not the harness's — and `CLAUDE.md` is the file every cycle is told to read before writing anything.
