### PR TITLE
NAS-142339 / 27.0.0-BETA.1 / fix(list-option): make the option checkbox presentational so it is not a nested control

### DIFF
--- a/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
@@ -241,10 +241,11 @@ describe('tn-list-option accessibility (#213)', () => {
      * anyway — the picture and the state disagreeing, from a click on the
      * picture.
      *
-     * `inert` in the template is what actually blocks the pointer; this
-     * declaration is the fallback for a browser without it, which is why it is
-     * guarded separately rather than treated as covered by the inert assertion
-     * above.
+     * Guarded separately from `inert`, and not covered by it: an inert subtree
+     * does not receive targeted mouse events, which stops the checkbox acting
+     * on a click without handing that click to the row. This declaration is
+     * what does that, so deleting it would leave the click dead rather than
+     * merely unstyled.
      */
     it('keeps the checkbox from taking the click', () => {
       expect(scssBlock('&__checkbox {')).toMatch(/pointer-events:\s*none\s*;/);

--- a/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
@@ -68,6 +68,36 @@ describe('tn-list-option accessibility (#213)', () => {
     ) as HTMLInputElement;
   }
 
+  const scss = readFileSync(join(__dirname, './list-option.component.scss'), 'utf8');
+
+  /**
+   * The body of one SCSS rule, brace-matched from its header.
+   *
+   * Two assertions below are about declarations Jest cannot observe: jsdom has
+   * no layout engine and Jest does not compile the component's SCSS, so the
+   * stylesheet is read directly — the same constraint that makes
+   * `chip-a11y.spec.ts` read its own SCSS. Brace-matched rather than regexed
+   * over the whole file, because both declarations appear in more than one rule
+   * here: `--disabled` also sets `pointer-events: none`, and `outline` is set
+   * by more than one state. Matching the wrong one would stay green with the
+   * rule under test deleted.
+   */
+  function scssBlock(header: string): string {
+    const start = scss.indexOf(header);
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const open = scss.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < scss.length; i++) {
+      if (scss[i] === '{') {
+        depth++;
+      } else if (scss[i] === '}' && --depth === 0) {
+        return scss.slice(open + 1, i);
+      }
+    }
+    throw new Error(`unterminated block for ${header}`);
+  }
+
   describe('nested-interactive', () => {
     // `evaluated` is asserted alongside every empty `violated`, because an empty
     // `violations` is also what axe returns when it evaluated nothing at all.
@@ -209,39 +239,15 @@ describe('tn-list-option accessibility (#213)', () => {
      * either. It used to swallow the click with `$event.stopPropagation()`,
      * which stopped the row from toggling while the native input flipped itself
      * anyway — the picture and the state disagreeing, from a click on the
-     * picture. `pointer-events: none` is what replaced that handler.
+     * picture.
      *
      * `inert` in the template is what actually blocks the pointer; this
      * declaration is the fallback for a browser without it, which is why it is
      * guarded separately rather than treated as covered by the inert assertion
      * above.
-     *
-     * Asserted against the stylesheet because jsdom has no layout engine and
-     * Jest does not compile the component's SCSS, so the behaviour itself is
-     * not observable here — the same constraint that makes `chip-a11y.spec.ts`
-     * read its SCSS directly. Brace-matched rather than regexed over the whole
-     * file: `--disabled` sets the identical declaration, and matching that one
-     * would be green with the checkbox rule deleted.
      */
     it('keeps the checkbox from taking the click', () => {
-      const scss = readFileSync(join(__dirname, './list-option.component.scss'), 'utf8');
-      const start = scss.indexOf('&__checkbox {');
-      expect(start).toBeGreaterThanOrEqual(0);
-
-      const open = scss.indexOf('{', start);
-      let depth = 0;
-      let end = -1;
-      for (let i = open; i < scss.length; i++) {
-        if (scss[i] === '{') {
-          depth++;
-        } else if (scss[i] === '}' && --depth === 0) {
-          end = i;
-          break;
-        }
-      }
-      expect(end).toBeGreaterThan(open);
-
-      expect(scss.slice(open + 1, end)).toMatch(/pointer-events:\s*none\s*;/);
+      expect(scssBlock('&__checkbox {')).toMatch(/pointer-events:\s*none\s*;/);
     });
   });
 
@@ -306,6 +312,24 @@ describe('tn-list-option accessibility (#213)', () => {
       fixture.detectChanges();
 
       expect(option().getAttribute('aria-selected')).toBe('false');
+    });
+
+    /**
+     * A tab stop a keyboard user cannot see is not a tab stop they can use.
+     * This rule used to be `:host(:focus) { outline: none; … }`, which cost
+     * nothing while the host could not be focused; the moment it became the
+     * option's tab stop it left focus indicated only by the background tint
+     * `:hover` already applies.
+     *
+     * Asserted on the stylesheet for the reason given on `scssBlock` — and
+     * asserted on the block rather than on the file, because `outline: none`
+     * elsewhere in it would satisfy a looser match.
+     */
+    it('draws a visible focus ring on the tab stop', () => {
+      const focusRule = scssBlock(':host(:focus-visible) {');
+
+      expect(focusRule).toMatch(/outline:\s*[1-9]/);
+      expect(focusRule).not.toMatch(/outline:\s*none/);
     });
 
     it('leaves the presentational checkbox unfocusable', () => {

--- a/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
@@ -211,6 +211,11 @@ describe('tn-list-option accessibility (#213)', () => {
      * anyway — the picture and the state disagreeing, from a click on the
      * picture. `pointer-events: none` is what replaced that handler.
      *
+     * `inert` in the template is what actually blocks the pointer; this
+     * declaration is the fallback for a browser without it, which is why it is
+     * guarded separately rather than treated as covered by the inert assertion
+     * above.
+     *
      * Asserted against the stylesheet because jsdom has no layout engine and
      * Jest does not compile the component's SCSS, so the behaviour itself is
      * not observable here — the same constraint that makes `chip-a11y.spec.ts`
@@ -262,6 +267,54 @@ describe('tn-list-option accessibility (#213)', () => {
       fixture.detectChanges();
 
       expect(option().getAttribute('aria-selected')).toBe('false');
+    });
+  });
+
+  /**
+   * Making the checkbox presentational takes away the only focusable element
+   * this component had, so the option has to become the tab stop itself — one
+   * per option either way, but now on the element that acts on the keypress.
+   *
+   * The checkbox was never a working one: it swallowed the click, so Space on
+   * the focused input flipped the input and left `aria-selected` behind. These
+   * assert the replacement is a real stop and not merely a present attribute.
+   */
+  describe('the option is reachable from the keyboard', () => {
+    it('is in the tab order', () => {
+      expect(option().tabIndex).toBe(0);
+    });
+
+    it('leaves a disabled option out of the tab order', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(option().hasAttribute('tabindex')).toBe(false);
+    });
+
+    it.each([' ', 'Enter'])('toggles selection on %s', (key) => {
+      option().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-selected')).toBe('true');
+    });
+
+    it.each([' ', 'Enter'])('does not toggle on %s when disabled', (key) => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      option().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('leaves the presentational checkbox unfocusable', () => {
+      // `inert` is what does this in a browser. jsdom does not implement it, so
+      // the assertion is on the attribute that carries the intent rather than
+      // on `document.activeElement` — which here would report the input as
+      // focused and say nothing about the shipped behaviour.
+      expect(checkboxWrapper().hasAttribute('inert')).toBe(true);
+      expect(checkboxInput().hasAttribute('tabindex')).toBe(false);
     });
   });
 

--- a/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
@@ -1,0 +1,307 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnListOptionComponent } from './list-option.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the structure fixed for #213: `tn-list-option` sets `role="option"` on
+ * its host and rendered a `tn-checkbox` — a real `<input type="checkbox">` —
+ * inside it, which fails axe's `nested-interactive` rule. Assistive technology
+ * flattens the inner control, so a listener hears the selection twice and finds
+ * a control that is not theirs to operate.
+ *
+ * Same family as #188 (chip) and #194 (banner/radio/checkbox), and the same
+ * rule, but the fix is the opposite shape. The chip had two real controls and
+ * had to stop nesting them; the option has ONE control — the option itself,
+ * whose selection `aria-selected` on the host already reports — so the checkbox
+ * is a picture of that state rather than a second control. It is made
+ * presentational instead of being restructured.
+ *
+ * `nested-interactive` is pure DOM structure and axe evaluates it correctly
+ * under jsdom — verified by watching it report the violation on the real
+ * component before the fix, not only on the reconstructed markup in the
+ * positive control below.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnListOptionComponent],
+  template: `<tn-list-option [selected]="selected()" [disabled]="disabled()">Option one</tn-list-option>`
+})
+class TestHostComponent {
+  selected = signal(false);
+  disabled = signal(false);
+}
+
+describe('tn-list-option accessibility (#213)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document itself, which axe needs — it
+    // walks up to the document root to decide visibility, and treats a detached
+    // tree as hidden and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function option(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-list-option') as HTMLElement;
+  }
+
+  function checkboxWrapper(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-list-option__checkbox') as HTMLElement;
+  }
+
+  function checkboxInput(): HTMLInputElement {
+    return fixture.nativeElement.querySelector(
+      '.tn-list-option__checkbox input[type="checkbox"]'
+    ) as HTMLInputElement;
+  }
+
+  describe('nested-interactive', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing at all.
+    // It is non-vacuous here: the rule selects on widget role and the host
+    // carries `role="option"`, so the host is the node it both passes and — as
+    // the positive control below shows — fails on.
+    it('raises no violation on an unselected option', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, option(), ['nested-interactive']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('nested-interactive');
+    });
+
+    it('raises no violation on a selected option', async () => {
+      host.selected.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, option(), ['nested-interactive']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('nested-interactive');
+    });
+
+    /**
+     * A disabled option would pass this rule whatever the template said: axe
+     * treats a `disabled` native control as unfocusable, so the checkbox stops
+     * being a nested WIDGET the moment `[disabled]` is bound through to it.
+     * The case is asserted because it is the one users of a disabled list hit,
+     * not because it discriminates — the two above are what discriminate.
+     */
+    it('raises no violation on a disabled option', async () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, option(), ['nested-interactive']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('nested-interactive');
+    });
+
+    /**
+     * Positive control, and the strongest guard in this spec — the only one that
+     * shows axe FAILING on the defect rather than passing on the fix.
+     *
+     * Every assertion above is `toEqual([])`, which is also what axe returns
+     * when it evaluates nothing at all: an upgrade that narrows which nodes the
+     * rule selects, or a jsdom change that makes the tree invisible to it.
+     * (Renaming or dropping the rule outright is the case that does not go
+     * quiet — axe rejects with "Could not find configured rule".) This rebuilds
+     * the structure `tn-list-option` had before #213 and requires axe to still
+     * object to it.
+     *
+     * The `tabindex="-1"` is on the WRAPPER and not on the input, because that
+     * is where the old template had it — on the `<tn-checkbox>` element rather
+     * than on the native control inside it. Reproducing that placement is the
+     * point: it is what made the old markup look fixed while axe still walked
+     * past the wrapper and found a focusable checkbox underneath.
+     *
+     * It runs through the shared `axeResult` on purpose, so it is also the
+     * control for that wrapper: an attribution bug there — a filter that matched
+     * nothing — would empty `violated` in every spec that uses it, and this is
+     * the assertion that would catch it.
+     */
+    it('still reports the violation for the structure the option used to have', async () => {
+      const previous = document.createElement('div');
+      previous.innerHTML =
+        '<div role="option" aria-selected="false" aria-disabled="false">'
+        + '<span>Option one</span>'
+        + '<span tabindex="-1"><input type="checkbox" aria-label="Checkbox" /></span>'
+        + '</div>';
+      document.body.appendChild(previous);
+
+      // try/finally, because `axeResult` throws rather than returning a vacuous
+      // pass — and a fixture left in `document.body` by that throw would be
+      // scanned by every later test in this file.
+      let violated: string[];
+      try {
+        ({ violated } = await axeResult(
+          previous, previous.querySelector('[role="option"]'), ['nested-interactive']
+        ));
+      } finally {
+        previous.remove();
+      }
+
+      expect(violated).toEqual(['nested-interactive']);
+    });
+  });
+
+  /**
+   * `inert` is what removes the checkbox from the accessibility tree AND from
+   * the focus order in one attribute. `aria-hidden="true"` alone would do only
+   * the first half: the native input stays focusable, which leaves
+   * `nested-interactive` reporting exactly as before and adds an
+   * `aria-hidden-focus` violation of its own. The same reasoning is already
+   * written into `expansion-panel.component.html`.
+   */
+  describe('the checkbox is presentational', () => {
+    it('marks the checkbox subtree inert', () => {
+      expect(checkboxWrapper().hasAttribute('inert')).toBe(true);
+    });
+
+    it('leaves no aria-hidden container holding a focusable control', async () => {
+      const { violated } = await axeResult(
+        fixture.nativeElement, [option(), checkboxWrapper()],
+        ['aria-hidden-focus', 'nested-interactive']
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    it('still renders the checkbox, so selection stays visible', () => {
+      expect(checkboxInput()).not.toBeNull();
+    });
+
+    it('reflects selection on the rendered checkbox', () => {
+      expect(checkboxInput().checked).toBe(false);
+
+      host.selected.set(true);
+      fixture.detectChanges();
+
+      expect(checkboxInput().checked).toBe(true);
+    });
+
+    it('reflects the disabled state on the rendered checkbox', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(checkboxInput().disabled).toBe(true);
+    });
+
+    /**
+     * The other half of "presentational": the checkbox must not take the mouse
+     * either. It used to swallow the click with `$event.stopPropagation()`,
+     * which stopped the row from toggling while the native input flipped itself
+     * anyway — the picture and the state disagreeing, from a click on the
+     * picture. `pointer-events: none` is what replaced that handler.
+     *
+     * Asserted against the stylesheet because jsdom has no layout engine and
+     * Jest does not compile the component's SCSS, so the behaviour itself is
+     * not observable here — the same constraint that makes `chip-a11y.spec.ts`
+     * read its SCSS directly. Brace-matched rather than regexed over the whole
+     * file: `--disabled` sets the identical declaration, and matching that one
+     * would be green with the checkbox rule deleted.
+     */
+    it('keeps the checkbox from taking the click', () => {
+      const scss = readFileSync(join(__dirname, './list-option.component.scss'), 'utf8');
+      const start = scss.indexOf('&__checkbox {');
+      expect(start).toBeGreaterThanOrEqual(0);
+
+      const open = scss.indexOf('{', start);
+      let depth = 0;
+      let end = -1;
+      for (let i = open; i < scss.length; i++) {
+        if (scss[i] === '{') {
+          depth++;
+        } else if (scss[i] === '}' && --depth === 0) {
+          end = i;
+          break;
+        }
+      }
+      expect(end).toBeGreaterThan(open);
+
+      expect(scss.slice(open + 1, end)).toMatch(/pointer-events:\s*none\s*;/);
+    });
+  });
+
+  /**
+   * Removing the checkbox's click handler is part of the fix, so the toggle it
+   * used to suppress is worth pinning down: a click anywhere on the row — the
+   * only control here — still moves the option's own state, which is what
+   * `aria-selected` reports.
+   */
+  describe('the option is still the control', () => {
+    it('toggles selection when the row is clicked', () => {
+      option().click();
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('does not toggle when the option is disabled', () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      option().click();
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-selected')).toBe('false');
+    });
+  });
+
+  /**
+   * The host's own ARIA is the half of the fix that was already right, and the
+   * half a "just delete the checkbox" regression would take down with it: with
+   * the checkbox presentational, `aria-selected` is the ONLY thing left telling
+   * a listener whether the option is picked.
+   */
+  describe('the option reports its own state', () => {
+    it('reports selection through aria-selected', () => {
+      expect(option().getAttribute('aria-selected')).toBe('false');
+
+      host.selected.set(true);
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('reports the disabled state through aria-disabled', () => {
+      expect(option().getAttribute('aria-disabled')).toBe('false');
+
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(option().getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('keeps role="option" on the host', () => {
+      expect(option().getAttribute('role')).toBe('option');
+    });
+
+    it('raises no ARIA violation for the attributes it sets', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, option(),
+        ['aria-allowed-attr', 'aria-valid-attr-value']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-valid-attr-value');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.html
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.html
@@ -39,13 +39,14 @@
        order in one attribute — the same reasoning already written into
        expansion-panel.component.html.
 
-       `inert` covers the pointer too, so the click handler that used to sit
-       here goes with it. It stopped a checkbox click from reaching the host's
-       toggle, which left the native input flipping itself while the option's
-       own selection did not move; the click now lands on the row and toggles
-       the option once, as a click anywhere else on the row already did. The
-       stylesheet's `pointer-events: none` is belt and braces for a browser
-       without `inert` — see the comment there.
+       The mouse is the stylesheet's job, not `inert`'s. An inert subtree does
+       not RECEIVE targeted mouse events, which is not the same as passing them
+       on, so `pointer-events: none` in `&__checkbox` is what actually puts the
+       click on the row — see the comment there. That is what replaces the
+       `$event.stopPropagation()` this element used to carry: the handler kept a
+       checkbox click from reaching the host's toggle, leaving the native input
+       to flip itself while the option's own selection did not move. The click
+       now toggles the option once, as a click anywhere else on the row did.
 
        `select.component.html` makes the same nested checkbox presentational a
        different way, with `[disabled]="true"`. That also stops axe reporting,

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.html
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.html
@@ -22,13 +22,32 @@
     }
   </div>
 
-  <!-- Checkbox on the right -->
-  <div class="tn-list-option__checkbox">
+  <!-- Checkbox on the right: a PICTURE of the option's selection, not a second
+       control. The host carries role="option" and binds aria-selected, which is
+       how a listbox option is supposed to report selection, so a real checkbox
+       in here says the same thing twice and offers a control that is not the
+       listener's to operate. axe scores that `nested-interactive` (#213).
+
+       `inert` rather than aria-hidden, and rather than the tabindex="-1" this
+       used to carry. The tabindex was on the <tn-checkbox> ELEMENT, not on the
+       native <input> inside it, so the control stayed focusable and axe kept
+       reporting — and even on the input it would only have left the tab order,
+       which axe explicitly treats as an unreliable way to hide a widget.
+       aria-hidden="true" fixes the other half only: the input stays focusable,
+       so nested-interactive still reports and aria-hidden-focus joins it.
+       `inert` removes the subtree from the accessibility tree AND the focus
+       order in one attribute — the same reasoning already written into
+       expansion-panel.component.html.
+
+       The click handler that used to sit here stopped a checkbox click from
+       reaching the host's toggle, which left the native input flipping itself
+       while the option's own state did not move. `pointer-events: none` in the
+       stylesheet replaces it: the click lands on the row and toggles the option
+       once, which is what a click anywhere else on the row already did. -->
+  <div class="tn-list-option__checkbox" inert>
     <tn-checkbox
-      tabindex="-1"
       [checked]="effectiveSelected()"
       [disabled]="effectiveDisabled()"
-      [hideLabel]="true"
-      (click)="$event.stopPropagation()" />
+      [hideLabel]="true" />
   </div>
 </div>

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.html
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.html
@@ -39,11 +39,21 @@
        order in one attribute — the same reasoning already written into
        expansion-panel.component.html.
 
-       The click handler that used to sit here stopped a checkbox click from
-       reaching the host's toggle, which left the native input flipping itself
-       while the option's own state did not move. `pointer-events: none` in the
-       stylesheet replaces it: the click lands on the row and toggles the option
-       once, which is what a click anywhere else on the row already did. -->
+       `inert` covers the pointer too, so the click handler that used to sit
+       here goes with it. It stopped a checkbox click from reaching the host's
+       toggle, which left the native input flipping itself while the option's
+       own selection did not move; the click now lands on the row and toggles
+       the option once, as a click anywhere else on the row already did. The
+       stylesheet's `pointer-events: none` is belt and braces for a browser
+       without `inert` — see the comment there.
+
+       `select.component.html` makes the same nested checkbox presentational a
+       different way, with `[disabled]="true"`. That also stops axe reporting,
+       because axe treats a disabled native control as unfocusable, but it
+       greys the checkbox through `tn-checkbox--disabled` and it is not
+       available here: this option binds `[disabled]` to its OWN disabled
+       state, which has to keep meaning what it says. -->
+
   <div class="tn-list-option__checkbox" inert>
     <tn-checkbox
       [checked]="effectiveSelected()"

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.scss
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.scss
@@ -64,6 +64,11 @@
     position: relative;
     display: flex;
     align-items: center;
+    // The checkbox is presentational (see the template's `inert`), so it must
+    // not swallow the click either: without this, a click on the checkbox
+    // toggles the native input and leaves the option's own state where it was.
+    // With it, the click reaches the row and toggles the option once.
+    pointer-events: none;
   }
 
 

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.scss
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.scss
@@ -64,14 +64,13 @@
     position: relative;
     display: flex;
     align-items: center;
-    // Belt and braces for the pointer half of "presentational". `inert` in the
-    // template is what actually removes this subtree from hit testing, and in
-    // every browser that supports it this declaration changes nothing; it is
-    // here for the ones that do not, where an inert checkbox would still take
-    // the click, toggle its own native input, and leave the option's selection
-    // where it was — which is the desync the `$event.stopPropagation()` handler
-    // it replaces used to produce. Either way the click reaches the row and
-    // toggles the option once.
+    // The pointer half of "presentational", and the template's `inert` does not
+    // cover it: an inert subtree does not RECEIVE targeted mouse events, which
+    // stops the checkbox acting on a click without handing that click to
+    // anything else. This is what puts it on the row, so clicking the checkbox
+    // toggles the option exactly as clicking its label does — where the
+    // `$event.stopPropagation()` this replaces produced the opposite, a native
+    // input flipping itself while the option's own selection stayed put.
     pointer-events: none;
   }
 

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.scss
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.scss
@@ -64,10 +64,14 @@
     position: relative;
     display: flex;
     align-items: center;
-    // The checkbox is presentational (see the template's `inert`), so it must
-    // not swallow the click either: without this, a click on the checkbox
-    // toggles the native input and leaves the option's own state where it was.
-    // With it, the click reaches the row and toggles the option once.
+    // Belt and braces for the pointer half of "presentational". `inert` in the
+    // template is what actually removes this subtree from hit testing, and in
+    // every browser that supports it this declaration changes nothing; it is
+    // here for the ones that do not, where an inert checkbox would still take
+    // the click, toggle its own native input, and leave the option's selection
+    // where it was — which is the desync the `$event.stopPropagation()` handler
+    // it replaces used to produce. Either way the click reaches the row and
+    // toggles the option once.
     pointer-events: none;
   }
 

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.scss
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.scss
@@ -132,8 +132,20 @@
   }
 }
 
-:host(:focus) {
-  outline: none;
+// The host is the tab stop now (#213), so its focus has to be visible AS focus.
+// This rule used to set `outline: none` and tint the background, which was
+// harmless while nothing in the option could be focused at all — the only
+// focusable element was the checkbox's own input, and that drew its own ring.
+// With a real tab stop here, `outline: none` would leave a keyboard user with
+// nothing but the tint `:hover` already uses, which does not tell them where
+// focus is.
+//
+// The offset is inset rather than the +2px the chip uses: options sit flush
+// against each other in a list, so an outward ring would be clipped by, or
+// overlap, the neighbouring option.
+:host(:focus-visible) {
+  outline: 2px solid var(--tn-primary);
+  outline-offset: -2px;
 
   .tn-list-option__content {
     background-color: var(--tn-alt-bg2);

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -15,6 +15,26 @@ import { TnCheckboxComponent } from '../checkbox/checkbox.component';
     '[class.tn-list-option--selected]': 'effectiveSelected()',
     '[class.tn-list-option--disabled]': 'effectiveDisabled()',
     'role': 'option',
+    // The option is the control, so it has to be the tab stop. Before #213 the
+    // only focusable thing in here was the nested checkbox's native <input>,
+    // and reaching it did nothing useful: the checkbox swallowed the click, so
+    // Space flipped the input and left the option's own selection where it was.
+    // Making the checkbox presentational removes that tab stop, and the
+    // keydown.space / keydown.enter handlers below have always needed one —
+    // the host was never focusable, so they could not fire. This is what makes
+    // them reachable, and it keeps the count the same: one tab stop per option,
+    // now on the element that acts on it.
+    //
+    // A listbox should really manage a single roving tabindex across its
+    // options rather than making each one a stop; tn-selection-list has no
+    // keyboard handling at all today, so that is its own piece of work and is
+    // proposed on the PR rather than done here.
+    //
+    // A disabled option is left out of the tab order, matching the
+    // `pointer-events: none` the disabled modifier already sets — every other
+    // route into toggle() is closed for it, so offering focus would only be a
+    // stop where nothing happens.
+    '[attr.tabindex]': 'effectiveDisabled() ? null : 0',
     '[attr.aria-selected]': 'effectiveSelected()',
     '[attr.aria-disabled]': 'effectiveDisabled()'
   }


### PR DESCRIPTION
Fixes #213.

`tn-list-option` sets `role="option"` on its host and rendered a `tn-checkbox` — a real `<input type="checkbox">` — inside it, so axe reported `nested-interactive` (serious) on every enabled option. Assistive technology flattens the inner control: a listener hears the selection twice and finds a control that is not theirs to operate.

## The model chosen: presentational, via `inert`

The ticket asked which model this took. The checkbox is now a **picture of the option's selection, not a second control**. The host already binds `aria-selected` from `effectiveSelected()`, which is how a listbox option is supposed to report selection, so the checkbox had nothing left to say.

`inert` on the checkbox wrapper, rather than the two alternatives:

- **`tabindex="-1"`**, which the template already carried, is not a fix. It sat on the `<tn-checkbox>` *element*, not on the native `<input>` inside it, so the control stayed focusable and axe kept reporting. Even on the input it would only have left the tab order — which axe explicitly classifies as an unreliable way to hide a widget (`usesUnreliableHidingStrategy`, and it changes the violation's message rather than clearing it).
- **`aria-hidden="true"`** fixes one half only. The input stays focusable, so `nested-interactive` still reports *and* `aria-hidden-focus` joins it.

`inert` removes the subtree from the accessibility tree and the focus order together. `expansion-panel.component.html` already carries the same reasoning.

`select.component.html` reaches the same end a third way, with `[disabled]="true"` on its nested checkbox. That also silences axe — a disabled native control is unfocusable — but it greys the checkbox through `tn-checkbox--disabled`, and it is not available here anyway: this option binds `[disabled]` to its *own* disabled state, which has to keep meaning what it says. The template notes the divergence so the next reader does not have to rediscover it.

## Two consequences that had to be handled

**The option is now the tab stop.** Making the checkbox presentational removed the only focusable element in the component, and nothing replaced it: the host had no `tabindex` and `tn-selection-list` does no roving focus, so a keyboard user would have had no way into an option at all. The host takes `tabindex="0"` instead.

That keeps the count the same — one tab stop per option, before and after — and puts it on the element that acts on the keypress. The `keydown.space` / `keydown.enter` handlers have been on this component all along and could never fire, because the host was never focusable. The old stop was not a working one either: the checkbox swallowed the click, so Space on the focused input flipped the input and left `aria-selected` behind it. A disabled option is left out of the tab order, matching the `pointer-events: none` its disabled modifier already sets.

**Focus had to become visible.** `:host(:focus)` set `outline: none` and tinted the background — free while nothing here could be focused, and a real problem the moment the host became a tab stop, since the tint is the same one `:hover` applies. It is now `:host(:focus-visible)` with the 2px `--tn-primary` ring the chip uses, inset rather than offset outwards because options sit flush against each other in a list.

**The checkbox's `(click)="$event.stopPropagation()"` is gone**, replaced by `pointer-events: none` on its wrapper. `inert` does not cover this: an inert subtree does not *receive* targeted mouse events, which stops the checkbox acting on a click without handing that click to anything else. `pointer-events: none` is what puts the click on the row. The old handler produced a desync — the native input flipped itself while the option's selection stayed put — and a click on the checkbox now toggles the option once, as a click anywhere else on the row already did.

## Tests

`list-option-a11y.spec.ts`, through the shared `axeResult` wrapper in `lib/a11y/axe-testing.ts`, with a **positive control** that rebuilds the pre-fix markup — `tabindex="-1"` on the wrapper and a native checkbox underneath it, which is where the old template actually had it — and requires axe to still object.

Confirmed by running the spec against the old template before touching it: it failed on the unselected and selected cases and **not** on the disabled one. That is expected and is called out in the spec — axe treats a `disabled` native control as unfocusable, so a disabled option passes this rule whatever the template says, and that case never discriminated.

Also covered: `aria-selected` and `aria-disabled` still track their inputs and `role="option"` is unchanged; the checkbox still renders and still reflects both; click and Space/Enter toggle the option and do nothing when it is disabled; the host is in the tab order and a disabled option is not.

Two assertions read `list-option.component.scss` directly, because jsdom has no layout engine and Jest does not compile the component's SCSS — the same constraint that makes `chip-a11y.spec.ts` read its own stylesheet. Both are brace-matched to the rule under test, since `pointer-events: none` and `outline` each appear in more than one rule in that file.

## Checks run locally

`yarn lint`, `yarn test` (104 suites, 2465 tests), `yarn build`. Lint reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither of them touched here. `yarn test:scripts` and the Storybook interaction tests were not run locally.

**Local review: clean.** The project's own reviewer ran here — same rubric, threshold and parser as the required check — and the third round returned nothing at MEDIUM or above. Two rounds preceded it, one HIGH (the missing tab stop) and one MEDIUM (the missing focus ring), both fixed above and both re-reviewed. A fourth commit after the clean round corrects comments only — three of them had `inert` and `pointer-events` the wrong way round — and was not re-reviewed, per the prose-only exception in the developer prompt.

## Findings left unfixed, and why

All LOW. Recorded here so the reviewer on this PR and the next ticket can see them rather than rediscover them:

- **No roving tabindex.** Every option is its own tab stop, so a long list costs one Tab press per option. `tn-selection-list` has `role="listbox"` and no keyboard handling whatever — no arrow keys, no focus management — so the fix is a listbox-level piece of work, not an option-level one. Proposed as its own ticket on #213.
- **A disabled option is dropped from the tab order** rather than staying focusable with `aria-disabled`, which APG suggests for discoverability. Every other route into `toggle()` is already closed for a disabled option, including `pointer-events: none`, so a focusable stop there would be one where nothing happens. Worth revisiting alongside the roving-tabindex work, where focus management is the subject.
- **A browser without `inert`** would leave the inner input focusable and `nested-interactive` real, since the `tabindex="-1"` is gone. `inert` has been in Chrome since 102, Safari 15.5 and Firefox 112.
- **No test covers a click on the checkbox area toggling the option in a real browser.** The SCSS assertion is a proxy; a Storybook play function would cover it for real.
- **The focus ring is drawn on the host, which has no `border-radius`, while the tint sits on `.tn-list-option__content`, which rounds to 4px.** The inset offset keeps the ring inside the row either way; squaring the two would mean deciding which element owns the row's shape.
