### PR TITLE
NAS-142350 / 27.0.0-BETA.1 / fix(side-panel,drawer): emit lifecycle outputs when no transition runs

### DIFF
--- a/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, NgZone, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TnDrawerComponent } from './drawer.component';
@@ -46,9 +46,10 @@ class TestHostComponent {
  * ----------------------------------------------------------------------
  * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
  * timer is only reachable by `tick()` if it was scheduled inside that
- * `fakeAsync` zone. Angular arms this one from an `effect`, which runs in the
- * `NgZone`, which `TestBed` creates once, lazily, at the FIRST
- * `TestBed.createComponent` of the suite. A `beforeEach` that creates a fixture
+ * `fakeAsync` zone. This one is armed with `runOutsideAngular`, so it lands in
+ * the zone `NgZone` was CONSTRUCTED in — and `TestBed` constructs that once,
+ * lazily, at the FIRST `TestBed.createComponent` of the suite. A `beforeEach`
+ * that creates a fixture
  * therefore fixes the zone for every test after it, and the fallback then fires
  * on the real clock a third of a second after the test has already finished.
  *
@@ -188,6 +189,22 @@ describe('TnDrawerComponent lifecycle outputs', () => {
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does not hold NgZone unstable while the fallback is armed', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+
+    // The timer is armed from an `effect`, which runs inside
+    // `ApplicationRef.tick()` inside `NgZone.run(...)`, so scheduling it
+    // without `runOutsideAngular` makes it an Angular-zone macrotask — and
+    // `fixture.whenStable()` and CDK's `forceStabilize()` would then block for
+    // the whole fallback window after every open and every close, in every
+    // downstream suite that toggles one of these components.
+    expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false);
+
+    tick(TN_TRANSITION_FALLBACK_MS);
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
   }));
 
   it('emits nothing after the drawer is destroyed mid-transition', fakeAsync(() => {

--- a/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, viewChild } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TnDrawerComponent } from './drawer.component';
@@ -12,7 +12,6 @@ import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-drawer
-      #drawer
       ariaLabel="Navigation"
       [mode]="mode()"
       [(opened)]="opened"
@@ -23,7 +22,6 @@ import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
   `,
 })
 class TestHostComponent {
-  drawer = viewChild.required<TnDrawerComponent>('drawer');
   mode = signal<TnDrawerMode>('side');
   opened = signal(false);
   openedComplete = jest.fn();
@@ -78,10 +76,11 @@ describe('TnDrawerComponent lifecycle outputs', () => {
   });
 
   /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
-  function createDrawer(mode: TnDrawerMode = 'side'): void {
+  function createDrawer(mode: TnDrawerMode = 'side', opened = false): void {
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
     host.mode.set(mode);
+    host.opened.set(opened);
     fixture.detectChanges();
   }
 
@@ -162,6 +161,23 @@ describe('TnDrawerComponent lifecycle outputs', () => {
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits nothing for a drawer that RENDERS open, which never opened', fakeAsync(() => {
+    createDrawer('side', true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).not.toHaveBeenCalled();
+    expect(host.closed).not.toHaveBeenCalled();
+  }));
+
+  it('still emits closed for a drawer that rendered open and is then closed', fakeAsync(() => {
+    createDrawer('side', true);
+    setOpened(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).not.toHaveBeenCalled();
+    expect(host.closed).toHaveBeenCalledTimes(1);
   }));
 
   it('emits only the final state when a close interrupts an open', fakeAsync(() => {

--- a/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
@@ -1,0 +1,185 @@
+import { Component, signal, viewChild } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TnDrawerComponent } from './drawer.component';
+import type { TnDrawerMode } from './drawer.component';
+import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnDrawerComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-drawer
+      #drawer
+      ariaLabel="Navigation"
+      [mode]="mode()"
+      [(opened)]="opened"
+      (openedComplete)="openedComplete()"
+      (closed)="closed()">
+      <p>Side menu content</p>
+    </tn-drawer>
+  `,
+})
+class TestHostComponent {
+  drawer = viewChild.required<TnDrawerComponent>('drawer');
+  mode = signal<TnDrawerMode>('side');
+  opened = signal(false);
+  openedComplete = jest.fn();
+  closed = jest.fn();
+}
+
+/**
+ * `openedComplete` and `closed` fire exactly once per open and per close,
+ * whether or not a transition runs (#218).
+ *
+ * WHY THE REDUCED-MOTION CASE IS REACHED BY DOING NOTHING
+ * ------------------------------------------------------
+ * `prefers-reduced-motion: reduce` removes this component's transitions
+ * (`drawer.component.scss`), and a transition that does not run fires no
+ * `transitionend`. jsdom applies no stylesheet and runs no transition, so the
+ * way to reproduce that user's experience is to simply NOT dispatch the event —
+ * which is also the ONLY way, since jsdom would not fire one for a working
+ * transition either. `finishTransition()` below is the other half: it stands in
+ * for the browser that does.
+ *
+ * WHY THE FIXTURE IS BUILT INSIDE EACH TEST, AND WHY THIS IS ITS OWN FILE
+ * ----------------------------------------------------------------------
+ * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
+ * timer is only reachable by `tick()` if it was scheduled inside that
+ * `fakeAsync` zone. Angular arms this one from an `effect`, which runs in the
+ * `NgZone`, which `TestBed` creates once, lazily, at the FIRST
+ * `TestBed.createComponent` of the suite. A `beforeEach` that creates a fixture
+ * therefore fixes the zone for every test after it, and the fallback then fires
+ * on the real clock a third of a second after the test has already finished.
+ *
+ * That is why this is a separate file rather than another `describe` in
+ * `drawer.component.spec.ts`: sharing a suite means sharing that first
+ * `createComponent`, and the fix is not local to the block that needs it.
+ */
+describe('TnDrawerComponent lifecycle outputs', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    // The over-mode panel and backdrop are portaled to `document.body`, and
+    // `destroy()` only takes the overlay wrapper the component holds a
+    // reference to.
+    document.body.querySelectorAll('.tn-drawer__panel--over').forEach((el) => el.remove());
+    document.body.querySelectorAll('.tn-drawer__backdrop').forEach((el) => el.remove());
+  });
+
+  /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
+  function createDrawer(mode: TnDrawerMode = 'side'): void {
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.mode.set(mode);
+    fixture.detectChanges();
+  }
+
+  function setOpened(opened: boolean): void {
+    host.opened.set(opened);
+    fixture.detectChanges();
+  }
+
+  /**
+   * The `transitionend` a browser fires when the panel finishes moving.
+   *
+   * Assembled from `Event`, because jsdom implements no `TransitionEvent`
+   * constructor — `propertyName` is the only field of it the handler reads.
+   * Dispatched on whichever panel the current mode rendered: side mode keeps it
+   * inline, over mode portals it to `document.body`.
+   */
+  function finishTransition(): void {
+    const panel = host.mode() === 'over'
+      ? document.body.querySelector('.tn-drawer__panel--over')!
+      : fixture.nativeElement.querySelector('.tn-drawer__panel');
+    panel.dispatchEvent(Object.assign(new Event('transitionend'), { propertyName: 'transform' }));
+  }
+
+  it('emits openedComplete when no transitionend arrives', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+    expect(host.closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits closed when no transitionend arrives', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+    setOpened(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+    expect(host.closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits in over mode too, where the panel is portaled', fakeAsync(() => {
+    createDrawer('over');
+    setOpened(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+    setOpened(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+    expect(host.closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits once, not twice, when the transition does complete', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    finishTransition();
+
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+
+    tick(TN_TRANSITION_FALLBACK_MS);
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+  }));
+
+  it('ignores a transitionend that arrives after the fallback already fired', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+    finishTransition();
+
+    expect(host.openedComplete).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits nothing while the drawer stays closed', fakeAsync(() => {
+    createDrawer();
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).not.toHaveBeenCalled();
+    expect(host.closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits only the final state when a close interrupts an open', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    setOpened(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).not.toHaveBeenCalled();
+    expect(host.closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits nothing after the drawer is destroyed mid-transition', fakeAsync(() => {
+    createDrawer();
+    setOpened(true);
+    fixture.destroy();
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.openedComplete).not.toHaveBeenCalled();
+  }));
+});

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -15,6 +15,7 @@ import {
 } from '@angular/core';
 import { tnAccessibleName } from '../a11y/accessible-name';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { tnTransitionLifecycle } from '../utils/transition-lifecycle';
 
 export type TnDrawerMode = 'side' | 'over';
 export type TnDrawerPosition = 'start' | 'end';
@@ -84,10 +85,27 @@ export class TnDrawerComponent implements OnDestroy {
    */
   testId = input<TnTestIdValue>(undefined);
 
-  /** Fires after the open transition completes */
+  /**
+   * Fires once the drawer has finished opening.
+   *
+   * "Finished" means the open transition ended, OR that it was going to take
+   * longer than `TN_TRANSITION_FALLBACK_MS` to say so — which is what a user
+   * with `prefers-reduced-motion: reduce` gets, since this component's own
+   * stylesheet removes the transition for them and one that does not run fires
+   * no `transitionend` (#218). A consumer may assume the drawer has reached its
+   * open state and that `opened()` is true; it may NOT assume the animation is
+   * visually complete, because for that user there was none.
+   */
   openedComplete = output<void>();
 
-  /** Fires after the close transition completes */
+  /**
+   * Fires once the drawer has finished closing. Same guarantee as
+   * `openedComplete`, and the same caveat: it reports the state, not the
+   * animation.
+   *
+   * Focus restoration does NOT hang off this — it happens as soon as the drawer
+   * closes (#214). See the effect in the constructor.
+   */
   closed = output<void>();
 
   /** Whether the component has rendered (prevents transition flash on load) */
@@ -137,6 +155,17 @@ export class TnDrawerComponent implements OnDestroy {
 
   /** Previous focus element for restoration (only captured in over mode) */
   private previousFocus: HTMLElement | null = null;
+
+  /**
+   * Decides when an open or a close counts as finished, so that the outputs
+   * above fire exactly once per change whether or not a transition ran. A field
+   * initializer rather than the constructor, because it registers an `effect`
+   * and so needs an injection context.
+   */
+  private lifecycle = tnTransitionLifecycle(
+    this.opened,
+    (opened) => (opened ? this.openedComplete.emit() : this.closed.emit())
+  );
 
   constructor() {
     // Capture focus before opening in over mode, and restore it on close
@@ -221,19 +250,22 @@ export class TnDrawerComponent implements OnDestroy {
   }
 
   /**
-   * Handle transition end — emit the open/close events once the animation is
-   * over. Focus restoration is NOT here; it happens as soon as the drawer
-   * closes, because this event does not fire under `prefers-reduced-motion`.
+   * Handle transition end — report the open/close early, since the animation is
+   * demonstrably over. Focus restoration is NOT here; it happens as soon as the
+   * drawer closes, because this event does not fire under
+   * `prefers-reduced-motion` — and neither, for the same reason, does the
+   * emission depend on it any more (#218).
+   *
+   * Which output to emit is `lifecycle`'s to decide, from the state the change
+   * it is tracking settled into — NOT from `opened()` read here. The two differ
+   * exactly when this event is late: a drawer reopened while the close was still
+   * animating reads `opened() === true` on the stale close's event.
    */
   protected onTransitionEnd(event: TransitionEvent): void {
     if (event.propertyName !== 'transform' || event.target !== event.currentTarget) {
       return;
     }
-    if (this.opened()) {
-      this.openedComplete.emit();
-    } else {
-      this.closed.emit();
-    }
+    this.lifecycle.transitionEnded();
   }
 
   private restoreFocus(): void {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
@@ -1,0 +1,164 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TnSidePanelComponent } from './side-panel.component';
+import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
+
+/**
+ * `opened` and `closed` fire exactly once per open and per close, whether or
+ * not a transition runs (#218).
+ *
+ * WHY THE REDUCED-MOTION CASE IS REACHED BY DOING NOTHING
+ * ------------------------------------------------------
+ * `prefers-reduced-motion: reduce` zeroes this component's transition durations
+ * (`side-panel.component.scss`), and a zero-duration transition fires no
+ * `transitionend`. jsdom applies no stylesheet and runs no transition, so the
+ * way to reproduce that user's experience is to simply NOT dispatch the event —
+ * which is also the ONLY way, since jsdom would not fire one for a working
+ * transition either. `finishTransition()` below is the other half: it stands in
+ * for the browser that does.
+ *
+ * WHY THE FIXTURE IS BUILT INSIDE EACH TEST, AND WHY THIS IS ITS OWN FILE
+ * ----------------------------------------------------------------------
+ * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
+ * timer is only reachable by `tick()` if it was scheduled inside that
+ * `fakeAsync` zone. Angular arms this one from an `effect`, which runs in the
+ * `NgZone`, which `TestBed` creates once, lazily, at the FIRST
+ * `TestBed.createComponent` of the suite. A `beforeEach` that creates a fixture
+ * therefore fixes the zone for every test after it, and the fallback then fires
+ * on the real clock a third of a second after the test has already finished.
+ *
+ * That is why this is a separate file rather than another `describe` in
+ * `side-panel.component.spec.ts`: sharing a suite means sharing that first
+ * `createComponent`, and the fix is not local to the block that needs it.
+ * Measured while writing these: with the shared fixture, three of the six below
+ * failed and the other three passed on the `transitionend` path alone — which
+ * is the failure mode worth naming, because a suite that half-passes reads as a
+ * suite that works.
+ */
+describe('TnSidePanelComponent lifecycle outputs', () => {
+  let panel: ComponentFixture<TnSidePanelComponent>;
+  let opened: jest.Mock;
+  let closed: jest.Mock;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TnSidePanelComponent],
+      // The panel's icon registry fetches the sprite config over HTTP, and
+      // `fakeAsync` refuses a real XHR outright — "Cannot make XHRs from within
+      // a fake async test". The testing backend answers nothing and is never
+      // flushed here, which is the whole intent: no icon in this suite is
+      // asserted on, and the request must simply not reach the network.
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    // Every fixture here is untitled and unlabelled, and #214 makes an unnamed
+    // panel warn in dev mode — which Jest is. Silenced so this suite's output
+    // stays readable; the warning itself is asserted in `side-panel-a11y.spec.ts`.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Destroys the portaled overlay this suite appended to `document.body`.
+    panel.destroy();
+    warn.mockRestore();
+  });
+
+  /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
+  function createPanel(): void {
+    panel = TestBed.createComponent(TnSidePanelComponent);
+    panel.detectChanges();
+
+    opened = jest.fn();
+    closed = jest.fn();
+    panel.componentInstance.opened.subscribe(opened);
+    panel.componentInstance.closed.subscribe(closed);
+  }
+
+  function setOpen(open: boolean): void {
+    panel.componentRef.setInput('open', open);
+    panel.detectChanges();
+  }
+
+  /**
+   * The `transitionend` a browser fires when the panel finishes moving.
+   *
+   * Assembled from `Event`, because jsdom implements no `TransitionEvent`
+   * constructor — `propertyName` is the only field of it the handler reads.
+   */
+  function finishTransition(): void {
+    const event = Object.assign(new Event('transitionend'), { propertyName: 'transform' });
+    document
+      .querySelector(`[data-tn-panel="${panel.componentInstance.panelId}"] .tn-side-panel__panel`)!
+      .dispatchEvent(event);
+  }
+
+  it('emits opened when no transitionend arrives', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits closed when no transitionend arrives', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+    setOpen(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits once, not twice, when the transition does complete', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    finishTransition();
+
+    expect(opened).toHaveBeenCalledTimes(1);
+
+    tick(TN_TRANSITION_FALLBACK_MS);
+    expect(opened).toHaveBeenCalledTimes(1);
+  }));
+
+  it('ignores a transitionend that arrives after the fallback already fired', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+    finishTransition();
+
+    expect(opened).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits nothing while the panel stays closed', fakeAsync(() => {
+    createPanel();
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).not.toHaveBeenCalled();
+    expect(closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits only the final state when a close interrupts an open', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    setOpen(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).not.toHaveBeenCalled();
+    expect(closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('emits nothing after the panel is destroyed mid-transition', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+    panel.destroy();
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).not.toHaveBeenCalled();
+  }));
+});

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
@@ -67,8 +67,9 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
   });
 
   /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
-  function createPanel(): void {
+  function createPanel(open = false): void {
     panel = TestBed.createComponent(TnSidePanelComponent);
+    panel.componentRef.setInput('open', open);
     panel.detectChanges();
 
     opened = jest.fn();
@@ -141,6 +142,23 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).not.toHaveBeenCalled();
+  }));
+
+  it('emits nothing for a panel that RENDERS open, which never opened', fakeAsync(() => {
+    createPanel(true);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).not.toHaveBeenCalled();
+    expect(closed).not.toHaveBeenCalled();
+  }));
+
+  it('still emits closed for a panel that rendered open and is then closed', fakeAsync(() => {
+    createPanel(true);
+    setOpen(false);
+    tick(TN_TRANSITION_FALLBACK_MS);
+
+    expect(opened).not.toHaveBeenCalled();
+    expect(closed).toHaveBeenCalledTimes(1);
   }));
 
   it('emits only the final state when a close interrupts an open', fakeAsync(() => {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
@@ -1,5 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { NgZone } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TnSidePanelComponent } from './side-panel.component';
@@ -23,9 +24,10 @@ import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
  * ----------------------------------------------------------------------
  * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
  * timer is only reachable by `tick()` if it was scheduled inside that
- * `fakeAsync` zone. Angular arms this one from an `effect`, which runs in the
- * `NgZone`, which `TestBed` creates once, lazily, at the FIRST
- * `TestBed.createComponent` of the suite. A `beforeEach` that creates a fixture
+ * `fakeAsync` zone. This one is armed with `runOutsideAngular`, so it lands in
+ * the zone `NgZone` was CONSTRUCTED in — and `TestBed` constructs that once,
+ * lazily, at the FIRST `TestBed.createComponent` of the suite. A `beforeEach`
+ * that creates a fixture
  * therefore fixes the zone for every test after it, and the fallback then fires
  * on the real clock a third of a second after the test has already finished.
  *
@@ -169,6 +171,22 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does not hold NgZone unstable while the fallback is armed', fakeAsync(() => {
+    createPanel();
+    setOpen(true);
+
+    // The timer is armed from an `effect`, which runs inside
+    // `ApplicationRef.tick()` inside `NgZone.run(...)`, so scheduling it
+    // without `runOutsideAngular` makes it an Angular-zone macrotask — and
+    // `fixture.whenStable()` and CDK's `forceStabilize()` would then block for
+    // the whole fallback window after every open and every close, in every
+    // downstream suite that toggles one of these components.
+    expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false);
+
+    tick(TN_TRANSITION_FALLBACK_MS);
+    expect(opened).toHaveBeenCalledTimes(1);
   }));
 
   it('emits nothing after the panel is destroyed mid-transition', fakeAsync(() => {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -13,6 +13,7 @@ import { tnAccessibleName } from '../a11y/accessible-name';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+import { tnTransitionLifecycle } from '../utils/transition-lifecycle';
 
 /**
  * The accessible name an open panel falls back to when it has no `title` and the
@@ -138,8 +139,26 @@ export class TnSidePanelComponent implements OnDestroy {
    */
   ariaLabelledby = input<string | null>(null);
 
-  // Outputs
+  /**
+   * Fires once the panel has finished opening.
+   *
+   * "Finished" means the open transition ended, OR that it was going to take
+   * longer than `TN_TRANSITION_FALLBACK_MS` to say so — which is what a user
+   * with `prefers-reduced-motion: reduce` gets, since this component's own
+   * stylesheet zeroes the duration for them and a transition that does not run
+   * fires no `transitionend` (#218). A consumer may assume the panel has
+   * reached its open state and that `open()` is true; it may NOT assume the
+   * animation is visually complete, because for that user there was none.
+   */
   opened = output<void>();
+
+  /**
+   * Fires once the panel has finished closing. Same guarantee as `opened`, and
+   * the same caveat: it reports the state, not the animation.
+   *
+   * Focus restoration does NOT hang off this — it happens as soon as the panel
+   * closes (#214). See the effect in the constructor.
+   */
   closed = output<void>();
 
   // Content projection queries
@@ -187,6 +206,17 @@ export class TnSidePanelComponent implements OnDestroy {
 
   // Focus restoration
   private previouslyFocusedElement: HTMLElement | null = null;
+
+  /**
+   * Decides when an open or a close counts as finished, so that the outputs
+   * above fire exactly once per change whether or not a transition ran. A field
+   * initializer rather than the constructor, because it registers an `effect`
+   * and so needs an injection context.
+   */
+  private lifecycle = tnTransitionLifecycle(
+    this.open,
+    (open) => (open ? this.opened.emit() : this.closed.emit())
+  );
 
   constructor() {
     this.registerMdiIcons();
@@ -251,11 +281,11 @@ export class TnSidePanelComponent implements OnDestroy {
       return;
     }
 
-    if (this.open()) {
-      this.opened.emit();
-    } else {
-      this.closed.emit();
-    }
+    // Which output to emit is `lifecycle`'s to decide, from the state the change
+    // it is tracking settled into — NOT from `open()` read here. The two differ
+    // exactly when this event is late: a panel reopened while the close was
+    // still animating reads `open() === true` on the stale close's event.
+    this.lifecycle.transitionEnded();
   }
 
   private restoreFocus(): void {

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
@@ -112,14 +112,30 @@ export function tnTransitionLifecycle(
     settled(settledState);
   }
 
-  // The initial state is not a change: nothing transitioned into it, so a panel
-  // that renders closed and stays closed must emit no `closed`. `previous`
-  // starts at the state's own first value rather than at a sentinel so that
-  // there is one rule here and not two.
-  let previous = state();
+  /**
+   * The last state reported on, or `null` before the first `effect` run has
+   * established what the component STARTED in.
+   *
+   * That first run is the only place the starting value can be read. This
+   * function is called from a field initializer, which runs during
+   * construction — before Angular has applied any input binding — so `state()`
+   * there is the input's DEFAULT, not the caller's `[open]="true"`. Seeding
+   * from it would make a component that renders already open look like an
+   * immediate open, and emit a lifecycle event, 400ms after init, for an
+   * animation that never happened. The effect's first run is after bindings,
+   * and is the earliest point that reads what the caller asked for.
+   *
+   * The initial state is not a change either way: nothing transitioned into it,
+   * so a panel that renders closed and stays closed emits no `closed`.
+   */
+  let previous: boolean | null = null;
 
   effect(() => {
     const current = state();
+    if (previous === null) {
+      previous = current;
+      return;
+    }
     if (current === previous) {
       return;
     }

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
@@ -1,0 +1,141 @@
+import { DestroyRef, effect, inject } from '@angular/core';
+import type { Signal } from '@angular/core';
+
+/**
+ * The one place that decides WHEN a component whose open/close is animated by a
+ * CSS transition may announce that the transition is over.
+ *
+ * WHY THIS EXISTS AT ALL
+ * ----------------------
+ * `transitionend` does not fire when no transition runs, and a transition that
+ * is disabled still counts as "no transition". Every component here disables its
+ * own under `@media (prefers-reduced-motion: reduce)` — `tn-side-panel` with
+ * `transition-duration: 0ms`, `tn-drawer` with `transition: none` — so a
+ * lifecycle output emitted from a `transitionend` handler alone never fires for
+ * a user who asked for less motion. A consumer waiting on `(closed)` to release
+ * a resource, refresh a list or return focus waits forever, and only for that
+ * population (#218). Reduced motion is merely the reproducible cause: a panel
+ * inside a `display: none` ancestor, or a caller's own stylesheet override, ends
+ * up in the same place.
+ *
+ * So the event is treated as an OPTIMISATION rather than as the trigger. Every
+ * state change arms a timer; a real `transitionend` disarms it and reports early.
+ * Exactly one of the two reports, per change, whichever arrives first.
+ *
+ * WHY A SHARED FUNCTION AND NOT A COPY PER COMPONENT
+ * -------------------------------------------------
+ * The same reasoning as `../a11y/accessible-name.ts`, and the same evidence.
+ * `tn-side-panel` and `tn-drawer` reached #218 with identical bugs because the
+ * second was written from the first — and #214 then fixed focus restoration in
+ * both, separately, in prose that had to be kept in step by hand. What is subtle
+ * here is not the timer but the three cases around it: an interrupted change, a
+ * late event after the fallback already reported, and the initial state, which
+ * has not transitioned into anything and must stay silent. A second copy of
+ * those is a second chance to get one of them wrong, and two copies cannot
+ * disagree loudly.
+ *
+ * Not exported from `public-api.ts`, and must not be — it is how this library's
+ * own components agree with each other, not API. A consumer wanting the same
+ * guarantee has `(closed)`, which is the point.
+ */
+
+/**
+ * How long to wait for `transitionend` before concluding it is not coming.
+ *
+ * COUPLED TO THE STYLESHEETS: it must outlast the longest transition either
+ * component animates, which is `transform 0.3s` in `drawer.component.scss` and
+ * `transform 300ms` in `side-panel.component.scss`. Lengthening one of those
+ * past this value is what breaks the coupling, and the symptom is mild — the
+ * fallback reports first and the real event is ignored as late, so the output
+ * still fires exactly once, just before the animation is quite finished.
+ *
+ * The margin is for the ordinary case of a browser firing `transitionend` a
+ * frame or two after the nominal duration, under load. It is not a budget for a
+ * longer animation.
+ *
+ * Exported so specs advance the clock by name rather than by a copied literal.
+ */
+export const TN_TRANSITION_FALLBACK_MS = 400;
+
+/** What `tnTransitionLifecycle` gives back to its caller. */
+export interface TnTransitionLifecycle {
+  /**
+   * Call from the component's `(transitionend)` handler, once it has filtered
+   * the event down to the one property whose end means the panel has arrived.
+   *
+   * A no-op unless a change is still awaiting its report, so a late event after
+   * the fallback already fired — and any second `transitionend` for the same
+   * change — is dropped rather than emitted twice.
+   */
+  transitionEnded(): void;
+}
+
+/**
+ * Report each settled open/close exactly once, whether or not a transition runs.
+ *
+ * **Must be called from an injection context** — a field initializer or the
+ * constructor — because it registers an `effect` and takes a `DestroyRef` to
+ * cancel a timer that would otherwise emit from a destroyed component.
+ *
+ * @param state The animated state: the component's `open` / `opened` model.
+ * @param settled Called once per settled change, with the state settled into.
+ */
+export function tnTransitionLifecycle(
+  state: Signal<boolean>,
+  settled: (state: boolean) => void
+): TnTransitionLifecycle {
+  const destroyRef = inject(DestroyRef);
+
+  /**
+   * The state a change is waiting to report, or `null` when nothing is pending.
+   *
+   * Both reporters clear it before calling `settled`, which is what makes the
+   * fallback and a late `transitionend` mutually exclusive rather than additive.
+   */
+  let pending: boolean | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function disarm(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function report(): void {
+    if (pending === null) {
+      return;
+    }
+    const settledState = pending;
+    pending = null;
+    disarm();
+    settled(settledState);
+  }
+
+  // The initial state is not a change: nothing transitioned into it, so a panel
+  // that renders closed and stays closed must emit no `closed`. `previous`
+  // starts at the state's own first value rather than at a sentinel so that
+  // there is one rule here and not two.
+  let previous = state();
+
+  effect(() => {
+    const current = state();
+    if (current === previous) {
+      return;
+    }
+    previous = current;
+
+    // A change while one is already pending REPLACES it, and the superseded one
+    // is never reported. That is what the browser does with the transition
+    // itself: reversing mid-flight starts a new one and the interrupted one
+    // fires no `transitionend`, so a panel closed before it finished opening
+    // has not, at any point, finished opening.
+    disarm();
+    pending = current;
+    timer = setTimeout(report, TN_TRANSITION_FALLBACK_MS);
+  });
+
+  destroyRef.onDestroy(disarm);
+
+  return { transitionEnded: report };
+}

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, effect, inject } from '@angular/core';
+import { DestroyRef, NgZone, effect, inject } from '@angular/core';
 import type { Signal } from '@angular/core';
 
 /**
@@ -75,7 +75,8 @@ export interface TnTransitionLifecycle {
  *
  * **Must be called from an injection context** — a field initializer or the
  * constructor — because it registers an `effect` and takes a `DestroyRef` to
- * cancel a timer that would otherwise emit from a destroyed component.
+ * cancel a timer that would otherwise emit from a destroyed component, and an
+ * `NgZone` to keep that timer out of Angular's.
  *
  * @param state The animated state: the component's `open` / `opened` model.
  * @param settled Called once per settled change, with the state settled into.
@@ -85,6 +86,7 @@ export function tnTransitionLifecycle(
   settled: (state: boolean) => void
 ): TnTransitionLifecycle {
   const destroyRef = inject(DestroyRef);
+  const zone = inject(NgZone);
 
   /**
    * The state a change is waiting to report, or `null` when nothing is pending.
@@ -148,7 +150,20 @@ export function tnTransitionLifecycle(
     // has not, at any point, finished opening.
     disarm();
     pending = current;
-    timer = setTimeout(report, TN_TRANSITION_FALLBACK_MS);
+    // OUTSIDE the Angular zone, and back inside it only to report. This effect
+    // runs within `ApplicationRef.tick()`, which zone change detection invokes
+    // inside `NgZone.run(...)`, so a plain `setTimeout` here would be a zone
+    // macrotask and hold `NgZone` unstable for the whole fallback window after
+    // every open and close — even the ones a `transitionend` reports early.
+    // That is a cost paid by callers who never asked for a timer: a `fakeAsync`
+    // spec that toggles the state fails with "1 timer(s) still in the queue"
+    // naming a timer its author did not write, and `whenStable()` (so every
+    // component-harness interaction) waits the full window. The emit itself
+    // must be back inside, since `settled` is what fires the component's
+    // outputs and a consumer's handler has to be seen by change detection.
+    timer = zone.runOutsideAngular(() =>
+      setTimeout(() => zone.run(report), TN_TRANSITION_FALLBACK_MS)
+    );
   });
 
   destroyRef.onDestroy(disarm);


### PR DESCRIPTION
Fixes #218.

`tn-side-panel` and `tn-drawer` both emitted their lifecycle outputs from a
`transitionend` handler, and both stylesheets disable the transition that event
depends on under `@media (prefers-reduced-motion: reduce)` —
`transition-duration: 0ms` for the panel, `transition: none` for the drawer. A
transition that does not run fires no `transitionend`, so for those users
`opened`/`closed` and `openedComplete`/`closed` never fired **at all**. A
consumer waiting on `(closed)` to release a resource, refresh a list or return
focus waited forever, and only for the population least likely to be in anyone's
manual test pass.

## What changed

The event is now an **optimisation rather than the trigger**. Every state change
arms a fallback timer; a real `transitionend` disarms it and reports early.
Exactly one of the two reports per change, whichever arrives first.

That is the option the ticket names second, chosen over "emit on close" because
it keeps what the outputs mean in the normal case, and chosen over a
`matchMedia('(prefers-reduced-motion: reduce)')` gate because it covers the
whole failure class rather than the one known cause — a panel inside a
`display: none` ancestor, or a caller's own stylesheet override, lands in the
same place.

The timing lives in `lib/utils/transition-lifecycle.ts`, shared by both
components rather than written out twice. Same reasoning as
`lib/a11y/accessible-name.ts` next door, and the same evidence: these two
reached this bug with identical code because the second was written from the
first. What is subtle is not the timer but the three cases around it — an
interrupted change, a late event, and the initial state.

**What a consumer may assume** is written beside each output, per the ticket's
third criterion: that the component has reached the state and that
`open()`/`opened()` agrees; **not** that the animation is visually complete,
because for a reduced-motion user there was none.

**The wait is scheduled outside the Angular zone**, and re-enters it only to
report. The timer is armed from an `effect`, which runs inside
`ApplicationRef.tick()` inside `NgZone.run(...)`, so a plain `setTimeout` there
is an Angular-zone macrotask and holds `NgZone`/`ApplicationRef.isStable` false
for the whole 400ms window after every open and every close — including the
ones a real `transitionend` reports early. `runOutsideAngular` for the wait plus
`zone.run` for the emit keeps that cost off callers who never asked for a timer,
and belongs in this file rather than in either component, since the point of the
file is that neither has to know the timer exists.

## Timing, and its coupling to the stylesheets

`TN_TRANSITION_FALLBACK_MS` is 400ms, which must outlast the longest transition
either component animates — `transform 0.3s` in `drawer.component.scss` and
`transform 300ms` in `side-panel.component.scss`. The coupling is by comment,
and the failure if it is ever broken is mild rather than silent-wrong: the
fallback reports first and the real event is ignored as late, so the output
still fires exactly once, just before the animation is quite finished.

## Tests

21 specs across `side-panel-lifecycle.spec.ts` and `drawer-lifecycle.spec.ts`,
covering both directions with and without a `transitionend`, both drawer modes,
no double emission when a transition does complete, a late event on top of an
already-fired fallback, an interrupted change, destruction mid-transition, a
component that renders already open, and — one per component —
`NgZone.hasPendingMacrotasks` staying false while the fallback is armed. Both of
those last two fail against a plain in-zone `setTimeout`, checked by reverting
the scheduling and re-running.

Two things about these are worth knowing before editing them, and both are
written out in the files:

- **The reduced-motion path is reached by NOT dispatching the event.** jsdom
  applies no stylesheet and runs no transition, so that is not only the
  simplest way to reproduce that user's experience — it is the only one.
- **The fixture is built inside each `fakeAsync` body, and these are separate
  files rather than `describe` blocks in the existing specs.** The fallback is a
  timer, so `tick()` has to reach it, and it only can if the timer was scheduled
  inside that `fakeAsync` zone. It is armed with `runOutsideAngular`, so it
  lands in the zone `NgZone` was **constructed** in — and `TestBed` constructs
  that once, lazily, at the **first** `TestBed.createComponent` of the suite. A
  `beforeEach` that creates a fixture therefore fixes the zone for every test
  after it. Measured while writing these: with a shared fixture, three of six
  failed and the other three passed on the `transitionend` path alone — a suite
  half-passing reads as a suite that works.

## Verified locally

`yarn lint` (4 pre-existing `import/order` errors remain, in `input.component.ts`
and `menu-panel.component.ts` — neither touched here), `yarn test` (2588
passing, 109 suites), `yarn test:scripts` (42 passing), `yarn build`,
`yarn build-storybook`. **Not run:** the Storybook interaction tests, which need
Playwright browsers and a served build.

The project's own reviewer ran locally over the full diff, three times: round 1
returned a HIGH, fixed in the second commit; rounds 2 and 3 returned nothing at
MEDIUM or above.

## Reviewed and not changed

LOW findings, from this PR's review and the local one, left for follow-up rather
than fixed — each new fix is a new unreviewed diff, and none of these affect
behaviour:

1. `TN_TRANSITION_FALLBACK_MS` is coupled to the two SCSS durations by comment
   only. Real, and the mildest failure mode is described above; enforcing it
   would mean a shared custom property both stylesheets read, or reading the
   computed duration at runtime — both larger than this ticket.
2. The new JSDoc on `opened`/`openedComplete` does not spell out that a
   component which renders *already* open never emits them. True — that rule is
   enshrined in the specs and in `transition-lifecycle.ts`, and it is the
   behaviour that existed before this PR too.
3. `TN_TRANSITION_FALLBACK_MS` is named in three public outputs' JSDoc but is
   deliberately not in `public-api.ts`, so a consumer reading the generated docs
   cannot resolve the symbol. Writing the number into those docs instead is the
   fix.
4. The `onTransitionEnd` comment in both components justifies the change with a
   "reopened while still closing" case that behaves identically either way; the
   guarantee actually being pinned is the `pending === null` guard, which is
   what stops a `position` flip on a closed side-mode drawer emitting a spurious
   `closed`.
5. `afterEach` in both new spec files calls `destroy()` unguarded on a fixture
   assigned inside the test body, so a failure before the fixture is built would
   throw in teardown — and in the side-panel file that throw happens before
   `warn.mockRestore()`, leaking the `console.warn` mock into the next test.
   Reordering the two lines is the fix.
6. The drawer spec's `afterEach` sweeps portaled nodes that `ngOnDestroy` may
   already remove. Copied from `drawer.component.spec.ts`, which does the same.
7. `drawer-a11y.spec.ts:436` and `side-panel-a11y.spec.ts:407` still say
   `transitionend` is what emits `closed`, which this PR makes false. Both files
   are outside this diff.
8. `transition-lifecycle.ts` has no spec of its own; it is covered through both
   components.
9. Reduced-motion users wait the full 400ms rather than being reported on the
   next tick, which `matchMedia` or a computed `transition-duration` could
   detect. That is the design choice above — covering the whole failure class
   rather than the one known cause — and the wait is not user-visible, since
   the panel has already arrived.

## One correction to the review

The MEDIUM's first symptom does not reproduce here. A `fakeAsync` spec that
toggles `open` and never `tick`s the fallback does **not** throw
`1 timer(s) still in the queue` in this repo — checked by adding exactly that
spec against the *unfixed* scheduling, where it passed. The second symptom is
real and is what the fix is for: `whenStable()` and CDK `forceStabilize()` do
not resolve while an Angular-zone macrotask is pending, so every harness
interaction that toggles one of these components paid the full window. The
`hasPendingMacrotasks` specs pin that half.
