### PR TITLE
NAS-142353 / 27.0.0-BETA.1 / fix(dialog): give an untitled dialog a name, and stop rendering an empty heading

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -584,6 +584,19 @@ tn-dialog-shell {
   margin-left: 16px; /* Space between title and button */
 }
 
+/*
+  What pushes the header chrome to the right edge when there is no title.
+  `.tn-dialog__title` has `flex: 1` and used to do that job, but since #219 an
+  untitled dialog renders no heading at all — an empty `<h2>` is an
+  `empty-heading` violation — and the buttons would otherwise sit hard left.
+  Only the FIRST of them takes the auto margin, so the 16px between the
+  fullscreen and close buttons is unchanged.
+*/
+.tn-dialog__header > .tn-dialog__fullscreen:first-child,
+.tn-dialog__header > .tn-dialog__close:first-child {
+  margin-left: auto;
+}
+
 .tn-dialog__close:hover {
   background: var(--tn-alt-bg1, #f8f9fa);
   color: var(--tn-fg1, #000000);

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -639,14 +639,21 @@ tn-dialog-shell {
   gap: 16px;
 }
 
-/* Hide a content section / actions footer that has nothing to show, so it
-   doesn't render as an empty bordered, padded bar.
+/* Hide a header / content section / actions footer that has nothing to show, so
+   it doesn't render as an empty bordered, padded bar.
    - `:empty` covers dialogs that project nothing into the slot (the ng-content
      comment anchor is ignored by `:empty`, but real text/elements are not).
    - The `--hidden` modifier (driven by the [hideContent]/[hideActions] inputs)
      covers slots that always project a wrapper element whose contents are
      conditional, so the slot is never truly `:empty`.
+   The header joined this list with #219: it used to render its `<h2>`
+   unconditionally and so was never empty, but an untitled dialog now renders no
+   heading — and one opened with [showCloseButton]="false" and no fullscreen
+   button has nothing else in its header either. The `@if` anchors it is left
+   with are comment nodes, which `:empty` ignores, same as the ng-content anchor
+   above.
    Declared after the layout rules above so it wins on equal specificity. */
+.tn-dialog__header:empty,
 .tn-dialog__content:empty,
 .tn-dialog__content--hidden,
 .tn-dialog__actions:empty,

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
@@ -47,6 +47,7 @@ interface DialogShellA11yState {
   title: WritableSignal<string>;
   ariaLabel: WritableSignal<string | null>;
   ariaLabelledby: WritableSignal<string | null>;
+  showCloseButton: WritableSignal<boolean>;
 }
 
 /* eslint-disable @angular-eslint/component-max-inline-declarations */
@@ -59,7 +60,8 @@ interface DialogShellA11yState {
     <tn-dialog-shell
       [title]="state.title()"
       [ariaLabel]="state.ariaLabel()"
-      [ariaLabelledby]="state.ariaLabelledby()">
+      [ariaLabelledby]="state.ariaLabelledby()"
+      [showCloseButton]="state.showCloseButton()">
       <p>Dialog body</p>
     </tn-dialog-shell>
   `,
@@ -119,6 +121,7 @@ describe('tn-dialog-shell accessibility (#219)', () => {
       title: signal('Delete dataset'),
       ariaLabel: signal<string | null>(null),
       ariaLabelledby: signal<string | null>(null),
+      showCloseButton: signal(true),
     };
     dialog = TestBed.inject(TnDialog);
     cdkDialog = TestBed.inject(Dialog);
@@ -323,6 +326,40 @@ describe('tn-dialog-shell accessibility (#219)', () => {
       // asserted where it does have a target: `still reports the empty heading
       // itself`, below.
       expect(container().querySelectorAll('h1, h2, h3, h4, h5, h6')).toHaveLength(0);
+    });
+
+    /**
+     * The header used to render its `<h2>` unconditionally, so it always had an
+     * element in it. An untitled dialog with no fullscreen button and
+     * `[showCloseButton]="false"` now has nothing in its header at all, and
+     * `.tn-dialog__header` is a bordered, padded bar — so `themes.css` hides it
+     * with `:empty`, the same rule the content section and the actions footer
+     * already use.
+     *
+     * What is asserted here is that rule's PRECONDITION, not the rule: jsdom
+     * loads no stylesheet, so `display: none` cannot be observed from a spec.
+     * `:empty` ignores comment nodes — which is all Angular leaves behind for an
+     * `@if` that did not render — so it matches exactly when the header has no
+     * element children, and that is what this measures.
+     */
+    it('leaves no element in the header when there is no title and no chrome', () => {
+      state.title.set('');
+      state.showCloseButton.set(false);
+      openDialog();
+
+      const header = container().querySelector('.tn-dialog__header')!;
+      expect(header.children).toHaveLength(0);
+      // The nodes it does hold are comments, which is what makes `:empty` match.
+      expect([...header.childNodes].every((node) => node.nodeType === Node.COMMENT_NODE)).toBe(true);
+    });
+
+    it('keeps the header when there is chrome but no title', () => {
+      state.title.set('');
+      openDialog();
+
+      const header = container().querySelector('.tn-dialog__header')!;
+      expect(header.querySelector('.tn-dialog__close')).not.toBeNull();
+      expect(header.children.length).toBeGreaterThan(0);
     });
 
     it('renders the heading, with the id the dialog points at, when there is one', async () => {

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
@@ -1,0 +1,426 @@
+import { Dialog, DIALOG_DATA } from '@angular/cdk/dialog';
+import type { DialogConfig } from '@angular/cdk/dialog';
+import { Component, inject, signal } from '@angular/core';
+import type { WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TN_DIALOG_SHELL_DEFAULT_LABEL, TnDialogShellComponent } from './dialog-shell.component';
+import { TnDialog } from './dialog.service';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the accessible name of `tn-dialog-shell` (#219).
+ *
+ * WHAT WAS REPORTED, AND WHAT WAS MEASURED
+ * ----------------------------------------
+ * The ticket read the defect off the template rather than from a scan, and
+ * described the untitled dialog as being NAMED BY the empty `<h2>`. Measured
+ * against the unchanged component, it was worse than that: the effect that
+ * points `aria-labelledby` at the heading returned early when `title` was
+ * empty, so the CDK container carried no naming attribute at all —
+ *
+ *     {ariaLabelledby: null, ariaLabel: null, role: 'dialog'}
+ *     axe: violated ['aria-dialog-name'] on the dialog, ['empty-heading'] on the h2
+ *
+ * — and the dialog had no name from any route. `aria-dialog-name` reports
+ * either way, which is why the distinction did not change the fix. Both shapes
+ * are kept as positive controls in `the structure this replaced`, because they
+ * are different markups and only one of them was ever in this repository.
+ *
+ * A TITLED dialog was already clean before this ticket, and the same scan says
+ * so above: `aria-dialog-name` evaluated and did not report. So the change here
+ * is only about the untitled case, and `is named by its visible heading` is a
+ * regression guard rather than a fix.
+ *
+ * WHERE THE MARKUP IS
+ * -------------------
+ * The dialog is portaled into `.cdk-overlay-container` on `document.body`, and
+ * `role="dialog"` is on the CDK's `<cdk-dialog-container>` — an ancestor of
+ * this component, not part of its own template. So the scans are rooted in the
+ * overlay and target the CDK element, and the component reaches it with
+ * `closest()`. `evaluates no dialog rule against the host element` keeps that
+ * measurement, and fails if the portal is ever removed.
+ */
+
+/** Inputs the tests vary, in signals so a case sets them before opening. */
+interface DialogShellA11yState {
+  title: WritableSignal<string>;
+  ariaLabel: WritableSignal<string | null>;
+  ariaLabelledby: WritableSignal<string | null>;
+}
+
+/* eslint-disable @angular-eslint/component-max-inline-declarations */
+
+@Component({
+  selector: 'tn-dialog-shell-a11y-content',
+  standalone: true,
+  imports: [TnDialogShellComponent],
+  template: `
+    <tn-dialog-shell
+      [title]="state.title()"
+      [ariaLabel]="state.ariaLabel()"
+      [ariaLabelledby]="state.ariaLabelledby()">
+      <p>Dialog body</p>
+    </tn-dialog-shell>
+  `,
+})
+class DialogShellA11yContentComponent {
+  protected state = inject<DialogShellA11yState>(DIALOG_DATA);
+}
+
+/** Holds the element the `ariaLabelledby` cases point at. */
+@Component({
+  selector: 'tn-dialog-shell-a11y-host',
+  standalone: true,
+  template: '<h2 id="external-dialog-title">Delete dataset</h2>',
+})
+class DialogShellA11yHostComponent {}
+
+/* eslint-enable @angular-eslint/component-max-inline-declarations */
+
+/**
+ * The rules an open dialog's structure can be wrong under.
+ *
+ * `aria-dialog-name` is the one the fix is about. The rest are here because the
+ * change moved what names the dialog and writes two attributes onto the same
+ * element: the cheapest way for that to go wrong is an attribute landing on a
+ * role that does not allow it, or an IDREF that resolves to nothing.
+ *
+ * NOT `empty-heading`: it reports on the `<h2>`, not on the dialog, so it is
+ * asserted where its target is — in `the heading the dialog is named by`.
+ */
+const DIALOG_RULES = [
+  'aria-dialog-name',
+  'aria-allowed-attr',
+  'aria-required-attr',
+  'aria-valid-attr-value',
+  'aria-allowed-role',
+  'aria-roles',
+];
+
+describe('tn-dialog-shell accessibility (#219)', () => {
+  let fixture: ComponentFixture<DialogShellA11yHostComponent>;
+  let state: DialogShellA11yState;
+  let dialog: TnDialog;
+  let cdkDialog: Dialog;
+  let warn: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DialogShellA11yHostComponent, DialogShellA11yContentComponent],
+    }).compileComponents();
+
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    fixture = TestBed.createComponent(DialogShellA11yHostComponent);
+    fixture.detectChanges();
+
+    state = {
+      title: signal('Delete dataset'),
+      ariaLabel: signal<string | null>(null),
+      ariaLabelledby: signal<string | null>(null),
+    };
+    dialog = TestBed.inject(TnDialog);
+    cdkDialog = TestBed.inject(Dialog);
+  });
+
+  afterEach(() => {
+    // An open dialog lives in `document.body` rather than in the fixture, so a
+    // test that left one there would be scanned by the next one as well as its
+    // own. `mockRestore` last, so a throw from either close cannot leak the
+    // `console.warn` mock into the following test.
+    cdkDialog.closeAll();
+    fixture.destroy();
+    warn.mockRestore();
+  });
+
+  function openDialog(config: Partial<DialogConfig> = {}): void {
+    dialog.open(DialogShellA11yContentComponent, { ...config, data: state });
+    fixture.detectChanges();
+  }
+
+  /** The CDK element that carries `role="dialog"` — what has to be named. */
+  function container(): HTMLElement {
+    return document.body.querySelector('cdk-dialog-container') as HTMLElement;
+  }
+
+  /** The scanned root: the dialog is portaled here, not into the fixture. */
+  function overlayContainer(): HTMLElement {
+    return document.body.querySelector('.cdk-overlay-container') as HTMLElement;
+  }
+
+  function heading(): HTMLElement | null {
+    return container().querySelector('.tn-dialog__title');
+  }
+
+  describe('the dialog has a name', () => {
+    it('is named by its visible heading when it has a title', () => {
+      openDialog();
+
+      expect(container().getAttribute('aria-labelledby')).toBe(heading()!.id);
+      expect(heading()!.textContent!.trim()).toBe('Delete dataset');
+      // No `aria-label` beside it: it would win the name calculation over the
+      // heading and replace what the user can see with something they cannot.
+      expect(container().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a generic name when it has no title and no label', () => {
+      state.title.set('');
+      openDialog();
+
+      expect(container().getAttribute('aria-labelledby')).toBeNull();
+      expect(container().getAttribute('aria-label')).toBe(TN_DIALOG_SHELL_DEFAULT_LABEL);
+    });
+
+    it('warns in dev mode when it falls back, and names the input to use', () => {
+      state.title.set('');
+      openDialog();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('[tn-dialog-shell]');
+      expect(warn.mock.calls[0][0]).toContain('title');
+    });
+
+    it('takes an explicit ariaLabel for a dialog that renders no heading', () => {
+      state.title.set('');
+      state.ariaLabel.set('Add dataset');
+      openDialog();
+
+      expect(container().getAttribute('aria-label')).toBe('Add dataset');
+      expect(container().getAttribute('aria-labelledby')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('takes an ariaLabelledby, and renders no aria-label beside it', () => {
+      state.title.set('');
+      state.ariaLabelledby.set('external-dialog-title');
+      openDialog();
+
+      expect(container().getAttribute('aria-labelledby')).toBe('external-dialog-title');
+      expect(container().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    /**
+     * `aria-labelledby` wins the ARIA name calculation when it resolves, so the
+     * visible heading is what a listener hears — but an explicit `ariaLabel` is
+     * still emitted beside it. That is `tnAccessibleName`'s rule and not this
+     * component's: suppressing an explicit label would be safe only while the
+     * IDREF resolves, and against a heading that has not rendered it would
+     * leave the dialog unnamed in exactly the case where the caller named it.
+     */
+    it('is named by the visible title, and keeps an explicit label beside it', () => {
+      state.ariaLabel.set('Something else');
+      state.ariaLabelledby.set('external-dialog-title');
+      openDialog();
+
+      expect(container().getAttribute('aria-labelledby')).toBe(heading()!.id);
+      expect(container().getAttribute('aria-label')).toBe('Something else');
+    });
+
+    it('treats a whitespace-only title as no title', () => {
+      state.title.set('   ');
+      openDialog();
+
+      expect(heading()).toBeNull();
+      expect(container().getAttribute('aria-label')).toBe(TN_DIALOG_SHELL_DEFAULT_LABEL);
+    });
+  });
+
+  /**
+   * A dialog can also be named through CDK's own route, `DialogConfig`. This
+   * component writes both naming attributes onto the container the config would
+   * have rendered them on, so without consulting the config it would clear a
+   * name the opener had supplied — and replace it with the generic fallback,
+   * which is the one case where the fallback would be actively worse than
+   * nothing.
+   */
+  describe('a name passed to TnDialog.open rather than to the shell', () => {
+    it('keeps a DialogConfig ariaLabel, and raises no fallback warning', () => {
+      state.title.set('');
+      openDialog({ ariaLabel: 'Add dataset' });
+
+      expect(container().getAttribute('aria-label')).toBe('Add dataset');
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('keeps a DialogConfig ariaLabelledBy', () => {
+      state.title.set('');
+      openDialog({ ariaLabelledBy: 'external-dialog-title' });
+
+      expect(container().getAttribute('aria-labelledby')).toBe('external-dialog-title');
+      expect(container().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('is still named by its own title, which is the visible one', () => {
+      openDialog({ ariaLabelledBy: 'external-dialog-title' });
+
+      expect(container().getAttribute('aria-labelledby')).toBe(heading()!.id);
+    });
+  });
+
+  describe('the heading the dialog is named by', () => {
+    it('renders no heading element at all when there is no title', () => {
+      state.title.set('');
+      openDialog();
+
+      expect(heading()).toBeNull();
+
+      // Said again without the class, because `heading()` depends on one:
+      // renaming `.tn-dialog__title` while still rendering an unconditional
+      // empty `<h2>` would leave the assertion above passing with an empty
+      // level-2 heading back in the header and back in the document outline.
+      //
+      // Not an axe scan. `empty-heading` selects heading elements, so with none
+      // rendered there is nothing for it to evaluate and it reports clean
+      // whatever the header holds — a vacuous result. The rule's teeth are
+      // asserted where it does have a target: `still reports the empty heading
+      // itself`, below.
+      expect(container().querySelectorAll('h1, h2, h3, h4, h5, h6')).toHaveLength(0);
+    });
+
+    it('renders the heading, with the id the dialog points at, when there is one', async () => {
+      openDialog();
+
+      expect(heading()!.tagName).toBe('H2');
+      const { violated, evaluated } = await axeResult(
+        container(), heading(), ['empty-heading']
+      );
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('empty-heading');
+    });
+  });
+
+  describe('axe over the open dialog', () => {
+    // `evaluated` is asserted alongside every empty `violated`, because an empty
+    // `violations` is also what axe returns when it evaluated nothing.
+    it('raises no violation on a titled dialog, and does evaluate the dialog rules', async () => {
+      openDialog();
+
+      const { violated, evaluated } = await axeResult(
+        overlayContainer(), container(), DIALOG_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+
+    it('raises no violation on an untitled dialog, which is the default', async () => {
+      state.title.set('');
+      openDialog();
+
+      const { violated, evaluated } = await axeResult(
+        overlayContainer(), container(), DIALOG_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-dialog-name');
+    });
+
+    it('raises no violation on a dialog named by an IDREF outside it', async () => {
+      state.title.set('');
+      state.ariaLabelledby.set('external-dialog-title');
+      openDialog();
+
+      const { violated, evaluated } = await axeResult(
+        overlayContainer(), container(), DIALOG_RULES
+      );
+
+      // `aria-valid-attr-value` is the one that would report if the IDREF did
+      // not resolve — the target is in the fixture, outside the scanned root,
+      // and axe resolves IDREFs against the document.
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-valid-attr-value');
+    });
+  });
+
+  /**
+   * Positive controls. Everything above asserts an empty `violated`, which axe
+   * also returns when it looked at nothing — so these are the assertions that
+   * keep the rest honest.
+   */
+  describe('the reported scan, and the structure this replaced', () => {
+    async function scan(html: string, target: string, rules: string[]) {
+      const previous = document.createElement('div');
+      previous.innerHTML = html;
+      document.body.appendChild(previous);
+
+      // `await` inside the try, not `return axeResult(...)` — returning the
+      // promise runs `finally` before axe has read anything, which detaches the
+      // tree mid-scan and is precisely the vacuous pass this is guarding.
+      try {
+        return await axeResult(previous, previous.querySelector(target), rules);
+      } finally {
+        previous.remove();
+      }
+    }
+
+    /**
+     * Why every scan above is rooted in the overlay container: the dialog is
+     * portaled out of the component tree, so a scan rooted at the fixture
+     * evaluates nothing about it. If the portal is ever removed, this fails and
+     * those scans should be rooted at the fixture instead.
+     */
+    it('evaluates no dialog rule against the host element, which holds no dialog', async () => {
+      openDialog();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, fixture.nativeElement, DIALOG_RULES
+      );
+
+      expect(evaluated).toEqual([]);
+      expect(violated).toEqual([]);
+      expect(fixture.nativeElement.querySelector('cdk-dialog-container')).toBeNull();
+    });
+
+    /**
+     * What this component actually did before the fix: the naming effect
+     * returned early on an empty title, so the container carried no naming
+     * attribute at all.
+     */
+    it('still reports a dialog with no naming attribute', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true">'
+        + '<header><h2 id="t"></h2></header>'
+        + '<button type="button">Close dialog</button>'
+        + '</div>',
+        '[role="dialog"]',
+        ['aria-dialog-name'],
+      );
+
+      expect(violated).toEqual(['aria-dialog-name']);
+    });
+
+    /**
+     * And the shape the ticket described — named by the empty heading. Not what
+     * was in this repository, but it is what pointing the existing effect at the
+     * heading unconditionally would have produced, so it is worth pinning that
+     * doing so would have cleared nothing.
+     */
+    it('still reports a dialog named by an empty heading', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true" aria-labelledby="t">'
+        + '<header><h2 id="t"></h2></header>'
+        + '</div>',
+        '[role="dialog"]',
+        ['aria-dialog-name'],
+      );
+
+      expect(violated).toEqual(['aria-dialog-name']);
+    });
+
+    it('still reports the empty heading itself', async () => {
+      const { violated } = await scan(
+        '<div role="dialog" aria-modal="true" aria-labelledby="t">'
+        + '<header><h2 id="t"></h2></header>'
+        + '</div>',
+        'h2',
+        ['empty-heading'],
+      );
+
+      expect(violated).toEqual(['empty-heading']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell-a11y.spec.ts
@@ -259,6 +259,50 @@ describe('tn-dialog-shell accessibility (#219)', () => {
 
       expect(container().getAttribute('aria-labelledby')).toBe(heading()!.id);
     });
+
+    /**
+     * A BLANK input is not a name, and must not count as one while the routes
+     * are being chosen between. Coalescing with `??` would stop at the empty
+     * string — "provided" — never reach the config, and hand the dialog the
+     * generic fallback while a real name sat one route further down. That is
+     * the single case where the fallback is worse than doing nothing, so both
+     * routes are pinned here rather than left to the helper.
+     */
+    it('does not let a blank ariaLabel input shadow a DialogConfig ariaLabel', () => {
+      state.title.set('');
+      state.ariaLabel.set('');
+      openDialog({ ariaLabel: 'Add dataset' });
+
+      expect(container().getAttribute('aria-label')).toBe('Add dataset');
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not let a blank ariaLabelledby input clear a DialogConfig ariaLabelledBy', () => {
+      state.title.set('');
+      state.ariaLabelledby.set('   ');
+      openDialog({ ariaLabelledBy: 'external-dialog-title' });
+
+      expect(container().getAttribute('aria-labelledby')).toBe('external-dialog-title');
+      expect(container().getAttribute('aria-label')).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    /**
+     * With nothing to fall through TO, a blank input still ends at the fallback
+     * and still warns — the same state as passing nothing at all. This is what
+     * says the fix above changed which route is consulted rather than making a
+     * blank string into a name.
+     */
+    it('still falls back, and warns, when the only names offered are blank', () => {
+      state.title.set('');
+      state.ariaLabel.set('');
+      state.ariaLabelledby.set('   ');
+      openDialog();
+
+      expect(container().getAttribute('aria-labelledby')).toBeNull();
+      expect(container().getAttribute('aria-label')).toBe(TN_DIALOG_SHELL_DEFAULT_LABEL);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('the heading the dialog is named by', () => {

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.html
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.html
@@ -1,5 +1,13 @@
 <header class="tn-dialog__header">
-  <h2 class="tn-dialog__title" [id]="titleId">{{ title() }}</h2>
+  <!--
+    No heading element at all when there is no title, rather than an empty one:
+    an `<h2>` with no text is an `empty-heading` violation, and it puts a level-2
+    heading with nothing in it into the document outline (#219). The dialog is
+    then named by `ariaLabel`/`ariaLabelledby` instead — see the component.
+  -->
+  @if (hasTitle()) {
+    <h2 class="tn-dialog__title" [id]="titleId">{{ title() }}</h2>
+  }
   @if (showFullscreenButton()) {
     <button
       type="button"

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -2,9 +2,32 @@ import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { DOCUMENT } from '@angular/common';
 import { Component, ElementRef, computed, effect, input, signal, inject } from '@angular/core';
 import type { OnInit} from '@angular/core';
+import { tnAccessibleName } from '../a11y/accessible-name';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 let nextUniqueId = 0;
+
+/**
+ * The accessible name a dialog falls back to when it renders no `title` and the
+ * caller named it through neither this component nor the `DialogConfig` (#219).
+ *
+ * `title` defaults to `''`, so the DEFAULT rendering of this component put an
+ * empty `<h2>` in the header and left the CDK container with no naming
+ * attribute at all — measured as `empty-heading` on the heading and
+ * `aria-dialog-name` on the dialog. A dialog with no name is announced as
+ * "dialog" and nothing else, which is the whole of what a screen-reader user is
+ * told about a surface that just took over the page and trapped their focus.
+ *
+ * "Dialog" is a poor name, and says almost exactly what the role already says.
+ * It is still better than the two alternatives: leaving the surface unnamed, or
+ * withholding `role="dialog"` until there is a name — the latter would move a
+ * listener into a focus trap with no announcement that anything had opened. So
+ * it is paired with the dev-mode warning `tnAccessibleName` raises, which is
+ * what keeps the fallback from becoming a quiet way to ship a nameless dialog.
+ *
+ * Exported so specs assert against it by name rather than by a copied literal.
+ */
+export const TN_DIALOG_SHELL_DEFAULT_LABEL = 'Dialog';
 
 @Component({
   selector: 'tn-dialog-shell',
@@ -43,6 +66,24 @@ export class TnDialogShellComponent implements OnInit {
   testId = input<TnTestIdValue>(undefined);
 
   /**
+   * Accessible name for the dialog itself, for a dialog that renders no `title`.
+   *
+   * A `title` outranks it: the heading is what the user can see, and
+   * `aria-labelledby` wins the ARIA name calculation while it resolves. The
+   * attribute is still rendered beside the heading rather than suppressed — see
+   * `tnAccessibleName`, which owns that rule for every component in this
+   * library, and the reason it is safer than the alternative.
+   */
+  ariaLabel = input<string | null>(null);
+
+  /**
+   * IDREF naming the dialog from text elsewhere on the page, for a dialog that
+   * renders no `title`. Same precedence: a `title` wins, because it is the
+   * visible heading.
+   */
+  ariaLabelledby = input<string | null>(null);
+
+  /**
    * The `testId` base normalized to a flat segment array. Nothing is dropped
    * here — `composeTestId` (via the `[tnTestId]` directive) filters falsy
    * segments, so an unset base collapses to the bare role (`button-close`).
@@ -77,17 +118,81 @@ export class TnDialogShellComponent implements OnInit {
   private host = inject<ElementRef<HTMLElement>>(ElementRef);
   private data = inject(DIALOG_DATA, { optional: true });
 
+  /**
+   * Whether there is a heading to render, and to name the dialog from.
+   *
+   * Trimmed, because a whitespace-only title renders a heading that looks empty
+   * to a sighted user and names the dialog with nothing — which is the state
+   * this ticket fixed, arriving by a second route.
+   */
+  protected hasTitle = computed(() => this.title().trim() !== '');
+
+  /**
+   * What the dialog is named by, in the order ARIA resolves: the visible
+   * heading when there is one, then the caller's IDREF, then one passed to
+   * `TnDialog.open` in the `DialogConfig`.
+   *
+   * The config is consulted so that the fallback below cannot overwrite a name
+   * the opener supplied through CDK's own route. Reading it back through
+   * `ref.config` rather than leaving CDK's binding to render it, because this
+   * component writes both attributes onto that element and would otherwise
+   * clear one it did not set.
+   */
+  private resolvedAriaLabelledby = computed(
+    () => (this.hasTitle() ? this.titleId : this.ariaLabelledby() ?? this.ref.config.ariaLabelledBy ?? null)
+  );
+
+  /** An explicit label, from this component's input or from the `DialogConfig`. */
+  private explicitAriaLabel = computed(() => this.ariaLabel() ?? this.ref.config.ariaLabel ?? null);
+
+  /**
+   * The name to render as `aria-label`, or `null` to render none — and the
+   * dev-mode warning when the dialog has no name from any route.
+   *
+   * Both halves live in `../a11y/accessible-name`, shared with `tn-side-panel`,
+   * `tn-drawer` and the three progressbars, where the reasoning for each branch
+   * is set out. `title` reaches it as the `ariaLabelledby` above, so a titled
+   * dialog is named, takes no fallback and raises no warning.
+   */
+  private resolvedAriaLabel = tnAccessibleName({
+    selector: 'tn-dialog-shell',
+    fallback: TN_DIALOG_SHELL_DEFAULT_LABEL,
+    activity: 'open',
+    hint: 'On this component the usual route is title, which is also the visible heading.',
+    ariaLabel: this.explicitAriaLabel,
+    ariaLabelledby: this.resolvedAriaLabelledby,
+  });
+
   constructor() {
-    // Give the CDK dialog container an accessible name by pointing its
-    // aria-labelledby at the visible title heading. Tracked in an effect so a
-    // title set after init is still reflected.
+    // The CDK dialog container is what carries `role="dialog"`, and it is an
+    // ANCESTOR of this component rather than part of its template — so the name
+    // is written onto it here instead of being bound in the template. In an
+    // effect so a title arriving, or being cleared, after init is reflected.
     effect(() => {
-      if (!this.title()) {
+      // Both signals are read before the container is looked up, so that this
+      // effect keeps its dependencies even on a run that finds no container and
+      // writes nothing.
+      const labelledby = this.resolvedAriaLabelledby();
+      const label = this.resolvedAriaLabel();
+      const container = this.host.nativeElement.closest('cdk-dialog-container');
+      if (!container) {
         return;
       }
-      const container = this.host.nativeElement.closest('cdk-dialog-container');
-      container?.setAttribute('aria-labelledby', this.titleId);
+      // Removed rather than left behind when the value goes away: a dialog
+      // whose title is cleared would otherwise keep an `aria-labelledby`
+      // pointing at a heading that is no longer rendered, which resolves to
+      // nothing and leaves the dialog unnamed.
+      this.applyName(container, 'aria-labelledby', labelledby);
+      this.applyName(container, 'aria-label', label);
     });
+  }
+
+  private applyName(container: Element, attribute: string, value: string | null): void {
+    if (value) {
+      container.setAttribute(attribute, value);
+    } else {
+      container.removeAttribute(attribute);
+    }
   }
 
   ngOnInit() {

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -29,6 +29,22 @@ let nextUniqueId = 0;
  */
 export const TN_DIALOG_SHELL_DEFAULT_LABEL = 'Dialog';
 
+/**
+ * The first value that is a name, or `null` if none of them is one.
+ *
+ * Blank is not a name — the rule `tnAccessibleName` already applies to what it
+ * is handed, and this is the same rule applied one step earlier, while the
+ * routes are still being chosen between. `??` would answer that a blank input
+ * had been "provided" and stop there, so an empty `ariaLabel` on the shell
+ * would shadow a real one passed to `TnDialog.open` and the dialog would take
+ * the generic fallback instead — the one case where the fallback is worse than
+ * doing nothing. Blank `ariaLabelledby` is the same shape and worse in effect:
+ * it would clear the IDREF the config had put on the container.
+ */
+function firstNonBlank(...values: (string | null | undefined)[]): string | null {
+  return values.find((value) => (value ?? '').trim() !== '') ?? null;
+}
+
 @Component({
   selector: 'tn-dialog-shell',
   templateUrl: './dialog-shell.component.html',
@@ -138,12 +154,14 @@ export class TnDialogShellComponent implements OnInit {
    * component writes both attributes onto that element and would otherwise
    * clear one it did not set.
    */
-  private resolvedAriaLabelledby = computed(
-    () => (this.hasTitle() ? this.titleId : this.ariaLabelledby() ?? this.ref.config.ariaLabelledBy ?? null)
-  );
+  private resolvedAriaLabelledby = computed(() => (
+    this.hasTitle() ? this.titleId : firstNonBlank(this.ariaLabelledby(), this.ref.config.ariaLabelledBy)
+  ));
 
   /** An explicit label, from this component's input or from the `DialogConfig`. */
-  private explicitAriaLabel = computed(() => this.ariaLabel() ?? this.ref.config.ariaLabel ?? null);
+  private explicitAriaLabel = computed(
+    () => firstNonBlank(this.ariaLabel(), this.ref.config.ariaLabel)
+  );
 
   /**
    * The name to render as `aria-label`, or `null` to render none — and the

--- a/projects/truenas-ui/src/lib/dialog/dialog.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog.harness.spec.ts
@@ -318,6 +318,21 @@ describe('TnDialogHarness', () => {
   });
 
   describe('with() filter', () => {
+    // The two untitled-dialog cases below trip `tnAccessibleName`'s dev-mode
+    // warning by design — it is what tells a developer their dialog fell back
+    // to a generic name. Mocked so an expected warning does not print a stack
+    // trace over every run of this suite; it is asserted on properly in
+    // `dialog-shell-a11y.spec.ts`.
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
     it('should filter by exact title', async () => {
       tnDialog.open(TestDialogComponent, { data: { title: 'First Dialog' } });
       fixture.detectChanges();
@@ -345,6 +360,32 @@ describe('TnDialogHarness', () => {
       expect(
         await dialogLoader.hasHarness(TnDialogHarness.with({ title: 'NonExistent' })),
       ).toBe(false);
+    });
+
+    /**
+     * A dialog with no title renders no heading at all since #219, so the
+     * harness's title locator is optional. Both halves matter: `getTitle()`
+     * answers `''` rather than rejecting, and — because `with({title})` calls
+     * it on every candidate — one untitled dialog in the document must not
+     * make a title-filtered lookup of a DIFFERENT dialog throw.
+     */
+    it('reports an empty title for a dialog that renders no heading', async () => {
+      tnDialog.open(TestDialogComponent, { data: { title: '' } });
+      fixture.detectChanges();
+
+      const dialog = await dialogLoader.getHarness(TnDialogHarness);
+      expect(await dialog.getTitle()).toBe('');
+    });
+
+    it('filters by title with an untitled dialog also open', async () => {
+      tnDialog.open(TestDialogComponent, { data: { title: '' } });
+      tnDialog.open(TestDialogComponent, { data: { title: 'Second Dialog' } });
+      fixture.detectChanges();
+
+      const dialog = await dialogLoader.getHarness(
+        TnDialogHarness.with({ title: 'Second Dialog' }),
+      );
+      expect(await dialog.getTitle()).toBe('Second Dialog');
     });
 
     it('should distinguish between multiple open dialogs', async () => {

--- a/projects/truenas-ui/src/lib/dialog/dialog.harness.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog.harness.ts
@@ -27,7 +27,12 @@ export class TnDialogHarness extends ComponentHarness {
    */
   static hostSelector = 'tn-dialog-shell';
 
-  private _title = this.locatorFor('.tn-dialog__title');
+  // Optional, because since #219 a dialog with no title renders no heading at
+  // all rather than an empty one. `locatorFor` would REJECT there, and it is
+  // reached from `with({title})` — so one untitled dialog anywhere in the
+  // document would have made every title-filtered lookup throw instead of
+  // simply not matching.
+  private _title = this.locatorForOptional('.tn-dialog__title');
   private _closeButton = this.locatorFor('.tn-dialog__close');
   private _fullscreenButton = this.locatorForOptional('.tn-dialog__fullscreen');
   private _content = this.locatorFor('.tn-dialog__content');
@@ -59,7 +64,9 @@ export class TnDialogHarness extends ComponentHarness {
   }
 
   /**
-   * Gets the dialog's title text.
+   * Gets the dialog's title text, or `''` for a dialog opened with no title —
+   * which renders no heading at all (#219), and is named by `ariaLabel` or
+   * `ariaLabelledby` instead.
    *
    * @returns Promise resolving to the dialog title.
    *
@@ -71,7 +78,7 @@ export class TnDialogHarness extends ComponentHarness {
    */
   async getTitle(): Promise<string> {
     const title = await this._title();
-    return (await title.text()).trim();
+    return title ? (await title.text()).trim() : '';
   }
 
   /**

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -584,6 +584,19 @@ tn-dialog-shell {
   margin-left: 16px; /* Space between title and button */
 }
 
+/*
+  What pushes the header chrome to the right edge when there is no title.
+  `.tn-dialog__title` has `flex: 1` and used to do that job, but since #219 an
+  untitled dialog renders no heading at all — an empty `<h2>` is an
+  `empty-heading` violation — and the buttons would otherwise sit hard left.
+  Only the FIRST of them takes the auto margin, so the 16px between the
+  fullscreen and close buttons is unchanged.
+*/
+.tn-dialog__header > .tn-dialog__fullscreen:first-child,
+.tn-dialog__header > .tn-dialog__close:first-child {
+  margin-left: auto;
+}
+
 .tn-dialog__close:hover {
   background: var(--tn-alt-bg1, #f8f9fa);
   color: var(--tn-fg1, #000000);

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -639,14 +639,21 @@ tn-dialog-shell {
   gap: 16px;
 }
 
-/* Hide a content section / actions footer that has nothing to show, so it
-   doesn't render as an empty bordered, padded bar.
+/* Hide a header / content section / actions footer that has nothing to show, so
+   it doesn't render as an empty bordered, padded bar.
    - `:empty` covers dialogs that project nothing into the slot (the ng-content
      comment anchor is ignored by `:empty`, but real text/elements are not).
    - The `--hidden` modifier (driven by the [hideContent]/[hideActions] inputs)
      covers slots that always project a wrapper element whose contents are
      conditional, so the slot is never truly `:empty`.
+   The header joined this list with #219: it used to render its `<h2>`
+   unconditionally and so was never empty, but an untitled dialog now renders no
+   heading — and one opened with [showCloseButton]="false" and no fullscreen
+   button has nothing else in its header either. The `@if` anchors it is left
+   with are comment nodes, which `:empty` ignores, same as the ng-content anchor
+   above.
    Declared after the layout rules above so it wins on equal specificity. */
+.tn-dialog__header:empty,
 .tn-dialog__content:empty,
 .tn-dialog__content--hidden,
 .tn-dialog__actions:empty,


### PR DESCRIPTION
Fixes #219.

`title` defaults to `''`, and `dialog-shell.component.html` rendered its `<h2>`
unconditionally while the effect that points the CDK container's
`aria-labelledby` at that heading returned early on an empty title.

## What was measured, and how it differs from the ticket

The ticket read the defect off the template and described the untitled dialog as
being **named by** the empty heading. Scanned first, against the unchanged
component, it was worse than that:

```
container: {role: 'dialog', aria-labelledby: null, aria-label: null}
axe:       violated ['aria-dialog-name'] on the dialog   (evaluated, not vacuous)
           violated ['empty-heading']   on the <h2>
```

The dialog had **no name from any route** — not a bad one. A screen-reader user
was told "dialog" and nothing else about a surface that had just taken over the
page and trapped their focus.

Both rules were reported and both were *evaluated*, so this is a measurement
rather than an empty `violations` array from a scan that looked at nothing. A
**titled** dialog was already clean on the same scan, which is why nothing here
changes that path except to guard it.

## What changed

- The heading renders only when there is a title — trimmed, so a whitespace-only
  title counts as none, which is the same defect arriving by a second route.
- The name resolves through the shared `tnAccessibleName` in
  `lib/a11y/accessible-name.ts`, the helper `tn-side-panel`, `tn-drawer` and the
  three progressbars already use, rather than a fourth copy of the rule. New
  `ariaLabel` / `ariaLabelledby` inputs feed it.
- `TN_DIALOG_SHELL_DEFAULT_LABEL` (`'Dialog'`) is exported so specs assert the
  fallback by name rather than by a copied literal.

**"Dialog" is a poor name and says almost what the role already says.** It is
still better than the two alternatives — leaving the surface unnamed, or
withholding `role="dialog"` until there is a name, which would move a listener
into a focus trap with no announcement that anything had opened. That is why it
is paired with `tnAccessibleName`'s dev-mode warning: the fallback keeps a
missing label from reaching assistive technology as silence, and the warning
keeps it from reaching the developer as silence.

**Where the attributes are written.** `role="dialog"` is on the CDK's
`<cdk-dialog-container>`, an ancestor of this component rather than part of its
template, so the name is written there imperatively from an effect — as it
already was — rather than bound in the template. The effect now also *removes*
each attribute when its value goes away, so a dialog whose title is cleared is
not left with an `aria-labelledby` pointing at a heading that is no longer
rendered.

**A name passed to `TnDialog.open` is kept.** The shell writes both naming
attributes onto the element `DialogConfig` would have rendered them on, so it
reads `ref.config` and defers to a name the opener supplied. Without that, the
generic fallback would replace an explicit name — the one case where the
fallback is worse than nothing.

**Blank is not a name, on either route.** The two config routes coalesce through
a small `firstNonBlank` rather than `??`, so an `[ariaLabel]=""` on the shell
does not count as "provided", shadow a real `DialogConfig.ariaLabel` and drop
the dialog to the generic fallback. `[ariaLabelledby]=""` was the same shape
with a worse effect — the blank value reached the container as a truthy write
and replaced the IDREF the config had put there. This is the rule
`tnAccessibleName` already applies to what it is handed, applied one step
earlier while the routes are still being chosen between; with nothing non-blank
to fall through to, the fallback and its warning are unchanged.

## Two things the change drags with it

- **Header layout.** `.tn-dialog__title` had `flex: 1`, which is what pushed the
  chrome to the right edge. With no heading the buttons would sit hard left, so
  the first of them takes `margin-left: auto`. Same fix `tn-side-panel` made for
  the same reason in #214; only the first, so the 16px between the fullscreen
  and close buttons is unchanged.

  And a dialog with no title, no fullscreen button and `[showCloseButton]="false"`
  now has nothing in its header at all, where before the `<h2>` was always there
  — so `.tn-dialog__header:empty` joins the rule the content section and the
  actions footer already use, and the bordered padded bar is not rendered. The
  `@if` anchors the header is left with are comment nodes, which `:empty`
  ignores, the same property that rule already relies on for the ng-content
  anchor.
- **`TnDialogHarness`.** Its title locator is now optional and `getTitle()`
  answers `''` for a dialog with no heading. `locatorFor` *rejects* on a missing
  element and `with({title})` calls `getTitle()` on every candidate, so one
  untitled dialog anywhere in the document would have made every title-filtered
  lookup throw rather than simply not match.

## Tests

`dialog-shell-a11y.spec.ts`, 24 specs through the shared `axeResult` wrapper:
both naming routes and their precedence, the `DialogConfig` route and the three
blank-input cases above, the whitespace-only title, no heading element of any
level when there is no title, and axe over the open dialog titled, untitled and
named by an external IDREF.

Four positive controls, because `expect(violated).toEqual([])` is also what axe
returns when it evaluated nothing:

- a scan rooted at the fixture evaluates **no** dialog rule, since the dialog is
  portaled to `document.body` — which is why every other scan is rooted in the
  overlay, and this fails if that ever stops being true;
- the pre-fix markup (`role="dialog"` with no naming attribute) still reports
  `aria-dialog-name`;
- the markup the ticket described (named by an empty `<h2>`) still reports it
  too, so pointing the old effect at the heading unconditionally is pinned as
  clearing nothing;
- the empty `<h2>` itself still reports `empty-heading`.

The two header specs assert the `:empty` rule's **precondition** rather than the
rule — jsdom loads no stylesheet, so `display: none` cannot be observed from a
spec. What they measure is that the header holds no element and only comment
nodes, which is exactly when `:empty` matches.

Plus two cases in `dialog.harness.spec.ts` for the harness change: an untitled
dialog reports `''`, and one open alongside a titled dialog does not break a
title-filtered lookup.

## Verified locally

`yarn lint` (4 pre-existing `import/order` errors remain, in `input.component.ts`
and `menu-panel.component.ts` — neither touched here), `yarn test` (2614
passing, 110 suites), `yarn test:scripts` (42 passing), `yarn build`,
`yarn build-storybook`. **Not run:** the Storybook interaction tests, which need
Playwright browsers and a served build.

The project's own reviewer ran locally over the full diff after each round, and
the last round returned nothing at MEDIUM or above.

## Round 2

Both findings the PR review raised at MEDIUM or above are fixed above rather
than deferred:

- **BLOCKER** — the title's `a11y` type. `.github/workflows/pr-title.yml` accepts
  only the standard Conventional Commit types and `.releaserc.json` has no rules
  for `a11y`, so this is retitled `fix(dialog)`, matching how the sibling a11y
  work landed in #222.
- **HIGH** — the blank-input shadowing, described under *What changed*. It was
  listed as a deferred LOW in the first version of this description; that is no
  longer true and the entry is gone.

The local review then raised a MEDIUM of its own — the empty header bar — which
is the `.tn-dialog__header:empty` rule above.

## Round 3

**No change to the diff, and none is warranted.** The round-2 review's only finding
at MEDIUM or above is a BLOCKER on the title's `a11y` type — a title this PR stopped
carrying at 09:57:39Z, 49 seconds after that review job started and 10m 46s before it
finished. It read the pre-rename title. `Validate Conventional Commit Title` re-ran on
the rename and is green on the present title, on this same head; `fix` is in
`.releaserc.json`'s release rules and in its release-notes `presetConfig.types`, so the
squash merge cuts a patch version and lands under **Bug Fixes**. The review job is
being re-run rather than pushed to, because the diff is not what failed. Timings and
the full disposition of the four LOWs are in the round-3 comment on this PR.

## Reviewed and not changed

Findings left for follow-up. Each fix is a new unreviewed diff, and none affects
the behaviour this ticket is about:

1. `applyName` writes onto attributes CDK also owns through a host binding over
   its mutable `_ariaLabelledByQueue`, so a `cdkDialogTitle` in the dialog body
   could clobber the shell's name. Nothing in this repository uses
   `cdkDialogTitle` inside a `tn-dialog-shell`, and the underscore-prefixed
   queue is not public API to write through.
2. The header chrome is pushed to the right edge by `:first-child` on each button
   rather than by a wrapper element, so it silently stops applying if anything is
   ever added to the header ahead of those buttons. `tn-side-panel` has the
   order-independent form — `margin-left: auto` on a
   `.tn-side-panel__header-actions` wrapper, from #214 — and this should match it.
   Doing so is a `.tn-dialog__header` markup change plus its styles and a
   regenerated `themes.css`, in a path jsdom cannot cover, for a layout the
   current rule gets right on every header this component can render today.
3. The new inputs and the untitled rendering have no Storybook story and are
   missing from the `ChromeInputs` table in `dialog.stories.ts`.
4. The `console.warn` spy added to the `with() filter` describe covers three
   pre-existing tests that were never meant to warn, so a new warning in them
   would go unseen. It is there because the two untitled-dialog cases raise the
   dev-mode warning by design.
5. `hasTitle` calls `.trim()` on the raw `title` signal, so an explicit
   `[title]="undefined"` would throw where `firstNonBlank` in the same file
   guards with `?? ''`. The input is typed `string` and defaults to `''`, so
   reaching it takes deliberately binding `undefined` past the type.
6. The `afterEach` comment in `dialog-shell-a11y.spec.ts` says restoring the
   `console.warn` spy last protects against a throw from `closeAll`; it does the
   opposite, since a throw there skips `mockRestore` and this project sets no
   `restoreMocks`. The comment is wrong about why the order is safe, not about
   the order.

`.storybook/public/themes.css` is regenerated with `yarn copy-themes` rather
than hand-edited, so the checked-in copy matches its source. `storybook` and
`build-storybook` both run `copy-assets` first, so this changes nothing that is
served either way.
