### PR TITLE
NAS-142354 / 27.0.0-BETA.1 / fix(selection-list): make [disabled] reach the options

### DIFF
--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -68,7 +68,39 @@ export class TnListOptionComponent implements AfterContentInit {
     return internal !== null ? internal : this.selected();
   });
 
+  /**
+   * Whether the parent `tn-selection-list` is disabled as a whole, pushed down
+   * by the listbox (#221). `false` when there is no parent.
+   *
+   * Kept apart from `internalDisabled` rather than written into it, because the
+   * two answer different questions and a single slot cannot hold both. The list
+   * disabling itself must not erase an option the consumer disabled on its own,
+   * and re-enabling the list is exactly where a shared slot loses that: the
+   * parent has no record of what the option's own state was before it wrote
+   * over it, so `[disabled]="true"` on the option never comes back. That is not
+   * hypothetical — it is what `setDisabledState()` did to a per-option
+   * `[disabled]` on every `control.enable()` before this signal existed.
+   *
+   * A plain boolean rather than the nullable this sits beside: absent and
+   * not-disabled are the same thing for a parent's opinion, whereas
+   * `internalDisabled` needs `null` to mean "the input still speaks".
+   */
+  listDisabled = signal<boolean>(false);
+
+  /**
+   * Disabled if EITHER source says so — the list as a whole, or this option.
+   *
+   * Not a precedence: a disabled list cannot be overridden by an enabled
+   * option, and a list that is enabled has nothing to say about an option that
+   * disabled itself. Only the second half is a fallback chain, and it is the
+   * one that already existed: `internalDisabled` is the `ControlValueAccessor`
+   * slot and outranks the input when it has been written.
+   */
   effectiveDisabled = computed(() => {
+    if (this.listDisabled()) {
+      return true;
+    }
+
     const internal = this.internalDisabled();
     return internal !== null ? internal : this.disabled();
   });

--- a/projects/truenas-ui/src/lib/list-option/list-option.component.ts
+++ b/projects/truenas-ui/src/lib/list-option/list-option.component.ts
@@ -93,8 +93,11 @@ export class TnListOptionComponent implements AfterContentInit {
    * Not a precedence: a disabled list cannot be overridden by an enabled
    * option, and a list that is enabled has nothing to say about an option that
    * disabled itself. Only the second half is a fallback chain, and it is the
-   * one that already existed: `internalDisabled` is the `ControlValueAccessor`
-   * slot and outranks the input when it has been written.
+   * one that already existed: `internalDisabled` outranks the input when it has
+   * been written. Nothing in the library writes it any more — `setDisabledState()`
+   * was its only writer and now stops at `listDisabled` — so it is kept for the
+   * public surface it has always been part of, alongside `internalSelected` and
+   * `internalColor`, rather than because a path in here still uses it.
    */
   effectiveDisabled = computed(() => {
     if (this.listDisabled()) {

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
@@ -1,0 +1,323 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import type { TnSelectionChange } from './selection-list.component';
+import { TnSelectionListComponent } from './selection-list.component';
+import { TnListOptionComponent } from '../list-option/list-option.component';
+
+/**
+ * `[disabled]` on `tn-selection-list` reaching its options (#221).
+ *
+ * Two routes put the list into the same state and only one of them used to
+ * arrive: `setDisabledState()` — the `ControlValueAccessor` hook, so a reactive
+ * form only — wrote each option's `internalDisabled`, while the plain
+ * `[disabled]` INPUT fed `isDisabled()`, which drove `.tn-selection-list--disabled`
+ * and nothing else. That class sets `opacity: 0.6` and `pointer-events: none`, so
+ * the list looked disabled and could not be clicked, and Space or Enter on a
+ * focused option toggled it anyway — `selectionChange` and all. The options also
+ * kept reporting `aria-disabled="false"` individually, telling assistive
+ * technology they were actionable.
+ *
+ * WHY THE CLICK IS ASSERTED AT THE COMPONENT LEVEL
+ * -----------------------------------------------
+ * `pointer-events: none` is a rendering property and jsdom has no layout engine,
+ * so `HTMLElement.click()` dispatches through it regardless. A spec that trusted
+ * the CSS would therefore be asserting nothing here, and — worse — the CSS is not
+ * the guard anyone should be relying on: it is defeated by a click synthesised in
+ * script, and it disappears the moment a consumer overrides the modifier class.
+ * The guard that counts is `TnListOptionComponent.onClick`'s own
+ * `effectiveDisabled()` test, which is what these assertions reach.
+ *
+ * THE PART MOST LIKELY TO BE GOT WRONG
+ * -----------------------------------
+ * `internalDisabled` is a single nullable signal serving two sources, so pushing
+ * the list's state into it makes re-enabling the list clobber an option that was
+ * disabled on its own — `[disabled]="true"` on the option is overwritten by
+ * `internalDisabled.set(false)` from the parent, and never comes back. The
+ * fix keeps the list's state in a signal of its own (`listDisabled`) and ORs the
+ * two, so neither source can erase the other. Every re-enable case below exists
+ * to pin that.
+ */
+
+interface TestOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+}
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnSelectionListComponent, TnListOptionComponent],
+  // Held to three lines by @angular-eslint/component-max-inline-declarations,
+  // which is why the @for body is not broken up the way it would be in a real
+  // template.
+  template: `<tn-selection-list [disabled]="listDisabled()" (selectionChange)="onSelectionChange($event)">
+    @for (item of items(); track item.value) {<tn-list-option [value]="item.value"
+      [disabled]="item.disabled">{{ item.label }}</tn-list-option>}</tn-selection-list>`
+})
+class TestHostComponent {
+  listDisabled = signal<boolean>(false);
+
+  items = signal<TestOption[]>([
+    { value: 'a', label: 'Option A', disabled: false },
+    { value: 'b', label: 'Option B', disabled: false },
+    { value: 'c', label: 'Option C', disabled: true }
+  ]);
+
+  changes: TnSelectionChange[] = [];
+
+  onSelectionChange(event: TnSelectionChange): void {
+    this.changes.push(event);
+  }
+}
+
+@Component({
+  selector: 'tn-form-host',
+  standalone: true,
+  imports: [TnSelectionListComponent, TnListOptionComponent, ReactiveFormsModule],
+  template: `<tn-selection-list [formControl]="control"><tn-list-option value="a">Option A</tn-list-option>
+    <tn-list-option value="b">Option B</tn-list-option>
+    <tn-list-option value="c" [disabled]="true">Option C</tn-list-option></tn-selection-list>`
+})
+class FormHostComponent {
+  control = new FormControl<unknown[]>([]);
+}
+
+describe('tn-selection-list [disabled] (#221)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, FormHostComponent]
+    }).compileComponents();
+
+    // Attached to the document, which real focus needs: `HTMLElement.focus()` on
+    // a detached element leaves `document.activeElement` on `<body>`, so a
+    // keypress dispatched at "the focused option" would land on the body and
+    // every assertion about it would pass vacuously.
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function options(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('tn-list-option'));
+  }
+
+  function ariaSelected(): (string | null)[] {
+    return options().map((option) => option.getAttribute('aria-selected'));
+  }
+
+  function ariaDisabled(): (string | null)[] {
+    return options().map((option) => option.getAttribute('aria-disabled'));
+  }
+
+  /** Dispatch a key on an option, as a browser would on the focused one. */
+  function press(index: number, key: string): KeyboardEvent {
+    options()[index].focus();
+    fixture.detectChanges();
+
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    (document.activeElement as HTMLElement).dispatchEvent(event);
+    fixture.detectChanges();
+
+    return event;
+  }
+
+  function disableList(): void {
+    host.listDisabled.set(true);
+    fixture.detectChanges();
+  }
+
+  describe('an enabled list, so the assertions below are not vacuous', () => {
+    it.each([' ', 'Enter'])('toggles an option on %s', (key) => {
+      press(0, key);
+
+      expect(ariaSelected()[0]).toBe('true');
+      expect(host.changes).toHaveLength(1);
+    });
+
+    it('toggles an option on click', () => {
+      options()[0].click();
+      fixture.detectChanges();
+
+      expect(ariaSelected()[0]).toBe('true');
+    });
+
+    it('leaves an independently disabled option disabled', () => {
+      expect(ariaDisabled()).toEqual(['false', 'false', 'true']);
+    });
+  });
+
+  describe('a disabled list refuses its options', () => {
+    beforeEach(() => {
+      disableList();
+    });
+
+    it.each([' ', 'Enter'])('does not toggle an option on %s', (key) => {
+      press(0, key);
+
+      expect(ariaSelected()).toEqual(['false', 'false', 'false']);
+    });
+
+    it.each([' ', 'Enter'])('does not emit selectionChange on %s', (key) => {
+      press(0, key);
+
+      expect(host.changes).toEqual([]);
+    });
+
+    /**
+     * Declining to toggle is not the same as declining the key: Space scrolls
+     * the page on any element that is neither a form control nor a scroller, and
+     * the option host is neither. `tn-list-option` consumes it before its
+     * disabled guard for that reason, and a disabled LIST must not be the one
+     * case where that stops happening.
+     */
+    it('still consumes Space rather than letting the page scroll', () => {
+      expect(press(0, ' ').defaultPrevented).toBe(true);
+    });
+
+    it('does not toggle an option on click', () => {
+      options()[0].click();
+      fixture.detectChanges();
+
+      expect(ariaSelected()).toEqual(['false', 'false', 'false']);
+      expect(host.changes).toEqual([]);
+    });
+
+    it('reports aria-disabled="true" on every option', () => {
+      expect(ariaDisabled()).toEqual(['true', 'true', 'true']);
+    });
+
+    /**
+     * The list is still readable with the arrow keys while disabled — the same
+     * reasoning that has them visit a disabled OPTION (#216) — so the options
+     * must keep the roving tabindex rather than dropping out of reach.
+     */
+    it('keeps exactly one tab stop, so the list can still be read', () => {
+      const tabindexes = options().map((option) => option.getAttribute('tabindex'));
+
+      expect(tabindexes.filter((value) => value === '0')).toHaveLength(1);
+    });
+
+    it('does not toggle an option that was already selected', () => {
+      host.listDisabled.set(false);
+      fixture.detectChanges();
+      options()[0].click();
+      fixture.detectChanges();
+      disableList();
+
+      press(0, ' ');
+
+      expect(ariaSelected()[0]).toBe('true');
+      expect(host.changes).toHaveLength(1);
+    });
+  });
+
+  describe('re-enabling the list', () => {
+    beforeEach(() => {
+      disableList();
+      host.listDisabled.set(false);
+      fixture.detectChanges();
+    });
+
+    it('restores toggling on Space', () => {
+      press(0, ' ');
+
+      expect(ariaSelected()[0]).toBe('true');
+      expect(host.changes).toHaveLength(1);
+    });
+
+    it('restores toggling on click', () => {
+      options()[0].click();
+      fixture.detectChanges();
+
+      expect(ariaSelected()[0]).toBe('true');
+    });
+
+    /**
+     * The clobber. `[disabled]="true"` on option C was set by the consumer and
+     * has nothing to do with the list's own state, so a list that disables and
+     * re-enables must hand C back exactly as it found it.
+     */
+    it('leaves an independently disabled option disabled', () => {
+      expect(ariaDisabled()).toEqual(['false', 'false', 'true']);
+    });
+
+    it('still refuses to toggle an independently disabled option', () => {
+      press(2, ' ');
+      options()[2].click();
+      fixture.detectChanges();
+
+      expect(ariaSelected()[2]).toBe('false');
+      expect(host.changes).toEqual([]);
+    });
+  });
+
+  /**
+   * The route that already worked, pinned so that unifying the two does not
+   * quietly cost the one that was correct. Both routes reach `isDisabled()` and
+   * are asserted to behave identically — including on the re-enable, where the
+   * form path used to clobber a per-option `[disabled]` in exactly the same way
+   * the input path would have if it had been wired to `internalDisabled`.
+   */
+  describe('the reactive-form route behaves the same way', () => {
+    let formFixture: ComponentFixture<FormHostComponent>;
+    let formHost: FormHostComponent;
+
+    beforeEach(() => {
+      formFixture = TestBed.createComponent(FormHostComponent);
+      formHost = formFixture.componentInstance;
+      formFixture.detectChanges();
+    });
+
+    function formOptions(): HTMLElement[] {
+      return Array.from(formFixture.nativeElement.querySelectorAll('tn-list-option'));
+    }
+
+    it('disables every option on control.disable()', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+
+      expect(formOptions().map((option) => option.getAttribute('aria-disabled')))
+        .toEqual(['true', 'true', 'true']);
+    });
+
+    it('does not toggle an option while the control is disabled', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+
+      formOptions()[0].click();
+      formFixture.detectChanges();
+
+      expect(formOptions()[0].getAttribute('aria-selected')).toBe('false');
+      expect(formHost.control.value).toEqual([]);
+    });
+
+    it('restores toggling on control.enable()', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+      formHost.control.enable();
+      formFixture.detectChanges();
+
+      formOptions()[0].click();
+      formFixture.detectChanges();
+
+      expect(formOptions()[0].getAttribute('aria-selected')).toBe('true');
+      expect(formHost.control.value).toEqual(['a']);
+    });
+
+    it('leaves an independently disabled option disabled through disable/enable', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+      formHost.control.enable();
+      formFixture.detectChanges();
+
+      expect(formOptions().map((option) => option.getAttribute('aria-disabled')))
+        .toEqual(['false', 'false', 'true']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -120,13 +120,24 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   private onTouched = () => {};
 
   constructor() {
-    // Effect to update options when they change
+    // Push what the list decides for all of its options down onto each of them,
+    // re-running both when the decision changes and when the set of options
+    // does — an option added after the list was rendered has to arrive carrying
+    // the list's current state rather than its own defaults.
+    //
+    // `isDisabled()` and not the `disabled` input, so that the plain input and
+    // `setDisabledState()` reach the options by the same route and cannot come
+    // apart again (#221). It lands on `option.listDisabled`, a signal of the
+    // option's own that is ORed with its `[disabled]` input rather than
+    // overwriting it — see TnListOptionComponent.effectiveDisabled.
     effect(() => {
       const opts = this.options();
       const currentColor = this.color();
+      const disabled = this.isDisabled();
       opts.forEach(option => {
         option.selectionList = this;
         option.internalColor.set(currentColor);
+        option.listDisabled.set(disabled);
       });
     });
 
@@ -182,16 +193,11 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * reasoning that has the arrow keys visit disabled options at all.
    *
    * That is a statement about NAVIGATION only, and deliberately not the wider
-   * claim that a disabled list cannot be toggled. It cannot be toggled by
-   * mouse — `.tn-selection-list--disabled` sets `pointer-events: none` — and it
-   * cannot be toggled through a reactive form, because `setDisabledState`
-   * pushes down to each `option.internalDisabled` and the option's own guard
-   * then refuses. But the plain `[disabled]` INPUT reaches neither: it feeds
-   * `isDisabled()`, which drives that class and nothing else, so Space on an
-   * option of a `[disabled]` list still toggles it. That gap predates the
-   * keyboard handling added here and is not widened by it — arrow keys move
-   * focus and never toggle — so it is reported on the PR rather than fixed
-   * under a ticket about navigation.
+   * claim that a disabled list can be toggled. It cannot: `isDisabled()` is
+   * pushed onto every option's `listDisabled` by the effect in the constructor
+   * (#221), so the option's own guard refuses the toggle whichever route asked
+   * for it — mouse, Space, Enter or a reactive form. What a disabled list still
+   * allows is moving through it, which selects nothing.
    *
    * Only keys pressed ON an option host are the listbox's. The handler is on
    * the host and hears everything that bubbles through it, so without that test
@@ -315,12 +321,20 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     this.onTouched = fn;
   }
 
+  /**
+   * Records the form's state and stops there — the effect in the constructor is
+   * what reaches the options, via `isDisabled()`.
+   *
+   * It used to also write each `option.internalDisabled` directly, which is the
+   * only reason this route enforced anything while `[disabled]` enforced
+   * nothing. Two problems, both fixed by routing it through the same signal the
+   * input uses: the two paths could disagree, and `internalDisabled` is the
+   * slot an option's own `[disabled]` input falls back to — so `control.enable()`
+   * wrote `false` over an option the consumer had disabled independently, and
+   * never gave it back.
+   */
   setDisabledState(isDisabled: boolean): void {
     this.formDisabled.set(isDisabled);
-    const opts = this.options();
-    opts.forEach(option => {
-      option.internalDisabled.set(isDisabled);
-    });
   }
 
   onOptionSelectionChange(): void {


### PR DESCRIPTION
Fixes #221.

`tn-selection-list`'s `disabled` input fed `isDisabled()`, which was bound to
`.tn-selection-list--disabled` on the host and to nothing else. That class sets
`opacity: 0.6` and `pointer-events: none` — so the list *looked* disabled and could
not be clicked, and that was the whole of the enforcement. The options were never
told, so Space or Enter on a focused option still toggled it, `selectionChange`
still fired, `aria-selected` still flipped, and every option kept reporting
`aria-disabled="false"` to assistive technology.

The reactive-form route behaved correctly, because `setDisabledState()` wrote each
option's `internalDisabled` directly. Two routes to the same state, and the one
that looked disabled was the one that was not.

## Reproduced first

`selection-list-disabled.spec.ts` was written and run against the unchanged
component before anything was fixed. 8 of its 21 assertions failed, and they are the
report:

- `does not toggle an option on ` / `on Enter` — Space and Enter toggled a
  `[disabled]` list's option
- `does not emit selectionChange on ` / `on Enter` — and told the consumer about it
- `does not toggle an option on click` — the click guard is `pointer-events: none`,
  which jsdom does not honour and script-synthesised clicks go straight through
- `reports aria-disabled="true" on every option` — got `false, false, true`
- `does not toggle an option that was already selected`
- `leaves an independently disabled option disabled through disable/enable` — the
  clobber below, on the route that otherwise worked

## The fix

Both routes now reach the options by one path. The effect that already pushes
`internalColor` down also pushes `isDisabled()` — which covers the `[disabled]`
input *and* `formDisabled` — onto a new `listDisabled` signal on the option, and
`setDisabledState()` does nothing but record the form's state.

`listDisabled` is a signal of its own rather than a write into `internalDisabled`,
and that is the part the ticket flagged as most likely to be got wrong.
`internalDisabled` is the slot an option's own `[disabled]` input falls back to, so
writing the list's state into it makes re-enabling the list clobber an option the
consumer disabled independently — the parent has no record of what to restore.
That is not hypothetical: `control.enable()` did exactly this before this change,
and it is now pinned by a spec. The two sources are ORed, so neither can erase the
other.

Navigation is deliberately untouched: a disabled list can still be read through
with the arrow keys, which selects nothing. Space is still consumed rather than
left to scroll the page — declining to toggle is not the same as declining the key.

## Checks

Run locally: `yarn lint`, `yarn test` (2635 passing, 111 suites), `yarn test:scripts`
(42 passing), `yarn build`, `yarn build-storybook` — all pass.

`yarn lint` reports 4 pre-existing `import/order` errors in `input.component.ts` and
`menu-panel.component.ts`. Neither file is touched here and both errors are present
on `main`; they do not appear in CI.

**Not run locally:** Storybook interaction tests, which need `npx playwright install
--with-deps chromium` and a served Storybook. CI runs them.

## Review

`local-review.py` ran the project's own reviewer — same rubric, threshold and parser
as the required check — in a separate process, and returned **nothing at MEDIUM or
above**. Four LOWs, none folded into the diff except the one that made this diff's
own prose wrong:

1. **`internalDisabled` is now written by nothing in the library, and the doc still
   called it the ControlValueAccessor slot.** *Fixed* (comment only, second commit) —
   the description was of the code as it was, not as this PR leaves it. The signal
   itself is kept: it is public surface alongside `internalSelected` and
   `internalColor`, and removing it is a breaking change this ticket did not ask for.
2. **The push-down mirror diverges from the library's pull pattern** —
   `radio.component.ts:76` reads its group's `isDisabled` through DI instead. A fair
   point about consistency, and not taken here: this component already pushes
   `internalColor` and `rovingTabindex` down the same way, the ticket itself names
   that effect as the place the fix belongs, and converting `tn-list-option` to DI
   would restructure a component the ticket is not about.
3. **The `role="listbox"` host never sets `aria-disabled`** — so assistive technology
   sees a normal listbox whose options are each disabled. Real, outside this ticket's
   acceptance criteria, and proposed as a follow-up ticket on #221.
4. **The spec's test host duplicates the near-identical one in
   `selection-list-a11y.spec.ts:57`.** Left as is: the two hosts already diverge (this
   one binds `[disabled]` on the list and carries three options rather than four), and
   sharing them couples two spec files that guard different tickets.

`tn-selection-list`'s `multiple` input, which the ticket mentions in passing as
likewise enforcing nothing, was **not** investigated or changed — it is a separate
claim, unverified in the ticket, and not in the acceptance criteria.
