### PR TITLE
NAS-142319 / 27.0.0-BETA.1 / fix(a11y): model tn-particle-progress-bar as a named, valued progressbar

### DIFF
--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar-a11y.spec.ts
@@ -1,0 +1,508 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import {
+  TnParticleProgressBarComponent,
+  TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL
+} from './particle-progress-bar.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * #209: the fourth component in this library shaped like a progress bar, and
+ * the first that no check could have found.
+ *
+ * `tn-progress-bar` and `tn-spinner` were found by failing
+ * `aria-progressbar-name` (#202/#205). `tn-branded-spinner` failed nothing and
+ * was found by a human reading the folder (#206). This one is a step further
+ * again: it never claimed `role="progressbar"`, and a rule that selects on the
+ * role cannot report on an element that does not carry it. Measured on the
+ * unchanged component under jsdom, over five rules a progressbar can fail:
+ *
+ *   host attributes   class="tn-particle-progress-bar"  — and nothing else
+ *   role              null
+ *   aria-*            none
+ *   text content      ""
+ *   axe               0 violations, 0 passes, 0 incomplete
+ *
+ * Zero passes is the part that matters, and it is why this file leads with a
+ * test that keeps that measurement rather than merely describing it: an empty
+ * `violations` reads as a clean bill of health, and here it meant axe had not
+ * looked at anything at all. `axe-testing.ts` exists for exactly that
+ * confusion, and `evaluated` is asserted beside every empty `violated` below.
+ *
+ * The reasoning for answering "progressbar" rather than "decoration" is on the
+ * component, where a reader meets it before the attributes it produced.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnParticleProgressBarComponent],
+  template: `<span id="tn-external-label">Restoring pool</span>
+    <tn-particle-progress-bar [width]="width()" [fill]="fill()"
+      [ariaLabel]="ariaLabel()" [ariaLabelledby]="ariaLabelledby()" />`
+})
+class TestHostComponent {
+  width = signal(600);
+  fill = signal(300);
+  ariaLabel = signal<string | null>(null);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+/**
+ * The rules a progressbar in this library can fail. Named as a list so that a
+ * rule which stops matching shows up as a shrinking `evaluated` in one place,
+ * rather than as a quietly narrower scan in whichever test happened to name it.
+ *
+ * Two fixtures below deliberately do NOT use it — the ones whose
+ * `aria-labelledby` dangles, where `aria-valid-attr-value` is undecidable. The
+ * reason is written beside them.
+ */
+const PROGRESSBAR_RULES = [
+  'aria-progressbar-name',
+  'aria-required-attr',
+  'aria-valid-attr-value',
+  'aria-allowed-attr'
+];
+
+describe('tn-particle-progress-bar accessibility (#209)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    // jsdom has no canvas implementation, so `getContext` returns null and the
+    // component's `ngAfterViewInit` would throw on the first `clearRect`. Stubbed
+    // on the prototype rather than by replacing `canvasRef` as
+    // `particle-progress-bar.component.spec.ts` does: that spec is about the
+    // drawing, this one is about the DOM, and it needs the real template rendered.
+    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      clearRect: jest.fn(), beginPath: jest.fn(), arc: jest.fn(), fill: jest.fn(), fillStyle: ''
+    } as unknown as CanvasRenderingContext2D);
+    // Returns a handle without ever invoking the callback, so `animate` runs the
+    // one synchronous pass `ngAfterViewInit` triggers and does not schedule a
+    // loop that would outlive the test.
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(123);
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // Silenced rather than merely observed: the component warns on every unnamed
+    // bar by design, and most fixtures in this file are unnamed.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // TestBed attaches the fixture to the document, which axe needs: it walks up
+    // to the document root to decide visibility and treats a detached tree as
+    // hidden, and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // Destroyed rather than left to the next test: the component drives a
+    // requestAnimationFrame loop from `ngAfterViewInit` and cancels it only in
+    // `ngOnDestroy`.
+    fixture.destroy();
+    jest.restoreAllMocks();
+  });
+
+  function bar(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-particle-progress-bar') as HTMLElement;
+  }
+
+  /**
+   * The reported defect, kept as a test rather than as a paragraph.
+   *
+   * This rebuilds the markup the component shipped before #209 — the host class,
+   * the SVG, the canvas, and no role — and requires axe to still evaluate
+   * NOTHING on it. It is the control for every `expect(violated).toEqual([])`
+   * in this file: on this markup that same assertion passed, and meant nothing.
+   *
+   * If a future axe-core starts reporting on a roleless div like this one, this
+   * test fails. That is the correct response, not a nuisance: it would mean the
+   * library had gained a check that could have found this component on its own,
+   * and the comment above about how it was found needs rewriting.
+   */
+  it('evaluated nothing at all on the markup this component used to have', async () => {
+    const previous = document.createElement('div');
+    previous.innerHTML =
+      '<div class="tn-particle-progress-bar">'
+      + '<svg width="600" height="40">'
+      + '<rect x="50" width="500" height="20"></rect>'
+      + '<rect x="50" width="300" height="20"></rect>'
+      + '<foreignObject x="0" y="0" width="600" height="40">'
+      + '<canvas width="600" height="40"></canvas>'
+      + '</foreignObject>'
+      + '</svg></div>';
+    document.body.appendChild(previous);
+
+    // try/finally, because `axeResult` throws rather than returning a vacuous
+    // pass — and a fixture left in `document.body` by that throw would be
+    // scanned by every later test in this file.
+    let violated: string[];
+    let evaluated: string[];
+    try {
+      ({ violated, evaluated } = await axeResult(
+        previous, previous.querySelector('.tn-particle-progress-bar'), PROGRESSBAR_RULES
+      ));
+    } finally {
+      previous.remove();
+    }
+
+    expect(violated).toEqual([]);
+    expect(evaluated).toEqual([]);
+  });
+
+  describe('the rules a progressbar can fail', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing at all —
+    // which is precisely what it returned on this component before #209.
+    it('is clean, and is actually examined, in its default state', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), PROGRESSBAR_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabel is set', async () => {
+      host.ariaLabel.set('Restoring pool');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), PROGRESSBAR_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation when ariaLabelledby is set', async () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), PROGRESSBAR_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    it('raises no violation with no value range to report', async () => {
+      host.width.set(100);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), PROGRESSBAR_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * Positive control, and the only assertion here that shows axe FAILING
+     * rather than passing. It is equally the control for the shared `axeResult`
+     * wrapper: an attribution bug there would empty `violated` in every spec
+     * that uses it, and every expectation above would still be green.
+     *
+     * The shape is what this component would render if the fix kept the role
+     * and lost the name — the regression the assertions above guard.
+     */
+    it('reports the violation for a particle bar with the role but no name', async () => {
+      const unnamed = document.createElement('div');
+      unnamed.innerHTML =
+        '<div role="progressbar" class="tn-particle-progress-bar" '
+        + 'aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"></div>';
+      document.body.appendChild(unnamed);
+
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          unnamed, unnamed.querySelector('[role="progressbar"]'), PROGRESSBAR_RULES
+        ));
+      } finally {
+        unnamed.remove();
+      }
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+  });
+
+  /**
+   * The answer to the ticket's question, asserted on the markup rather than
+   * only argued in a comment: the host claims the role, and the drawing that
+   * carries no information is hidden.
+   */
+  describe('the decision, as markup', () => {
+    it('claims the progressbar role on the host', () => {
+      expect(bar().getAttribute('role')).toBe('progressbar');
+    });
+
+    it('is not hidden from assistive technology', () => {
+      expect(bar().hasAttribute('aria-hidden')).toBe(false);
+    });
+
+    /**
+     * `role="progressbar"` is children-presentational in ARIA, so the subtree
+     * would be pruned even without this — but support for that pruning varies,
+     * and the canvas is opaque to a screen reader in every implementation. The
+     * attribute is asserted here because it is the half of the decision that
+     * says the DRAWING is decoration while the component is not.
+     */
+    it('hides the whole drawing, canvas included', () => {
+      const svg = bar().querySelector('svg') as SVGElement;
+
+      expect(svg.getAttribute('aria-hidden')).toBe('true');
+      expect(svg.contains(bar().querySelector('canvas'))).toBe(true);
+    });
+  });
+
+  /**
+   * `fill` is a px length along the track and `aria-valuenow` is a percentage of
+   * it, so these are the tests that the two agree — the announced value is the
+   * one thing here a reader cannot check against the drawing by eye.
+   */
+  describe('the value range', () => {
+    it('reports fill as a percentage of the track, on a 0-100 range', () => {
+      // width 600 less the 50px inset at each end is a 500px track; fill 300 of
+      // it is 60%. The px never reach the accessibility tree.
+      expect(bar().getAttribute('aria-valuenow')).toBe('60');
+      expect(bar().getAttribute('aria-valuemin')).toBe('0');
+      expect(bar().getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it('reports 0 for an empty bar', () => {
+      host.fill.set(0);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    it('tracks the track, not the SVG width, when width changes', () => {
+      // Same fill, wider bar: 300 of a 700px track is less progress, and the
+      // announced value has to fall with the drawing rather than stay at 60.
+      host.width.set(800);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-valuenow')).toBe(`${(300 / 700) * 100}`);
+    });
+
+    /**
+     * `fill` is not clamped for drawing — the story alone drives it to 600
+     * against a 500px track, where the rect simply overflows. `aria-valuenow`
+     * may not exceed `aria-valuemax`, so the announcement is clamped even though
+     * the drawing is not.
+     */
+    it('clamps an overflowing fill to 100 rather than exceeding valuemax', () => {
+      host.fill.set(600);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-valuenow')).toBe('100');
+      expect(bar().getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it('clamps a negative fill to 0', () => {
+      host.fill.set(-50);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    /**
+     * A width at or below twice the inset leaves no track to measure against.
+     * The role stays — "something is in progress" is still true — and the value
+     * range is withheld, which is how ARIA spells an indeterminate progressbar.
+     * The alternative is a value from a division by zero or a negative range.
+     */
+    it.each([100, 80, 0])('omits the value range when width %i leaves no track', (width) => {
+      host.width.set(width);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('role')).toBe('progressbar');
+      expect(bar().hasAttribute('aria-valuenow')).toBe(false);
+      expect(bar().hasAttribute('aria-valuemin')).toBe(false);
+      expect(bar().hasAttribute('aria-valuemax')).toBe(false);
+    });
+
+    it('reinstates the value range when the width grows back', () => {
+      host.width.set(100);
+      fixture.detectChanges();
+      host.width.set(600);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-valuenow')).toBe('60');
+    });
+  });
+
+  /**
+   * The naming rule is `tnAccessibleName`'s, shared with the other three
+   * progressbars, which is what #209 asked for — "no fourth naming rule". These
+   * assertions are that the routing is real, case for case with
+   * `progress-bar-a11y.spec.ts`, rather than a fourth copy that happens to agree
+   * today.
+   */
+  describe('where the name comes from', () => {
+    it('falls back to the default label when neither input is set', () => {
+      expect(bar().getAttribute('aria-label')).toBe(TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+
+    it('uses the same generic name as tn-progress-bar', () => {
+      expect(TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL).toBe('Progress');
+    });
+
+    it('prefers an explicit ariaLabel over the fallback', () => {
+      host.ariaLabel.set('Restoring pool');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe('Restoring pool');
+    });
+
+    it('treats a blank ariaLabel as no label at all', () => {
+      host.ariaLabel.set('   ');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe(TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+
+    /**
+     * `aria-labelledby` wins the name calculation only while its IDREF RESOLVES,
+     * so the generic fallback is withheld beside one — there it would mask a
+     * dangling reference with a name that says nothing — while an explicit
+     * `ariaLabel` is not, because it is the only name left when the reference
+     * does not resolve. These are that pair.
+     */
+    it('withholds the generic fallback when only ariaLabelledby is set', () => {
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(bar().hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('keeps an explicit ariaLabel alongside ariaLabelledby', () => {
+      host.ariaLabel.set('Restoring pool');
+      host.ariaLabelledby.set('tn-external-label');
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-labelledby')).toBe('tn-external-label');
+      expect(bar().getAttribute('aria-label')).toBe('Restoring pool');
+    });
+
+    it('omits aria-labelledby when the input is not set', () => {
+      expect(bar().hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    /**
+     * The two fixtures with a dangling IDREF scan `aria-progressbar-name` alone,
+     * not `PROGRESSBAR_RULES`. Measured: `aria-valid-attr-value` lands in
+     * `incomplete` on an `aria-labelledby` that resolves to nothing — axe will
+     * not say whether a reference it cannot follow is valid — and `axeResult`
+     * throws on an incomplete result rather than counting it either way. The
+     * name is what these two are about, and it is decidable.
+     */
+    it('still names the bar when ariaLabelledby points at nothing', async () => {
+      host.ariaLabel.set('Restoring pool');
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-progressbar-name');
+    });
+
+    /**
+     * The evidence for withholding the generic fallback beside an
+     * `ariaLabelledby` — a dangling IDREF alone is still a violation, so it is
+     * reported rather than papered over — and equally what stops the test above
+     * passing for free, by showing that axe resolves the IDREF rather than
+     * treating any `aria-labelledby` as a name.
+     */
+    it('reports a bar whose only name is an ariaLabelledby pointing at nothing', async () => {
+      host.ariaLabelledby.set('tn-no-such-element');
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, bar(), ['aria-progressbar-name']
+      );
+
+      expect(violated).toEqual(['aria-progressbar-name']);
+    });
+
+    it('reinstates the fallback if the caller clears ariaLabel again', () => {
+      host.ariaLabel.set('Restoring pool');
+      fixture.detectChanges();
+      host.ariaLabel.set(null);
+      fixture.detectChanges();
+
+      expect(bar().getAttribute('aria-label')).toBe(TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL);
+    });
+  });
+
+  /**
+   * The fallback keeps a forgotten label from reaching assistive technology as
+   * silence; this keeps it from reaching the DEVELOPER as silence. Without it,
+   * giving this component a role would have satisfied axe while leaving an
+   * unnamed bar looking correct to every check the library can run — which is
+   * the state it was already in, one level up.
+   */
+  describe('the dev-mode warning', () => {
+    function messages(): string[] {
+      return warn.mock.calls.map((call) => String(call[0]));
+    }
+
+    it('warns, naming the component, when neither input is set', () => {
+      expect(messages()).toHaveLength(1);
+      expect(messages()[0]).toContain('tn-particle-progress-bar');
+      expect(messages()[0]).toContain('ariaLabel');
+    });
+
+    it('does not warn when ariaLabel is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabel.set('Restoring pool');
+      named.detectChanges();
+      named.destroy();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when ariaLabelledby is set from the start', () => {
+      warn.mockClear();
+      const named = TestBed.createComponent(TestHostComponent);
+      named.componentInstance.ariaLabelledby.set('tn-external-label');
+      named.detectChanges();
+      named.destroy();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    // One warning per bar that stays unnamed, not one per change detection: a
+    // per-cycle warning on a component that animates by definition floods the
+    // console and trains developers to ignore it.
+    it('warns once, however many times the bar is re-rendered', () => {
+      host.fill.set(400);
+      fixture.detectChanges();
+      host.fill.set(450);
+      fixture.detectChanges();
+
+      expect(messages()).toHaveLength(1);
+    });
+
+    it('stops warning once the bar is named', () => {
+      host.ariaLabel.set('Restoring pool');
+      fixture.detectChanges();
+      warn.mockClear();
+      fixture.detectChanges();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar-a11y.spec.ts
@@ -16,13 +16,14 @@ import { axeResult } from '../a11y/axe-testing';
  * was found by a human reading the folder (#206). This one is a step further
  * again: it never claimed `role="progressbar"`, and a rule that selects on the
  * role cannot report on an element that does not carry it. Measured on the
- * unchanged component under jsdom, over five rules a progressbar can fail:
+ * unchanged component under jsdom, sweeping `svg-img-alt` and the four
+ * `PROGRESSBAR_RULES` below:
  *
  *   host attributes   class="tn-particle-progress-bar"  — and nothing else
  *   role              null
  *   aria-*            none
  *   text content      ""
- *   axe               0 violations, 0 passes, 0 incomplete
+ *   axe               0 violations, 0 passes, 0 incomplete — on all five
  *
  * Zero passes is the part that matters, and it is why this file leads with a
  * test that keeps that measurement rather than merely describing it: an empty
@@ -50,11 +51,18 @@ class TestHostComponent {
 }
 
 /**
- * The rules a progressbar in this library can fail. Named as a list so that a
- * rule which stops matching shows up as a shrinking `evaluated` in one place,
- * rather than as a quietly narrower scan in whichever test happened to name it.
+ * The rules a progressbar in this library can fail. Named as a list so that the
+ * scans below widen together rather than each naming whichever rules its author
+ * had in mind — every one of these gets to object to every fixture.
  *
- * Two fixtures below deliberately do NOT use it — the ones whose
+ * What the `evaluated` assertions then check is `aria-progressbar-name` and
+ * only that: it is the rule that selects on the role, so it is the one whose
+ * silence WAS the defect, and the one whose disappearance would make an empty
+ * `violated` vacuous again. The other three are here to fail if they ever
+ * object — a real violation from any of them lands in `violated`, which is
+ * asserted empty — not to be proven to have run.
+ *
+ * Two fixtures below deliberately do NOT use this list — the ones whose
  * `aria-labelledby` dangles, where `aria-valid-attr-value` is undecidable. The
  * reason is written beside them.
  */

--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.html
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.html
@@ -1,4 +1,14 @@
-<svg [attr.width]="width()" [attr.height]="height()">
+<!--
+  The whole drawing is hidden from assistive technology: it carries nothing the
+  host's `aria-valuenow` does not already say, and the particle `<canvas>` is
+  opaque to a screen reader in any case.
+
+  `role="progressbar"` on the host is already "children presentational" in ARIA,
+  so this is belt and braces rather than the only thing pruning the subtree —
+  but support for that pruning varies, and #209 asked for markup that states the
+  answer rather than leaving it to be inferred.
+-->
+<svg aria-hidden="true" [attr.width]="width()" [attr.height]="height()">
   <defs>
     <linearGradient id="fadeToPrimary" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" stop-color="transparent" />
@@ -8,12 +18,12 @@
   </defs>
 
   <!-- Background bar -->
-  <rect x="50" fill="rgba(0,0,0,0.1)" [attr.y]="height() / 2 - height() / 4" [attr.width]="width() - 100" [attr.height]="height() / 2" [attr.rx]="height() / 4" />
+  <rect fill="rgba(0,0,0,0.1)" [attr.x]="trackInset" [attr.y]="height() / 2 - height() / 4" [attr.width]="trackLength()" [attr.height]="height() / 2" [attr.rx]="height() / 4" />
 
   <!-- Fill bar -->
   <rect
-    x="50"
     fill="url(#fadeToPrimary)"
+    [attr.x]="trackInset"
     [attr.y]="height() / 2 - height() / 4"
     [attr.width]="fill()"
     [attr.height]="height() / 2"

--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.spec.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.spec.ts
@@ -9,6 +9,13 @@ describe('TnParticleProgressBarComponent', () => {
   let mockContext: Partial<CanvasRenderingContext2D>;
 
   beforeEach(async () => {
+    // Every fixture here is unnamed, and #209 makes an unnamed bar warn in dev
+    // mode — which Jest is. Silenced so this suite's output stays readable; the
+    // warning itself is asserted in `particle-progress-bar-a11y.spec.ts`. Not
+    // held in a variable because the existing `jest.restoreAllMocks()` below
+    // already puts it back, and nothing here asserts on it.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     // Mock canvas context
     mockContext = {
       clearRect: jest.fn(),

--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.ts
@@ -46,10 +46,10 @@ const TRACK_INSET = 50;
  * nothing else — no role, no name, no value — and because it never claimed
  * `role="progressbar"` it could not fail `aria-progressbar-name` either, so
  * every axe-based check in this library was silent on it by construction.
- * Measured on the unchanged component under jsdom, over the five rules a
- * progressbar can fail: 0 violations, 0 passes, 0 incomplete. Not clean —
- * unexamined. `particle-progress-bar-a11y.spec.ts` keeps that measurement as a
- * test.
+ * Measured on the unchanged component under jsdom, sweeping `svg-img-alt` and
+ * the four rules `particle-progress-bar-a11y.spec.ts` keeps: 0 violations, 0
+ * passes, 0 incomplete, on every one of them. Not clean — unexamined. That
+ * spec keeps the measurement as its first test.
  *
  * It is a progressbar because it is a WHOLE indicator rather than an overlay on
  * someone else's. The SVG draws its own background track and its own fill rect,

--- a/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.ts
+++ b/projects/truenas-ui/src/lib/progress-bar/particle-progress-bar.component.ts
@@ -10,7 +10,83 @@ import {
   viewChild,
   ChangeDetectionStrategy
 } from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
 
+/**
+ * The accessible name this bar falls back to when the caller names neither
+ * `ariaLabel` nor `ariaLabelledby` (#209).
+ *
+ * The same string and the same reasoning as `TN_PROGRESS_BAR_DEFAULT_LABEL`
+ * next door, and deliberately a separate constant rather than an import of it:
+ * `tnAccessibleName` takes a fallback PER COMPONENT because the least-bad
+ * generic name differs by what the component is ("Progress" for a bar,
+ * "Loading" for a spinner), and sharing the binding would make a future
+ * divergence in one a silent change to the other. Exported so specs assert
+ * against it by name rather than by a copied string literal.
+ */
+export const TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL = 'Progress';
+
+/**
+ * The gap in px between the edge of the SVG and each end of the track, on both
+ * sides — the `x` the two rects are drawn at, and half of what is subtracted
+ * from `width` to size the background.
+ *
+ * Named rather than left as the literal `50`/`100` it was, because `fill` is
+ * measured in these same px and the ARIA value is `fill` as a proportion of the
+ * track. Drawing and announcing now read the one number: an edit to the inset
+ * that missed the other would leave a bar that says "60%" while showing
+ * something else, which is the class of defect this ticket is about.
+ */
+const TRACK_INSET = 50;
+
+/**
+ * THE DECISION #209 ASKED FOR: THIS IS A PROGRESSBAR, NOT DECORATION
+ * ------------------------------------------------------------------
+ * Both readings were open. Before the change the host carried a class and
+ * nothing else — no role, no name, no value — and because it never claimed
+ * `role="progressbar"` it could not fail `aria-progressbar-name` either, so
+ * every axe-based check in this library was silent on it by construction.
+ * Measured on the unchanged component under jsdom, over the five rules a
+ * progressbar can fail: 0 violations, 0 passes, 0 incomplete. Not clean —
+ * unexamined. `particle-progress-bar-a11y.spec.ts` keeps that measurement as a
+ * test.
+ *
+ * It is a progressbar because it is a WHOLE indicator rather than an overlay on
+ * someone else's. The SVG draws its own background track and its own fill rect,
+ * and `fill` sizes the second against the first; that is a determinate progress
+ * value, whatever the particles on top of it are doing. The alternative reading
+ * — an ambient flourish shown BESIDE a real indicator, where a role would be
+ * the redundant second announcement #203 was about — needs the real indicator
+ * to exist, and nothing here provides one.
+ *
+ * The usage evidence points the same way, weakly but only in one direction. Its
+ * only consumer in this repository is its own Storybook story: it has never
+ * been placed next to a `tn-progress-bar`, so the redundancy risk is
+ * hypothetical. It IS exported from `public-api.ts`, so consumers outside this
+ * repository may already be showing it as the only progress on a screen — and
+ * that asymmetry is what settles it. Choosing `aria-hidden` would assert a
+ * usage constraint the library cannot enforce, and when that assertion is wrong
+ * a screen-reader user gets nothing at all where a sighted user sees a bar
+ * filling — strictly worse than the unnamed progressbars #202/#205/#206 fixed.
+ * Choosing the role when the component really is ambient costs a redundant
+ * announcement a consumer can silence with `aria-hidden` on its own wrapper.
+ * The two errors are not the same size.
+ *
+ * The canvas IS decoration, and that is a separate question from what the host
+ * is. It draws particles and carries no information the fill rect does not, so
+ * the whole drawing is hidden and the ARIA value is what conveys the progress —
+ * see the `aria-hidden` on the `<svg>` in the template.
+ *
+ * WHY THE VALUE IS A PERCENTAGE AND `fill` IS NOT
+ * ----------------------------------------------
+ * `fill` is a px length along the track, not a percentage — the story's control
+ * runs it 0–600 while `width` runs 200–800, so the same `fill` means different
+ * progress at different widths. `aria-valuenow` is reported on 0–100 instead,
+ * matching `tn-progress-bar`, so that two bars from one library do not announce
+ * on two different scales and no layout px reaches the accessibility tree.
+ * Assistive technology derives the percentage from the range either way; what
+ * this fixes is which range a consumer reads in the DOM.
+ */
 @Component({
   selector: 'tn-particle-progress-bar',
   standalone: true,
@@ -18,7 +94,13 @@ import {
   styleUrls: ['./particle-progress-bar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    'class': 'tn-particle-progress-bar'
+    'class': 'tn-particle-progress-bar',
+    'role': 'progressbar',
+    '[attr.aria-valuenow]': 'valuePercent()',
+    '[attr.aria-valuemin]': 'valuePercent() === null ? null : 0',
+    '[attr.aria-valuemax]': 'valuePercent() === null ? null : 100',
+    '[attr.aria-label]': 'resolvedAriaLabel()',
+    '[attr.aria-labelledby]': 'ariaLabelledby() || null'
   }
 })
 export class TnParticleProgressBarComponent implements AfterViewInit, OnDestroy {
@@ -27,8 +109,63 @@ export class TnParticleProgressBarComponent implements AfterViewInit, OnDestroy 
   height = input<number>(40);
   width = input<number>(600);
   fill = input<number>(300);
+  ariaLabel = input<string | null>(null);
+  ariaLabelledby = input<string | null>(null);
 
   canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
+
+  /** Exposed to the template so the rects and the ARIA value share one inset. */
+  readonly trackInset = TRACK_INSET;
+
+  /**
+   * The name to render, or `null` to render no `aria-label` at all — and the
+   * dev-mode warning when the caller named neither input.
+   *
+   * Both halves live in `../a11y/accessible-name`, shared with the other three
+   * progressbars in this library (#206), where the reasoning for each is set
+   * out: why an explicit `ariaLabel` always survives, and why the generic
+   * fallback is withheld beside an `ariaLabelledby`. Routed through that helper
+   * rather than given a rule of its own, which is what #209 asked for — a
+   * fourth naming rule is how `tn-branded-spinner` ended up divergent.
+   *
+   * A field initializer rather than the constructor, because it registers an
+   * `effect` and so needs an injection context; this is one, and it keeps the
+   * signal beside the inputs it reads.
+   */
+  resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-particle-progress-bar',
+    fallback: TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL,
+    activity: 'progressing',
+    ariaLabel: this.ariaLabel,
+    ariaLabelledby: this.ariaLabelledby
+  });
+
+  /** The drawable length of the track: the SVG width less the inset at each end. */
+  trackLength = computed(() => this.width() - TRACK_INSET * 2);
+
+  /**
+   * `fill` as a percentage of the track, or `null` when there is no track to
+   * measure against.
+   *
+   * Clamped, because `fill` is not: the story alone can drive it to 600 against
+   * a 500px track, where the fill rect simply overflows. `aria-valuenow` may not
+   * exceed `aria-valuemax`, and 100 is also what such a bar visually reads as —
+   * a track filled end to end. The clamp is on the announcement only; nothing
+   * here changes what is drawn.
+   *
+   * `null` on a non-positive track — `width` at or below twice the inset — is
+   * what makes the host announce as an INDETERMINATE progressbar rather than
+   * carrying a value derived from a division by zero or a negative range. The
+   * role stays either way, because "something is in progress" is true even when
+   * how far is not answerable.
+   */
+  valuePercent = computed<number | null>(() => {
+    const track = this.trackLength();
+    if (track <= 0) {
+      return null;
+    }
+    return Math.max(0, Math.min(100, (this.fill() / track) * 100));
+  });
 
   private ctx!: CanvasRenderingContext2D;
   private particles: Array<{
@@ -112,7 +249,7 @@ export class TnParticleProgressBarComponent implements AfterViewInit, OnDestroy 
       p.x += p.speed;
       p.opacity -= this.speedConfig().fadeRate;
 
-      if (p.x > 50 + this.fill() - 12 || p.opacity <= 0) {
+      if (p.x > TRACK_INSET + this.fill() - 12 || p.opacity <= 0) {
         this.particles.splice(i, 1);
         i--;
       }
@@ -130,7 +267,7 @@ export class TnParticleProgressBarComponent implements AfterViewInit, OnDestroy 
     const color = this.shades[Math.floor(Math.random() * this.shades.length)];
     const speed = speedMin + Math.random() * (speedMax - speedMin);
     this.particles.push({
-      x: 50,
+      x: TRACK_INSET,
       y: this.height() / 2 + (Math.random() * (this.height() / 2) - this.height() / 4),
       radius: Math.random() * 2 + 1,
       speed,


### PR DESCRIPTION
Fixes #209.

## The decision: it is a progressbar

The ticket asked which of two things `tn-particle-progress-bar` is, and to say so in the markup rather than by omission. The answer is **progressbar**, and the reasoning is on the component where a reader meets it before the attributes it produced.

**It is a whole indicator, not an overlay on someone else's.** The SVG draws its own background track and its own fill rect, and `fill` sizes the second against the first. That is a determinate progress value, whatever the particles on top of it are doing. The competing reading — an ambient flourish shown *beside* a real indicator, where a role would be the redundant second announcement #203 was about — needs that real indicator to exist, and nothing provides one.

**The usage evidence is weak, but it points one way only.** Its sole consumer in this repository is its own Storybook story; it has never been placed next to a `tn-progress-bar`, so the redundancy risk is hypothetical. It *is* exported from `public-api.ts`, so consumers outside this repository may already be showing it as the only progress on a screen. That asymmetry settles it: choosing `aria-hidden` asserts a usage constraint the library cannot enforce, and when that assertion is wrong a screen-reader user gets nothing at all where a sighted user sees a bar filling — strictly worse than the unnamed progressbars #202/#205/#206 fixed. Choosing the role when the component really is ambient costs a redundant announcement a consumer can silence with `aria-hidden` on its own wrapper. The two errors are not the same size.

**The canvas is decoration, and that is a separate question from what the host is.** It carries nothing the fill rect does not, so the whole `<svg>` is hidden and the ARIA value conveys the progress.

## The defect, observed first

This is a `bug` ticket, so the reproduction came before the diff. Run against the unchanged component under jsdom:

```
host attributes   class="tn-particle-progress-bar"  — and nothing else
role              null
aria-*            none
text content      ""
axe               0 violations, 0 passes, 0 incomplete
```

Swept `svg-img-alt` and the four rules the new spec keeps; zero on every one. The report is exactly right, and the interesting number is **zero passes**: a component cannot fail `aria-progressbar-name` if it never claims the role, so every axe-based check in this library was silent on it by construction. Not clean — unexamined.

That measurement is the **first test in the new spec**, not just a paragraph here, because it is what makes every other `expect(violated).toEqual([])` in the file mean something. If a future axe-core starts reporting on a roleless div like the pre-#209 markup, that test fails — which is the correct response, since it would mean the library had gained a check that could have found this component on its own.

## What changed

- **The host carries `role="progressbar"`** and names itself through `tnAccessibleName`, with new `ariaLabel`/`ariaLabelledby` inputs and its own `TN_PARTICLE_PROGRESS_BAR_DEFAULT_LABEL`. The shared rule, not a fourth one — which is what the ticket asked for, and what `tn-branded-spinner` diverging taught #206.
- **`aria-valuenow` is a percentage on a 0–100 range**, matching `tn-progress-bar`. `fill` is a px length along the track, so the raw input would announce on a scale that silently changes with `width`; a consumer reading two bars from one library should not meet two different scales, and no layout px should reach the accessibility tree. Assistive technology derives the same percentage either way.
- **Clamped, because `fill` is not.** The story alone drives `fill` to 600 against a 500px track, where the rect simply overflows. `aria-valuenow` may not exceed `aria-valuemax`, and 100 is what such a bar visually reads as. The clamp is on the announcement only; nothing changes what is drawn.
- **Withheld entirely when there is no track.** A `width` at or below twice the inset leaves nothing to measure against, so the value range is omitted and the host announces as an *indeterminate* progressbar. The role stays — "something is in progress" is still true when "how far" is not answerable — and the alternative is a value from a division by zero or a negative range.
- **The 50px track inset is named once** (`TRACK_INSET`) and shared by the rects and the value computation. It was the literal `50`/`100` in four places. `fill` is measured in those px and the ARIA value is `fill` as a proportion of the track, so an edit to the inset that missed the other would leave a bar saying "60%" while showing something else — the exact class of defect this ticket is about.
- **`aria-hidden="true"` on the `<svg>`.** `role="progressbar"` is already children-presentational in ARIA, so this is belt and braces rather than the only thing pruning the subtree — but support for that pruning varies, and the ticket asked for markup that states the answer rather than leaving it inferred.
- **`particle-progress-bar.component.spec.ts` silences the new dev-mode warning**, the same way #202/#205/#206 did in the three sibling unit specs. Every fixture there is unnamed and Jest is dev mode, so without it the suite's output is flooded. The warning itself is asserted in the a11y spec.

## Tests

New `particle-progress-bar-a11y.spec.ts` on the convention the other eleven a11y specs follow: the shared `axeResult` wrapper, `evaluated` asserted beside every empty `violated`, and a positive control. 33 tests; `particle-progress-bar.component.spec.ts` passes with only the warning-silencing change, which is what shows the ARIA additions disturbed no behaviour.

Two controls are worth calling out, since this ticket is specifically about a clean scan meaning nothing:

1. **The reported defect, kept as a test.** The pre-#209 markup is scanned for the same four rules and `evaluated` comes back **empty**. That is why `expect(violated).toEqual([])` was worth nothing on it.
2. **The rule still fires.** A `role="progressbar"` with the value attributes and no name still reports `aria-progressbar-name`. It runs through the shared `axeResult` on purpose, so it is equally the control for that wrapper — an attribution bug there would empty `violated` in every spec using it.

One measurement worth recording: **two fixtures deliberately scan `aria-progressbar-name` alone rather than the full rule list.** `aria-valid-attr-value` lands in `incomplete` on an `aria-labelledby` that resolves to nothing — axe will not say whether a reference it cannot follow is valid — and `axeResult` throws on an incomplete result rather than counting it either way. The name is what those two are about, and it is decidable. `progress-bar-a11y.spec.ts` narrows the same pair for the same reason.

Run locally: `yarn lint` (clean for every file this touches — the 4 `import/order` errors in `input.component.ts` and `menu-panel.component.ts` are pre-existing and untouched), `yarn test` (2441 passed, 103 suites), `yarn test:scripts` (42 passed), and `yarn build`. **Not run locally:** the Storybook interaction tests, which need a Playwright/Chromium install. `yarn build-storybook` was not run either.

**Not verified in a browser.** jsdom has no canvas implementation, so the spec stubs `getContext` and `requestAnimationFrame`; the drawing itself is unchanged by this diff and the geometry refactor is covered by the existing unit spec.

## Local review, and what was left

The project's own reviewer ran here in a separate process — same rubric, severity threshold and parser as the required check. **Round 1 returned nothing at or above MEDIUM** (3 LOWs), which ended the local loop.

Two of the three LOWs were comments overclaiming what the code does, so they were corrected in a second, prose-only commit:

1. Two comments said the measurement covered "five rules a progressbar can fail" while `PROGRESSBAR_RULES` lists four. Both now name what was actually swept.
2. The `PROGRESSBAR_RULES` comment claimed a rule that stopped matching would show as a shrinking `evaluated`. It would not — only `aria-progressbar-name` is asserted there. Rewritten to say what the other three are actually for.

**The third LOW is left unfixed, on purpose**, because fixing it means touching executable code and every new diff is unreviewed:

3. **`particle-progress-bar.stories.ts` has no `ariaLabel`/`ariaLabelledby` controls**, unlike the sibling fixes, so the Default story now logs the new dev-mode warning with no control to set a name. True, and it is a real gap worth a follow-up. It is also the warning behaving exactly as designed — every unnamed component in this library does the same in Storybook — so the story is telling the truth about itself.

## Not changed, and worth their own tickets

Two defects observed while reading this component, neither in scope for #209:

- **`<linearGradient id="fadeToPrimary">` is a hardcoded, non-unique id.** Two particle bars on one page collide, and the second one's fill will reference the first's gradient. Not an accessibility issue, and a real rendering bug.
- **No `prefers-reduced-motion` handling.** The component drives a permanent `requestAnimationFrame` particle loop with no way to opt out. That *is* an accessibility issue (WCAG 2.3.3), but it is a motion question rather than the role/name/value question #209 asked, and fixing it means changing the animation rather than the markup.
