### PR TITLE
NAS-142355 / 27.0.0-BETA.1 / fix(selection-list): report aria-disabled on the listbox host

### DIFF
--- a/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
@@ -4,7 +4,6 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import type { TnSelectionChange } from './selection-list.component';
 import { TnSelectionListComponent } from './selection-list.component';
-import { axeResult } from '../a11y/axe-testing';
 import { TnListOptionComponent } from '../list-option/list-option.component';
 
 /**
@@ -233,42 +232,24 @@ describe('tn-selection-list [disabled] (#221, #225)', () => {
     });
 
     /**
-     * `aria-disabled` on `role="listbox"` is a supported combination, and this
-     * is what says so rather than the ARIA spec being quoted in a comment. The
-     * rules are the two that can object to an attribute the host did not carry
-     * before: whether it is allowed on the role at all, and whether its value
-     * is one the attribute accepts.
+     * NO AXE ASSERTION HERE, DELIBERATELY.
+     *
+     * The obvious one to reach for is `aria-allowed-attr` on the host, and it
+     * cannot see this fix: `aria-disabled` is a GLOBAL ARIA attribute, allowed
+     * on every role, so the rule never weighs it against `role="listbox"` at
+     * all. Measured rather than reasoned — with the host binding deleted, a
+     * scan for `aria-allowed-attr` and `aria-valid-attr-value` still returned
+     * `violated: []` with both rules in `evaluated`, because the host carries
+     * `aria-multiselectable` and the rules attribute themselves to it either
+     * way. `aria-required-children` / `aria-required-parent` are the same
+     * story: a global attribute on the parent cannot move them, and
+     * `selection-list-a11y.spec.ts` already scans both over these elements.
+     *
+     * So the DOM assertions above are the guard, and they are the real one —
+     * all seven fail with the binding removed. An axe scan added here would
+     * have passed either way, which is the vacuous green `axe-testing.ts`
+     * exists to warn about.
      */
-    it('raises no axe violation for the attribute it added', async () => {
-      const { violated, evaluated } = await axeResult(
-        fixture.nativeElement,
-        [list()],
-        ['aria-allowed-attr', 'aria-valid-attr-value']
-      );
-
-      expect(violated).toEqual([]);
-      expect(evaluated).toContain('aria-allowed-attr');
-      expect(evaluated).toContain('aria-valid-attr-value');
-    });
-
-    /**
-     * The structure rules `selection-list-a11y.spec.ts` runs on an ENABLED
-     * list, run again here — the host attribute is new on this element and the
-     * listbox/option relationship is what an attribute on the parent could
-     * disturb. Scanned over the host and its options together, matching that
-     * spec's own targets.
-     */
-    it('keeps the listbox structure axe checks green while disabled', async () => {
-      const { violated, evaluated } = await axeResult(
-        fixture.nativeElement,
-        [list(), ...options()],
-        ['aria-required-children', 'aria-required-parent']
-      );
-
-      expect(violated).toEqual([]);
-      expect(evaluated).toContain('aria-required-children');
-      expect(evaluated).toContain('aria-required-parent');
-    });
 
     /**
      * The list is still readable with the arrow keys while disabled — the same

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-disabled.spec.ts
@@ -4,10 +4,12 @@ import type { ComponentFixture } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import type { TnSelectionChange } from './selection-list.component';
 import { TnSelectionListComponent } from './selection-list.component';
+import { axeResult } from '../a11y/axe-testing';
 import { TnListOptionComponent } from '../list-option/list-option.component';
 
 /**
- * `[disabled]` on `tn-selection-list` reaching its options (#221).
+ * `[disabled]` on `tn-selection-list` reaching its options (#221), and the
+ * listbox reporting that state on its own host (#225).
  *
  * Two routes put the list into the same state and only one of them used to
  * arrive: `setDisabledState()` — the `ControlValueAccessor` hook, so a reactive
@@ -38,6 +40,15 @@ import { TnListOptionComponent } from '../list-option/list-option.component';
  * fix keeps the list's state in a signal of its own (`listDisabled`) and ORs the
  * two, so neither source can erase the other. Every re-enable case below exists
  * to pin that.
+ *
+ * WHAT #225 ADDED, AND WHY IT IS A SEPARATE CLAIM
+ * ----------------------------------------------
+ * #221 left the listbox host itself saying nothing, so assistive technology had
+ * to read the list's state off its children. That inference fails in two
+ * ordinary cases the per-option assertions above cannot see: a disabled list
+ * with no options has nothing to infer from, and a list whose options are each
+ * disabled by the consumer is not a disabled list. Both are asserted below,
+ * alongside the host attribute itself on both routes.
  */
 
 interface TestOption {
@@ -85,7 +96,7 @@ class FormHostComponent {
   control = new FormControl<unknown[]>([]);
 }
 
-describe('tn-selection-list [disabled] (#221)', () => {
+describe('tn-selection-list [disabled] (#221, #225)', () => {
   let host: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
@@ -103,8 +114,16 @@ describe('tn-selection-list [disabled] (#221)', () => {
     fixture.detectChanges();
   });
 
+  function list(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-selection-list') as HTMLElement;
+  }
+
   function options(): HTMLElement[] {
     return Array.from(fixture.nativeElement.querySelectorAll('tn-list-option'));
+  }
+
+  function hostAriaDisabled(): string | null {
+    return list().getAttribute('aria-disabled');
   }
 
   function ariaSelected(): (string | null)[] {
@@ -150,6 +169,10 @@ describe('tn-selection-list [disabled] (#221)', () => {
     it('leaves an independently disabled option disabled', () => {
       expect(ariaDisabled()).toEqual(['false', 'false', 'true']);
     });
+
+    it('reports aria-disabled="false" on the host', () => {
+      expect(hostAriaDisabled()).toBe('false');
+    });
   });
 
   describe('a disabled list refuses its options', () => {
@@ -190,6 +213,61 @@ describe('tn-selection-list [disabled] (#221)', () => {
 
     it('reports aria-disabled="true" on every option', () => {
       expect(ariaDisabled()).toEqual(['true', 'true', 'true']);
+    });
+
+    it('reports aria-disabled="true" on the host', () => {
+      expect(hostAriaDisabled()).toBe('true');
+    });
+
+    /**
+     * The case the per-option assertions structurally cannot cover: with no
+     * options there is nothing for assistive technology to infer the state
+     * from, so the host attribute is the only thing left saying it.
+     */
+    it('still reports it on an empty list', () => {
+      host.items.set([]);
+      fixture.detectChanges();
+
+      expect(options()).toEqual([]);
+      expect(hostAriaDisabled()).toBe('true');
+    });
+
+    /**
+     * `aria-disabled` on `role="listbox"` is a supported combination, and this
+     * is what says so rather than the ARIA spec being quoted in a comment. The
+     * rules are the two that can object to an attribute the host did not carry
+     * before: whether it is allowed on the role at all, and whether its value
+     * is one the attribute accepts.
+     */
+    it('raises no axe violation for the attribute it added', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [list()],
+        ['aria-allowed-attr', 'aria-valid-attr-value']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-allowed-attr');
+      expect(evaluated).toContain('aria-valid-attr-value');
+    });
+
+    /**
+     * The structure rules `selection-list-a11y.spec.ts` runs on an ENABLED
+     * list, run again here — the host attribute is new on this element and the
+     * listbox/option relationship is what an attribute on the parent could
+     * disturb. Scanned over the host and its options together, matching that
+     * spec's own targets.
+     */
+    it('keeps the listbox structure axe checks green while disabled', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [list(), ...options()],
+        ['aria-required-children', 'aria-required-parent']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+      expect(evaluated).toContain('aria-required-parent');
     });
 
     /**
@@ -255,6 +333,28 @@ describe('tn-selection-list [disabled] (#221)', () => {
       expect(ariaSelected()[2]).toBe('false');
       expect(host.changes).toEqual([]);
     });
+
+    it('reports aria-disabled="false" on the host again', () => {
+      expect(hostAriaDisabled()).toBe('false');
+    });
+  });
+
+  /**
+   * The other half of #225's claim, and the one an inference from the children
+   * gets backwards: every option being disabled is a property of the options.
+   * The list is still enabled — a consumer can enable any of them without
+   * touching it, and it must not announce itself as disabled meanwhile.
+   */
+  describe('every option disabled independently is not a disabled list', () => {
+    beforeEach(() => {
+      host.items.update((items) => items.map((item) => ({ ...item, disabled: true })));
+      fixture.detectChanges();
+    });
+
+    it('leaves aria-disabled="false" on the host', () => {
+      expect(ariaDisabled()).toEqual(['true', 'true', 'true']);
+      expect(hostAriaDisabled()).toBe('false');
+    });
   });
 
   /**
@@ -276,6 +376,11 @@ describe('tn-selection-list [disabled] (#221)', () => {
 
     function formOptions(): HTMLElement[] {
       return Array.from(formFixture.nativeElement.querySelectorAll('tn-list-option'));
+    }
+
+    function formHostAriaDisabled(): string | null {
+      return (formFixture.nativeElement.querySelector('tn-selection-list') as HTMLElement)
+        .getAttribute('aria-disabled');
     }
 
     it('disables every option on control.disable()', () => {
@@ -318,6 +423,26 @@ describe('tn-selection-list [disabled] (#221)', () => {
 
       expect(formOptions().map((option) => option.getAttribute('aria-disabled')))
         .toEqual(['false', 'false', 'true']);
+    });
+
+    it('reports aria-disabled="false" on the host while the control is enabled', () => {
+      expect(formHostAriaDisabled()).toBe('false');
+    });
+
+    it('reports aria-disabled="true" on the host on control.disable()', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+
+      expect(formHostAriaDisabled()).toBe('true');
+    });
+
+    it('reports aria-disabled="false" on the host again on control.enable()', () => {
+      formHost.control.disable();
+      formFixture.detectChanges();
+      formHost.control.enable();
+      formFixture.detectChanges();
+
+      expect(formHostAriaDisabled()).toBe('false');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -29,6 +29,14 @@ export interface TnSelectionChange {
     '[class.tn-selection-list--dense]': 'dense()',
     '[class.tn-selection-list--disabled]': 'isDisabled()',
     'role': 'listbox',
+    // The listbox states its own disabled-ness rather than leaving assistive
+    // technology to infer it from its children (#225). Inferring is not the same
+    // claim and is wrong in two ordinary cases: an empty disabled list has no
+    // children to read it off, and a consumer who disables every option
+    // individually has not disabled the LIST. `isDisabled()` and not the
+    // `disabled` input, so the plain input and `setDisabledState()` reach it by
+    // the same route the options do — see the effect in the constructor.
+    '[attr.aria-disabled]': 'isDisabled()',
     '[attr.aria-multiselectable]': 'multiple()',
     // Both listeners are on the host and rely on bubbling from the options,
     // rather than being bound per option: contentChildren gives components, not


### PR DESCRIPTION
Fixes #225.

## What was wrong

#221 pushed the list's disabled state down onto every option, so each one now
carries `aria-disabled="true"` and refuses every route into `toggle()`. The
listbox host itself still said nothing, leaving assistive technology to infer
the list's state from its children.

That inference is a different claim, and it is wrong in two ordinary cases:

- a disabled list with **no options** has nothing to infer from;
- a list whose options are **each disabled by the consumer** is not a disabled
  list — enabling any one of them takes nothing away from the list.

## The change

One host binding in `selection-list.component.ts`:

```ts
'[attr.aria-disabled]': 'isDisabled()',
```

`isDisabled()` and not the `disabled` input, so the plain `[disabled]` input and
a reactive form's `control.disable()` reach the host by the same route they
already reach the options — the two cannot come apart the way #221 fixed. This
is the pattern `tn-list-option` already follows one level down
(`list-option.component.ts:42`).

## Tests

Added to `selection-list-disabled.spec.ts`, which already had both hosts #225
needs — the `[disabled]`-input host and the `[formControl]` host — rather than
standing up a third copy of them. Eight assertions:

- `aria-disabled="false"` on the host while enabled, `"true"` while disabled,
  `"false"` again on re-enable, by **both** routes;
- `"true"` on an **empty** disabled list, which is the case the per-option
  assertions structurally cannot cover;
- `"false"` when every option is independently disabled.

All eight fail with the host binding removed — checked, not assumed.

## No axe assertion, deliberately — and the AC bullet that asked for one

The ticket's third acceptance criterion asks that the existing axe assertions in
`selection-list-a11y.spec.ts` still pass on a disabled list. They do (the full
suite is green), but I did **not** add an axe scan over the disabled list,
because every scan I could write here is vacuous:

- `aria-disabled` is a **global** ARIA attribute, allowed on every role, so
  `aria-allowed-attr` never weighs it against `role="listbox"`;
- `aria-required-children` / `aria-required-parent` cannot be moved by a global
  attribute on the parent, and `selection-list-a11y.spec.ts` already scans both
  over these same elements.

I wrote both scans first and local review flagged them. Measured before removing
them: with the host binding deleted, both still returned `violated: []` with
both rules in `evaluated`, because the host carries `aria-multiselectable` and
the rules attribute themselves to it either way. That is exactly the vacuous
green `axe-testing.ts` was written to warn about, so the second commit removes
them and leaves a comment in their place recording why. The DOM assertions are
the guard.

## Checks run locally

`yarn lint`, `yarn test` (2643 passing, 111 suites), `yarn test:scripts` (42
passing) and `yarn build` all pass.

`yarn lint` reports 4 pre-existing `import/order` errors in
`input.component.ts` and `menu-panel.component.ts` — untouched by this PR and
present on `main` before it.

**Not run locally:** the Storybook interaction tests, which need a Playwright
Chromium install. CI runs them.

## Local review

Round 1 returned nothing at MEDIUM or above, plus the two LOWs about the axe
assertions described above — both acted on, since a test that passes with the
fix deleted is a false guard rather than polish. Nothing else was left
unaddressed.
