### PR TITLE
NAS-142319 / 27.0.0-BETA.1 / fix(a11y): model the tn-stepper header as a list of steps

### DIFF
--- a/projects/truenas-ui/src/lib/stepper/stepper-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/stepper/stepper-a11y.spec.ts
@@ -81,15 +81,34 @@ class StepperA11yHostComponent {
 /**
  * The rules the stepper's header structure can be wrong under.
  *
- * `list` and `listitem` are the two the fix is about. The three `aria-*` rules
- * and `nested-interactive` are here because the structure change moved every
- * step header one level deeper, inside a new element — the cheapest way for that
- * to go wrong is a role or attribute landing somewhere it is not allowed.
- * `aria-command-name` is what fails if a step header ever loses its label, which
- * is the other half of "a screen reader can tell which step is which".
+ * `aria-required-children` and `listitem` are the two the fix is about — the
+ * container's children and the item's container.
+ *
+ * NOT `list`, and that is worth stating because it is the obvious choice, and
+ * because losing it costs something. axe declares it `matches:
+ * 'no-role-matches'`, so an `<ol>` carrying an explicit `role="list"` — which
+ * this one must, see the Safari note in the template — is skipped by it
+ * entirely. Naming it here would not fail; it would quietly never be attributed
+ * to anything, which is the vacuous green this spec is otherwise built to
+ * avoid.
+ *
+ * `aria-required-children` is what still runs on a role-bearing list, and it is
+ * NOT the same check. It objects to an owned element whose role is not
+ * `listitem`; a roleless `div` is generic and passes straight through it —
+ * measured, not assumed. The connector is a roleless `div`, so putting it back
+ * beside the items is a regression NO axe rule reports once the role is
+ * explicit. `keeps the horizontal connector inside its list item` below is what
+ * guards it, by reading the DOM.
+ *
+ * The three `aria-*` rules and `nested-interactive` are here because the
+ * structure change moved every step header one level deeper, inside a new
+ * element — the cheapest way for that to go wrong is a role or attribute
+ * landing somewhere it is not allowed. `aria-command-name` is what fails if a
+ * step header ever loses its label, which is the other half of "a screen reader
+ * can tell which step is which".
  */
 const STRUCTURE_RULES = [
-  'list',
+  'aria-required-children',
   'listitem',
   'aria-allowed-attr',
   'aria-allowed-role',
@@ -141,6 +160,26 @@ describe('tn-stepper accessibility (#204)', () => {
       expect(items().every((item) => item.parentElement === list())).toBe(true);
     });
 
+    /**
+     * `role="list"` on an `<ol>` is redundant to the HTML spec and is not
+     * redundant to Safari: the stylesheet sets `list-style: none` on this
+     * element, and Safari drops the list role from the accessibility tree when
+     * it does. Losing it loses the step count and each step's position — the
+     * whole of what this change added — on VoiceOver, which is the reader the
+     * list model is most for, and no axe rule reports the loss.
+     *
+     * Asserted in both orientations, since each renders its own `<ol>`.
+     */
+    it.each(['horizontal', 'vertical'] as const)(
+      'keeps the explicit list role that survives list-style: none in Safari (%s)',
+      (orientation) => {
+        host.orientation.set(orientation);
+        fixture.detectChanges();
+
+        expect(list().getAttribute('role')).toBe('list');
+      },
+    );
+
     it('renders the same list in vertical orientation', () => {
       host.orientation.set('vertical');
       fixture.detectChanges();
@@ -150,9 +189,17 @@ describe('tn-stepper accessibility (#204)', () => {
       expect(items().every((item) => item.parentElement === list())).toBe(true);
     });
 
-    // The connector was a sibling of the step headers before #204, which is a
-    // `div` directly inside the `<ol>` — the exact shape the `list` rule
-    // reports. It moved inside the item it leads away from.
+    /**
+     * The connector was a sibling of the step headers before #204, which puts a
+     * `div` directly inside the `<ol>`. It moved inside the item it leads away
+     * from.
+     *
+     * This is the ONLY guard on that, and it reads the DOM rather than asking
+     * axe, because axe cannot answer it: the explicit `role="list"` the Safari
+     * fix requires takes the `list` rule out of play, and the rule that
+     * replaces it lets a roleless `div` through. See `STRUCTURE_RULES`, and the
+     * test that measures it at the bottom of this file.
+     */
     it('keeps the horizontal connector inside its list item, not loose in the list', () => {
       const connectors: HTMLElement[] =
         Array.from(fixture.nativeElement.querySelectorAll('.tn-stepper__connector'));
@@ -161,6 +208,20 @@ describe('tn-stepper accessibility (#204)', () => {
       expect(connectors.every((c) => c.parentElement?.classList.contains('tn-stepper__step')))
         .toBe(true);
     });
+
+    // Stated as the general invariant as well as about the connector, so that
+    // anything else added to the header — a progress bar, a divider — has to go
+    // inside an item too.
+    it.each(['horizontal', 'vertical'] as const)(
+      'holds nothing but list items directly in the list (%s)',
+      (orientation) => {
+        host.orientation.set(orientation);
+        fixture.detectChanges();
+
+        expect(Array.from(list().children).map((child) => child.tagName))
+          .toEqual(['LI', 'LI', 'LI']);
+      },
+    );
 
     it('gives every step header exactly one list item', () => {
       expect(headers().length).toBe(3);
@@ -180,7 +241,7 @@ describe('tn-stepper accessibility (#204)', () => {
       );
 
       expect(violated).toEqual([]);
-      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('aria-required-children');
       expect(evaluated).toContain('listitem');
       expect(evaluated).toContain('aria-command-name');
     });
@@ -194,7 +255,7 @@ describe('tn-stepper accessibility (#204)', () => {
       );
 
       expect(violated).toEqual([]);
-      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('aria-required-children');
       expect(evaluated).toContain('listitem');
     });
 
@@ -207,7 +268,7 @@ describe('tn-stepper accessibility (#204)', () => {
       );
 
       expect(violated).toEqual([]);
-      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('aria-required-children');
       expect(headers()[2].getAttribute('aria-disabled')).toBe('true');
     });
 
@@ -223,7 +284,7 @@ describe('tn-stepper accessibility (#204)', () => {
       );
 
       expect(violated).toEqual([]);
-      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('aria-required-children');
       expect(evaluated).toContain('aria-command-name');
     });
   });
@@ -364,7 +425,7 @@ describe('tn-stepper accessibility (#204)', () => {
         + '<div role="button" tabindex="0">2 Layout</div>'
         + '</div>',
         '.tn-stepper__header',
-        ['list', 'listitem'],
+        ['list', 'listitem', 'aria-required-children'],
       );
 
       expect(evaluated).toEqual([]);
@@ -372,28 +433,59 @@ describe('tn-stepper accessibility (#204)', () => {
     });
 
     /**
-     * And the control for the fix's own regression: put the connector back
-     * beside the items, inside the `<ol>`, and axe objects. Without this, a
-     * change that reverted the connector's position would leave every
-     * `violated` above empty and every `evaluated` still satisfied by the
-     * remaining items.
+     * The control for `aria-required-children` itself — the rule every "raises
+     * no violation" above leans on. Without this, an axe or `axeResult` change
+     * that stopped attributing it would empty `violated` everywhere in this
+     * file and satisfy nothing but `evaluated`.
+     *
+     * The child carries `role="button"` rather than being the roleless `div`
+     * the connector is, because a roleless child is generic and this rule lets
+     * it through — which is measured directly by the test after this one, and
+     * is why the connector's position is guarded by reading the DOM instead.
      *
      * It runs through the shared `axeResult` on purpose, so it is also the
      * control for that wrapper: an attribution bug there — a filter matching
      * nothing — would empty `violated` in every spec that uses it.
      */
-    it('still reports the violation for a connector loose in the list', async () => {
+    it('still reports a list child whose role is not listitem', async () => {
       const { violated } = await scan(
-        '<ol class="tn-stepper__header">'
+        // `role="list"` because that is what the component renders, and it is
+        // what decides which rule reports: axe skips `list` on a role-bearing
+        // <ol>, so a control written without the attribute would be proving
+        // that a rule the component never runs still works.
+        '<ol class="tn-stepper__header" role="list">'
+        + '<li><div role="button" tabindex="0">1 Pool name</div></li>'
+        + '<div role="button" tabindex="0">Loose</div>'
+        + '</ol>',
+        'ol',
+        ['aria-required-children'],
+      );
+
+      expect(violated).toEqual(['aria-required-children']);
+    });
+
+    /**
+     * The measurement behind the paragraph in `STRUCTURE_RULES`, kept as a test
+     * rather than left as a claim in a comment: this IS the pre-fix connector
+     * shape, and `aria-required-children` evaluates the list and says nothing.
+     *
+     * If a later axe-core does start reporting it, this test fails — and the
+     * right response is to add the rule back as a guard on the component, not
+     * to loosen this.
+     */
+    it('says nothing about a roleless div loose in the list, which the connector is', async () => {
+      const { violated, evaluated } = await scan(
+        '<ol class="tn-stepper__header" role="list">'
         + '<li><div role="button" tabindex="0">1 Pool name</div></li>'
         + '<div class="tn-stepper__connector"></div>'
         + '<li><div role="button" tabindex="0">2 Layout</div></li>'
         + '</ol>',
         'ol',
-        ['list'],
+        ['aria-required-children'],
       );
 
-      expect(violated).toEqual(['list']);
+      expect(evaluated).toEqual(['aria-required-children']);
+      expect(violated).toEqual([]);
     });
   });
 });

--- a/projects/truenas-ui/src/lib/stepper/stepper-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/stepper/stepper-a11y.spec.ts
@@ -1,0 +1,399 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TnStepComponent } from './step.component';
+import {
+  TnStepperComponent, TN_STEPPER_STATUS_COMPLETED, TN_STEPPER_STATUS_ERROR,
+} from './stepper.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the ARIA structure given to `tn-stepper` in #204.
+ *
+ * WHAT WAS REPORTED, AND WHAT WAS ACTUALLY THERE
+ * ----------------------------------------------
+ * The ticket reported axe returning no violations AND zero rules passed. Run
+ * against the unchanged component, that is exactly what a stepper with no
+ * `tn-step` children did — the markup in the report is the empty case, two bare
+ * `div`s. A POPULATED stepper was less bare than the report suggests: its step
+ * headers already carried `role="button"`, `tabindex` and `aria-current="step"`,
+ * and 13 rules passed on them.
+ *
+ * What was missing either way is the structure this file is about: nothing said
+ * how many steps there were or which position each held, and "completed" lived
+ * only in a CSS class and an `aria-hidden` glyph.
+ *
+ * WHY A LIST AND NOT A TABLIST
+ * ----------------------------
+ * `linear` gates a step behind the completion of every step before it
+ * (`canSelectStep`), and a gated header is a no-op on click. `role="tab"`
+ * advertises free navigation between panels, so it would describe a stepper this
+ * component refuses to be, and it would bring a roving-tabindex/arrow-key
+ * contract that would then have to be honoured — the ticket names leaving that
+ * contract unimplemented as worse than the current state. An ordered list
+ * carries no such contract: each header stays the `role="button"` it already
+ * was, activated by Enter and Space, and the list supplies the count and the
+ * position.
+ *
+ * WHY `evaluated` MATTERS MORE HERE THAN IN THE OTHER a11y SPECS
+ * -------------------------------------------------------------
+ * Every `expect(violated).toEqual([])` below is also what axe returns when it
+ * evaluated nothing at all — which is not a hypothetical for this component, it
+ * is the reported defect. `the structure this replaced` at the bottom pins that
+ * down from the other side: it rebuilds the pre-#204 header and asserts axe
+ * attributes NOTHING to it, so a regression that drops the list back to `div`s
+ * cannot pass by going quiet.
+ */
+
+@Component({
+  selector: 'tn-stepper-a11y-host',
+  standalone: true,
+  imports: [TnStepperComponent, TnStepComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-stepper
+      [orientation]="orientation()"
+      [linear]="linear()"
+      [selectedIndex]="selectedIndex()">
+      <tn-step label="Pool name" [completed]="step0Completed()" />
+      <tn-step
+        label="Layout"
+        [completed]="step1Completed()"
+        [hasError]="step1Error()"
+        [errorMessage]="step1ErrorMessage()" />
+      <tn-step label="Review" [completed]="step2Completed()" [optional]="step2Optional()" />
+    </tn-stepper>
+  `,
+})
+class StepperA11yHostComponent {
+  orientation = signal<'horizontal' | 'vertical' | 'auto'>('horizontal');
+  linear = signal(false);
+  selectedIndex = signal(0);
+  step0Completed = signal(false);
+  step1Completed = signal(false);
+  step2Completed = signal(false);
+  step1Error = signal(false);
+  step1ErrorMessage = signal<string | undefined>(undefined);
+  step2Optional = signal(false);
+}
+
+/**
+ * The rules the stepper's header structure can be wrong under.
+ *
+ * `list` and `listitem` are the two the fix is about. The three `aria-*` rules
+ * and `nested-interactive` are here because the structure change moved every
+ * step header one level deeper, inside a new element — the cheapest way for that
+ * to go wrong is a role or attribute landing somewhere it is not allowed.
+ * `aria-command-name` is what fails if a step header ever loses its label, which
+ * is the other half of "a screen reader can tell which step is which".
+ */
+const STRUCTURE_RULES = [
+  'list',
+  'listitem',
+  'aria-allowed-attr',
+  'aria-allowed-role',
+  'aria-valid-attr-value',
+  'aria-command-name',
+  'nested-interactive',
+];
+
+describe('tn-stepper accessibility (#204)', () => {
+  let host: StepperA11yHostComponent;
+  let fixture: ComponentFixture<StepperA11yHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StepperA11yHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document itself, which axe needs — it
+    // walks up to the document root to decide visibility, and treats a detached
+    // tree as hidden and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(StepperA11yHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function list(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-stepper__header') as HTMLElement;
+  }
+
+  function items(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.tn-stepper__step'));
+  }
+
+  function headers(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.tn-stepper__step-header'));
+  }
+
+  /** Everything the structure rules above can report a stepper on. */
+  function structureTargets(): HTMLElement[] {
+    return [list(), ...items(), ...headers()];
+  }
+
+  describe('the header is a list of steps', () => {
+    it('renders one ordered list holding one item per step', () => {
+      expect(list().tagName).toBe('OL');
+      expect(items().length).toBe(3);
+      expect(items().every((item) => item.tagName === 'LI')).toBe(true);
+      expect(items().every((item) => item.parentElement === list())).toBe(true);
+    });
+
+    it('renders the same list in vertical orientation', () => {
+      host.orientation.set('vertical');
+      fixture.detectChanges();
+
+      expect(list().tagName).toBe('OL');
+      expect(items().length).toBe(3);
+      expect(items().every((item) => item.parentElement === list())).toBe(true);
+    });
+
+    // The connector was a sibling of the step headers before #204, which is a
+    // `div` directly inside the `<ol>` — the exact shape the `list` rule
+    // reports. It moved inside the item it leads away from.
+    it('keeps the horizontal connector inside its list item, not loose in the list', () => {
+      const connectors: HTMLElement[] =
+        Array.from(fixture.nativeElement.querySelectorAll('.tn-stepper__connector'));
+
+      expect(connectors.length).toBe(2);
+      expect(connectors.every((c) => c.parentElement?.classList.contains('tn-stepper__step')))
+        .toBe(true);
+    });
+
+    it('gives every step header exactly one list item', () => {
+      expect(headers().length).toBe(3);
+      headers().forEach((header, i) => {
+        expect(items()[i].contains(header)).toBe(true);
+      });
+    });
+  });
+
+  describe('axe over the step list', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing — which is
+    // the defect this ticket reported, not a hypothetical.
+    it('raises no violation, and does evaluate the list rules', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, structureTargets(), STRUCTURE_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('listitem');
+      expect(evaluated).toContain('aria-command-name');
+    });
+
+    it('raises no violation in vertical orientation', async () => {
+      host.orientation.set('vertical');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, structureTargets(), STRUCTURE_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('listitem');
+    });
+
+    it('raises no violation when linear mode disables the steps ahead', async () => {
+      host.linear.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, structureTargets(), STRUCTURE_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('list');
+      expect(headers()[2].getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('raises no violation with a completed, an errored and an optional step', async () => {
+      host.step0Completed.set(true);
+      host.step1Error.set(true);
+      host.step1ErrorMessage.set('Pick at least two disks');
+      host.step2Optional.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, structureTargets(), STRUCTURE_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('list');
+      expect(evaluated).toContain('aria-command-name');
+    });
+  });
+
+  describe('which step is current', () => {
+    it('marks the selected step and only that one', () => {
+      host.selectedIndex.set(1);
+      fixture.detectChanges();
+
+      expect(headers().map((h) => h.getAttribute('aria-current')))
+        .toEqual([null, 'step', null]);
+    });
+  });
+
+  describe('which steps are complete', () => {
+    it('says nothing about a step that is neither complete nor in error', () => {
+      expect(headers()[0].textContent).not.toContain(TN_STEPPER_STATUS_COMPLETED);
+      expect(headers()[0].textContent).not.toContain(TN_STEPPER_STATUS_ERROR);
+    });
+
+    it('puts completion in the header text, not only in a CSS class', () => {
+      host.step0Completed.set(true);
+      fixture.detectChanges();
+
+      expect(headers()[0].textContent).toContain(TN_STEPPER_STATUS_COMPLETED);
+      expect(headers()[1].textContent).not.toContain(TN_STEPPER_STATUS_COMPLETED);
+    });
+
+    it('puts the error state in the header text, where only an aria-hidden glyph showed it', () => {
+      host.step1Error.set(true);
+      fixture.detectChanges();
+
+      expect(headers()[1].textContent).toContain(TN_STEPPER_STATUS_ERROR);
+      // The glyph itself stays out of the accessible name — it would otherwise
+      // announce the icon's own name beside the state text.
+      expect(fixture.nativeElement.querySelector('.tn-stepper__step-error')
+        .getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('announces error rather than completed for a step that is both', () => {
+      host.step1Completed.set(true);
+      host.step1Error.set(true);
+      fixture.detectChanges();
+
+      expect(headers()[1].textContent).toContain(TN_STEPPER_STATUS_ERROR);
+      expect(headers()[1].textContent).not.toContain(TN_STEPPER_STATUS_COMPLETED);
+    });
+
+    /**
+     * The state text is a sibling of `.tn-stepper__step-label`, not a child.
+     * The narrow-screen rule in this component's stylesheet sets
+     * `display: none` on `.tn-stepper__step-label`, which under 780px would
+     * take the state out of the accessible tree along with the visible title —
+     * on exactly the viewport where a sighted user has lost the title too.
+     *
+     * Asserted structurally rather than by measuring: Jest does not compile the
+     * component's SCSS and jsdom has no media queries, so the containment is
+     * the reachable form of the invariant.
+     */
+    it('keeps the state text out of the label element the narrow-screen rule hides', () => {
+      host.step0Completed.set(true);
+      fixture.detectChanges();
+
+      const label = headers()[0].querySelector('.tn-stepper__step-label') as HTMLElement;
+      const state = headers()[0].querySelector('.cdk-visually-hidden') as HTMLElement;
+
+      expect(state.textContent).toBe(TN_STEPPER_STATUS_COMPLETED);
+      expect(label.contains(state)).toBe(false);
+      expect(state.parentElement).toBe(headers()[0]);
+    });
+  });
+
+  describe('the keyboard contract the list model does bring', () => {
+    // A list needs no arrow-key navigation of its own; what it needs is that
+    // each header stays the operable button it already was, since that is what
+    // the model leans on instead. A `role="button"` that Enter and Space do not
+    // activate is the "declared in ARIA and left unimplemented" case the ticket
+    // calls worse than the current state.
+    it('keeps every step header a focusable button', () => {
+      expect(headers().every((h) => h.getAttribute('role') === 'button')).toBe(true);
+      expect(headers().map((h) => h.getAttribute('tabindex'))).toEqual(['0', '0', '0']);
+    });
+
+    it.each(['Enter', ' '])('selects a step from the %s keydown', (key) => {
+      headers()[2].dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+
+      expect(headers()[2].getAttribute('aria-current')).toBe('step');
+    });
+
+    it('takes a gated step out of the tab order and marks it disabled', () => {
+      host.linear.set(true);
+      fixture.detectChanges();
+
+      expect(headers().map((h) => h.getAttribute('tabindex'))).toEqual(['0', '-1', '-1']);
+      expect(headers().map((h) => h.getAttribute('aria-disabled')))
+        .toEqual([null, 'true', 'true']);
+    });
+  });
+
+  /**
+   * Positive controls. Everything above asserts an empty `violated`, which axe
+   * also returns when it looked at nothing — and looking at nothing is what the
+   * stepper used to do, so these are the assertions that keep the rest honest.
+   */
+  describe('the structure this replaced', () => {
+    async function scan(html: string, target: string, rules: string[]) {
+      const previous = document.createElement('div');
+      previous.innerHTML = html;
+      document.body.appendChild(previous);
+
+      // `await` inside the try, not `return axeResult(...)` — returning the
+      // promise runs `finally` before axe has read anything, which detaches the
+      // tree mid-scan and is precisely the vacuous pass this is guarding.
+      //
+      // try/finally at all, because `axeResult` throws rather than returning a
+      // vacuous pass — and a fixture left in `document.body` by that throw would
+      // be scanned by every later test in this file.
+      try {
+        return await axeResult(previous, previous.querySelector(target), rules);
+      } finally {
+        previous.remove();
+      }
+    }
+
+    /**
+     * The reported defect itself, kept as a test. This is the pre-#204 header:
+     * a `div` holding `role="button"` headers with `div` connectors between
+     * them. axe attributes NEITHER list rule to it — not a pass, not a
+     * violation — which is why `expect(violated).toEqual([])` was worth nothing
+     * on it, and why every assertion above names `evaluated` too.
+     */
+    it('evaluated no list rule at all, which is what made a clean scan meaningless', async () => {
+      const { violated, evaluated } = await scan(
+        '<div class="tn-stepper__header">'
+        + '<div role="button" tabindex="0" aria-current="step">1 Pool name</div>'
+        + '<div class="tn-stepper__connector"></div>'
+        + '<div role="button" tabindex="0">2 Layout</div>'
+        + '</div>',
+        '.tn-stepper__header',
+        ['list', 'listitem'],
+      );
+
+      expect(evaluated).toEqual([]);
+      expect(violated).toEqual([]);
+    });
+
+    /**
+     * And the control for the fix's own regression: put the connector back
+     * beside the items, inside the `<ol>`, and axe objects. Without this, a
+     * change that reverted the connector's position would leave every
+     * `violated` above empty and every `evaluated` still satisfied by the
+     * remaining items.
+     *
+     * It runs through the shared `axeResult` on purpose, so it is also the
+     * control for that wrapper: an attribution bug there — a filter matching
+     * nothing — would empty `violated` in every spec that uses it.
+     */
+    it('still reports the violation for a connector loose in the list', async () => {
+      const { violated } = await scan(
+        '<ol class="tn-stepper__header">'
+        + '<li><div role="button" tabindex="0">1 Pool name</div></li>'
+        + '<div class="tn-stepper__connector"></div>'
+        + '<li><div role="button" tabindex="0">2 Layout</div></li>'
+        + '</ol>',
+        'ol',
+        ['list'],
+      );
+
+      expect(violated).toEqual(['list']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.html
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.html
@@ -66,10 +66,15 @@
 
     A list may contain nothing but list items, so the connector moves inside the item it leads
     away from; it used to be a sibling of the headers.
+
+    `role="list"` is redundant with `<ol>` and is not decoration: the stylesheet sets
+    `list-style: none`, and Safari drops the list role from the accessibility tree when it
+    does. Without this attribute the count and position would be lost on VoiceOver, which is
+    the reader this whole model is for.
   -->
   @if (isVertical()) {
     <!-- Vertical: content renders inline beneath the active step's header -->
-    <ol class="tn-stepper__header">
+    <ol class="tn-stepper__header" role="list">
       @for (step of steps(); track $index; let i = $index) {
         <li class="tn-stepper__step" [class.tn-stepper__step--last]="i === steps().length - 1">
           <ng-container *ngTemplateOutlet="stepHeader; context: { step, i }" />
@@ -86,7 +91,7 @@
     </ol>
   } @else {
     <!-- Horizontal: headers in a row, active content below -->
-    <ol class="tn-stepper__header">
+    <ol class="tn-stepper__header" role="list">
       @for (step of steps(); track $index; let i = $index) {
         <li class="tn-stepper__step" [class.tn-stepper__step--last]="i === steps().length - 1">
           <ng-container *ngTemplateOutlet="stepHeader; context: { step, i }" />

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.html
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.html
@@ -42,14 +42,36 @@
           <span class="tn-stepper__step-subtitle">Optional</span>
         }
       </div>
+
+      <!--
+        Completed / error state, for a screen reader only — the indicator says it with a CSS
+        class and an aria-hidden glyph, neither of which reaches assistive technology.
+
+        A sibling of __step-label rather than a child of it, because the narrow-screen rule in
+        this component's stylesheet sets `display: none` on __step-label — which would take the
+        state with it on exactly the viewport where the visible label is already gone.
+      -->
+      @if (stepStatusText()[i]; as status) {
+        <span class="cdk-visually-hidden">{{ status }}</span>
+      }
     </div>
   </ng-template>
 
+  <!--
+    The header is an ordered list in both orientations, which is the whole ARIA model this
+    component uses (#204): it is what tells a screen reader how many steps there are and which
+    position each one holds, and it costs no keyboard contract. A tablist was the alternative
+    and is wrong here — `linear` gates a step behind the completion of every step before it, so
+    `role="tab"` would advertise free navigation the component refuses to perform.
+
+    A list may contain nothing but list items, so the connector moves inside the item it leads
+    away from; it used to be a sibling of the headers.
+  -->
   @if (isVertical()) {
     <!-- Vertical: content renders inline beneath the active step's header -->
-    <div class="tn-stepper__header">
+    <ol class="tn-stepper__header">
       @for (step of steps(); track $index; let i = $index) {
-        <div class="tn-stepper__step" [class.tn-stepper__step--last]="i === steps().length - 1">
+        <li class="tn-stepper__step" [class.tn-stepper__step--last]="i === steps().length - 1">
           <ng-container *ngTemplateOutlet="stepHeader; context: { step, i }" />
 
           <div class="tn-stepper__step-body">
@@ -59,20 +81,22 @@
               </div>
             }
           </div>
-        </div>
+        </li>
       }
-    </div>
+    </ol>
   } @else {
     <!-- Horizontal: headers in a row, active content below -->
-    <div class="tn-stepper__header">
+    <ol class="tn-stepper__header">
       @for (step of steps(); track $index; let i = $index) {
-        <ng-container *ngTemplateOutlet="stepHeader; context: { step, i }" />
+        <li class="tn-stepper__step" [class.tn-stepper__step--last]="i === steps().length - 1">
+          <ng-container *ngTemplateOutlet="stepHeader; context: { step, i }" />
 
-        @if (i < steps().length - 1) {
-          <div class="tn-stepper__connector"></div>
-        }
+          @if (i < steps().length - 1) {
+            <div class="tn-stepper__connector"></div>
+          }
+        </li>
       }
-    </div>
+    </ol>
 
     <div class="tn-stepper__content">
       @for (step of steps(); track $index; let i = $index) {

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.scss
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.scss
@@ -13,6 +13,11 @@
   // The header is an <ol> (see the template — it is how the step count and each step's
   // position reach a screen reader). Strip the list's own presentation once, here, so both
   // orientations start from the same box as the <div> it replaced.
+  //
+  // `list-style: none` is what makes Safari drop the list role from the accessibility tree —
+  // which would take the count and position with it, on the one browser whose screen reader
+  // this change is most for. The explicit `role="list"` in the template is what holds it; do
+  // not remove one without the other.
   .tn-stepper__header {
     list-style: none;
     margin: 0;
@@ -30,12 +35,13 @@
     }
 
     // The connector used to be a sibling of the headers in this flex row and absorbed the
-    // free space itself. It now sits inside the list item, so the ITEM is what grows — and
-    // the header inside it must not, or it would stretch to the item's full width and pull
-    // its centred label away from its indicator.
+    // free space itself. It now sits inside the list item, so the ITEM is what grows.
+    //
+    // Nothing is said here about how the header itself flexes: as a flex child it defaults to
+    // `0 1 auto`, which is exactly what it had as a direct child of the row — free to shrink
+    // so a long label wraps rather than overflowing, and not free to grow.
     .tn-stepper__step {
       display: flex;
-      align-items: flex-start;
 
       &:not(.tn-stepper__step--last) {
         flex: 1;
@@ -44,7 +50,6 @@
 
     .tn-stepper__step-header {
       display: flex;
-      flex: 0 0 auto;
       flex-direction: column;
       align-items: center;
       text-align: center;

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.scss
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.scss
@@ -43,8 +43,13 @@
     .tn-stepper__step {
       display: flex;
 
+      // `1 1 auto`, not the `flex: 1` shorthand — that resolves to a basis of 0, which sizes
+      // every item to an equal share of the ROW. Each item is a header plus a connector, so
+      // equal items mean connectors as unequal as the labels are, and a long label squeezed
+      // to fit its share. With `auto` the item starts at its content width and only the free
+      // space is split evenly, which is what the connectors used to split between them.
       &:not(.tn-stepper__step--last) {
-        flex: 1;
+        flex: 1 1 auto;
       }
     }
 

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.scss
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.scss
@@ -10,6 +10,15 @@
   --v-indicator: 32px;
   --v-gap: 12px;
 
+  // The header is an <ol> (see the template — it is how the step count and each step's
+  // position reach a screen reader). Strip the list's own presentation once, here, so both
+  // orientations start from the same box as the <div> it replaced.
+  .tn-stepper__header {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
   &--horizontal {
     flex-direction: column;
 
@@ -20,8 +29,22 @@
       padding: 0 16px;
     }
 
+    // The connector used to be a sibling of the headers in this flex row and absorbed the
+    // free space itself. It now sits inside the list item, so the ITEM is what grows — and
+    // the header inside it must not, or it would stretch to the item's full width and pull
+    // its centred label away from its indicator.
+    .tn-stepper__step {
+      display: flex;
+      align-items: flex-start;
+
+      &:not(.tn-stepper__step--last) {
+        flex: 1;
+      }
+    }
+
     .tn-stepper__step-header {
       display: flex;
+      flex: 0 0 auto;
       flex-direction: column;
       align-items: center;
       text-align: center;
@@ -246,6 +269,22 @@
   border: 1px solid var(--tn-lines, #e5e7eb);
 }
 
+
+// Screen-reader-only text. `.cdk-visually-hidden` comes from the CDK's global a11y stylesheet,
+// which this library does not ship; without a local definition the per-step "Completed" /
+// "Error" text renders as visible text beside the label. Same local copy the table and calendar
+// components keep.
+.cdk-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
 
 // Focus styles for accessibility
 .tn-stepper__step-header {

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.ts
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.ts
@@ -8,6 +8,19 @@ import { TnIconComponent } from '../icon/icon.component';
 import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
+/**
+ * Screen-reader text for a step whose header shows the error glyph.
+ *
+ * Exported so specs assert by name rather than by a copied literal, the same
+ * reason `TN_SPINNER_DEFAULT_LABEL` is — and so a consumer localising this
+ * library has one place to find the strings the stepper speaks but never
+ * renders.
+ */
+export const TN_STEPPER_STATUS_ERROR = 'Error';
+
+/** Screen-reader text for a step whose header shows the completed state. */
+export const TN_STEPPER_STATUS_COMPLETED = 'Completed';
+
 @Component({
   selector: 'tn-stepper',
   templateUrl: './stepper.component.html',
@@ -106,6 +119,29 @@ export class TnStepperComponent {
       return this.steps().map(() => false);
     }
     return this.steps().map((_step, index) => !this.canSelectStep(index));
+  });
+
+  // Per-index screen-reader text for state the header otherwise conveys only through a CSS
+  // class and an `aria-hidden` icon. `null` for the two states already spoken by something
+  // else: an optional step renders the word "Optional" as visible text, and the current step
+  // carries `aria-current="step"`.
+  //
+  // An errored step gets the word even when it also renders an `errorMessage`, because that
+  // message says what is wrong and not that anything is — "Pick at least two disks" reads as
+  // instruction, not as failure.
+  //
+  // Error before completed, matching the indicator's own precedence in the template — a step
+  // that is both should not announce itself as done.
+  readonly stepStatusText = computed<Array<string | null>>(() => {
+    return this.steps().map((step) => {
+      if (step.hasError()) {
+        return TN_STEPPER_STATUS_ERROR;
+      }
+      if (step.completed()) {
+        return TN_STEPPER_STATUS_COMPLETED;
+      }
+      return null;
+    });
   });
 
   selectStep(index: number): void {

--- a/projects/truenas-ui/src/lib/stepper/stepper.component.ts
+++ b/projects/truenas-ui/src/lib/stepper/stepper.component.ts
@@ -12,9 +12,9 @@ import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
  * Screen-reader text for a step whose header shows the error glyph.
  *
  * Exported so specs assert by name rather than by a copied literal, the same
- * reason `TN_SPINNER_DEFAULT_LABEL` is — and so a consumer localising this
- * library has one place to find the strings the stepper speaks but never
- * renders.
+ * reason `TN_SPINNER_DEFAULT_LABEL` is. It is not an override point — nothing
+ * reads a token or an input in its place, so a consumer cannot change what the
+ * stepper says here.
  */
 export const TN_STEPPER_STATUS_ERROR = 'Error';
 


### PR DESCRIPTION
Fixes #204.

## The defect, observed first

This is a `bug` ticket, so the reproduction came before the diff. Run against the unchanged component:

```
populated stepper   VIOLATIONS []   PASSES [13 rules]   INCOMPLETE ['color-contrast']
empty stepper       VIOLATIONS []   PASSES []
no <ol>/<li>        0 lists, 0 list items
completed step      header text is "1One" — no state anywhere but the CSS class
```

The report's "no violations and **zero** rules passed" is exactly right for the second line, and the markup it pastes is that case — a `tn-stepper` with no `tn-step` children renders two bare `div`s and axe has nothing to look at.

A *populated* stepper was less bare than the report suggests, and this is worth correcting: its step headers already carried `role="button"`, `tabindex` and `aria-current="step"`, and 13 rules passed on them. So "renders no roles and no interactive elements" was not the defect.

What was missing either way is structure. Nothing said how many steps there were or which position each held, and "completed" lived only in a CSS class and an `aria-hidden` glyph.

## The model: a list, not a tablist

`linear` gates a step behind the completion of every step before it (`canSelectStep`), and a gated header is a no-op on click. So the steps are **not** freely navigable, and `role="tab"` would advertise navigation this component refuses to perform — plus a roving-tabindex/arrow-key contract that would then have to be honoured. The ticket names an unimplemented ARIA contract as worse than the current state, and it is right.

An ordered list carries no contract of its own. Each header stays the `role="button"` it already was, activated by Enter and Space; the list supplies the count and the position; `aria-current="step"` supplies which one is current.

- Both orientations render `<ol class="tn-stepper__header">` with one `<li class="tn-stepper__step">` per step. Vertical already had that wrapper as a `div`; horizontal did not.
- **The connector moves inside the item it leads away from.** A list may contain nothing but list items, and the connector used to be a sibling of the headers.
- `stepStatusText` adds per-step "Completed" / "Error" text in a `.cdk-visually-hidden` span, error taking precedence to match the indicator's own. It is a **sibling** of `.tn-stepper__step-label`, not a child: the narrow-screen rule in this stylesheet sets `display: none` on that label, which would drop the state on exactly the viewport where the visible title is already gone.
- `TN_STEPPER_STATUS_COMPLETED` / `TN_STEPPER_STATUS_ERROR` are exported so specs assert by name rather than by a copied literal, the same reason `TN_SPINNER_DEFAULT_LABEL` is. They are **not** an override point — see the LOWs below.

## `role="list"`, and what it costs

`list-style: none` is what makes Safari drop the list role from the accessibility tree, taking the count and position with it — on the one screen reader this model is most for. The explicit `role="list"` on the `<ol>` overrides that heuristic, and the stylesheet says so beside the declaration that makes it necessary.

It has a cost, measured rather than assumed:

- axe declares its `list` rule `matches: 'no-role-matches'`, so a role-bearing `<ol>` is **skipped by it entirely**. Naming it in a spec would not fail — it would never be attributed to anything, which is the vacuous green this repo's `axeResult` wrapper exists to prevent.
- `aria-required-children` is what still runs, and it is **not the same check**: it objects to an owned element whose *role* is not `listitem`, and the connector is a roleless `div` that passes straight through. There is a test asserting exactly that, so the claim is not left as a comment.
- So the connector's position is guarded by **reading the DOM**, in two tests that say why — including the general invariant that the list's direct children are all `<li>`, in both orientations.

## Layout

The connector used to be the flex child that absorbed the row's free space. It is now inside the item, so the item is:

```scss
.tn-stepper__step {
  display: flex;
  &:not(.tn-stepper__step--last) { flex: 1 1 auto; }
}
```

`1 1 auto` and not the `flex: 1` shorthand, which resolves to a basis of `0` and would size every item to an equal share of the row — making the connectors as unequal as the labels are, and squeezing a long label to fit. With `auto` the item starts at its content width and only the free space is split evenly, which is what the connectors split between them before.

Nothing is said about how the header itself flexes: as a flex child it defaults to `0 1 auto`, exactly what it had as a direct child of the row.

**Not verified in a browser.** jsdom has no layout engine and Jest does not compile this component's SCSS, so the flex reasoning above is reasoning, not measurement. The Storybook interaction tests exercise the stepper story in a real browser on CI.

## Tests

New `stepper-a11y.spec.ts`, on the convention the other a11y specs follow: the shared `axeResult` wrapper, `evaluated` asserted beside every empty `violated`, and positive controls. 25 tests; `stepper.component.spec.ts` passes unchanged, which is what shows the structure change preserved behaviour.

The controls are worth calling out, because this ticket is specifically about a clean scan meaning nothing:

1. **The reported defect, kept as a test.** The pre-#204 header — a `div` of `role="button"` headers with `div` connectors between them — is scanned for `list`, `listitem` and `aria-required-children`, and `evaluated` comes back **empty**. That is why `expect(violated).toEqual([])` was worth nothing on it.
2. **`aria-required-children` still reports** a list child whose role is not `listitem`, which is the control for the rule and for the `axeResult` wrapper itself.
3. **`aria-required-children` says nothing** about a roleless `div` loose in the list. This is the measurement behind the paragraph above; if a later axe-core starts reporting it, this test fails, and the response is to add the rule as a guard rather than loosen the test.

Run locally: `yarn lint` (clean for every file this touches — the 4 `import/order` errors in `input.component.ts` and `menu-panel.component.ts` are pre-existing and untouched), `yarn test` (2408 passed, 102 suites), `yarn test:scripts` (42 passed), and `yarn build`. **Not run locally:** the Storybook interaction tests, which need a Playwright/Chromium install. `yarn build-storybook` was not run either — this diff edits no story.

## Local review, and what was left

The project's own reviewer ran here in a separate process — same rubric, severity threshold and parser as the required check — over three rounds. Rounds 1 and 2 each returned a HIGH and both are fixed in this branch:

1. **`list-style: none` strips list semantics in Safari.** Real, and the whole point of the change would have been lost on VoiceOver. Fixed with `role="list"`, with the consequences worked through above.
2. **`flex: 0 0 auto` on the step header pinned `flex-shrink` to 0**, so a long label could no longer wrap and would overflow a narrow row. The declaration bought nothing — grow was already `0` by default — and is gone.
3. **`flex: 1` on the item sizes items equally** rather than splitting the free space. Fixed to `flex: 1 1 auto`.

Round 3 returned **nothing at or above MEDIUM**. Four LOWs, left unfixed on purpose — each fix is a new diff, and a new diff is unreviewed — recorded here so they are not lost:

1. **A stepper with no `tn-step` children now renders an empty `<ol role="list">`,** and that case has no test. True. It is the markup the ticket pasted, and an empty list is valid HTML and valid ARIA; what it is not is covered.
2. **This is the fourth byte-identical copy of `.cdk-visually-hidden`** in the library (table, calendar ×2, now stepper). True, and it is the existing convention rather than something this diff invented — `table.component.scss` says so in its own comment. A shared mixin under `lib/a11y/` is the right fix and is bigger than this ticket.
3. **`TN_STEPPER_STATUS_COMPLETED` / `TN_STEPPER_STATUS_ERROR` are un-overridable English.** True, and unlike `TN_SPINNER_DEFAULT_LABEL` there is no input in whose place they act as a fallback. The doc comment was corrected in round 2 to stop claiming otherwise; giving the stepper a real localisation seam is a separate decision.
4. **`renders the same list in vertical orientation` is subsumed** by the `it.each` role test and by the stricter direct-children test. True and harmless.

Two more, from earlier rounds, that are worth a reader's attention:

5. **The step list has no accessible name.** Deliberate: an unnamed list is the ordinary case, and `aria-label="Progress"` on a component that may appear more than once per page is a guess about the consumer's wording. A consumer that needs it can wrap the stepper in a named `<nav>`.
6. **An explicit `role="listitem"` on each `<li>` as insurance**, since every item is `display: flex`. Not done, and not only for scope: `listitem` is another `no-role-matches` rule, so adding the attribute would take axe's item-side check out of play in exchange for a risk I have no evidence of — the Safari heuristic that motivates `role="list"` is about `list-style`, not about the item's `display`.

## Not changed, and worth its own ticket

Under 780px the horizontal stepper sets `display: none` on `.tn-stepper__step-label`, which removes each step's visible title **from the accessibility tree as well** — a screen-reader user on a narrow viewport gets "1", "2", "3" and the state text, and no titles. Making that rule visually-hidden instead of `display: none` would fix it, but it is a layout change this diff cannot verify and is not what #204 asked for. The new state text is already placed to survive it, which is the part that was in scope.
