### PR TITLE
NAS-142345 / 27.0.0-BETA.1 / fix(selection-list): give the listbox a roving tabindex and arrow keys

### DIFF
--- a/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option-a11y.spec.ts
@@ -275,6 +275,35 @@ describe('tn-list-option accessibility (#213)', () => {
 
       expect(option().getAttribute('aria-selected')).toBe('false');
     });
+
+    /**
+     * The option acts on its OWN key presses. Its keydown handler is on the
+     * host, which hears everything that bubbles out of projected content, so a
+     * consumer's text input inside an option would otherwise find Space
+     * `preventDefault()`ed away and the option toggling as it typed.
+     */
+    it.each([' ', 'Enter'])('leaves %s alone when a projected control has focus', (key) => {
+      @Component({
+        selector: 'tn-projected-host',
+        standalone: true,
+        imports: [TnListOptionComponent],
+        template: `<tn-list-option><input /></tn-list-option>`
+      })
+      class ProjectedHostComponent {}
+
+      const projected = TestBed.createComponent(ProjectedHostComponent);
+      projected.detectChanges();
+
+      const input = projected.nativeElement.querySelector('input') as HTMLInputElement;
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+      projected.detectChanges();
+
+      const optionHost = projected.nativeElement.querySelector('tn-list-option') as HTMLElement;
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(optionHost.getAttribute('aria-selected')).toBe('false');
+    });
   });
 
   /**

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -25,16 +25,19 @@ import { TnCheckboxComponent } from '../checkbox/checkbox.component';
     // them reachable, and it keeps the count the same: one tab stop per option,
     // now on the element that acts on it.
     //
-    // A listbox should really manage a single roving tabindex across its
-    // options rather than making each one a stop; tn-selection-list has no
-    // keyboard handling at all today, so that is its own piece of work and is
-    // proposed on the PR rather than done here.
+    // Inside a tn-selection-list that is no longer true: the listbox owns a
+    // single roving tabindex across its options (#216) and hands each one the
+    // value it should carry, so the list costs one Tab press however long it
+    // is. What is below is the STANDALONE behaviour — tn-list-option is
+    // exported on its own, and an option with no parent list has to stay the
+    // plain tab stop #213 made it rather than fall out of the tab order.
     //
-    // A disabled option is left out of the tab order, matching the
+    // Standalone, a disabled option is left out of the tab order, matching the
     // `pointer-events: none` the disabled modifier already sets — every other
     // route into toggle() is closed for it, so offering focus would only be a
-    // stop where nothing happens.
-    '[attr.tabindex]': 'effectiveDisabled() ? null : 0',
+    // stop where nothing happens. Under a roving tabindex that trade is
+    // different and the listbox decides it differently; see effectiveTabindex.
+    '[attr.tabindex]': 'effectiveTabindex()',
     '[attr.aria-selected]': 'effectiveSelected()',
     '[attr.aria-disabled]': 'effectiveDisabled()'
   }
@@ -75,6 +78,35 @@ export class TnListOptionComponent implements AfterContentInit {
     return internal !== null ? internal : this.color();
   });
 
+  /**
+   * The tabindex a parent `tn-selection-list` has assigned, or `null` when this
+   * option is standalone.
+   *
+   * Set by the listbox's roving tabindex (#216): 0 on the one option that is
+   * the list's single tab stop, -1 on the rest. `null` is not "no tab stop" but
+   * "no parent" — it is what keeps a `tn-list-option` used on its own behaving
+   * as #213 left it, and it is why this is a nullable number rather than a
+   * number defaulting to -1.
+   */
+  rovingTabindex = signal<number | null>(null);
+
+  /**
+   * -1 rather than a removed attribute for a disabled option under a roving
+   * tabindex, which is the one place these two paths disagree. An element with
+   * no `tabindex` cannot be focused programmatically either, so dropping the
+   * attribute would leave the listbox's arrow keys with nothing to move focus
+   * to — and the listbox deliberately visits disabled options, so that they can
+   * be perceived rather than silently skipped. Standalone, where every stop
+   * costs a Tab press, the disabled option is still left out entirely.
+   */
+  effectiveTabindex = computed(() => {
+    const roving = this.rovingTabindex();
+    if (roving !== null) {
+      return roving;
+    }
+    return this.effectiveDisabled() ? null : 0;
+  });
+
   protected hasLeadingContent = signal<boolean>(false);
   protected hasSecondaryTextContent = signal<boolean>(false);
   protected hasPrimaryTextDirective = signal<boolean>(false);
@@ -103,6 +135,19 @@ export class TnListOptionComponent implements AfterContentInit {
       element.querySelector('[tnListItemTitle]') ||
       element.querySelector('[tnListItemPrimary]')
     ));
+  }
+
+  /**
+   * Move real DOM focus to this option.
+   *
+   * Called by the parent listbox as the arrow keys move (#216). Focus lands on
+   * the host, which is both the element carrying the roving tabindex and the
+   * element `:host(:focus-visible)` draws the #215 focus ring on — the two
+   * reasons the listbox moves focus rather than pointing at the option with
+   * `aria-activedescendant`.
+   */
+  focus(): void {
+    (this.elementRef.nativeElement as HTMLElement).focus();
   }
 
   @HostListener('click', ['$event'])

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -159,14 +159,29 @@ export class TnListOptionComponent implements AfterContentInit {
     this.toggle();
   }
 
+  /**
+   * The key is swallowed BEFORE the disabled guard, not after it.
+   *
+   * Declining to toggle is not the same as declining the key. Space scrolls the
+   * page on any element that is neither a form control nor a scroller, and the
+   * option host is neither — so bailing out first hands the browser a Space
+   * with its default action intact, on an element the user deliberately focused
+   * and got nothing from. Nothing upstream saves it either: the listbox's own
+   * handler falls through for Space on purpose, so that the key reaches here.
+   *
+   * Only reachable under a parent `tn-selection-list` (#216), whose roving
+   * tabindex is what makes a disabled option focusable — standalone it carries
+   * no `tabindex`, so it cannot hold focus and this never fires on it.
+   */
   @HostListener('keydown.space', ['$event'])
   @HostListener('keydown.enter', ['$event'])
   onKeydown(event: Event): void {
+    event.preventDefault();
+
     if (this.effectiveDisabled()) {
       return;
     }
 
-    event.preventDefault();
     this.toggle();
   }
 

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -172,10 +172,20 @@ export class TnListOptionComponent implements AfterContentInit {
    * Only reachable under a parent `tn-selection-list` (#216), whose roving
    * tabindex is what makes a disabled option focusable — standalone it carries
    * no `tabindex`, so it cannot hold focus and this never fires on it.
+   *
+   * Which is safe only because the key has to have been pressed on the host
+   * itself. A host listener hears whatever bubbles out of projected content, so
+   * a consumer's `<input>` inside an option would otherwise have its Space
+   * swallowed by the `preventDefault()` above — and, on an enabled option,
+   * toggle the option as well as typing.
    */
   @HostListener('keydown.space', ['$event'])
   @HostListener('keydown.enter', ['$event'])
   onKeydown(event: Event): void {
+    if (event.target !== this.elementRef.nativeElement) {
+      return;
+    }
+
     event.preventDefault();
 
     if (this.effectiveDisabled()) {

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -517,6 +517,97 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
 
       expect(tabindexes().filter((value) => value === '0')).toHaveLength(1);
     });
+
+    /**
+     * Removal and insertion ABOVE the option the user is standing on, which is
+     * where an index and a caret come apart.
+     *
+     * Every case above changes the list at or below the caret, where clamping a
+     * remembered index happens to land on the right option and hides the
+     * question. Editing above it shifts every option down or up by one while
+     * DOM focus stays put, so an index remembered from before the edit now
+     * names a DIFFERENT option — the tab stop moves off the focused option, and
+     * the next arrow key starts counting from somewhere the user is not.
+     *
+     * Five options rather than the default four, because with four the clamp
+     * `Math.min(3, 2)` coincidentally lands back on the focused option.
+     */
+    describe('an option is added or removed above the caret', () => {
+      beforeEach(() => {
+        host.items.update((items) => [
+          ...items,
+          { value: 'e', label: 'Option E', disabled: false }
+        ]);
+        fixture.detectChanges();
+
+        options()[3].focus();
+        fixture.detectChanges();
+      });
+
+      /** a b c d e, focus on d, remove a — d is index 2 of b c d e. */
+      it('keeps the tab stop on the focused option when one above it is removed', () => {
+        host.items.update((items) => items.slice(1));
+        fixture.detectChanges();
+
+        expect(focusedIndex()).toBe(2);
+        expect(tabindexes()).toEqual(['-1', '-1', '0', '-1']);
+      });
+
+      /**
+       * The same drift, felt as a keypress: one ArrowDown from d should be e,
+       * and lands two options away if it counts from the remembered index.
+       */
+      it('moves focus one option from where focus actually is', () => {
+        host.items.update((items) => items.slice(1));
+        fixture.detectChanges();
+
+        press('ArrowDown');
+
+        expect(focusedIndex()).toBe(3);
+      });
+
+      it('moves focus back one option from where focus actually is', () => {
+        host.items.update((items) => items.slice(1));
+        fixture.detectChanges();
+
+        press('ArrowUp');
+
+        expect(focusedIndex()).toBe(1);
+      });
+
+      /** The other direction: z a b c d e, focus still on d, now index 4. */
+      it('keeps the tab stop on the focused option when one is inserted above it', () => {
+        host.items.update((items) => [
+          { value: 'z', label: 'Option Z', disabled: false },
+          ...items
+        ]);
+        fixture.detectChanges();
+
+        expect(focusedIndex()).toBe(4);
+        expect(tabindexes()).toEqual(['-1', '-1', '-1', '-1', '0', '-1']);
+      });
+
+      /**
+       * And with focus elsewhere on the page, where there is no caret to read
+       * the answer off. The tab stop is where a returning Tab lands, so it has
+       * to follow the option the user was last on rather than the slot that
+       * option used to occupy — otherwise a list edited while they were away
+       * returns them to a neighbour.
+       */
+      it('keeps the tab stop with the last visited option after focus has left', () => {
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        outside.focus();
+        fixture.detectChanges();
+
+        host.items.update((items) => items.slice(1));
+        fixture.detectChanges();
+
+        expect(tabindexes()).toEqual(['-1', '-1', '0', '-1']);
+
+        outside.remove();
+      });
+    });
   });
 
   /**

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -233,6 +233,27 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
       expect(event.defaultPrevented).toBe(true);
     });
 
+    /**
+     * A modified navigation key is somebody else's. Ctrl/Cmd+Home and
+     * Ctrl/Cmd+End jump to the top and bottom of the document, and
+     * Shift+ArrowDown is APG's extend-the-selection, which this listbox does
+     * not implement — so consuming them takes a shortcut away and gives the
+     * user nothing in exchange.
+     */
+    it.each([
+      ['Home', { ctrlKey: true }],
+      ['End', { metaKey: true }],
+      ['ArrowDown', { shiftKey: true }],
+      ['ArrowUp', { altKey: true }]
+    ])('leaves a modified %s to the browser', (key, modifier) => {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...modifier });
+      (document.activeElement as HTMLElement).dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(focusedIndex()).toBe(0);
+    });
+
     it.each(['Tab', 'Escape', 'a'])('leaves %s to the browser', (key) => {
       const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
       (document.activeElement as HTMLElement).dispatchEvent(event);

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -499,6 +499,40 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
   });
 
   /**
+   * The listener is on the listbox host and hears every keydown that bubbles
+   * through it, so the navigation keys are claimed only when the option host
+   * itself is the target. Nothing in this library projects a focusable control
+   * into an option and `role="option"` arguably forbids one, but a consumer can
+   * — and Home taken off an input's caret, with a `preventDefault()` on top, is
+   * the listbox reaching into a control it does not own.
+   */
+  describe('a focusable control projected into an option', () => {
+    it('keeps the navigation keys', () => {
+      @Component({
+        selector: 'tn-projected-host',
+        standalone: true,
+        imports: [TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-selection-list><tn-list-option value="a"><input /></tn-list-option>
+          <tn-list-option value="b">Option B</tn-list-option></tn-selection-list>`
+      })
+      class ProjectedHostComponent {}
+
+      const projected = TestBed.createComponent(ProjectedHostComponent);
+      projected.detectChanges();
+
+      const input = projected.nativeElement.querySelector('input') as HTMLInputElement;
+      input.focus();
+
+      const event = new KeyboardEvent('keydown', { key: 'End', bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+      projected.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  /**
    * `tn-list-option` is exported on its own and is used outside a
    * `tn-selection-list`. The roving tabindex is the parent's, so an option with
    * no parent has to stay the plain tab stop #213 made it — otherwise this fix

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -283,6 +283,34 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
       expect(options()[2].getAttribute('aria-selected')).toBe('false');
       expect(host.changes).toEqual([]);
     });
+
+    /**
+     * The other half of that keypress, and the half the toggle assertion above
+     * cannot see: refusing to toggle is not the same as consuming the key.
+     *
+     * Space has a default action — scroll the page — on any element that is
+     * neither a form control nor a scroller, and the option host is neither.
+     * Nothing else swallows it either: the listbox's own handler falls through
+     * `default:` for `' '`, deliberately, so that Space reaches the option. So
+     * a Space the option declines has to be prevented by the option.
+     *
+     * This became reachable with the roving tabindex: a disabled option
+     * previously carried no `tabindex`, so it could not hold focus and its
+     * guard could never be hit by a real keypress.
+     */
+    it('consume Space rather than letting the page scroll', () => {
+      press('ArrowDown');
+      press('ArrowDown');
+
+      expect(focusedIndex()).toBe(2);
+
+      const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+      (document.activeElement as HTMLElement).dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(host.changes).toEqual([]);
+    });
   });
 
   /**

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -1,0 +1,452 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { TnSelectionChange } from './selection-list.component';
+import { TnSelectionListComponent } from './selection-list.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TnListOptionComponent } from '../list-option/list-option.component';
+
+/**
+ * Keyboard navigation for `tn-selection-list` (#216).
+ *
+ * The host has carried `role="listbox"` all along with no keyboard handling of
+ * any kind. That went unnoticed while nothing in an option was a working tab
+ * stop either; #213 made the option itself the stop, which left the component
+ * reachable but at one Tab press per option — a twenty-item list costing twenty
+ * stops, where WAI-ARIA APG expects one stop and nineteen ArrowDown presses.
+ *
+ * WHICH MODEL, AND WHY
+ * --------------------
+ * Roving tabindex over REAL DOM FOCUS, not `aria-activedescendant`. Two reasons,
+ * both specific to this component rather than general preference:
+ *
+ * 1. `tn-list-option` already carries the `keydown.space` / `keydown.enter`
+ *    handlers that toggle it, and they fire on the focused element. Under
+ *    `aria-activedescendant` focus would sit on the listbox and those handlers
+ *    could never fire, so the parent would have to toggle the active option
+ *    itself — a second route into `toggle()` and the double-toggle this spec
+ *    guards against.
+ * 2. The focus ring #215 added is `:host(:focus-visible)` on the option. It
+ *    fires on DOM focus and nothing else, so an `aria-activedescendant` model
+ *    would have silently taken the indicator away and needed a class-based
+ *    replacement. Moving real focus keeps the rule that already exists working.
+ *
+ * `tn-select` makes the opposite choice, and correctly: it is a combobox whose
+ * options live in an overlay while focus stays on the trigger, so
+ * `aria-activedescendant` is the only model available to it. The two components
+ * diverge because the shape of the widget differs, not by oversight.
+ */
+
+interface TestOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+}
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSelectionListComponent, TnListOptionComponent],
+  // Held to three lines by @angular-eslint/component-max-inline-declarations,
+  // which is why the @for body is not broken up the way it would be in a real
+  // template.
+  template: `<tn-selection-list (selectionChange)="onSelectionChange($event)">
+    @for (item of items(); track item.value) {<tn-list-option [value]="item.value"
+      [disabled]="item.disabled">{{ item.label }}</tn-list-option>}</tn-selection-list>`
+})
+class TestHostComponent {
+  items = signal<TestOption[]>([
+    { value: 'a', label: 'Option A', disabled: false },
+    { value: 'b', label: 'Option B', disabled: false },
+    { value: 'c', label: 'Option C', disabled: true },
+    { value: 'd', label: 'Option D', disabled: false }
+  ]);
+
+  changes: TnSelectionChange[] = [];
+
+  onSelectionChange(event: TnSelectionChange): void {
+    this.changes.push(event);
+  }
+}
+
+describe('tn-selection-list keyboard navigation (#216)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    // Attached to the document, which axe needs — it walks up to the document
+    // root to decide visibility and exempts a detached tree from every rule.
+    // Real focus needs it too: `HTMLElement.focus()` on a detached element
+    // leaves `document.activeElement` on `<body>`, so every assertion about
+    // where focus landed would be vacuous.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function list(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-selection-list') as HTMLElement;
+  }
+
+  function options(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('tn-list-option'));
+  }
+
+  function tabindexes(): (string | null)[] {
+    return options().map((option) => option.getAttribute('tabindex'));
+  }
+
+  /** Dispatch a key on whatever currently holds focus, as a browser would. */
+  function press(key: string): void {
+    const target = (document.activeElement ?? list()) as HTMLElement;
+    target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+    fixture.detectChanges();
+  }
+
+  function focusedIndex(): number {
+    return options().indexOf(document.activeElement as HTMLElement);
+  }
+
+  describe('the listbox is a single tab stop', () => {
+    /**
+     * The defect, stated as an assertion: before #216 every option carried
+     * `tabindex="0"` (bar the disabled one, which carried none), so a four-item
+     * list cost four Tab presses and a twenty-item list cost twenty.
+     */
+    it('puts exactly one option in the tab order', () => {
+      expect(tabindexes().filter((value) => value === '0')).toHaveLength(1);
+    });
+
+    it('gives every other option tabindex="-1" rather than removing it', () => {
+      // -1 rather than absent, including on the disabled option: an option with
+      // no `tabindex` at all cannot be focused programmatically either, so the
+      // arrow keys would have nothing to move focus to.
+      expect(tabindexes()).toEqual(['0', '-1', '-1', '-1']);
+    });
+
+    it('starts the roving tabindex on the first option when nothing is selected', () => {
+      expect(tabindexes()[0]).toBe('0');
+    });
+
+    /**
+     * APG puts the initial stop on the selected option, so tabbing into a list
+     * that already has a selection lands where the user left off rather than at
+     * the top.
+     */
+    it('starts the roving tabindex on the first selected option', () => {
+      options()[2 - 1].click();
+      fixture.detectChanges();
+
+      expect(tabindexes()).toEqual(['-1', '0', '-1', '-1']);
+    });
+
+    it('moves the tab stop to the option the arrow keys land on', () => {
+      options()[0].focus();
+      press('ArrowDown');
+
+      expect(tabindexes()).toEqual(['-1', '0', '-1', '-1']);
+    });
+
+    it('moves the tab stop to an option that is clicked', () => {
+      options()[3].focus();
+      options()[3].click();
+      fixture.detectChanges();
+
+      expect(tabindexes()).toEqual(['-1', '-1', '-1', '0']);
+    });
+  });
+
+  describe('arrow keys move focus', () => {
+    beforeEach(() => {
+      options()[0].focus();
+      fixture.detectChanges();
+    });
+
+    it('moves focus down the list on ArrowDown', () => {
+      press('ArrowDown');
+
+      expect(focusedIndex()).toBe(1);
+    });
+
+    it('moves focus up the list on ArrowUp', () => {
+      press('ArrowDown');
+      press('ArrowDown');
+      press('ArrowUp');
+
+      expect(focusedIndex()).toBe(1);
+    });
+
+    /**
+     * Wrapping rather than stopping, matching `tn-select`'s option list — the
+     * two widgets differ on the focus model and there is no reason for them to
+     * also differ on what the last ArrowDown does.
+     */
+    it('wraps from the last option to the first', () => {
+      press('End');
+      press('ArrowDown');
+
+      expect(focusedIndex()).toBe(0);
+    });
+
+    it('wraps from the first option to the last', () => {
+      press('ArrowUp');
+
+      expect(focusedIndex()).toBe(3);
+    });
+
+    it('jumps to the first option on Home', () => {
+      press('End');
+      press('Home');
+
+      expect(focusedIndex()).toBe(0);
+    });
+
+    it('jumps to the last option on End', () => {
+      press('End');
+
+      expect(focusedIndex()).toBe(3);
+    });
+
+    /**
+     * The keys the listbox claims are the ones it acts on, and no others: a
+     * `preventDefault()` on every keydown would swallow Tab and trap the user
+     * in the list.
+     */
+    it.each(['ArrowDown', 'ArrowUp', 'Home', 'End'])('prevents the default scroll on %s', (key) => {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      (document.activeElement as HTMLElement).dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it.each(['Tab', 'Escape', 'a'])('leaves %s to the browser', (key) => {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      (document.activeElement as HTMLElement).dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(focusedIndex()).toBe(0);
+    });
+  });
+
+  /**
+   * THE DISABLED-OPTION DECISION, ASSERTED EITHER WAY.
+   *
+   * Arrow keys DO visit a disabled option. APG keeps `aria-disabled` options
+   * focusable so a keyboard user can perceive that they exist, and the objection
+   * `tn-list-option` recorded against that — "offering focus would only be a
+   * stop where nothing happens" — was about the TAB ORDER, where each extra stop
+   * costs a Tab press. Under a roving tabindex there is exactly one tab stop
+   * whatever the arrow keys visit, so that cost is gone and skipping the option
+   * only hides it.
+   *
+   * `tn-select` skips its disabled options, and that divergence is deliberate
+   * for the same reason: its options are in an overlay a user opens to pick
+   * from, so a stop that cannot be picked is noise. An inline list is something
+   * a user reads.
+   */
+  describe('disabled options', () => {
+    beforeEach(() => {
+      options()[0].focus();
+      fixture.detectChanges();
+    });
+
+    it('are visited by the arrow keys', () => {
+      press('ArrowDown');
+      press('ArrowDown');
+
+      expect(focusedIndex()).toBe(2);
+      expect(options()[2].getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('can be moved past in both directions', () => {
+      press('End');
+      press('ArrowUp');
+
+      expect(focusedIndex()).toBe(2);
+
+      press('ArrowUp');
+
+      expect(focusedIndex()).toBe(1);
+    });
+
+    it('do not toggle on Space', () => {
+      press('ArrowDown');
+      press('ArrowDown');
+      press(' ');
+
+      expect(options()[2].getAttribute('aria-selected')).toBe('false');
+      expect(host.changes).toEqual([]);
+    });
+  });
+
+  /**
+   * The parent claims the navigation keys and nothing else. `tn-list-option`
+   * has toggled on Space and Enter since before this ticket, and both events
+   * bubble to the listbox host — so a parent handler that also toggled would
+   * toggle twice, selecting and immediately deselecting, and look like nothing
+   * happened at all.
+   */
+  describe('Space and Enter still toggle, exactly once', () => {
+    beforeEach(() => {
+      options()[0].focus();
+      fixture.detectChanges();
+    });
+
+    it.each([' ', 'Enter'])('toggles the focused option on %s', (key) => {
+      press(key);
+
+      expect(options()[0].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it.each([' ', 'Enter'])('emits one selectionChange per %s', (key) => {
+      press(key);
+
+      expect(host.changes).toHaveLength(1);
+      expect(host.changes[0].options.map((option) => option.value())).toEqual(['a']);
+    });
+
+    it.each([' ', 'Enter'])('toggles back off on a second %s', (key) => {
+      press(key);
+      press(key);
+
+      expect(options()[0].getAttribute('aria-selected')).toBe('false');
+      expect(host.changes).toHaveLength(2);
+      expect(host.changes[1].options).toEqual([]);
+    });
+
+    it('toggles the option the arrow keys moved to, not the one tabbed into', () => {
+      press('ArrowDown');
+      press(' ');
+
+      expect(options()[0].getAttribute('aria-selected')).toBe('false');
+      expect(options()[1].getAttribute('aria-selected')).toBe('true');
+    });
+  });
+
+  /**
+   * The focus indicator #215 added is `:host(:focus-visible)`, which fires on
+   * DOM focus and on nothing else. jsdom has no layout engine and does not
+   * evaluate `:focus-visible`, so what is asserted here is the precondition the
+   * rule needs — that real focus actually lands on the option the arrow keys
+   * chose, rather than the listbox merely pointing at it with
+   * `aria-activedescendant`. `list-option-a11y.spec.ts` asserts the rule itself
+   * is still in the stylesheet.
+   */
+  describe('focus really moves, so the #215 focus ring still shows', () => {
+    it('leaves DOM focus on the option the arrow keys chose', () => {
+      options()[0].focus();
+      press('ArrowDown');
+
+      expect(document.activeElement).toBe(options()[1]);
+    });
+
+    it('does not keep focus on the listbox itself', () => {
+      options()[0].focus();
+      press('ArrowDown');
+
+      expect(document.activeElement).not.toBe(list());
+    });
+
+    /**
+     * `aria-activedescendant` is the model this component did NOT choose, and
+     * setting it while DOM focus is elsewhere points assistive technology at one
+     * option while the browser focuses another.
+     */
+    it('does not also drive aria-activedescendant', () => {
+      options()[0].focus();
+      press('ArrowDown');
+
+      expect(list().hasAttribute('aria-activedescendant')).toBe(false);
+    });
+  });
+
+  describe('the listbox structure axe checks', () => {
+    it('raises no violation on a populated list', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [list(), ...options()],
+        ['aria-required-children', 'aria-required-parent']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+      expect(evaluated).toContain('aria-required-parent');
+    });
+
+    it('keeps role="listbox" on the host', () => {
+      expect(list().getAttribute('role')).toBe('listbox');
+    });
+
+    it('keeps every child a role="option"', () => {
+      expect(options().map((option) => option.getAttribute('role')))
+        .toEqual(['option', 'option', 'option', 'option']);
+    });
+  });
+
+  /**
+   * An empty list and a list whose options change under it are where a roving
+   * index goes out of bounds — an index kept in a field, pointing past the end
+   * after the last option is removed, and a keypress that throws.
+   */
+  describe('when the options change', () => {
+    it('survives arrow keys on an empty list', () => {
+      host.items.set([]);
+      fixture.detectChanges();
+
+      expect(() => {
+        list().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      }).not.toThrow();
+    });
+
+    it('keeps exactly one tab stop after options are removed', () => {
+      options()[3].focus();
+      fixture.detectChanges();
+
+      host.items.update((items) => items.slice(0, 2));
+      fixture.detectChanges();
+
+      expect(tabindexes().filter((value) => value === '0')).toHaveLength(1);
+    });
+
+    it('keeps exactly one tab stop after options are added', () => {
+      host.items.update((items) => [
+        ...items,
+        { value: 'e', label: 'Option E', disabled: false }
+      ]);
+      fixture.detectChanges();
+
+      expect(tabindexes().filter((value) => value === '0')).toHaveLength(1);
+    });
+  });
+
+  /**
+   * `tn-list-option` is exported on its own and is used outside a
+   * `tn-selection-list`. The roving tabindex is the parent's, so an option with
+   * no parent has to stay the plain tab stop #213 made it — otherwise this fix
+   * takes a standalone option out of the tab order entirely.
+   */
+  describe('an option outside a selection list is unaffected', () => {
+    it('stays in the tab order', async () => {
+      @Component({
+        selector: 'tn-lone-host',
+        standalone: true,
+        imports: [TnListOptionComponent],
+        template: `<tn-list-option value="lone">Lone option</tn-list-option>`
+      })
+      class LoneHostComponent {}
+
+      const lone = TestBed.createComponent(LoneHostComponent);
+      lone.detectChanges();
+
+      const option = lone.nativeElement.querySelector('tn-list-option') as HTMLElement;
+
+      expect(option.tabIndex).toBe(0);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-a11y.spec.ts
@@ -151,9 +151,18 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
       expect(tabindexes()).toEqual(['-1', '0', '-1', '-1']);
     });
 
-    it('moves the tab stop to an option that is clicked', () => {
+    /**
+     * The route a click takes, walked directly rather than through `click()`.
+     *
+     * What moves the tab stop on a click is the focus a real browser gives the
+     * option on mousedown — `onFocusIn` is the only handler involved, and the
+     * listbox has no click handler at all. jsdom's `HTMLElement.click()` runs
+     * none of that: it dispatches a `MouseEvent` and no focus default. A test
+     * written as focus-then-click therefore asserts nothing the click did, and
+     * would stay green if clicking stopped moving the stop entirely.
+     */
+    it('moves the tab stop to an option that takes focus, as a click does', () => {
       options()[3].focus();
-      options()[3].click();
       fixture.detectChanges();
 
       expect(tabindexes()).toEqual(['-1', '-1', '-1', '0']);
@@ -440,6 +449,42 @@ describe('tn-selection-list keyboard navigation (#216)', () => {
       fixture.detectChanges();
 
       expect(tabindexes().filter((value) => value === '0')).toHaveLength(1);
+    });
+
+    /**
+     * Removing the option a user is standing on takes their focus with it —
+     * the browser drops it to `<body>`, so the next Tab restarts from the top
+     * of the document rather than continuing past the list. Moving the tab stop
+     * does not cover this: the stop is where focus would RESUME, not where it
+     * currently is.
+     */
+    it('moves focus to the new tab stop when the focused option is removed', () => {
+      options()[3].focus();
+      fixture.detectChanges();
+
+      expect(focusedIndex()).toBe(3);
+
+      host.items.update((items) => items.slice(0, 2));
+      fixture.detectChanges();
+
+      expect(focusedIndex()).toBe(1);
+      expect(tabindexes()).toEqual(['-1', '0']);
+    });
+
+    /** The other side of that: focus the list does not hold is not the list's to take. */
+    it('leaves focus alone when the options change from outside the list', () => {
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+
+      options()[3].focus();
+      outside.focus();
+
+      host.items.update((items) => items.slice(0, 2));
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(outside);
+
+      outside.remove();
     });
 
     it('keeps exactly one tab stop after options are added', () => {

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -29,7 +29,15 @@ export interface TnSelectionChange {
     '[class.tn-selection-list--dense]': 'dense()',
     '[class.tn-selection-list--disabled]': 'isDisabled()',
     'role': 'listbox',
-    '[attr.aria-multiselectable]': 'multiple()'
+    '[attr.aria-multiselectable]': 'multiple()',
+    // Both listeners are on the host and rely on bubbling from the options,
+    // rather than being bound per option: contentChildren gives components, not
+    // template bindings, so there is nowhere to attach a per-option listener
+    // without the option knowing about its parent. Keydown bubbles from the
+    // focused option to here, which is also what lets tn-list-option keep its
+    // own Space/Enter handlers untouched — see onKeydown.
+    '(keydown)': 'onKeydown($event)',
+    '(focusin)': 'onFocusIn($event)'
   }
 })
 export class TnSelectionListComponent implements ControlValueAccessor {
@@ -47,6 +55,45 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   // Computed disabled state (combines input and form state)
   isDisabled = computed(() => this.disabled() || this.formDisabled());
 
+  /**
+   * The option the user has moved to, or `null` while they have not moved yet.
+   *
+   * Kept separate from `activeIndex` rather than seeded with a starting value,
+   * because "where the user last was" and "where a user who has not arrived yet
+   * would land" are different questions and only the second one should follow
+   * the selection around. See `activeIndex`.
+   */
+  private visitedIndex = signal<number | null>(null);
+
+  /**
+   * Which option carries the listbox's single tab stop.
+   *
+   * Before the user has touched the list this tracks the first selected option,
+   * which is what APG asks for — tabbing into a list that already has a
+   * selection should land where the user left off rather than at the top. Once
+   * they have moved, `visitedIndex` pins it and the selection no longer drags
+   * the tab stop around underneath them.
+   *
+   * Clamped rather than stored as a plain index, because the options are
+   * content children and the caller can remove them: an index held in a field
+   * outlives the option it pointed at, and the next keypress reads past the end
+   * of the array.
+   */
+  private activeIndex = computed(() => {
+    const opts = this.options();
+    if (opts.length === 0) {
+      return -1;
+    }
+
+    const visited = this.visitedIndex();
+    if (visited !== null) {
+      return Math.min(visited, opts.length - 1);
+    }
+
+    const firstSelected = opts.findIndex(option => option.effectiveSelected());
+    return firstSelected === -1 ? 0 : firstSelected;
+  });
+
   private onChange = (_: unknown[]) => {};
   private onTouched = () => {};
 
@@ -60,6 +107,97 @@ export class TnSelectionListComponent implements ControlValueAccessor {
         option.internalColor.set(currentColor);
       });
     });
+
+    // The roving tabindex itself: one stop for the whole listbox, moved rather
+    // than added to. Written from an effect because it has to re-run both when
+    // the active option changes and when the set of options does — an option
+    // added after the list was rendered would otherwise arrive with no tabindex
+    // assigned and fall back to its standalone value, putting a second stop in
+    // the tab order.
+    effect(() => {
+      const opts = this.options();
+      const active = this.activeIndex();
+      opts.forEach((option, index) => {
+        option.rovingTabindex.set(index === active ? 0 : -1);
+      });
+    });
+  }
+
+  /**
+   * ArrowUp / ArrowDown / Home / End, and deliberately nothing else.
+   *
+   * Space and Enter are absent because `tn-list-option` has handled them since
+   * before this component had any keyboard handling at all, and its keydown
+   * bubbles up to here. Toggling from both places would toggle twice — select
+   * then immediately deselect — which reads as the key doing nothing rather
+   * than as a bug, so it is worth stating why it is missing rather than leaving
+   * a later reader to add it.
+   *
+   * Every other key is left alone, Tab included: `preventDefault()` on an
+   * unrecognised key is how a widget traps a keyboard user inside it.
+   *
+   * Navigation is not gated on `isDisabled()`. Moving focus changes nothing —
+   * every route into `toggle()` is already closed for a disabled option by the
+   * option's own guard — and a disabled list a user can read through is the
+   * same reasoning that has the arrow keys visit disabled options at all.
+   */
+  onKeydown(event: KeyboardEvent): void {
+    const count = this.options().length;
+    if (count === 0) {
+      return;
+    }
+
+    const current = this.activeIndex();
+    let next: number;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        next = (current + 1) % count;
+        break;
+      case 'ArrowUp':
+        next = (current - 1 + count) % count;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = count - 1;
+        break;
+      default:
+        return;
+    }
+
+    // After the switch, so it happens only for the keys actually handled — and
+    // only once the list is known to be non-empty, so a swallowed key always
+    // moved something.
+    event.preventDefault();
+    this.visitedIndex.set(next);
+    this.options()[next].focus();
+  }
+
+  /**
+   * Keep the tab stop under whichever option actually holds focus.
+   *
+   * Covers the routes into the list that are not the arrow keys — a click, and
+   * a Tab that lands here — so that leaving the list and coming back returns to
+   * the option the user was last on, rather than to the one the arrow keys
+   * happened to leave the index at.
+   *
+   * `contains` rather than an identity check on the target, because focus can
+   * land on something projected into the option rather than on the option host.
+   */
+  onFocusIn(event: FocusEvent): void {
+    const target = event.target as Node | null;
+    if (target === null) {
+      return;
+    }
+
+    const index = this.options()
+      .findIndex(option => (option.elementRef.nativeElement as HTMLElement).contains(target));
+
+    if (index !== -1) {
+      this.visitedIndex.set(index);
+    }
   }
 
   // ControlValueAccessor implementation

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -179,10 +179,24 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * keyboard handling added here and is not widened by it — arrow keys move
    * focus and never toggle — so it is reported on the PR rather than fixed
    * under a ticket about navigation.
+   *
+   * Only keys pressed ON an option host are the listbox's. The handler is on
+   * the host and hears everything that bubbles through it, so without that test
+   * a consumer who projects a focusable control into an option — a text input,
+   * a slider — would have Home and End taken off its caret and the arrows taken
+   * off its value, and get a `preventDefault()` for it. Nothing in this library
+   * projects such a control today, which is why this is a target check rather
+   * than a redesign.
    */
   onKeydown(event: KeyboardEvent): void {
-    const count = this.options().length;
+    const opts = this.options();
+    const count = opts.length;
     if (count === 0) {
+      return;
+    }
+
+    const target = event.target as HTMLElement | null;
+    if (!opts.some(option => option.elementRef.nativeElement === target)) {
       return;
     }
 
@@ -211,7 +225,7 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     // moved something.
     event.preventDefault();
     this.visitedIndex.set(next);
-    this.options()[next].focus();
+    opts[next].focus();
   }
 
   /**

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -152,7 +152,8 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   }
 
   /**
-   * ArrowUp / ArrowDown / Home / End, and deliberately nothing else.
+   * ArrowUp / ArrowDown / Home / End — unmodified, and pressed on an option
+   * host — and deliberately nothing else.
    *
    * Space and Enter are absent because `tn-list-option` has handled them since
    * before this component had any keyboard handling at all, and its keydown
@@ -197,6 +198,16 @@ export class TnSelectionListComponent implements ControlValueAccessor {
 
     const target = event.target as HTMLElement | null;
     if (!opts.some(option => option.elementRef.nativeElement === target)) {
+      return;
+    }
+
+    // A MODIFIED navigation key belongs to someone else. Ctrl/Cmd+Home and
+    // Ctrl/Cmd+End are the browser's jump to the top and bottom of the
+    // document, and Shift+ArrowDown is APG's extend-the-selection, which this
+    // listbox does not implement — claiming any of them swallows a shortcut and
+    // gives nothing back. Tested inline rather than through
+    // `@angular/cdk/keycodes`, matching `select.component.ts`.
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
     }
 

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -136,10 +136,21 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * Every other key is left alone, Tab included: `preventDefault()` on an
    * unrecognised key is how a widget traps a keyboard user inside it.
    *
-   * Navigation is not gated on `isDisabled()`. Moving focus changes nothing —
-   * every route into `toggle()` is already closed for a disabled option by the
-   * option's own guard — and a disabled list a user can read through is the
-   * same reasoning that has the arrow keys visit disabled options at all.
+   * Navigation is not gated on `isDisabled()`, because moving focus selects
+   * nothing: a disabled list a user can still read through is the same
+   * reasoning that has the arrow keys visit disabled options at all.
+   *
+   * That is a statement about NAVIGATION only, and deliberately not the wider
+   * claim that a disabled list cannot be toggled. It cannot be toggled by
+   * mouse — `.tn-selection-list--disabled` sets `pointer-events: none` — and it
+   * cannot be toggled through a reactive form, because `setDisabledState`
+   * pushes down to each `option.internalDisabled` and the option's own guard
+   * then refuses. But the plain `[disabled]` INPUT reaches neither: it feeds
+   * `isDisabled()`, which drives that class and nothing else, so Space on an
+   * option of a `[disabled]` list still toggles it. That gap predates the
+   * keyboard handling added here and is not widened by it — arrow keys move
+   * focus and never toggle — so it is reported on the PR rather than fixed
+   * under a ticket about navigation.
    */
   onKeydown(event: KeyboardEvent): void {
     const count = this.options().length;

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -37,7 +37,8 @@ export interface TnSelectionChange {
     // focused option to here, which is also what lets tn-list-option keep its
     // own Space/Enter handlers untouched — see onKeydown.
     '(keydown)': 'onKeydown($event)',
-    '(focusin)': 'onFocusIn($event)'
+    '(focusin)': 'onFocusIn($event)',
+    '(focusout)': 'onFocusOut($event)'
   }
 })
 export class TnSelectionListComponent implements ControlValueAccessor {
@@ -94,6 +95,15 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     return firstSelected === -1 ? 0 : firstSelected;
   });
 
+  /**
+   * The option host that currently holds DOM focus, or `null`.
+   *
+   * Held as an element rather than an index, because the whole point of it is
+   * to outlive the option: an index still resolves after a removal, to whatever
+   * option moved into that slot.
+   */
+  private focusedOptionElement: HTMLElement | null = null;
+
   private onChange = (_: unknown[]) => {};
   private onTouched = () => {};
 
@@ -120,6 +130,24 @@ export class TnSelectionListComponent implements ControlValueAccessor {
       opts.forEach((option, index) => {
         option.rovingTabindex.set(index === active ? 0 : -1);
       });
+
+      // Moving the tab STOP is not enough when the option that held focus is
+      // the one that went away: the browser drops focus to <body>, so a
+      // keyboard user who filtered the list from inside it finds their next Tab
+      // starting at the top of the document. Put focus on whichever option the
+      // stop landed on, which is where they were.
+      //
+      // Both halves of the test carry weight. `isConnected` distinguishes an
+      // option that was REMOVED from one the user merely left, and
+      // `document.body` says nothing else has claimed focus since — without it
+      // an unrelated re-render could pull focus away from elsewhere on the page.
+      const lost = this.focusedOptionElement;
+      if (lost !== null && !lost.isConnected) {
+        this.focusedOptionElement = null;
+        if (active !== -1 && document.activeElement === document.body) {
+          opts[active].focus();
+        }
+      }
     });
   }
 
@@ -208,6 +236,22 @@ export class TnSelectionListComponent implements ControlValueAccessor {
 
     if (index !== -1) {
       this.visitedIndex.set(index);
+      this.focusedOptionElement = this.options()[index].elementRef.nativeElement as HTMLElement;
+    }
+  }
+
+  /**
+   * Forget the focused option once focus leaves it under its own steam.
+   *
+   * Guarded on the option still being in the document, because a `focusout`
+   * fired BY a removal — Firefox fires one, Chrome does not — is exactly the
+   * case the restore in the constructor exists for, and clearing on it would
+   * defeat that restore in one browser and not the other.
+   */
+  onFocusOut(event: FocusEvent): void {
+    const from = event.target as HTMLElement | null;
+    if (from !== null && from.isConnected) {
+      this.focusedOptionElement = null;
     }
   }
 

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -57,14 +57,24 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   isDisabled = computed(() => this.disabled() || this.formDisabled());
 
   /**
-   * The option the user has moved to, or `null` while they have not moved yet.
+   * The option the user has moved to, and the slot it occupied at the time —
+   * or `null` while they have not moved yet.
    *
    * Kept separate from `activeIndex` rather than seeded with a starting value,
    * because "where the user last was" and "where a user who has not arrived yet
    * would land" are different questions and only the second one should follow
    * the selection around. See `activeIndex`.
+   *
+   * The OPTION and not merely its index, because the options are content
+   * children and the caller can add or remove them ABOVE the one the user is
+   * standing on. An index survives that edit while quietly changing meaning —
+   * it names whichever option shifted into the slot — so the tab stop and the
+   * arrow keys' starting point both come away from the option holding focus,
+   * and one ArrowDown lands two options from where the user is. A reference
+   * cannot drift that way. The index rides along only as the fallback for the
+   * one case a reference cannot answer: the option itself being removed.
    */
-  private visitedIndex = signal<number | null>(null);
+  private visited = signal<{ option: TnListOptionComponent; index: number } | null>(null);
 
   /**
    * Which option carries the listbox's single tab stop.
@@ -72,13 +82,14 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * Before the user has touched the list this tracks the first selected option,
    * which is what APG asks for — tabbing into a list that already has a
    * selection should land where the user left off rather than at the top. Once
-   * they have moved, `visitedIndex` pins it and the selection no longer drags
-   * the tab stop around underneath them.
+   * they have moved, `visited` pins it and the selection no longer drags the
+   * tab stop around underneath them.
    *
-   * Clamped rather than stored as a plain index, because the options are
-   * content children and the caller can remove them: an index held in a field
-   * outlives the option it pointed at, and the next keypress reads past the end
-   * of the array.
+   * Resolved against the current options on every read rather than stored, so
+   * that a list edited underneath the user still points at the option they were
+   * on. Only once that option has left the list is there nothing to resolve,
+   * and the remembered slot is the best answer left — clamped, because an index
+   * held across a removal otherwise reads past the end of the array.
    */
   private activeIndex = computed(() => {
     const opts = this.options();
@@ -86,9 +97,10 @@ export class TnSelectionListComponent implements ControlValueAccessor {
       return -1;
     }
 
-    const visited = this.visitedIndex();
+    const visited = this.visited();
     if (visited !== null) {
-      return Math.min(visited, opts.length - 1);
+      const current = opts.indexOf(visited.option);
+      return current === -1 ? Math.min(visited.index, opts.length - 1) : current;
     }
 
     const firstSelected = opts.findIndex(option => option.effectiveSelected());
@@ -233,9 +245,13 @@ export class TnSelectionListComponent implements ControlValueAccessor {
 
     // After the switch, so it happens only for the keys actually handled — and
     // only once the list is known to be non-empty, so a swallowed key always
-    // moved something.
+    // has an option to land on. It may land on the one already focused: End at
+    // the last option, Home at the first, either arrow on a one-option list.
+    // Consuming those is still right — the key IS the listbox's and its default
+    // action is scrolling the page out from under a user who asked to move
+    // within the list.
     event.preventDefault();
-    this.visitedIndex.set(next);
+    this.visited.set({ option: opts[next], index: next });
     opts[next].focus();
   }
 
@@ -256,12 +272,13 @@ export class TnSelectionListComponent implements ControlValueAccessor {
       return;
     }
 
-    const index = this.options()
+    const opts = this.options();
+    const index = opts
       .findIndex(option => (option.elementRef.nativeElement as HTMLElement).contains(target));
 
     if (index !== -1) {
-      this.visitedIndex.set(index);
-      this.focusedOptionElement = this.options()[index].elementRef.nativeElement as HTMLElement;
+      this.visited.set({ option: opts[index], index });
+      this.focusedOptionElement = opts[index].elementRef.nativeElement as HTMLElement;
     }
   }
 


### PR DESCRIPTION
Fixes #216.

`tn-selection-list` has carried `role="listbox"` all along with no keyboard handling of any kind. That went unnoticed while nothing in an option was a working tab stop either; #213 made the option itself the stop, which left the component reachable but at **one Tab press per option** — a twenty-item list costing twenty stops where WAI-ARIA APG expects one stop and nineteen ArrowDown presses.

Reproduced before anything was changed: the new spec was run against the unmodified component first, and 20 of its 39 assertions failed. The tab order read `["0", "0", null, "0"]` — every enabled option a stop, the disabled one absent entirely — and ArrowDown from the first option left `document.activeElement` exactly where it was.

## Which model, and why

**Roving tabindex over real DOM focus**, not `aria-activedescendant`. The ticket asks which was chosen; two reasons, both specific to this component rather than general preference:

1. `tn-list-option` already toggles on `keydown.space` / `keydown.enter`, and those handlers fire on the **focused** element. Under `aria-activedescendant` focus would sit on the listbox and they could never fire, so the parent would have to toggle the active option itself — a second route into `toggle()`, and a keypress that selects and immediately deselects. Instead the parent claims the navigation keys **and nothing else**, which is what keeps the toggle single. There is a spec for exactly that: one `selectionChange` per Space, and one per Enter.
2. The focus ring #215 added is `:host(:focus-visible)` on the option, which fires on DOM focus and on nothing else. Moving real focus keeps that rule working as-is. This is the part the ticket flagged as most likely to be missed, and an `aria-activedescendant` model would have silently taken the indicator away and needed a class-based replacement.

`tn-select` makes the opposite choice, and correctly: it is a combobox whose options live in an overlay while focus stays on the trigger, so `aria-activedescendant` is the only model available to it. The two components diverge because the shape of the widget differs, not by oversight. They agree on wrapping — ArrowDown past the last option returns to the first — since there was no reason to differ there as well.

## Where the tab stop is, and how it is remembered

The listbox remembers **the option the user last moved to, as a reference to that option** — not the index it sat at. Both the tab stop and the arrow keys' starting point are resolved from it on every read.

That is not a detail. The options are content children and the caller can add or remove them **above** the one the user is standing on: a filter, a delete, a virtualised window. An index survives such an edit while quietly changing meaning, because it comes to name whichever option shifted into that slot. With five options `a b c d e` and focus on `d`, removing `a` left the tab stop on `e` while the focus ring stayed on `d`, and one ArrowDown landed on `b` — two options from where the user was. ArrowUp landed back on `d`, so the key read as doing nothing at all.

A reference cannot drift that way. The remembered slot is kept alongside it purely as the fallback for the one case a reference cannot answer — the visited option itself being removed — where it is clamped to the end of the list, which is the behaviour that was already there.

Before the user has touched the list there is nothing to resolve, and the stop tracks the first selected option instead, which is what APG asks for: tabbing into a list that already has a selection lands where the user left off rather than at the top.

## Which keys the listbox claims

ArrowUp, ArrowDown, Home and End — **unmodified, and pressed on an option host** — and nothing else.

- **Modified combinations are the browser's.** Ctrl/Cmd+Home and Ctrl/Cmd+End jump to the top and bottom of the document, and Shift+ArrowDown is APG's extend-the-selection, which this listbox does not implement. Consuming either takes a shortcut away and gives nothing back.
- **Keys from projected content are the consumer's.** The handler is on the listbox host and hears everything that bubbles through it, so it checks that the target is an option host. Without that, an `<input>` projected into an option would lose Home and End off its caret. `tn-list-option`'s own Space/Enter handler now makes the same check, for the same reason.

Nothing in this library projects a focusable control into an option, and `role="option"` arguably forbids one — these are target checks rather than a redesign.

A claimed key always has an option to land on, and sometimes that is the option already focused: End at the last option, Home at the first, either arrow on a one-option list. Consuming those is still right, since the default action is scrolling the page out from under a user who asked to move within the list.

## The disabled-option question, answered explicitly

**Arrow keys visit disabled options.** APG keeps `aria-disabled` options focusable so a keyboard user can perceive that they exist, and the objection `tn-list-option` recorded against that — *"offering focus would only be a stop where nothing happens"* — was about the **tab order**, where every extra stop costs a Tab press. Under a roving tabindex there is exactly one tab stop whatever the arrows visit, so that cost is gone and skipping the option only hides it.

Space and Enter on such an option toggle nothing, through the option's own guard, **and are consumed rather than handed back to the browser**. Declining to toggle is not declining the key: Space scrolls the page on an element that is neither a form control nor a scroller, and the listbox falls through for Space deliberately so that the key reaches the option. Both halves are asserted.

This is also why a disabled option under a listbox now carries `tabindex="-1"` instead of no `tabindex` at all: an element with no `tabindex` cannot be focused programmatically either, so the arrows would have had nothing to move focus to.

## Focus is put back when the option holding it is removed

Removing the option a user is standing on — a filter, a virtualised list — drops focus to `<body>`, so their next Tab restarts at the top of the document. The roving tabindex only moves the tab **stop**, which is where focus would resume, not where it is. So the stop's move is followed by a focus move, guarded twice: the tracked option must have been **removed** rather than merely left (`isConnected`), and nothing else may have claimed focus since (`document.activeElement === document.body`). Both directions are asserted — focus returns to the new stop, and a list that changes while focus is elsewhere on the page does not steal it.

## `tn-list-option` standalone is unchanged

It is exported on its own, so an option with no parent list keeps the plain `tabindex="0"` #213 gave it — otherwise this fix would have taken a standalone option out of the tab order entirely. The parent's assignment is a **nullable** signal for that reason: `null` means "no parent", not "no tab stop". `list-option-a11y.spec.ts` passes unchanged bar the one case added to it here, and there is a new spec covering the standalone case from the listbox's side.

## Checks

`yarn lint`, `yarn test` (2567 passing), `yarn test:scripts` (42 passing) and `yarn build` were all run locally on every round and are green. Lint reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts` — both untouched by this branch, and unchanged in count from `main`.

**Storybook interaction tests were not run locally** — they need Playwright browsers and a built Storybook. No `play` function touches `tn-selection-list`; `list.stories.ts` renders one with no interaction assertions.

The local review is the **real one** — the project's own reviewer, same rubric and threshold as the required check, in a separate process. Seven rounds, $10.73 in total.

**Round 7's review returned one HIGH, and it is argued with rather than fixed** — see the PR comment. Its premise is that `opacity: 0.6` applies to a disabled option's host and dims the focus ring drawn on it. That rule cannot reach the host: it is written as a plain `.tn-list-option--disabled` class inside the component's own emulated-encapsulation stylesheet, so the compiler scopes it to `[_ngcontent-…]`, and `EmulatedEncapsulationDomRenderer2.applyToHost` puts only `_nghost-…` on the host element. Nothing else in the library declares that class. So the ring on a disabled option is drawn at the same strength as on any other option, and there is no contrast to lose. That the dimming does not apply at all is a separate, pre-existing defect, proposed as its own ticket on #216.

### Round log

| Round | What it found, and what changed |
|---|---|
| 1 | The original diff. Clean at MEDIUM+, opened as this PR |
| — | **The required check's HIGH**: Space on a focused disabled option scrolled the page. Swallow the key, then bail |
| 2 | HIGH: focus lost when the focused option is removed. MEDIUM: the click test could not fail on the click |
| 3 | HIGH: the listbox claimed navigation keys bubbling from projected content |
| 4 | HIGH: the option's own Space/Enter did the same — widened by the fix above, which had moved `preventDefault()` ahead of the guard |
| 5 | HIGH: modified navigation keys were being consumed |
| 6 | Clean — nothing at or above MEDIUM |
| — | **The required check's HIGH**: the remembered index drifted off the focused option when the list changed above it. Remember the option instead; five new specs, each failing first |
| 7 | HIGH, refuted above. Four LOWs, one of them fixed because it made a comment untrue |

## What I did not change, and why

Round 7 returned five LOWs. One is fixed — the comment above `preventDefault()` claimed a swallowed key always moved something, which is untrue at the ends of the list and on a one-option list, and a comment that misdescribes the code below it is a defect however it is scored. The rest stand, because every fix is a new diff and a new diff reopens the review loop. All of them look right to me, and none can break the build.

- **`rovingTabindex` is a public mutable signal on an exported component**, so a consumer could write it and create a second `tabindex="0"`. It is public because the parent has to write it across a content-projection boundary; Angular has no narrower visibility for that. `internalSelected`, `internalDisabled` and `internalColor` on the same component are public for the same reason and predate this change. Injecting the optional parent list, so the option derives its own tabindex, is the structural alternative.
- **`contentChildren` does not see an option rendered inside another component's view** rather than projected into the list, so such an option keeps its standalone `tabindex="0"` and interleaves extra tab stops with the roving one. This is the pre-existing shape of the parent/child relationship here — `writeValue`, `setDisabledState` and the colour assignment all reach their options the same way — and narrowing it means injecting the list into the option instead.
- **The focus restoration lives inside the roving-tabindex effect** and reads a non-reactive field, so what triggers it is `options()` changing rather than anything it declares. That is the signal that actually matters here, but it is implicit.
- **The `count === 0` guard in `onKeydown` is now redundant** — the option-host target check below it returns on an empty list anyway.
- **`activeIndex` clamps the remembered slot on read without writing it back.** This now applies only once the visited option has left the list, where there is nothing else to resolve; if the list then regrows, the stop returns to the older slot rather than staying where the clamp put it.
- **No printable-character type-ahead and no PageUp/PageDown**, both of which APG's listbox pattern recommends for long lists, and no story or `play` function in `list.stories.ts` demonstrating the new single-tab-stop model. Out of scope for this ticket, and worth its own.
- **`outside.remove()` in two specs runs after their assertions rather than in an `afterEach`**, so a failure would leak a focused button into later tests in the file. Pre-existing in one of the two.

**A `[disabled]` list is not a list of disabled options**, and that gap is still open — and is wider than #221 currently describes it. The input feeds `isDisabled()`, which drives `.tn-selection-list--disabled` and nothing else. A reactive form is stopped by `setDisabledState` pushing into each `option.internalDisabled`, but **Space on an option of a `[disabled]` list still toggles it** — and, by the encapsulation mechanism above, that class's `pointer-events: none` does not reach the list host either, so the mouse is not stopped by it as an earlier revision of this description claimed. All of that predates this ticket and none of it is widened by it (arrow keys move focus and never toggle), so only the comment that misdescribed it was corrected here. It belongs to #221, whose scope this should extend.
