### PR TITLE
NAS-142342 / 27.0.0-BETA.1 / fix(drawer,side-panel): name the surface, and make it inert while closed

### DIFF
--- a/projects/truenas-ui/src/lib/a11y/accessible-name.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name.ts
@@ -68,6 +68,13 @@ export interface TnAccessibleNameConfig {
    * `'progressing'` for a progress bar, `'loading'` for a spinner.
    */
   activity: string;
+  /**
+   * Appended to the warning when the component has a naming route of its own
+   * that the standard advice does not mention — `tn-side-panel` names itself
+   * from `title`, so a developer sent only to `ariaLabel` is sent to the wrong
+   * input. Optional: the three progressbars have no such route and pass nothing.
+   */
+  hint?: string;
   /** The component's `ariaLabel` input. */
   ariaLabel: Signal<string | null>;
   /** The component's `ariaLabelledby` input. */
@@ -111,6 +118,7 @@ export function tnAccessibleName(config: TnAccessibleNameConfig): Signal<string 
           `[${config.selector}] No ariaLabel or ariaLabelledby was set, so it falls back to `
           + `"${config.fallback}". Assistive technology cannot say WHAT is ${config.activity} `
           + `— pass ariaLabel, or ariaLabelledby pointing at visible text.`
+          + (config.hint ? ` ${config.hint}` : '')
         );
       }
     });

--- a/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
@@ -1,0 +1,438 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnDrawerContainerComponent } from './drawer-container.component';
+import { TnDrawerContentComponent } from './drawer-content.component';
+import { TN_DRAWER_DEFAULT_LABEL, TnDrawerComponent } from './drawer.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the ARIA structure of the drawer family after #214.
+ *
+ * WHAT WAS REPORTED, AND WHAT WAS ACTUALLY THERE
+ * ----------------------------------------------
+ * The ticket reported axe evaluating ZERO rules against `tn-drawer-container`.
+ * Measured against the unchanged component that is exactly right, and it is not
+ * a defect in the container: it renders `<ng-content />` and a stylesheet, so a
+ * container with nothing in it has nothing for a rule to match. The scan in the
+ * report was the childless case — the same way #204's turned out to be a stepper
+ * with no steps. `the reported scan` at the bottom keeps that measurement.
+ *
+ * The surface a user perceives is `tn-drawer`, and it already declared a model,
+ * one per mode: `role="navigation"` in `side` mode, `role="dialog"` with
+ * `aria-modal="true"` and a `cdkTrapFocus` in `over` mode. Escape, the backdrop
+ * click and focus restoration were implemented for `over` before this ticket.
+ *
+ * WHY THE CONTAINER STILL GETS NO ROLE
+ * ------------------------------------
+ * Giving it one would put a second, unnamed thing in the accessibility tree
+ * between a listener and the drawer, describing a flex row. `the container is a
+ * layout box` asserts that from both sides: nothing is attributed to the
+ * container, and the drawer inside it is what the rules do report on.
+ *
+ * WHAT WAS REALLY MISSING
+ * -----------------------
+ * - **A name in the default configuration.** `ariaLabel` defaults to
+ *   `undefined`, so an `over` drawer was a modal dialog with no name at all —
+ *   `aria-dialog-name`, measured. In `side` mode the same omission leaves a
+ *   `navigation` landmark unnamed, which axe does not report while a page has
+ *   only one.
+ * - **Inertness when closed.** The panel keeps whatever was projected into it
+ *   under `aria-hidden="true"`, so a keyboard user could Tab into a closed
+ *   drawer. axe cannot decide `aria-hidden-focus` under jsdom, and `axeResult`
+ *   throws on an undecided rule rather than counting it either way — so that
+ *   half is asserted against the DOM.
+ */
+
+@Component({
+  selector: 'tn-drawer-a11y-host',
+  standalone: true,
+  imports: [TnDrawerContainerComponent, TnDrawerComponent, TnDrawerContentComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger">Toggle</button>
+    <h2 id="external-title">Datasets</h2>
+    <tn-drawer-container>
+      <tn-drawer
+        [mode]="mode()"
+        [ariaLabel]="ariaLabel()"
+        [ariaLabelledby]="ariaLabelledby()"
+        [(opened)]="opened">
+        <button type="button" id="in-drawer">Pools</button>
+      </tn-drawer>
+      <tn-drawer-content>
+        <p>Main content</p>
+      </tn-drawer-content>
+    </tn-drawer-container>
+  `,
+})
+class DrawerA11yHostComponent {
+  mode = signal<'side' | 'over'>('side');
+  opened = signal(false);
+  ariaLabel = signal<string | undefined>(undefined);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+@Component({
+  selector: 'tn-bare-container-host',
+  standalone: true,
+  imports: [TnDrawerContainerComponent],
+  template: '<tn-drawer-container><p>Nothing but content</p></tn-drawer-container>',
+})
+class BareContainerHostComponent {}
+
+/**
+ * The rules a drawer panel's structure can be wrong under.
+ *
+ * `aria-dialog-name` is the one the fix is about in `over` mode. `aria-roles`
+ * and `aria-allowed-role` cover the mode-dependent role itself, and the three
+ * attribute rules cover `aria-modal`, `aria-label` and `aria-labelledby` landing
+ * on it.
+ *
+ * NOT `aria-hidden-focus` and NOT `color-contrast`: both come back `incomplete`
+ * under jsdom, and `axeResult` throws on an undecided rule rather than letting
+ * it satisfy an `evaluated` assertion while contributing nothing to `violated`.
+ * `a closed drawer is inert` covers the first from the DOM side.
+ *
+ * NOT `landmark-unique` either, which is the one that would report an unnamed
+ * `navigation` landmark — it needs two landmarks of the same role and name to
+ * report anything, so a single drawer cannot exercise it. `two side drawers`
+ * below is where it earns its place.
+ */
+const PANEL_RULES = [
+  'aria-dialog-name',
+  'aria-allowed-attr',
+  'aria-required-attr',
+  'aria-valid-attr-value',
+  'aria-allowed-role',
+  'aria-roles',
+  'nested-interactive',
+];
+
+describe('drawer accessibility (#214)', () => {
+  let fixture: ComponentFixture<DrawerA11yHostComponent>;
+  let host: DrawerA11yHostComponent;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawerA11yHostComponent, BareContainerHostComponent],
+    }).compileComponents();
+
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    fixture = TestBed.createComponent(DrawerA11yHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // In `over` mode the panel is portaled to document.body and only removed on
+    // destroy, so without this a later fixture scans the previous one's panel.
+    fixture.destroy();
+    warn.mockRestore();
+  });
+
+  /** Side mode renders inline; over mode is portaled to `document.body`. */
+  function panel(): HTMLElement {
+    return (host.mode() === 'over'
+      ? document.body.querySelector('.tn-drawer__panel--over')
+      : fixture.nativeElement.querySelector('.tn-drawer__panel')) as HTMLElement;
+  }
+
+  /** The tree a scan has to be rooted at for the panel to be inside it. */
+  function root(): HTMLElement {
+    return (host.mode() === 'over'
+      ? panel().parentElement
+      : fixture.nativeElement) as HTMLElement;
+  }
+
+  function container(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-drawer-container') as HTMLElement;
+  }
+
+  function openOver(): void {
+    host.mode.set('over');
+    host.opened.set(true);
+    fixture.detectChanges();
+  }
+
+  describe('the container is a layout box', () => {
+    it('renders no role, no landmark and no name of its own', () => {
+      expect(container().getAttribute('role')).toBeNull();
+      expect(container().getAttribute('aria-label')).toBeNull();
+      expect(container().getAttribute('aria-labelledby')).toBeNull();
+    });
+
+    /**
+     * The reported measurement, kept as a test: a container with nothing in it
+     * has nothing for a rule to match, so `violated` and `evaluated` are BOTH
+     * empty. This is what made the report's clean scan meaningless, and it is
+     * why every assertion below names `evaluated`.
+     */
+    it('evaluates no rule at all when it holds nothing, which is the reported scan', async () => {
+      const bare = TestBed.createComponent(BareContainerHostComponent);
+      bare.detectChanges();
+      const bareContainer = bare.nativeElement.querySelector('tn-drawer-container') as HTMLElement;
+
+      try {
+        const { violated, evaluated } = await axeResult(
+          bare.nativeElement, bareContainer, PANEL_RULES
+        );
+
+        expect(evaluated).toEqual([]);
+        expect(violated).toEqual([]);
+      } finally {
+        bare.destroy();
+      }
+    });
+
+    /**
+     * The other side of the same claim: with a drawer inside, rules DO run —
+     * and axe attributes them to the drawer's panel, never to the container.
+     * A role added to the container would break this, which is the point.
+     */
+    it('holds a drawer that the rules are attributed to instead', async () => {
+      host.opened.set(true);
+      fixture.detectChanges();
+
+      const onPanel = await axeResult(root(), panel(), PANEL_RULES);
+      const onContainer = await axeResult(root(), container(), PANEL_RULES);
+
+      expect(onPanel.evaluated.length).toBeGreaterThan(0);
+      expect(onContainer.evaluated).toEqual([]);
+    });
+  });
+
+  describe('the model each mode declares', () => {
+    it('is a navigation landmark in side mode, which the page stays usable behind', () => {
+      expect(panel().getAttribute('role')).toBe('navigation');
+      expect(panel().getAttribute('aria-modal')).toBeNull();
+    });
+
+    it('is a modal dialog in over mode', () => {
+      openOver();
+
+      expect(panel().getAttribute('role')).toBe('dialog');
+      expect(panel().getAttribute('aria-modal')).toBe('true');
+    });
+
+    // `aria-modal` is a claim about the rest of the page being unavailable, so
+    // it must not outlive the focus trap that makes it true.
+    it('drops aria-modal when the over drawer closes', () => {
+      openOver();
+      host.opened.set(false);
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-modal')).toBeNull();
+    });
+  });
+
+  describe('the drawer has a name', () => {
+    it('falls back to a generic name when the caller sets neither input', () => {
+      expect(panel().getAttribute('aria-label')).toBe(TN_DRAWER_DEFAULT_LABEL);
+    });
+
+    it('warns in dev mode when it falls back', () => {
+      expect(warn).toHaveBeenCalled();
+      expect(warn.mock.calls[0][0]).toContain('[tn-drawer]');
+    });
+
+    it('takes an explicit ariaLabel', () => {
+      host.ariaLabel.set('Storage navigation');
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-label')).toBe('Storage navigation');
+    });
+
+    it('takes an ariaLabelledby, and renders no fallback label beside it', () => {
+      host.ariaLabelledby.set('external-title');
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-labelledby')).toBe('external-title');
+      expect(panel().getAttribute('aria-label')).toBeNull();
+    });
+
+    it('names the over-mode dialog too, which is where axe reported it', async () => {
+      openOver();
+
+      expect(panel().getAttribute('aria-label')).toBe(TN_DRAWER_DEFAULT_LABEL);
+
+      const { violated, evaluated } = await axeResult(root(), panel(), PANEL_RULES);
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+  });
+
+  describe('axe over the open panel', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing — which is
+    // the defect this ticket reported, not a hypothetical.
+    it('raises no violation in side mode, and does evaluate the rules', async () => {
+      host.opened.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(root(), panel(), PANEL_RULES);
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-allowed-attr');
+      expect(evaluated).toContain('aria-roles');
+    });
+
+    it('raises no violation in over mode, labelled by the caller', async () => {
+      host.ariaLabel.set('Storage navigation');
+      openOver();
+
+      const { violated, evaluated } = await axeResult(root(), panel(), PANEL_RULES);
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+  });
+
+  describe('what a closed drawer exposes', () => {
+    it('is inert as well as aria-hidden while closed, in side mode', () => {
+      expect(panel().getAttribute('aria-hidden')).toBe('true');
+      expect(panel().hasAttribute('inert')).toBe(true);
+      // The inert subtree is around what the caller projected — which is what a
+      // keyboard user could otherwise Tab into while it is clipped to nothing.
+      expect(panel().querySelector('#in-drawer')).not.toBeNull();
+    });
+
+    it('is inert as well as aria-hidden while closed, in over mode', () => {
+      host.mode.set('over');
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-hidden')).toBe('true');
+      expect(panel().hasAttribute('inert')).toBe(true);
+    });
+
+    it('drops both when it opens', () => {
+      host.opened.set(true);
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-hidden')).toBeNull();
+      expect(panel().hasAttribute('inert')).toBe(false);
+    });
+
+    it('takes them back on close', () => {
+      openOver();
+      host.opened.set(false);
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('aria-hidden')).toBe('true');
+      expect(panel().hasAttribute('inert')).toBe(true);
+    });
+  });
+
+  describe('the keyboard contract each model brings', () => {
+    /**
+     * Focus restoration hangs off `transitionend`, which jsdom never fires — it
+     * has no layout and runs no transitions. The event has to carry
+     * `propertyName: 'transform'` and target the panel itself, because the
+     * handler ignores every other transition and anything bubbling from a child.
+     */
+    function endCloseTransition(): void {
+      const event = new Event('transitionend', { bubbles: false });
+      Object.defineProperty(event, 'propertyName', { value: 'transform' });
+      panel().dispatchEvent(event);
+      fixture.detectChanges();
+    }
+
+    it('closes an over drawer on Escape, which the modal model implies', () => {
+      openOver();
+      panel().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(host.opened()).toBe(false);
+    });
+
+    /**
+     * Side mode is persistent navigation and declares no modal contract, so
+     * Escape is not part of one — the toggle that opened it is the control. This
+     * is asserted rather than left implicit because the ticket's rule cuts both
+     * ways: a contract declared in ARIA has to be implemented, and one that is
+     * not declared must not be half-implemented either.
+     */
+    it('leaves a side drawer open on Escape, having declared no modal contract', () => {
+      host.opened.set(true);
+      fixture.detectChanges();
+      panel().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(host.opened()).toBe(true);
+    });
+
+    it('returns focus to the element that opened an over drawer', () => {
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+
+      openOver();
+      (panel().querySelector('#in-drawer') as HTMLElement).focus();
+
+      host.opened.set(false);
+      fixture.detectChanges();
+      endCloseTransition();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  /**
+   * Positive controls. Everything above asserts an empty `violated`, which axe
+   * also returns when it looked at nothing.
+   */
+  describe('the structure this replaced', () => {
+    async function scan(html: string, target: string, rules: string[]) {
+      const previous = document.createElement('div');
+      previous.innerHTML = html;
+      document.body.appendChild(previous);
+
+      // `await` inside the try, not `return axeResult(...)` — returning the
+      // promise runs `finally` before axe has read anything, which detaches the
+      // tree mid-scan and is precisely the vacuous pass this is guarding.
+      try {
+        return await axeResult(previous, previous.querySelector(target), rules);
+      } finally {
+        previous.remove();
+      }
+    }
+
+    /**
+     * The pre-#214 over-mode panel: a modal dialog with no name, because
+     * `ariaLabel` was optional and defaulted to nothing. This is the control for
+     * `aria-dialog-name` reporting at all, and for `axeResult` attributing it.
+     */
+    it('still reports an over-mode drawer with no accessible name', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true" tabindex="-1" class="tn-drawer__panel">'
+        + '<button type="button">Pools</button>'
+        + '</div>',
+        '[role="dialog"]',
+        ['aria-dialog-name'],
+      );
+
+      expect(violated).toEqual(['aria-dialog-name']);
+    });
+
+    /**
+     * Why `landmark-unique` is not in `PANEL_RULES`, measured rather than
+     * asserted in a comment: two unnamed `navigation` landmarks are what it
+     * takes to report, which one drawer on a page cannot produce. The generic
+     * fallback name does not fix this either — two drawers both called "Drawer"
+     * are still not unique — which is what the dev-mode warning is for, and what
+     * the LOW left unfixed in the pull request describes.
+     */
+    it('reports two unnamed navigation landmarks, which one drawer cannot', async () => {
+      const { violated } = await scan(
+        '<div><nav class="a"><a href="#x">One</a></nav>'
+        + '<nav class="b"><a href="#y">Two</a></nav></div>',
+        'nav.a',
+        ['landmark-unique'],
+      );
+
+      expect(violated).toEqual(['landmark-unique']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
@@ -326,19 +326,6 @@ describe('drawer accessibility (#214)', () => {
   });
 
   describe('the keyboard contract each model brings', () => {
-    /**
-     * Focus restoration hangs off `transitionend`, which jsdom never fires — it
-     * has no layout and runs no transitions. The event has to carry
-     * `propertyName: 'transform'` and target the panel itself, because the
-     * handler ignores every other transition and anything bubbling from a child.
-     */
-    function endCloseTransition(): void {
-      const event = new Event('transitionend', { bubbles: false });
-      Object.defineProperty(event, 'propertyName', { value: 'transform' });
-      panel().dispatchEvent(event);
-      fixture.detectChanges();
-    }
-
     it('closes an over drawer on Escape, which the modal model implies', () => {
       openOver();
       panel().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -363,20 +350,59 @@ describe('drawer accessibility (#214)', () => {
       expect(host.opened()).toBe(true);
     });
 
-    it('returns focus to the element that opened an over drawer', () => {
+    /**
+     * Restoration happens on close, and this test deliberately does NOT dispatch
+     * a `transitionend` — because that is exactly what a user with
+     * `prefers-reduced-motion` never gets. This component's stylesheet sets
+     * `transition: none` on an initialized panel under that preference, so the
+     * event never fires, and the panel is `inert` from the moment it closes:
+     * waiting for the event would leave focus on `<body>`.
+     */
+    it('returns focus to the opener on close, without waiting for a transition', () => {
       const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
       trigger.focus();
       expect(document.activeElement).toBe(trigger);
 
       openOver();
       (panel().querySelector('#in-drawer') as HTMLElement).focus();
+      expect(document.activeElement).not.toBe(trigger);
 
       host.opened.set(false);
       fixture.detectChanges();
-      endCloseTransition();
 
       expect(document.activeElement).toBe(trigger);
     });
+
+    it('does not pull focus back again when the close transition ends', () => {
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      const other = fixture.nativeElement.querySelector('#external-title') as HTMLElement;
+      trigger.focus();
+
+      openOver();
+      (panel().querySelector('#in-drawer') as HTMLElement).focus();
+      host.opened.set(false);
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(trigger);
+
+      other.tabIndex = -1;
+      other.focus();
+      endCloseTransition();
+
+      expect(document.activeElement).toBe(other);
+    });
+
+    /**
+     * `transitionend` is what emits `closed`, and jsdom never fires it — it has
+     * no layout and runs no transitions. The event has to carry
+     * `propertyName: 'transform'` and target the panel itself, because the
+     * handler ignores every other transition and anything bubbling from a child.
+     */
+    function endCloseTransition(): void {
+      const event = new Event('transitionend', { bubbles: false });
+      Object.defineProperty(event, 'propertyName', { value: 'transform' });
+      panel().dispatchEvent(event);
+      fixture.detectChanges();
+    }
   });
 
   /**

--- a/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
@@ -373,6 +373,47 @@ describe('drawer accessibility (#214)', () => {
       expect(document.activeElement).toBe(trigger);
     });
 
+    /**
+     * A responsive layout crossing its breakpoint switches `mode` while the
+     * drawer is open. That is not a close, so the component must not spend its
+     * one saved focus on it — the drawer is still on screen, and the close that
+     * follows later is what the saved element is for.
+     *
+     * Focus does still leave the drawer at the switch, and that is not this
+     * component: `mode` decides which of two panels the template renders, so the
+     * over-mode panel is DESTROYED, and `CdkTrapFocus.ngOnDestroy` restores the
+     * element it captured. Measured — with the guard below in place the effect
+     * does not run its restore branch, and focus lands on the opener anyway.
+     * Pre-existing, unchanged here, and noted on the pull request.
+     *
+     * What this asserts is the part the component owns: the saved element
+     * survives the mode change, so the eventual close still restores it. Without
+     * the `!opened` guard the mode change consumes it and the close below
+     * restores nothing.
+     */
+    it('saves its restore for the close, not for a mode change while open', () => {
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      const other = fixture.nativeElement.querySelector('#external-title') as HTMLElement;
+      other.tabIndex = -1;
+      trigger.focus();
+
+      openOver();
+      (panel().querySelector('#in-drawer') as HTMLElement).focus();
+
+      host.mode.set('side');
+      fixture.detectChanges();
+      expect(host.opened()).toBe(true);
+
+      // Somewhere else entirely, so the close below has something to restore
+      // FROM — otherwise focus sitting on the trigger would prove nothing.
+      other.focus();
+
+      host.opened.set(false);
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
     it('does not pull focus back again when the close transition ends', () => {
       const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
       const other = fixture.nativeElement.querySelector('#external-title') as HTMLElement;

--- a/projects/truenas-ui/src/lib/drawer/drawer-container.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-container.component.ts
@@ -1,5 +1,30 @@
 import { Component } from '@angular/core';
 
+/**
+ * The flex row that lays a `tn-drawer` out beside a `tn-drawer-content`.
+ *
+ * WHY IT CARRIES NO ROLE, NO LANDMARK AND NO NAME (#214)
+ * -----------------------------------------------------
+ * #214 reported axe evaluating ZERO rules against this component, which is true
+ * and is not a defect in it: the container renders `<ng-content />` and a
+ * stylesheet, so scanned on its own there is nothing there to have a role. The
+ * scan in the report was the childless case, the same way #204's turned out to
+ * be a stepper with no steps.
+ *
+ * The surface a user perceives is `tn-drawer`, and that is where the model is
+ * declared — `role="navigation"` in `side` mode, `role="dialog"` with
+ * `aria-modal` and a focus trap in `over` mode. Giving the container a role of
+ * its own would put a second, unnamed thing in the accessibility tree between a
+ * listener and that surface, describing a layout box.
+ *
+ * `role="main"` on `tn-drawer-content` is the other tempting one, and it belongs
+ * to the application rather than to this library: a page decides where its main
+ * landmark is, and a component library that claims it makes two `main`s the
+ * moment an app has its own.
+ *
+ * Guarded by `drawer-a11y.spec.ts`, which asserts the drawer inside the
+ * container is what axe attributes its results to.
+ */
 @Component({
   selector: 'tn-drawer-container',
   standalone: true,

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.html
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.html
@@ -14,8 +14,10 @@
 
   `aria-label` is `resolvedAriaLabel()` in both modes: `dialog` in over mode must
   have a name, and `navigation` in side mode wants one as soon as a page has more
-  than one landmark of that role. It is `null` whenever `ariaLabelledby` is set,
-  which is the branch `tnAccessibleName` owns.
+  than one landmark of that role. Beside an `ariaLabelledby` it is the GENERIC
+  FALLBACK that is withheld, not an explicit `ariaLabel` — which is always
+  emitted, so that a dangling IDREF cannot leave the panel unnamed. That branch
+  is `tnAccessibleName`'s, and its reasoning is set out there.
 -->
 
 <!-- Side mode: panel renders inline -->

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.html
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.html
@@ -3,6 +3,21 @@
   <ng-content />
 </ng-template>
 
+<!--
+  A CLOSED drawer is `inert` as well as `aria-hidden` (#214). It stays in the DOM
+  and keeps whatever the caller projected into it — nav links, buttons — so
+  `aria-hidden` alone hid a subtree a keyboard user could still Tab into, landing
+  focus on controls that are off-screen or clipped to zero width. `inert` takes
+  the subtree out of the focus order and the accessibility tree together;
+  `aria-hidden` stays beside it for browsers without `inert` (Firefox before
+  112), where it is still the half that works.
+
+  `aria-label` is `resolvedAriaLabel()` in both modes: `dialog` in over mode must
+  have a name, and `navigation` in side mode wants one as soon as a page has more
+  than one landmark of that role. It is `null` whenever `ariaLabelledby` is set,
+  which is the branch `tnAccessibleName` owns.
+-->
+
 <!-- Side mode: panel renders inline -->
 @if (mode() !== 'over') {
   <div
@@ -12,7 +27,9 @@
     [style.width]="width()"
     [attr.role]="panelRole()"
     [attr.aria-hidden]="!opened() ? 'true' : null"
-    [attr.aria-label]="ariaLabel()"
+    [attr.inert]="opened() ? null : ''"
+    [attr.aria-label]="resolvedAriaLabel()"
+    [attr.aria-labelledby]="ariaLabelledby()"
     [tnTestId]="testId()"
     (transitionend)="onTransitionEnd($event)">
     <ng-container *ngTemplateOutlet="drawerContent" />
@@ -37,7 +54,9 @@
       [attr.role]="panelRole()"
       [attr.aria-modal]="opened() ? 'true' : null"
       [attr.aria-hidden]="!opened() ? 'true' : null"
-      [attr.aria-label]="ariaLabel()"
+      [attr.inert]="opened() ? null : ''"
+      [attr.aria-label]="resolvedAriaLabel()"
+      [attr.aria-labelledby]="ariaLabelledby()"
       [tnTestId]="testId()"
       [cdkTrapFocus]="trapFocus()"
       [cdkTrapFocusAutoCapture]="trapFocus()"

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.spec.ts
@@ -37,6 +37,7 @@ class TestHostComponent {
 describe('TnDrawerComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
+  let warn: jest.SpyInstance;
 
   // Side mode: panel is inline in the fixture
   const getPanel = (): HTMLElement =>
@@ -60,12 +61,18 @@ describe('TnDrawerComponent', () => {
       imports: [TestHostComponent],
     }).compileComponents();
 
+    // Every fixture here is unlabelled, and #214 makes an unnamed drawer warn in
+    // dev mode — which Jest is. Silenced so this suite's output stays readable;
+    // the warning itself is asserted in `drawer-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   afterEach(() => {
+    warn.mockRestore();
     // Clean up portaled elements
     document.body.querySelectorAll('.tn-drawer__panel--over').forEach((el) => el.remove());
     document.body.querySelectorAll('.tn-drawer__backdrop').forEach((el) => el.remove());

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -13,10 +13,32 @@ import {
   viewChild,
   afterNextRender,
 } from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 export type TnDrawerMode = 'side' | 'over';
 export type TnDrawerPosition = 'start' | 'end';
+
+/**
+ * The accessible name a drawer falls back to when the caller names neither
+ * `ariaLabel` nor `ariaLabelledby` (#214).
+ *
+ * `ariaLabel` defaults to `undefined`, so the DEFAULT rendering in `over` mode
+ * was a `role="dialog"` with `aria-modal="true"` and no name — measured as an
+ * `aria-dialog-name` violation. In `side` mode the same omission leaves a
+ * `role="navigation"` landmark unnamed, which axe does not report while there is
+ * only one of them on the page, and which stops telling them apart the moment
+ * there are two.
+ *
+ * One fallback for both modes rather than one per mode: the drawer is the same
+ * surface either way, the name answers the same question ("what is this?"), and
+ * a rule that changes with the mode is one more thing for a caller to be wrong
+ * about. A generic name is still a poor one, so it is paired with the dev-mode
+ * warning `tnAccessibleName` raises.
+ *
+ * Exported so specs assert against it by name rather than by a copied literal.
+ */
+export const TN_DRAWER_DEFAULT_LABEL = 'Drawer';
 
 @Component({
   selector: 'tn-drawer',
@@ -53,6 +75,9 @@ export class TnDrawerComponent implements OnDestroy {
   /** Accessible label for the drawer panel */
   ariaLabel = input<string | undefined>(undefined);
 
+  /** IDREF naming the drawer panel from visible text elsewhere on the page */
+  ariaLabelledby = input<string | null>(null);
+
   /**
    * Test-id applied to the drawer panel. Rendered under whichever attribute name is
    * configured via `TN_TEST_ATTR` (default `data-testid`).
@@ -76,6 +101,26 @@ export class TnDrawerComponent implements OnDestroy {
 
   /** Role depends on mode: navigation for side, dialog for over */
   protected panelRole = computed(() => this.mode() === 'over' ? 'dialog' : 'navigation');
+
+  /**
+   * The name to render as `aria-label`, or `null` to render none — and the
+   * dev-mode warning when the caller named neither input.
+   *
+   * Both halves live in `../a11y/accessible-name`, shared with `tn-side-panel`
+   * and the three progressbars, where the reasoning for each branch is set out:
+   * why an explicit `ariaLabel` always survives, and why the generic fallback is
+   * withheld beside an `ariaLabelledby`.
+   *
+   * A field initializer rather than the constructor, because it registers an
+   * `effect` and so needs an injection context.
+   */
+  protected resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-drawer',
+    fallback: TN_DRAWER_DEFAULT_LABEL,
+    activity: 'open',
+    ariaLabel: computed(() => this.ariaLabel() ?? null),
+    ariaLabelledby: this.ariaLabelledby,
+  });
 
   /** Whether to show the backdrop */
   protected showBackdrop = computed(() => this.mode() === 'over');

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -139,10 +139,21 @@ export class TnDrawerComponent implements OnDestroy {
   private previousFocus: HTMLElement | null = null;
 
   constructor() {
-    // Capture focus before opening in over mode for later restoration
+    // Capture focus before opening in over mode, and restore it on close
     effect(() => {
       if (this.mode() === 'over' && this.opened()) {
         this.previousFocus = this.document.activeElement as HTMLElement;
+      } else {
+        // Restored HERE rather than on `transitionend` (#214). The panel becomes
+        // `inert` the moment it closes, so the browser blurs whatever inside it
+        // had focus and moves it to `<body>` immediately — and `transitionend`
+        // is not guaranteed to arrive to put it back. This component's own
+        // stylesheet sets `transition: none` on an initialized panel under
+        // `prefers-reduced-motion`, so for a user with that preference the event
+        // never fires at all and focus would be left on `<body>` every time.
+        //
+        // A no-op in side mode, where `previousFocus` is never captured.
+        this.restoreFocus();
       }
     });
 
@@ -201,7 +212,11 @@ export class TnDrawerComponent implements OnDestroy {
     }
   }
 
-  /** Handle transition end — emit events and restore focus after animation completes */
+  /**
+   * Handle transition end — emit the open/close events once the animation is
+   * over. Focus restoration is NOT here; it happens as soon as the drawer
+   * closes, because this event does not fire under `prefers-reduced-motion`.
+   */
   protected onTransitionEnd(event: TransitionEvent): void {
     if (event.propertyName !== 'transform' || event.target !== event.currentTarget) {
       return;
@@ -210,7 +225,6 @@ export class TnDrawerComponent implements OnDestroy {
       this.openedComplete.emit();
     } else {
       this.closed.emit();
-      this.restoreFocus();
     }
   }
 

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -141,9 +141,11 @@ export class TnDrawerComponent implements OnDestroy {
   constructor() {
     // Capture focus before opening in over mode, and restore it on close
     effect(() => {
-      if (this.mode() === 'over' && this.opened()) {
+      const opened = this.opened();
+
+      if (opened && this.mode() === 'over') {
         this.previousFocus = this.document.activeElement as HTMLElement;
-      } else {
+      } else if (!opened) {
         // Restored HERE rather than on `transitionend` (#214). The panel becomes
         // `inert` the moment it closes, so the browser blurs whatever inside it
         // had focus and moves it to `<body>` immediately — and `transitionend`
@@ -153,6 +155,12 @@ export class TnDrawerComponent implements OnDestroy {
         // never fires at all and focus would be left on `<body>` every time.
         //
         // A no-op in side mode, where `previousFocus` is never captured.
+        //
+        // Gated on `!opened` rather than on the negation of the branch above,
+        // because those are not the same condition: a drawer that switches from
+        // `over` to `side` WHILE OPEN — a responsive layout crossing its
+        // breakpoint — fails the first test without having closed, and would
+        // otherwise have focus yanked out of it and back to whatever opened it.
         this.restoreFocus();
       }
     });

--- a/projects/truenas-ui/src/lib/drawer/drawer.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.harness.spec.ts
@@ -39,11 +39,17 @@ describe('TnDrawerHarness', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
   let loader: HarnessLoader;
+  let warn: jest.SpyInstance;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
     }).compileComponents();
+
+    // Every fixture here is unlabelled, and #214 makes an unnamed drawer warn in
+    // dev mode — which Jest is. Silenced so this suite's output stays readable;
+    // the warning itself is asserted in `drawer-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
@@ -51,6 +57,7 @@ describe('TnDrawerHarness', () => {
   });
 
   afterEach(() => {
+    warn.mockRestore();
     document.body.querySelectorAll('.tn-drawer__panel--over').forEach((el) => el.remove());
     document.body.querySelectorAll('.tn-drawer__backdrop').forEach((el) => el.remove());
   });

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
@@ -1,0 +1,458 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TN_SIDE_PANEL_DEFAULT_LABEL, TnSidePanelComponent } from './side-panel.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the ARIA structure given to `tn-side-panel` in #214.
+ *
+ * WHAT WAS REPORTED, AND WHAT WAS ACTUALLY THERE
+ * ----------------------------------------------
+ * The ticket reported axe returning no violations AND zero rules passed. Run
+ * against the unchanged component that is exactly what a scan of the component's
+ * own element does — and it is an artefact of where the markup lives rather than
+ * of what it says. `afterNextRender` moves `.tn-side-panel__overlay` to
+ * `document.body`, so `<tn-side-panel>` itself is an empty element and a scan
+ * rooted at it evaluates two rules about the host and nothing about the panel.
+ * `the reported scan` at the bottom of this file keeps that measurement.
+ *
+ * Scanned where the overlay actually is, an OPEN panel WITH A TITLE already
+ * passed 24 rules including `aria-dialog-name`: the role, the modal flag, the
+ * focus trap, Escape and focus restoration were all there before this ticket.
+ *
+ * WHAT WAS REALLY MISSING
+ * -----------------------
+ * Two things, both measured rather than reasoned about:
+ *
+ * - **A name in the default configuration.** `title` defaults to `''`, so the
+ *   default rendering was `role="dialog"` pointing `aria-labelledby` at an empty
+ *   `<h2>` — `aria-dialog-name` and `empty-heading`, together.
+ * - **Inertness when closed.** The overlay stays in the DOM with its close
+ *   button and projected content, under `aria-hidden="true"`. axe cannot decide
+ *   `aria-hidden-focus` under jsdom (no layout engine), and `axeResult` throws
+ *   on an undecided rule rather than counting it either way — so that half is
+ *   asserted against the DOM, which is what the wrapper's own documentation says
+ *   to do.
+ *
+ * THE MODEL: MODAL
+ * ----------------
+ * The panel already trapped focus with `cdkTrapFocus`, auto-captured it on open,
+ * closed on Escape and restored focus to the opener on close. `role="dialog"`
+ * plus `aria-modal="true"` describes that, so this ticket implements no new
+ * contract for it — it makes the existing one nameable and stops it reaching the
+ * tab order while closed. Declaring a focus contract and not implementing it is
+ * what the ticket calls worse than the current state; this is the other case.
+ */
+
+@Component({
+  selector: 'tn-side-panel-a11y-host',
+  standalone: true,
+  imports: [TnSidePanelComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger" (click)="open.set(true)">Open</button>
+    <h2 id="external-title">Edit dataset</h2>
+    <tn-side-panel
+      [title]="title()"
+      [hasBackdrop]="hasBackdrop()"
+      [ariaLabel]="ariaLabel()"
+      [ariaLabelledby]="ariaLabelledby()"
+      [(open)]="open">
+      <p>Panel body</p>
+      <button type="button" id="inside">Inside</button>
+    </tn-side-panel>
+  `,
+})
+class SidePanelA11yHostComponent {
+  open = signal(false);
+  title = signal('Edit dataset');
+  hasBackdrop = signal(true);
+  ariaLabel = signal<string | null>(null);
+  ariaLabelledby = signal<string | null>(null);
+}
+
+/**
+ * The rules an open dialog's structure can be wrong under.
+ *
+ * `aria-dialog-name` is the one the fix is about. The rest are here because the
+ * change moved what names the dialog and added an attribute to the same element:
+ * the cheapest way for that to go wrong is an attribute landing on a role that
+ * does not allow it, or an IDREF that resolves to nothing.
+ *
+ * NOT `aria-hidden-focus`, and not `color-contrast`: both come back
+ * `incomplete` under jsdom, and `axeResult` throws on an undecided rule rather
+ * than letting it satisfy an `evaluated` assertion while contributing nothing to
+ * `violated`. `is inert as well as aria-hidden while closed` covers the first
+ * from the DOM side.
+ *
+ * NOT `empty-heading` either, for a different reason: it reports on the `<h2>`,
+ * not on the dialog, so it is asserted where its target is — in
+ * `the heading the dialog is named by`.
+ */
+const DIALOG_RULES = [
+  'aria-dialog-name',
+  'aria-allowed-attr',
+  'aria-required-attr',
+  'aria-valid-attr-value',
+  'aria-allowed-role',
+  'aria-roles',
+  'nested-interactive',
+];
+
+describe('tn-side-panel accessibility (#214)', () => {
+  let fixture: ComponentFixture<SidePanelA11yHostComponent>;
+  let host: SidePanelA11yHostComponent;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SidePanelA11yHostComponent],
+    }).compileComponents();
+
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    fixture = TestBed.createComponent(SidePanelA11yHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // The overlay is portaled to document.body and only removed on destroy, so
+    // without this every later fixture in this file scans the previous one's
+    // panel as well as its own.
+    fixture.destroy();
+    warn.mockRestore();
+  });
+
+  /**
+   * The overlay is in `document.body`, not in the fixture — see the header. Both
+   * the scanned root and the targets have to be found there, which is the whole
+   * point of the reported defect.
+   */
+  function overlay(): HTMLElement {
+    return document.body.querySelector('.tn-side-panel__overlay') as HTMLElement;
+  }
+
+  function panel(): HTMLElement {
+    return overlay().querySelector('.tn-side-panel__panel') as HTMLElement;
+  }
+
+  function heading(): HTMLElement | null {
+    return overlay().querySelector('.tn-side-panel__title');
+  }
+
+  function openPanel(): void {
+    host.open.set(true);
+    fixture.detectChanges();
+  }
+
+  /** The elements the dialog rules can report on. */
+  function dialogTargets(): HTMLElement[] {
+    return [overlay(), panel()];
+  }
+
+  describe('the dialog has a name', () => {
+    it('is named by its visible heading when it has a title', () => {
+      openPanel();
+
+      expect(overlay().getAttribute('aria-labelledby')).toBe(heading()!.id);
+      expect(heading()!.textContent!.trim()).toBe('Edit dataset');
+      // No `aria-label` beside it: it would win the name calculation over the
+      // heading and replace what the user can see with something they cannot.
+      expect(overlay().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a generic name when it has no title and no label', () => {
+      host.title.set('');
+      openPanel();
+
+      expect(overlay().getAttribute('aria-labelledby')).toBeNull();
+      expect(overlay().getAttribute('aria-label')).toBe(TN_SIDE_PANEL_DEFAULT_LABEL);
+    });
+
+    it('warns in dev mode when it falls back, and names the input to use', () => {
+      host.title.set('');
+      openPanel();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('[tn-side-panel]');
+      expect(warn.mock.calls[0][0]).toContain('title');
+    });
+
+    it('takes an explicit ariaLabel for a panel that renders no heading', () => {
+      host.title.set('');
+      host.ariaLabel.set('Add dataset');
+      openPanel();
+
+      expect(overlay().getAttribute('aria-label')).toBe('Add dataset');
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('takes an ariaLabelledby, and renders no aria-label beside it', () => {
+      host.title.set('');
+      host.ariaLabelledby.set('external-title');
+      openPanel();
+
+      expect(overlay().getAttribute('aria-labelledby')).toBe('external-title');
+      expect(overlay().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    /**
+     * `aria-labelledby` wins the ARIA name calculation when it resolves, so the
+     * visible heading is what a listener hears — but the explicit `ariaLabel` is
+     * still emitted beside it. That is `tnAccessibleName`'s rule and not this
+     * component's: suppressing an explicit label would be safe only while the
+     * IDREF resolves, and against a heading that has not rendered it would leave
+     * the dialog unnamed in exactly the case where the caller supplied a name.
+     */
+    it('is named by the visible title, and keeps an explicit label beside it', () => {
+      host.ariaLabel.set('Something else');
+      host.ariaLabelledby.set('external-title');
+      openPanel();
+
+      expect(overlay().getAttribute('aria-labelledby')).toBe(heading()!.id);
+      expect(overlay().getAttribute('aria-label')).toBe('Something else');
+    });
+
+    it('treats a whitespace-only title as no title', () => {
+      host.title.set('   ');
+      openPanel();
+
+      expect(heading()).toBeNull();
+      expect(overlay().getAttribute('aria-label')).toBe(TN_SIDE_PANEL_DEFAULT_LABEL);
+    });
+  });
+
+  describe('the heading the dialog is named by', () => {
+    it('renders no heading element at all when there is no title', async () => {
+      host.title.set('');
+      openPanel();
+
+      expect(heading()).toBeNull();
+
+      // The rule that reported the empty `<h2>`, asserted on the element that
+      // replaced it: the header is still there, and axe has nothing to object
+      // to in it.
+      const header = overlay().querySelector('.tn-side-panel__header') as HTMLElement;
+      const { violated } = await axeResult(overlay(), header, ['empty-heading']);
+      expect(violated).toEqual([]);
+    });
+
+    it('renders the heading, with the id the dialog points at, when there is one', async () => {
+      openPanel();
+
+      expect(heading()!.tagName).toBe('H2');
+      const { violated, evaluated } = await axeResult(
+        overlay(), heading(), ['empty-heading']
+      );
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('empty-heading');
+    });
+  });
+
+  describe('axe over the open dialog', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing — which is
+    // the defect this ticket reported, not a hypothetical.
+    it('raises no violation, and does evaluate the dialog rules', async () => {
+      openPanel();
+
+      const { violated, evaluated } = await axeResult(
+        overlay(), dialogTargets(), DIALOG_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+      expect(evaluated).toContain('aria-allowed-attr');
+    });
+
+    it('raises no violation on an untitled panel, which is the default', async () => {
+      host.title.set('');
+      openPanel();
+
+      const { violated, evaluated } = await axeResult(
+        overlay(), dialogTargets(), DIALOG_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+
+    it('raises no violation with no backdrop, which does not change the model', async () => {
+      // A panel without a backdrop still traps focus — `cdkTrapFocus` is on the
+      // panel unconditionally and auto-captures on open — so `aria-modal="true"`
+      // still describes it, and the same rules have to run over it.
+      host.hasBackdrop.set(false);
+      openPanel();
+
+      expect(overlay().querySelector('.tn-side-panel__backdrop')).toBeNull();
+      expect(overlay().getAttribute('aria-modal')).toBe('true');
+
+      const { violated, evaluated } = await axeResult(
+        overlay(), dialogTargets(), DIALOG_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+  });
+
+  describe('what a closed panel exposes', () => {
+    it('is inert as well as aria-hidden while closed', () => {
+      expect(overlay().getAttribute('aria-hidden')).toBe('true');
+      expect(overlay().hasAttribute('inert')).toBe(true);
+    });
+
+    it('drops both when it opens', () => {
+      openPanel();
+
+      expect(overlay().getAttribute('aria-hidden')).toBeNull();
+      expect(overlay().hasAttribute('inert')).toBe(false);
+      expect(overlay().getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('takes them back on close', () => {
+      openPanel();
+      host.open.set(false);
+      fixture.detectChanges();
+
+      expect(overlay().getAttribute('aria-hidden')).toBe('true');
+      expect(overlay().hasAttribute('inert')).toBe(true);
+    });
+
+    /**
+     * `inert` is what keeps the close button and the projected content out of
+     * the tab order while the panel is off-screen. jsdom implements neither
+     * layout nor `inert`'s focus semantics, so this asserts the attribute is on
+     * the ancestor of those controls rather than trying to Tab in — the same
+     * limit `aria-hidden-focus` runs into, which is why it is not in
+     * `DIALOG_RULES`.
+     */
+    it('puts the inert subtree around the controls a closed panel still holds', () => {
+      const inside = overlay().querySelector('#inside') as HTMLElement;
+      const close = overlay().querySelector('tn-icon-button') as HTMLElement;
+
+      expect(overlay().hasAttribute('inert')).toBe(true);
+      expect(overlay().contains(inside)).toBe(true);
+      expect(overlay().contains(close)).toBe(true);
+    });
+  });
+
+  describe('the keyboard contract the modal model brings', () => {
+    /**
+     * Focus restoration hangs off `transitionend` on the panel, which jsdom
+     * never fires — it has no layout and runs no transitions. Dispatching it is
+     * the only way to reach the branch, and it has to carry
+     * `propertyName: 'transform'` and target the panel itself, because the
+     * handler ignores every other transition and anything bubbling up from a
+     * child.
+     */
+    function endCloseTransition(): void {
+      const event = new Event('transitionend', { bubbles: false });
+      Object.defineProperty(event, 'propertyName', { value: 'transform' });
+      panel().dispatchEvent(event);
+      fixture.detectChanges();
+    }
+
+    it('closes on Escape', () => {
+      openPanel();
+      panel().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(host.open()).toBe(false);
+    });
+
+    it('returns focus to the element that opened it', () => {
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+
+      openPanel();
+      // The panel takes focus off the trigger the way a real open does, so the
+      // restoration below is restoring something rather than asserting that
+      // focus never moved.
+      (overlay().querySelector('#inside') as HTMLElement).focus();
+
+      host.open.set(false);
+      fixture.detectChanges();
+      endCloseTransition();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  /**
+   * Positive controls. Everything above asserts an empty `violated`, which axe
+   * also returns when it looked at nothing — and looking at nothing is what the
+   * reported scan did, so these are the assertions that keep the rest honest.
+   */
+  describe('the reported scan, and the structure this replaced', () => {
+    async function scan(html: string, target: string, rules: string[]) {
+      const previous = document.createElement('div');
+      previous.innerHTML = html;
+      document.body.appendChild(previous);
+
+      // `await` inside the try, not `return axeResult(...)` — returning the
+      // promise runs `finally` before axe has read anything, which detaches the
+      // tree mid-scan and is precisely the vacuous pass this is guarding.
+      try {
+        return await axeResult(previous, previous.querySelector(target), rules);
+      } finally {
+        previous.remove();
+      }
+    }
+
+    /**
+     * The reported measurement itself, kept as a test: scanning the component's
+     * own element evaluates NOTHING about the dialog, because the overlay is in
+     * `document.body`. This is why every assertion above roots its scan at the
+     * overlay, and it fails if the portal is ever removed — at which point the
+     * scans above should be rooted at the fixture instead.
+     */
+    it('evaluates no dialog rule against the component element, which is empty', async () => {
+      openPanel();
+      const hostElement = fixture.nativeElement.querySelector('tn-side-panel') as HTMLElement;
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, hostElement, DIALOG_RULES
+      );
+
+      expect(evaluated).toEqual([]);
+      expect(violated).toEqual([]);
+      expect(hostElement.querySelector('.tn-side-panel__overlay')).toBeNull();
+    });
+
+    /**
+     * The pre-#214 markup for an untitled panel: `aria-labelledby` pointing at
+     * an `<h2>` with no text in it. Both rules report, which is what makes
+     * `expect(violated).toEqual([])` above worth something.
+     */
+    it('still reports a dialog named by an empty heading', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true" aria-labelledby="t">'
+        + '<header><h2 id="t"></h2></header>'
+        + '<button type="button">Dismiss</button>'
+        + '</div>',
+        '[role="dialog"]',
+        ['aria-dialog-name'],
+      );
+
+      expect(violated).toEqual(['aria-dialog-name']);
+    });
+
+    it('still reports the empty heading itself', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true" aria-labelledby="t">'
+        + '<header><h2 id="t"></h2></header>'
+        + '</div>',
+        'h2',
+        ['empty-heading'],
+      );
+
+      expect(violated).toEqual(['empty-heading']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
@@ -227,18 +227,25 @@ describe('tn-side-panel accessibility (#214)', () => {
   });
 
   describe('the heading the dialog is named by', () => {
-    it('renders no heading element at all when there is no title', async () => {
+    it('renders no heading element at all when there is no title', () => {
       host.title.set('');
       openPanel();
 
       expect(heading()).toBeNull();
 
-      // The rule that reported the empty `<h2>`, asserted on the element that
-      // replaced it: the header is still there, and axe has nothing to object
-      // to in it.
-      const header = overlay().querySelector('.tn-side-panel__header') as HTMLElement;
-      const { violated } = await axeResult(overlay(), header, ['empty-heading']);
-      expect(violated).toEqual([]);
+      // Said again without the class, because `heading()` depends on one:
+      // renaming `.tn-side-panel__title` while still rendering an
+      // unconditional empty `<h2>` would leave the assertion above passing
+      // with an empty level-2 heading back in the header and back in the
+      // document outline.
+      //
+      // Not an axe scan. `empty-heading` selects heading elements, so with
+      // none rendered there is nothing for it to evaluate and it reports
+      // clean whatever the header holds — the vacuous result this file's
+      // header rules out. The rule's teeth are asserted where it does have a
+      // target: `still reports the empty heading itself`, below, on the
+      // markup this replaced.
+      expect(overlay().querySelectorAll('h1, h2, h3, h4, h5, h6')).toHaveLength(0);
     });
 
     it('renders the heading, with the id the dialog points at, when there is one', async () => {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
@@ -342,21 +342,6 @@ describe('tn-side-panel accessibility (#214)', () => {
   });
 
   describe('the keyboard contract the modal model brings', () => {
-    /**
-     * Focus restoration hangs off `transitionend` on the panel, which jsdom
-     * never fires — it has no layout and runs no transitions. Dispatching it is
-     * the only way to reach the branch, and it has to carry
-     * `propertyName: 'transform'` and target the panel itself, because the
-     * handler ignores every other transition and anything bubbling up from a
-     * child.
-     */
-    function endCloseTransition(): void {
-      const event = new Event('transitionend', { bubbles: false });
-      Object.defineProperty(event, 'propertyName', { value: 'transform' });
-      panel().dispatchEvent(event);
-      fixture.detectChanges();
-    }
-
     it('closes on Escape', () => {
       openPanel();
       panel().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -365,23 +350,64 @@ describe('tn-side-panel accessibility (#214)', () => {
       expect(host.open()).toBe(false);
     });
 
-    it('returns focus to the element that opened it', () => {
+    /**
+     * Restoration happens on close, and this test deliberately does NOT dispatch
+     * a `transitionend` — because that is exactly what a user with
+     * `prefers-reduced-motion` never gets. This component's stylesheet sets
+     * `transition-duration: 0ms` under that preference, a zero-duration
+     * transition fires no event, and the overlay is `inert` from the moment it
+     * closes, so waiting for the event would leave focus on `<body>`.
+     */
+    it('returns focus to the element that opened it, without waiting for a transition', () => {
       const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
       trigger.focus();
       expect(document.activeElement).toBe(trigger);
 
       openPanel();
-      // The panel takes focus off the trigger the way a real open does, so the
+      // Focus is moved off the trigger the way a real open does, so the
       // restoration below is restoring something rather than asserting that
       // focus never moved.
       (overlay().querySelector('#inside') as HTMLElement).focus();
+      expect(document.activeElement).not.toBe(trigger);
 
       host.open.set(false);
       fixture.detectChanges();
-      endCloseTransition();
 
       expect(document.activeElement).toBe(trigger);
     });
+
+    it('does not restore focus a second time when the close transition ends', () => {
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      const other = fixture.nativeElement.querySelector('#external-title') as HTMLElement;
+      trigger.focus();
+
+      openPanel();
+      (overlay().querySelector('#inside') as HTMLElement).focus();
+      host.open.set(false);
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(trigger);
+
+      // Whatever the user focused after the close stays focused: the restore is
+      // spent, so the late `transitionend` must not pull focus back again.
+      other.tabIndex = -1;
+      other.focus();
+      endCloseTransition();
+
+      expect(document.activeElement).toBe(other);
+    });
+
+    /**
+     * `transitionend` is what emits `closed`, and jsdom never fires it — it has
+     * no layout and runs no transitions. The event has to carry
+     * `propertyName: 'transform'` and target the panel itself, because the
+     * handler ignores every other transition and anything bubbling from a child.
+     */
+    function endCloseTransition(): void {
+      const event = new Event('transitionend', { bubbles: false });
+      Object.defineProperty(event, 'propertyName', { value: 'transform' });
+      panel().dispatchEvent(event);
+      fixture.detectChanges();
+    }
   });
 
   /**

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
@@ -1,4 +1,20 @@
-<!-- Overlay wrapper: portaled to document.body -->
+<!--
+  Overlay wrapper: portaled to document.body.
+
+  A CLOSED panel is `inert` as well as `aria-hidden` (#214). It stays in the DOM
+  and keeps its close button and its projected content, so `aria-hidden` alone
+  hid a subtree a keyboard user could still Tab into — landing focus on controls
+  that are translated off-screen. `inert` takes the subtree out of the focus
+  order and the accessibility tree together; `aria-hidden` stays beside it for
+  browsers without `inert` (Firefox before 112), where it is still the half that
+  works. Same reasoning as the checkbox in `list-option.component.html`.
+
+  `aria-label` and `aria-labelledby` are gated on `open()` for the same reason
+  `aria-modal` is: a closed panel is not in the accessibility tree, so a name on
+  it would describe nothing. `resolvedAriaLabelledby` prefers the visible
+  heading; `resolvedAriaLabel` is the fallback for a panel with no title, and is
+  `null` whenever the labelledby resolves.
+-->
 <div
   #overlay
   class="tn-side-panel__overlay"
@@ -9,8 +25,10 @@
   [class.tn-side-panel__overlay--initialized]="initialized()"
   [class.tn-side-panel__overlay--open]="open()"
   [attr.aria-modal]="open() ? 'true' : null"
-  [attr.aria-labelledby]="open() ? titleId : null"
-  [attr.aria-hidden]="!open() ? 'true' : null">
+  [attr.aria-labelledby]="open() ? resolvedAriaLabelledby() : null"
+  [attr.aria-label]="open() ? resolvedAriaLabel() : null"
+  [attr.aria-hidden]="!open() ? 'true' : null"
+  [attr.inert]="open() ? null : ''">
 
   <!-- Backdrop -->
   @if (hasBackdrop()) {
@@ -33,7 +51,14 @@
 
     <!-- Header -->
     <header class="tn-side-panel__header">
-      <h2 class="tn-side-panel__title" [id]="titleId">{{ title() }}</h2>
+      <!--
+        No heading element at all when there is no title, rather than an empty
+        one: an `<h2>` with no text is an `empty-heading` violation, and it puts
+        a level-2 heading with nothing in it into the document outline.
+      -->
+      @if (hasTitle()) {
+        <h2 class="tn-side-panel__title" [id]="titleId">{{ title() }}</h2>
+      }
       <div class="tn-side-panel__header-actions">
         <ng-content select="[tnSidePanelHeaderAction]" />
         <tn-icon-button

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
@@ -12,8 +12,9 @@
   `aria-label` and `aria-labelledby` are gated on `open()` for the same reason
   `aria-modal` is: a closed panel is not in the accessibility tree, so a name on
   it would describe nothing. `resolvedAriaLabelledby` prefers the visible
-  heading; `resolvedAriaLabel` is the fallback for a panel with no title, and is
-  `null` whenever the labelledby resolves.
+  heading. `resolvedAriaLabel` is `null` when the panel is named by a heading or
+  an IDREF and the caller passed no `ariaLabel` of their own — an explicit one is
+  always emitted, so that a dangling IDREF cannot leave the panel unnamed.
 -->
 <div
   #overlay

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.scss
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.scss
@@ -85,6 +85,11 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
+  // What pushes the close button to the right edge when there is no title.
+  // `.tn-side-panel__title` has `flex: 1` and used to do that job, but since
+  // #214 an untitled panel renders no heading at all — an empty `<h2>` is an
+  // `empty-heading` violation — and the actions would otherwise sit hard left.
+  margin-left: auto;
 }
 
 // Scrollable content area

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.spec.ts
@@ -7,6 +7,7 @@ import { TnSidePanelComponent } from './side-panel.component';
 describe('TnSidePanelComponent', () => {
   let component: TnSidePanelComponent;
   let fixture: ComponentFixture<TnSidePanelComponent>;
+  let warn: jest.SpyInstance;
 
   function getOverlay(): HTMLElement {
     return document.querySelector(`[data-tn-panel="${component.panelId}"].tn-side-panel__overlay`)!;
@@ -18,6 +19,12 @@ describe('TnSidePanelComponent', () => {
       providers: [provideHttpClient()],
     }).compileComponents();
 
+    // Almost every fixture here is untitled and unlabelled, and #214 makes an
+    // unnamed panel warn in dev mode — which Jest is. Silenced so this suite's
+    // output stays readable; the warning itself is asserted in
+    // `side-panel-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     fixture = TestBed.createComponent(TnSidePanelComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -26,6 +33,7 @@ describe('TnSidePanelComponent', () => {
   afterEach(() => {
     // Clean up portaled overlay from document.body
     fixture.destroy();
+    warn.mockRestore();
   });
 
   describe('overlay classes', () => {
@@ -70,7 +78,11 @@ describe('TnSidePanelComponent', () => {
       expect(getOverlay().getAttribute('aria-hidden')).toBeNull();
     });
 
-    it('should set aria-labelledby when open', () => {
+    // Titled, because since #214 the heading is what `aria-labelledby` points
+    // at and an untitled panel renders none — it is named by `aria-label`
+    // instead, which `side-panel-a11y.spec.ts` covers.
+    it('should set aria-labelledby to the title when open', () => {
+      fixture.componentRef.setInput('title', 'My Panel');
       fixture.componentRef.setInput('open', true);
       fixture.detectChanges();
       expect(getOverlay().getAttribute('aria-labelledby')).toBe(component.titleId);

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -9,9 +9,30 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { mdiClose } from '@mdi/js';
 import { take } from 'rxjs';
 import type { Observable } from 'rxjs';
+import { tnAccessibleName } from '../a11y/accessible-name';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+
+/**
+ * The accessible name an open panel falls back to when it has no `title` and the
+ * caller named neither `ariaLabel` nor `ariaLabelledby` (#214).
+ *
+ * `title` defaults to `''`, so the DEFAULT rendering of this component was a
+ * `role="dialog"` with `aria-labelledby` pointing at an empty `<h2>` — measured
+ * as an `aria-dialog-name` violation, alongside `empty-heading`. A dialog with no
+ * name is announced as "dialog" and nothing else, which is the whole of what a
+ * screen-reader user gets told about a surface that just covered the page.
+ *
+ * Withholding `role="dialog"` until there is a name would be the other way to
+ * clear the rule, and it is worse: the panel traps focus either way, so a
+ * listener would be moved into a region with no announcement that anything had
+ * opened. A generic name is still a poor one, so it is paired with the dev-mode
+ * warning `tnAccessibleName` raises.
+ *
+ * Exported so specs assert against it by name rather than by a copied literal.
+ */
+export const TN_SIDE_PANEL_DEFAULT_LABEL = 'Side panel';
 
 /**
  * Directive to mark an element as a side-panel footer action.
@@ -99,6 +120,24 @@ export class TnSidePanelComponent implements OnDestroy {
    */
   closeButtonAriaLabel = input<string>('Dismiss');
 
+  /**
+   * Accessible name for the panel itself, for a panel that renders no `title`.
+   *
+   * A `title` outranks it: the heading is what the user can see, and
+   * `aria-labelledby` wins the ARIA name calculation while it resolves. The
+   * attribute is still rendered beside the heading rather than suppressed — see
+   * `tnAccessibleName`, which owns that rule for every component in this
+   * library, and the reason it is safer than the alternative.
+   */
+  ariaLabel = input<string | null>(null);
+
+  /**
+   * IDREF naming the panel from text elsewhere on the page, for a panel that
+   * renders no `title`. Same precedence: a `title` wins, because it is the
+   * visible heading.
+   */
+  ariaLabelledby = input<string | null>(null);
+
   // Outputs
   opened = output<void>();
   closed = output<void>();
@@ -110,6 +149,41 @@ export class TnSidePanelComponent implements OnDestroy {
   // Unique IDs for aria-labelledby and portal correlation
   readonly panelId = `tn-side-panel-${Math.random().toString(36).substring(2, 9)}`;
   readonly titleId = `${this.panelId}-title`;
+
+  /**
+   * Whether there is a heading to render, and to name the dialog from.
+   *
+   * Trimmed, because a whitespace-only title renders a heading that looks empty
+   * to a sighted user and names the dialog with nothing — which is the state
+   * that failed `aria-dialog-name` before #214, arriving by a second route.
+   */
+  protected hasTitle = computed(() => this.title().trim() !== '');
+
+  /**
+   * What the dialog is named by, in the order ARIA resolves: the visible heading
+   * when there is one, the caller's IDREF otherwise.
+   */
+  protected resolvedAriaLabelledby = computed(
+    () => (this.hasTitle() ? this.titleId : this.ariaLabelledby())
+  );
+
+  /**
+   * The name to render as `aria-label`, or `null` to render none — and the
+   * dev-mode warning when the panel has no name from any route.
+   *
+   * Both halves live in `../a11y/accessible-name`, shared with the three
+   * progressbars, where the reasoning for each branch is set out. `title` reaches
+   * it as the `ariaLabelledby` above, so a titled panel is named, takes no
+   * fallback and raises no warning.
+   */
+  protected resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-side-panel',
+    fallback: TN_SIDE_PANEL_DEFAULT_LABEL,
+    activity: 'open',
+    hint: 'On this component the usual route is title, which is also the visible heading.',
+    ariaLabel: this.ariaLabel,
+    ariaLabelledby: this.resolvedAriaLabelledby,
+  });
 
   // Focus restoration
   private previouslyFocusedElement: HTMLElement | null = null;

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -194,6 +194,16 @@ export class TnSidePanelComponent implements OnDestroy {
     effect(() => {
       if (this.open()) {
         this.previouslyFocusedElement = this.document.activeElement as HTMLElement;
+      } else {
+        // Restored HERE rather than on `transitionend` (#214). The overlay
+        // becomes `inert` the moment it closes, so the browser blurs whatever
+        // inside it had focus and moves it to `<body>` immediately — and
+        // `transitionend` is not guaranteed to arrive to put it back. This
+        // component's own stylesheet sets `transition-duration: 0ms` under
+        // `prefers-reduced-motion`, and a zero-duration transition runs no
+        // transition and fires no event, so a user with that preference would
+        // have been left on `<body>` every time a panel closed.
+        this.restoreFocus();
       }
     });
 
@@ -245,7 +255,6 @@ export class TnSidePanelComponent implements OnDestroy {
       this.opened.emit();
     } else {
       this.closed.emit();
-      this.restoreFocus();
     }
   }
 

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.harness.spec.ts
@@ -92,6 +92,29 @@ describe('TnSidePanelHarness', () => {
       const panel = await loader.getHarness(TnSidePanelHarness);
       expect(await panel.getTitle()).toBe('Updated Title');
     });
+
+    // Since #214 an untitled panel renders no heading element at all, and the
+    // locator has to tolerate that: `locatorFor` would throw here, turning a
+    // panel with no title into an error rather than an empty title.
+    it('should return an empty string for a panel with no title', async () => {
+      hostComponent.title.set('');
+      fixture.detectChanges();
+
+      const panel = await loader.getHarness(TnSidePanelHarness);
+      expect(await panel.getTitle()).toBe('');
+    });
+
+    // And the same for the predicate built on it: an untitled panel must simply
+    // not match, rather than making the whole query fail.
+    it('should let with({title}) skip an untitled panel instead of rejecting', async () => {
+      hostComponent.title.set('');
+      fixture.detectChanges();
+
+      const matches = await loader.getAllHarnesses(
+        TnSidePanelHarness.with({ title: 'Test Panel' }),
+      );
+      expect(matches.length).toBe(0);
+    });
   });
 
   describe('isOpen()', () => {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.harness.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.harness.ts
@@ -37,14 +37,24 @@ export class TnSidePanelHarness extends ComponentHarness {
     return this.documentRootLocatorFactory().locatorFor(`[data-tn-panel="${panelId}"].tn-side-panel__overlay`)();
   }
 
-  /** Get the panel title text. */
+  /**
+   * Get the panel title text, or `''` for a panel that renders no title.
+   *
+   * `locatorForOptional`, not `locatorFor`: since #214 a panel with no `title`
+   * renders no heading element at all — an `<h2>` with nothing in it is an
+   * `empty-heading` violation — and `locatorFor` throws on a selector that
+   * matches nothing. That would turn `getTitle()` into an error rather than an
+   * empty string, and would make `TnSidePanelHarness.with({title})` REJECT on an
+   * untitled panel instead of simply not matching it, so a filter aimed at one
+   * panel would fail on the presence of another.
+   */
   async getTitle(): Promise<string> {
     const host = await this.host();
     const panelId = await host.getAttribute('data-tn-panel');
-    const titleEl = await this.documentRootLocatorFactory().locatorFor(
+    const titleEl = await this.documentRootLocatorFactory().locatorForOptional(
       `[data-tn-panel="${panelId}"] .tn-side-panel__title`,
     )();
-    return (await titleEl.text()).trim();
+    return titleEl ? (await titleEl.text()).trim() : '';
   }
 
   /** Whether the panel is currently open. */

--- a/projects/truenas-ui/src/stories/drawer.stories.ts
+++ b/projects/truenas-ui/src/stories/drawer.stories.ts
@@ -49,6 +49,13 @@ const meta: Meta<TnDrawerComponent> = {
       control: 'boolean',
       description: 'Prevent closing via backdrop click',
     },
+    ariaLabel: {
+      control: 'text',
+      description:
+        'Accessible name for the drawer panel. In `over` mode the panel is a modal dialog and '
+        + 'must have one; in `side` mode it is a navigation landmark, which wants one as soon as '
+        + 'a page has more than one. Falls back to "Drawer" with a dev-mode warning (#214).',
+    },
   },
 };
 
@@ -98,7 +105,7 @@ export const SideMode: Story = {
     },
     template: `
       <tn-drawer-container style="height: 400px; border: 1px solid var(--tn-lines);">
-        <tn-drawer [mode]="'side'" [(opened)]="opened" [position]="position" width="240px">
+        <tn-drawer ariaLabel="Navigation" [mode]="'side'" [(opened)]="opened" [position]="position" width="240px">
           ${navTemplate}
         </tn-drawer>
         <tn-drawer-content>
@@ -129,7 +136,7 @@ export const OverMode: Story = {
     },
     template: `
       <tn-drawer-container style="height: 400px; border: 1px solid var(--tn-lines);">
-        <tn-drawer [mode]="'over'" [(opened)]="isOpen" width="280px">
+        <tn-drawer ariaLabel="Navigation" [mode]="'over'" [(opened)]="isOpen" width="280px">
           ${navTemplate}
         </tn-drawer>
         <tn-drawer-content>
@@ -162,7 +169,7 @@ export const EndPosition: Story = {
             <tn-button label="Toggle Drawer" (onClick)="opened = !opened" />
           </div>
         </tn-drawer-content>
-        <tn-drawer [mode]="'side'" [position]="'end'" [(opened)]="opened" width="240px">
+        <tn-drawer ariaLabel="Details" [mode]="'side'" [position]="'end'" [(opened)]="opened" width="240px">
           <div style="padding: 16px; color: var(--tn-fg1);">
             <p style="font-weight: 600; margin-bottom: 12px;">Details Panel</p>
             <tn-divider />
@@ -193,7 +200,7 @@ export const Responsive: Story = {
         Current mode: <strong style="color: var(--tn-fg1);">{{ mode }}</strong>
       </div>
       <tn-drawer-container style="height: 360px;">
-        <tn-drawer [mode]="mode" [(opened)]="isOpen" width="240px">
+        <tn-drawer ariaLabel="Navigation" [mode]="mode" [(opened)]="isOpen" width="240px">
           ${navTemplate}
         </tn-drawer>
         <tn-drawer-content>
@@ -249,7 +256,7 @@ export const TestIds: Story = {
     template: `
       <tn-testid-inspector>
         <tn-drawer-container style="height: 200px; border: 1px solid var(--tn-lines);">
-          <tn-drawer mode="side" [opened]="true" testId="nav" width="220px">
+          <tn-drawer mode="side" ariaLabel="Navigation" [opened]="true" testId="nav" width="220px">
             <p style="padding:12px;">Drawer content</p>
           </tn-drawer>
           <tn-drawer-content><p style="padding:12px;">Main content</p></tn-drawer-content>
@@ -269,7 +276,7 @@ export const ScopedTestIds: Story = {
     template: `
       <tn-testid-inspector>
         <tn-drawer-container style="height: 200px; border: 1px solid var(--tn-lines);">
-          <tn-drawer mode="side" [opened]="true" [testId]="['settings','nav']" width="220px">
+          <tn-drawer mode="side" ariaLabel="Navigation" [opened]="true" [testId]="['settings','nav']" width="220px">
             <p style="padding:12px;">Drawer content</p>
           </tn-drawer>
           <tn-drawer-content><p style="padding:12px;">Main content</p></tn-drawer-content>


### PR DESCRIPTION
Fixes #214.

The ticket reported axe returning **no violations and zero rules passed** against `tn-side-panel` and `tn-drawer-container`, and read zero-passed as "neither renders a role, a landmark, or an accessible name". Both halves were reproduced before anything was changed, and the zero turned out to be two different artefacts — neither of them that absence.

## What the reported scan actually was

**`tn-side-panel` portals its overlay to `document.body`.** `afterNextRender` moves `.tn-side-panel__overlay` out of the component, so a scan rooted at `<tn-side-panel>` is scanning an empty element:

```
overlay in fixture? false
overlay in body?    true
open/fixture   passes: [button-name, nested-interactive]
open/overlay   passes: 24 rules, including aria-dialog-name
```

Scanned where the markup lives, an open panel **with a title** already passed 24 rules. The role, the modal flag, the `cdkTrapFocus`, Escape and focus restoration were all there before this ticket.

**`tn-drawer-container` renders `<ng-content />` and a stylesheet.** A container with nothing in it has nothing for a rule to match, which is exactly the reported result:

```
bare-container  violations: [] passes: [] incomplete: [color-contrast]
```

Same shape as #204, where the reported markup turned out to be the stepper's childless case. Both measurements are kept as tests, so a future reader does not have to redo them.

## The model each component takes

The ticket asked for a decision per component, and for the keyboard contract that follows it to be implemented rather than merely declared.

| Component | Model | Why |
|---|---|---|
| `tn-side-panel` | **Modal** — `role="dialog"`, `aria-modal="true"` | It traps focus with `cdkTrapFocus`, auto-captures on open, closes on Escape and returns focus to the opener. `aria-modal` describes what it already does. It stays true with `hasBackdrop="false"`, because the trap is on the panel unconditionally — asserted. |
| `tn-drawer` | **Per mode, unchanged** — `navigation` in `side`, `dialog` + `aria-modal` + focus trap in `over` | Already correct, and this PR does not touch it. Side mode is persistent navigation the page stays usable behind, so it declares no modal contract and Escape does not close it — also asserted, because a contract that is not declared must not be half-implemented either. |
| `tn-drawer-container` | **Neither** — no role, no landmark, no name | It is a flex row laying a drawer out beside content. A role here would put a second, unnamed thing in the accessibility tree between a listener and the surface. `role="main"` on `tn-drawer-content` is the other tempting one and belongs to the application, which would otherwise end up with two `main`s. The reasoning is in the component's own doc comment. |

## The two defects that were real

Both are in the **default** configuration of their component, which is why they survived this long.

**1. An untitled panel is a nameless dialog.** `title` defaults to `''`, so the default rendering pointed `aria-labelledby` at an empty `<h2>`:

```
open-untitled/overlay  violations: [aria-dialog-name, empty-heading]
```

The same shape in `tn-drawer`: `ariaLabel` defaults to `undefined`, so an over-mode drawer was a modal dialog with **no name at all** — `aria-dialog-name`, and labelling it cleared it.

Both now resolve their name through the shared `tnAccessibleName`, the same decision point `tn-progress-bar`, `tn-spinner` and `tn-branded-spinner` use since #206: a name from the caller if there is one, a generic fallback if not, and a dev-mode warning so the fallback does not become a way for a missing label to go quiet. The side panel prefers its own visible heading, so a titled panel is named, takes no fallback and raises no warning. An untitled panel renders **no heading element at all**, since an empty `<h2>` is a violation in its own right and puts an empty level-2 heading in the document outline.

`tnAccessibleName` gained one optional field, `hint`, appended to the warning. Without it a side-panel developer is sent to `ariaLabel` when the input they want is `title`.

**2. A closed panel is still in the tab order.** Both components keep their content in the DOM while closed, under `aria-hidden="true"` — so the close button and everything projected in was hidden from a screen reader and still reachable by Tab, landing focus on controls translated off-screen. Both are `inert` as well as `aria-hidden` now: `inert` removes the subtree from the focus order and the accessibility tree together, and `aria-hidden` stays beside it for browsers without `inert` (Firefox before 112), where it is still the half that works. Same reasoning as `list-option.component.html` (#213).

## Two consequences of that, both found by review

**Focus was being left on `<body>`.** `inert` blurs whatever inside the panel had focus the moment it closes, and restoration hung off `transitionend`. Both stylesheets disable their transition under `prefers-reduced-motion` — `transition-duration: 0ms` on the side panel, `transition: none` on the drawer — and a transition that does not run fires no event. For a user with that preference, every close would have stranded focus at the top of the document. Restoration now happens **as the panel closes**; `transitionend` keeps only its `opened` / `closed` emissions. The tests for it deliberately never dispatch a `transitionend`, because that is precisely the reduced-motion case, and a second pair asserts a late one does not pull focus back from wherever the user has since moved it.

**`TnSidePanelHarness.getTitle()` threw on an untitled panel**, because `locatorFor` rejects when its selector matches nothing and an untitled panel now renders no heading. Worse than the throw: `with({title})` is built on `getTitle()`, so a query aimed at one panel would have failed outright because a *different*, untitled panel existed on the page. It is `locatorForOptional` now, returning `''`, and both cases are covered in `side-panel.harness.spec.ts`.

## Tests

`side-panel-a11y.spec.ts` and `drawer-a11y.spec.ts`, both through the shared `axeResult` wrapper in `lib/a11y/axe-testing.ts`, with `evaluated` asserted alongside every empty `violated` — because an empty `violations` is also what axe returns when it looked at nothing, which here is not a hypothetical but the reported defect.

**Positive controls**, since that is what the ticket said matters most:

- The reported scans themselves, kept as tests: scanning `<tn-side-panel>` evaluates **nothing**, and a `tn-drawer-container` holding nothing evaluates **nothing**. The first fails if the portal is ever removed, at which point the scans above it should be re-rooted.
- The other side of the same claim: with a drawer inside, rules do run — and axe attributes them to the drawer's panel and **not** to the container. A role added to the container breaks this, which is the point.
- The pre-fix markup rebuilt: a dialog named by an empty heading still reports `aria-dialog-name`, the empty heading still reports `empty-heading`, and an unnamed over-mode drawer still reports `aria-dialog-name`.
- Two unnamed `navigation` landmarks reporting `landmark-unique` — the measurement behind leaving that rule out of the drawer's rule list, since one drawer on a page cannot exercise it.

`aria-hidden-focus` and `color-contrast` are deliberately **not** in either rule list: both come back `incomplete` under jsdom, which `axeResult` throws on rather than letting an undecided rule satisfy an "axe really ran" assertion while contributing nothing. The inert half is asserted against the DOM instead, which is what that wrapper's own documentation says to do.

Also covered: name precedence in all four combinations for the panel, `aria-modal` appearing and disappearing with the open state, Escape in both components, the mode-per-model split, and the drawer stories now naming their drawers so a consumer copying one does not copy an unnamed landmark.

## Checks run locally

`yarn lint`, `yarn test` (106 suites, 2513 tests), `yarn build`. Lint reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here. `yarn test:scripts` and the Storybook interaction tests were not run locally.

**Local review: clean.** The project's own reviewer ran here — same rubric, threshold and parser as the required check — and the round-5 review returned nothing at MEDIUM or above. Four rounds preceded it: one HIGH pair (the stranded focus and the throwing harness), one HIGH (the mode-change restore), a prose-only commit correcting two template comments, and the MEDIUM below. All were re-reviewed except the prose-only one, per the exception in the developer prompt.

**The one MEDIUM the required check found, and it was right.** `renders no heading element at all when there is no title` scanned the `<header>` for `empty-heading` — a rule that selects heading elements only, so axe attributed nothing to the target and `violated` came back empty whatever the header held. The one call in the file that broke the file's own rule, in a file whose whole subject is vacuous axe results. Rendering the `<h2>` unconditionally under a renamed class was measured to pass both of that test's assertions with an empty level-2 heading back in the header. It is a class-independent DOM assertion now — no `h1`–`h6` anywhere in the overlay — confirmed to fail on exactly that mutation. Not another axe scan: with no heading rendered there is no target, so the rule cannot report either way. Its teeth stay asserted where it does have one, in `still reports the empty heading itself`.

## Findings left unfixed, and why

All LOW, except where marked pre-existing. Recorded here so the reviewer on this PR and the next ticket can see them rather than rediscover them.

**Filed as their own tickets** (proposed on #214, filed by the dispatcher):

- **#218** — `closed`, `opened` and `openedComplete` still fire only from `transitionend`, which this PR documents as never arriving under `prefers-reduced-motion`. So a consumer waiting on `(closed)` never hears it for those users. Pre-existing, and larger than this ticket: the fix is an event contract that does not depend on an animation, for both components.
- **#219** — `tn-dialog`'s shell has the same defect one folder over. `dialog-shell.component.html` renders an unconditional `<h2>` and has no fallback name and no warning, so an untitled dialog is exactly what this PR just fixed twice. Not swept in, because a third component is a third decision about what its name should be.

**Raised by the review on this PR, and left:**

- **`scan()` in `side-panel-a11y.spec.ts` is its third verbatim copy** — `stepper-a11y.spec.ts` has the original, `drawer-a11y.spec.ts` the other new one — and both new copies dropped the original's note on why the `try/finally` is there. `lib/a11y/axe-testing.ts` is the home this library already built for it, and a `scanDetached(html, target, rules)` beside `axeResult` would leave one copy. Correct, and a refactor across three spec files that this ticket did not ask for.
- **`console.warn` is silenced suite-wide in `drawer.component.spec.ts` and `drawer.harness.spec.ts`** with nothing asserting what was silenced, so any other warning those fixtures start producing goes quiet for 30-odd tests. The narrower fix is to name the drawers in both host components so no warning is raised at all.
- **The no-backdrop test pins `aria-modal="true"`** on a panel whose `NoBackdrop` story is deliberately non-blocking for a mouse user. The two views disagree, and the unconditional `cdkTrapFocus` is arguably the half to revisit — a keyboard user cannot Tab out of a panel a mouse user can click past. Both halves are pre-existing; worth taking with #218.
- **The new naming inputs are undocumented in Storybook.** The drawer gained an `ariaLabel` argType; `ariaLabelledby` on both components and `ariaLabel` on the side panel have none, and no story renders the untitled panel — which is now a visibly different header, since the actions keep their right edge from `margin-left: auto` rather than from the title's `flex: 1`, and is the one configuration that logs the dev warning.

**Also noted, and not raised on the PR:**

- **Switching a drawer's `mode` while it is open moves focus to the opener.** Not the effect — the guard added in round 3 keeps it out of the restore branch, measured — but `mode` decides which of two panels the template renders, so the over-mode panel is destroyed and `CdkTrapFocus.ngOnDestroy` restores what it captured. Pre-existing, and arguably right: the element that had focus no longer exists. Worth revisiting with the responsive-breakpoint case in hand.
- **The dev-mode warning is not gated on the panel being open**, so a panel whose `title` arrives with data warns once before the data does. Gating it would mean a panel that is never opened never warns, which is the case a developer most needs told; the effect re-runs when the inputs change, so the warning stops once the title lands.
- **A side-mode close restores focus captured by an earlier over-mode open.** Reachable only by opening in `over`, switching to `side` and then closing — and after the round-3 guard the saved element is still the one the user came from, which is why it is deliberate rather than a leak. It does move focus for a non-modal surface, which is the part worth a second opinion.
- **`tn-drawer`'s `ariaLabel` is `string | undefined`** while `ariaLabelledby` and both side-panel inputs are `string | null`, which is why `tnAccessibleName` gets a one-line `computed` adapter. Narrowing the existing input is a breaking change for anyone binding `undefined` explicitly.
- **A browser without `inert`** falls back to `aria-hidden` alone, which hides the closed subtree without taking it out of the tab order. `inert` has been in Chrome since 102, Safari 15.5 and Firefox 112.
