### PR TITLE
NAS-142389 / 27.0.0-BETA.1 / fix(side-panel,drawer): move focus into a modal panel when it opens

### DIFF
--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -1,0 +1,131 @@
+import { Injector, afterNextRender, effect, inject } from '@angular/core';
+import type { Signal } from '@angular/core';
+
+/**
+ * The one place that decides WHERE focus goes when a modal surface opens.
+ *
+ * WHY THIS EXISTS AT ALL
+ * ----------------------
+ * `tn-side-panel` and `tn-drawer` both asked the CDK for it, with
+ * `[cdkTrapFocusAutoCapture]="open()"`, and both could open with focus still on
+ * the trigger BEHIND them (#227). Auto-capture calls
+ * `FocusTrap.focusFirstTabbableElement()`, which walks the panel for the first
+ * element the CDK's `InteractivityChecker` calls tabbable — a test that reads
+ * layout (`offsetWidth`, `getClientRects()`, computed `visibility`) — and
+ * returns `false`, silently, when it finds nothing. Nobody reads that `false`.
+ * So the guarantee was: focus moves inside IF the panel happens to contain
+ * something the browser considers tabbable at the moment capture runs.
+ *
+ * That is a guarantee about the caller's content, not about the component. A
+ * panel whose only control is its own × button is one layout detail away from
+ * having no tabbable at all, and a panel with no interactive content — a
+ * details pane, a preview — has none by construction. `aria-modal="true"` has
+ * meanwhile told assistive technology to ignore everything outside the dialog,
+ * so the user is left on a control their screen reader has just been told does
+ * not exist (WCAG 2.4.3).
+ *
+ * WHERE FOCUS GOES, AND WHY THERE
+ * -------------------------------
+ * **The panel container itself**, which both components already render with
+ * `tabindex="-1"`. Not its first tabbable, and not an explicit `cdkFocusInitial`:
+ *
+ * - It is the only target that exists whatever the caller projected. That is
+ *   the whole defect — a rule that depends on the content is a rule that has a
+ *   content shape it fails for, and this one failed for the commonest shape
+ *   there is.
+ * - A screen reader announces the container's name and role — "Edit dataset,
+ *   dialog" — and then reads into it. Landing on the × button instead announces
+ *   "Dismiss, button", which is the one control in the panel that tells the
+ *   listener nothing about what just opened.
+ * - Sequential navigation from a container proceeds INTO it, so the first Tab
+ *   still reaches the close button: the same place auto-capture aimed at, one
+ *   keystroke later, with the announcement first.
+ *
+ * A caller who needs a specific control focused instead — the first field of a
+ * form — should focus it themselves; there is no input for it, because nothing
+ * has asked for one and a per-component override is another way for the
+ * guarantee above to be conditional.
+ *
+ * WHY A SHARED FUNCTION AND NOT A COPY PER COMPONENT
+ * -------------------------------------------------
+ * The same reasoning as `accessible-name.ts` and `../utils/transition-lifecycle.ts`,
+ * and the same evidence: `tn-drawer` was written from `tn-side-panel`, and the
+ * two have now reached identical bugs three times (#214, #218, and this). What
+ * is subtle here is not the `focus()` call but WHEN it may run — see below — and
+ * a second copy of that is a second chance to get it wrong.
+ *
+ * Not exported from `public-api.ts`, and must not be: it is how this library's
+ * own components agree with each other, not API.
+ */
+
+/**
+ * Move focus into a modal surface as it opens, and keep it out of the way
+ * otherwise.
+ *
+ * **Must be called from an injection context** — a field initializer or the
+ * constructor — because it registers an `effect` and needs an `Injector` to
+ * schedule the focus for after the render.
+ *
+ * WHY `afterNextRender` AND NOT THE EFFECT ITSELF
+ * ----------------------------------------------
+ * A closed panel carries `inert`, and focusing an element inside an inert
+ * subtree does nothing at all — the browser drops the call without an error.
+ * The attribute is removed by the same change detection pass this effect runs
+ * in, so a `focus()` from inside the effect would race the binding that makes
+ * the element focusable in the first place. `afterNextRender` runs once that
+ * pass has written the DOM, which is the earliest moment the panel is
+ * guaranteed to be focusable.
+ *
+ * @param isOpen Whether the surface is open AND modal. `tn-drawer` is modal
+ *   only in `over` mode, so it passes a computed condition rather than its
+ *   `opened` model.
+ * @param target The element to focus, read at focus time. A `viewChild` inside
+ *   an `@if` returns `undefined` until it renders, which is exactly the case
+ *   the deferral above handles.
+ */
+export function tnFocusOnOpen(
+  isOpen: Signal<boolean>,
+  target: () => HTMLElement | null | undefined
+): void {
+  const injector = inject(Injector);
+
+  /**
+   * What the effect last saw, so that only a CHANGE into the open state moves
+   * focus.
+   *
+   * Seeded `false` because that is what a surface renders as by default, which
+   * makes a panel that renders already open — `[open]="true"` on first
+   * render — an edge into open, and it captures. That matches what auto-capture
+   * did: `CdkTrapFocus.ngAfterContentInit` captures when `autoCapture` is
+   * already true.
+   *
+   * Re-running with the state unchanged must NOT re-focus: the effect also
+   * re-runs when anything else it reads changes, and pulling focus back to the
+   * container while the user is typing in the panel is worse than the bug.
+   */
+  let wasOpen = false;
+
+  effect(() => {
+    const open = isOpen();
+    if (open === wasOpen) {
+      return;
+    }
+    wasOpen = open;
+
+    if (!open) {
+      return;
+    }
+
+    afterNextRender(
+      () => {
+        // Re-read rather than trusting the edge: a surface opened and closed
+        // again within one pass must not be focused after it has gone inert,
+        // which would fight the closing component's focus restoration.
+        if (isOpen()) {
+          target()?.focus();
+        }
+      },
+      { injector }
+    );
+  });
+}

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -161,9 +161,18 @@ export function tnFocusOnOpen(
     }
 
     afterNextRender(
-      () => zone.runOutsideAngular(
-        () => capture(isOpen, target, performance.now() + TN_TRANSITION_FALLBACK_MS)
-      ),
+      () => zone.runOutsideAngular(() => {
+        const element = target();
+        if (!element) {
+          return;
+        }
+
+        // Whose focus this capture is entitled to take: whatever holds it at
+        // the moment the surface opens, which is the trigger in the ordinary
+        // case. See `capture`.
+        const claimant = element.ownerDocument.activeElement;
+        capture(isOpen, target, claimant, performance.now() + TN_TRANSITION_FALLBACK_MS);
+      }),
       { injector }
     );
   });
@@ -203,10 +212,14 @@ function holdsFocus(element: HTMLElement): boolean {
  *
  * Recursive rather than a loop because each attempt has to wait for a frame,
  * and the deadline is what makes it terminate.
+ *
+ * @param claimant What held focus when the surface opened. A retry is only
+ *   entitled to take focus from THAT, or from `<body>` — see below.
  */
 function capture(
   isOpen: Signal<boolean>,
   target: () => HTMLElement | null | undefined,
+  claimant: Element | null,
   deadline: number
 ): void {
   // Re-read rather than trusting the edge: a surface opened and closed again
@@ -233,6 +246,21 @@ function capture(
     return;
   }
 
+  // Focus is somewhere this capture has no claim on, so it stops rather than
+  // taking it. `claimant` is what held focus when the surface opened — the
+  // trigger, ordinarily — and `<body>` is where the browser leaves it when the
+  // element holding it goes away.
+  //
+  // What this rules out is a SECOND surface opening inside the retry window: a
+  // nested panel, or a dialog raised from this one. Its capture succeeds, and
+  // without this the first panel's pending retry would take focus straight
+  // back off it on the next frame, from a panel the user has already left.
+  const doc = element.ownerDocument;
+  const active = doc.activeElement;
+  if (active !== claimant && active !== doc.body) {
+    return;
+  }
+
   element.focus();
 
   if (holdsFocus(element)) {
@@ -245,5 +273,5 @@ function capture(
     return;
   }
 
-  requestAnimationFrame(() => capture(isOpen, target, deadline));
+  requestAnimationFrame(() => capture(isOpen, target, claimant, deadline));
 }

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -1,5 +1,6 @@
 import { Injector, NgZone, afterNextRender, effect, inject } from '@angular/core';
 import type { Signal } from '@angular/core';
+import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
 
 /**
  * The one place that decides WHERE focus goes when a modal surface opens.
@@ -160,22 +161,28 @@ export function tnFocusOnOpen(
     }
 
     afterNextRender(
-      () => zone.runOutsideAngular(() => capture(isOpen, target, performance.now() + CAPTURE_WINDOW_MS)),
+      () => zone.runOutsideAngular(
+        () => capture(isOpen, target, performance.now() + TN_TRANSITION_FALLBACK_MS)
+      ),
       { injector }
     );
   });
 }
 
-/**
- * How long the capture may keep re-attempting before it gives up.
+/*
+ * HOW LONG THE CAPTURE MAY KEEP RE-ATTEMPTING
+ * -------------------------------------------
+ * `TN_TRANSITION_FALLBACK_MS`, which is the same question asked once: how long
+ * to allow for an opening transition that both stylesheets set to 300ms, plus
+ * a margin. A second constant here would be a second thing to remember when
+ * one of those durations changes, and this one fails SILENTLY when it is left
+ * behind — the capture just gives up early — where the lifecycle's fallback
+ * only reports a frame or two soon. The quieter failure is the worse one to
+ * couple loosely.
  *
- * A DURATION rather than a count of frames, because what it has to outlast is
- * the opening transition and that is measured in milliseconds: both components
- * transition for 300ms, and a frame budget picked to cover it at 60Hz covers
- * half of it on a 120Hz display — giving up early, silently, on exactly the
- * hardware where nobody would think to look. 400ms is the transition plus a
- * margin. There is no value in trying for longer: a panel still refusing focus
- * a full transition after it opened is not mid-anything.
+ * A duration and not a count of frames: a frame budget sized for 60Hz covers
+ * half the transition on a 120Hz display, which is exactly the hardware nobody
+ * would think to check.
  *
  * Giving up is silent, deliberately. This is a11y behaviour on a component in
  * a library, so the failure the user experiences is the bug in #227 — nothing
@@ -183,7 +190,6 @@ export function tnFocusOnOpen(
  * regression here are `side-panel-focus-capture.spec.ts` and the `play`
  * functions, which run where a maintainer is looking.
  */
-const CAPTURE_WINDOW_MS = 400;
 
 /** Whether focus is on `element` or on something inside it. */
 function holdsFocus(element: HTMLElement): boolean {

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -33,10 +33,14 @@ import type { Signal } from '@angular/core';
  *   the whole defect — a rule that depends on the content is a rule that has a
  *   content shape it fails for, and this one failed for the commonest shape
  *   there is.
- * - A screen reader announces the container's name and role — "Edit dataset,
- *   dialog" — and then reads into it. Landing on the × button instead announces
- *   "Dismiss, button", which is the one control in the panel that tells the
- *   listener nothing about what just opened.
+ * - Focus arriving on it is focus arriving in the dialog with nothing else
+ *   claimed: a screen reader announces the dialog it has just entered — its
+ *   name and role — and reads on into the content. That is the announcement the
+ *   ELEMENT CARRYING `role="dialog"` produces, which is this container in
+ *   `tn-drawer` and its parent overlay in `tn-side-panel`; the container is
+ *   inside it either way. Landing on the × button instead announces "Dismiss,
+ *   button" first, which is the one control in the panel that says nothing
+ *   about what just opened.
  * - Sequential navigation from a container proceeds INTO it, so the first Tab
  *   still reaches the close button: the same place auto-capture aimed at, one
  *   keystroke later, with the announcement first.

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -9,12 +9,14 @@ import type { Signal } from '@angular/core';
  * `tn-side-panel` and `tn-drawer` both asked the CDK for it, with
  * `[cdkTrapFocusAutoCapture]="open()"`, and both could open with focus still on
  * the trigger BEHIND them (#227). Auto-capture calls
- * `FocusTrap.focusFirstTabbableElement()`, which walks the panel for the first
- * element the CDK's `InteractivityChecker` calls tabbable — a test that reads
- * layout (`offsetWidth`, `getClientRects()`, computed `visibility`) — and
- * returns `false`, silently, when it finds nothing. Nobody reads that `false`.
- * So the guarantee was: focus moves inside IF the panel happens to contain
- * something the browser considers tabbable at the moment capture runs.
+ * `FocusTrap.focusInitialElement()`, which takes a `[cdkFocusInitial]` if the
+ * caller marked one and otherwise falls through to
+ * `focusFirstTabbableElement()` — a walk for the first element the CDK's
+ * `InteractivityChecker` calls tabbable, which is a test that reads layout
+ * (`offsetWidth`, `getClientRects()`, computed `visibility`). Both return
+ * `false`, silently, when they find nothing. Nobody reads that `false`. So the
+ * guarantee was: focus moves inside IF the panel happens to contain something
+ * the browser considers tabbable at the moment capture runs.
  *
  * That is a guarantee about the caller's content, not about the component. A
  * panel whose only control is its own × button is one layout detail away from
@@ -45,10 +47,18 @@ import type { Signal } from '@angular/core';
  *   still reaches the close button: the same place auto-capture aimed at, one
  *   keystroke later, with the announcement first.
  *
+ * **`[cdkFocusInitial]` NO LONGER DOES ANYTHING on either component**, and that
+ * is a removal, not an oversight: it was honoured by the auto-capture this
+ * replaced, `cdkTrapFocus` is still on both elements, and a consumer has every
+ * reason to expect the marker to keep working. Both components say so in their
+ * class documentation, which is where a consumer reads. Nothing in this
+ * repository uses it.
+ *
  * A caller who needs a specific control focused instead — the first field of a
- * form — should focus it themselves; there is no input for it, because nothing
- * has asked for one and a per-component override is another way for the
- * guarantee above to be conditional.
+ * form — should focus it themselves, which the capture leaves alone once focus
+ * is inside the panel. There is no input for it, because nothing has asked for
+ * one and a per-component override is another way for the guarantee above to be
+ * conditional.
  *
  * WHY A SHARED FUNCTION AND NOT A COPY PER COMPONENT
  * -------------------------------------------------

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -150,20 +150,22 @@ export function tnFocusOnOpen(
     }
 
     afterNextRender(
-      () => zone.runOutsideAngular(() => capture(isOpen, target, RETRY_FRAMES)),
+      () => zone.runOutsideAngular(() => capture(isOpen, target, performance.now() + CAPTURE_WINDOW_MS)),
       { injector }
     );
   });
 }
 
 /**
- * How many animation frames the capture may re-attempt over before giving up.
+ * How long the capture may keep re-attempting before it gives up.
  *
- * Both components transition for 300ms, which is 18 frames at 60Hz; 24 covers
- * that with a margin and is still a fifth of a second. There is no value in
- * trying for longer — a panel that is still refusing focus a full transition
- * after it opened is not mid-anything, and holding a callback alive past the
- * point it can help only delays the give-up.
+ * A DURATION rather than a count of frames, because what it has to outlast is
+ * the opening transition and that is measured in milliseconds: both components
+ * transition for 300ms, and a frame budget picked to cover it at 60Hz covers
+ * half of it on a 120Hz display — giving up early, silently, on exactly the
+ * hardware where nobody would think to look. 400ms is the transition plus a
+ * margin. There is no value in trying for longer: a panel still refusing focus
+ * a full transition after it opened is not mid-anything.
  *
  * Giving up is silent, deliberately. This is a11y behaviour on a component in
  * a library, so the failure the user experiences is the bug in #227 — nothing
@@ -171,19 +173,25 @@ export function tnFocusOnOpen(
  * regression here are `side-panel-focus-capture.spec.ts` and the `play`
  * functions, which run where a maintainer is looking.
  */
-const RETRY_FRAMES = 24;
+const CAPTURE_WINDOW_MS = 400;
+
+/** Whether focus is on `element` or on something inside it. */
+function holdsFocus(element: HTMLElement): boolean {
+  const active = element.ownerDocument.activeElement;
+  return element === active || element.contains(active);
+}
 
 /**
  * Focus `target`, read back whether it took, and try again next frame if it
- * did not.
+ * did not, until `deadline` (a `performance.now()` reading) passes.
  *
  * Recursive rather than a loop because each attempt has to wait for a frame,
- * and `framesLeft` is what makes it terminate.
+ * and the deadline is what makes it terminate.
  */
 function capture(
   isOpen: Signal<boolean>,
   target: () => HTMLElement | null | undefined,
-  framesLeft: number
+  deadline: number
 ): void {
   // Re-read rather than trusting the edge: a surface opened and closed again
   // must not be focused after it has gone inert, which would fight the closing
@@ -198,21 +206,28 @@ function capture(
     return;
   }
 
+  // BEFORE the call, not after it. `contains` rather than `===` so that
+  // someone already on a control INSIDE the panel is left there — a caller who
+  // focused the first field of their form, or a user who has started typing in
+  // one. That is not hypothetical while a retry is pending: the attempts below
+  // outlive the frame that scheduled them, so focus can arrive by another
+  // route between two of them. Reading this only AFTER the call would notice
+  // and stop, having already taken the focus away, which is the whole harm.
+  if (holdsFocus(element)) {
+    return;
+  }
+
   element.focus();
 
-  // `contains` rather than `===` so that a caller who focuses a control of
-  // their own inside the panel — the first field of a form — is left alone
-  // instead of being pulled back to the container on the next frame.
-  const active = element.ownerDocument.activeElement;
-  if (element === active || element.contains(active)) {
+  if (holdsFocus(element)) {
     return;
   }
 
   // `requestAnimationFrame` is absent in a non-browser platform, and the
   // give-up below is the right behaviour there rather than a crash.
-  if (framesLeft <= 0 || typeof requestAnimationFrame !== 'function') {
+  if (performance.now() >= deadline || typeof requestAnimationFrame !== 'function') {
     return;
   }
 
-  requestAnimationFrame(() => capture(isOpen, target, framesLeft - 1));
+  requestAnimationFrame(() => capture(isOpen, target, deadline));
 }

--- a/projects/truenas-ui/src/lib/a11y/initial-focus.ts
+++ b/projects/truenas-ui/src/lib/a11y/initial-focus.ts
@@ -1,4 +1,4 @@
-import { Injector, afterNextRender, effect, inject } from '@angular/core';
+import { Injector, NgZone, afterNextRender, effect, inject } from '@angular/core';
 import type { Signal } from '@angular/core';
 
 /**
@@ -77,8 +77,33 @@ import type { Signal } from '@angular/core';
  * The attribute is removed by the same change detection pass this effect runs
  * in, so a `focus()` from inside the effect would race the binding that makes
  * the element focusable in the first place. `afterNextRender` runs once that
- * pass has written the DOM, which is the earliest moment the panel is
- * guaranteed to be focusable.
+ * pass has written the DOM, which is the earliest point the panel can be
+ * focusable.
+ *
+ * WHY THE MOVE IS CHECKED RATHER THAN ASSUMED
+ * -------------------------------------------
+ * `HTMLElement.focus()` reports nothing. It is a request, and the browser
+ * declines it silently whenever the element is not focusable AT THAT INSTANT —
+ * which is the same silence that made the bug this file exists for invisible.
+ * A single deferred call is therefore a guess about timing, and CI measured it
+ * wrong: with the call in `afterNextRender` alone, `side-panel--default` and
+ * `drawer--over-mode` both opened with focus still outside the dialog, while
+ * `side-panel--with-actions` captured. Three shapes of the same component,
+ * two outcomes, one code path — so the deciding factor was the state of the
+ * panel when the call landed, not the call.
+ *
+ * **What that state is has not been established here**, and this comment will
+ * not pretend otherwise: no browser can run in the environment these cycles
+ * work in, so the evidence is the CI log and no more. The panel being mid
+ * transition is the ticket's own hypothesis and remains one.
+ *
+ * What does not need establishing is the remedy. Focus is observable —
+ * `document.activeElement` says where it went — so the move is READ BACK, and
+ * re-attempted on animation frames until it takes or the open transition has
+ * had time to finish. When the first call works, which is every jsdom spec and
+ * was `--with-actions` in CI, nothing after it runs and this costs one
+ * comparison. Reading back a write whose failure mode is silence is the same
+ * rule `handoff.py` follows for the same reason.
  *
  * @param isOpen Whether the surface is open AND modal. `tn-drawer` is modal
  *   only in `over` mode, so it passes a computed condition rather than its
@@ -92,6 +117,10 @@ export function tnFocusOnOpen(
   target: () => HTMLElement | null | undefined
 ): void {
   const injector = inject(Injector);
+  // The retries run outside Angular, because they touch no state it tracks: a
+  // `focus()` per frame inside the zone is a change detection pass per frame,
+  // for the whole length of an opening transition.
+  const zone = inject(NgZone);
 
   /**
    * What the effect last saw, so that only a CHANGE into the open state moves
@@ -121,15 +150,69 @@ export function tnFocusOnOpen(
     }
 
     afterNextRender(
-      () => {
-        // Re-read rather than trusting the edge: a surface opened and closed
-        // again within one pass must not be focused after it has gone inert,
-        // which would fight the closing component's focus restoration.
-        if (isOpen()) {
-          target()?.focus();
-        }
-      },
+      () => zone.runOutsideAngular(() => capture(isOpen, target, RETRY_FRAMES)),
       { injector }
     );
   });
+}
+
+/**
+ * How many animation frames the capture may re-attempt over before giving up.
+ *
+ * Both components transition for 300ms, which is 18 frames at 60Hz; 24 covers
+ * that with a margin and is still a fifth of a second. There is no value in
+ * trying for longer — a panel that is still refusing focus a full transition
+ * after it opened is not mid-anything, and holding a callback alive past the
+ * point it can help only delays the give-up.
+ *
+ * Giving up is silent, deliberately. This is a11y behaviour on a component in
+ * a library, so the failure the user experiences is the bug in #227 — nothing
+ * is gained by also writing to their console, and the assertions that catch a
+ * regression here are `side-panel-focus-capture.spec.ts` and the `play`
+ * functions, which run where a maintainer is looking.
+ */
+const RETRY_FRAMES = 24;
+
+/**
+ * Focus `target`, read back whether it took, and try again next frame if it
+ * did not.
+ *
+ * Recursive rather than a loop because each attempt has to wait for a frame,
+ * and `framesLeft` is what makes it terminate.
+ */
+function capture(
+  isOpen: Signal<boolean>,
+  target: () => HTMLElement | null | undefined,
+  framesLeft: number
+): void {
+  // Re-read rather than trusting the edge: a surface opened and closed again
+  // must not be focused after it has gone inert, which would fight the closing
+  // component's focus restoration. Checked on EVERY attempt, not only the
+  // first, because the retries outlive the frame that scheduled them.
+  if (!isOpen()) {
+    return;
+  }
+
+  const element = target();
+  if (!element) {
+    return;
+  }
+
+  element.focus();
+
+  // `contains` rather than `===` so that a caller who focuses a control of
+  // their own inside the panel — the first field of a form — is left alone
+  // instead of being pulled back to the container on the next frame.
+  const active = element.ownerDocument.activeElement;
+  if (element === active || element.contains(active)) {
+    return;
+  }
+
+  // `requestAnimationFrame` is absent in a non-browser platform, and the
+  // give-up below is the right behaviour there rather than a crash.
+  if (framesLeft <= 0 || typeof requestAnimationFrame !== 'function') {
+    return;
+  }
+
+  requestAnimationFrame(() => capture(isOpen, target, framesLeft - 1));
 }

--- a/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-a11y.spec.ts
@@ -379,12 +379,14 @@ describe('drawer accessibility (#214)', () => {
      * one saved focus on it — the drawer is still on screen, and the close that
      * follows later is what the saved element is for.
      *
-     * Focus does still leave the drawer at the switch, and that is not this
-     * component: `mode` decides which of two panels the template renders, so the
-     * over-mode panel is DESTROYED, and `CdkTrapFocus.ngOnDestroy` restores the
-     * element it captured. Measured — with the guard below in place the effect
-     * does not run its restore branch, and focus lands on the opener anyway.
-     * Pre-existing, unchanged here, and noted on the pull request.
+     * Focus does still leave the drawer at the switch: `mode` decides which of
+     * two panels the template renders, so the over-mode panel is DESTROYED and
+     * the browser drops focus on `<body>`. It used to be `CdkTrapFocus` that
+     * put it back, from a capture of its own — the component's saved element
+     * was never spent on it, which is what let the close below still restore.
+     * Both halves come out of the one saved element now (#227), and the
+     * component focuses it at the switch without consuming it, so what this
+     * test asserts is unchanged.
      *
      * What this asserts is the part the component owns: the saved element
      * survives the mode change, so the eventual close still restores it. Without

--- a/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
@@ -122,6 +122,24 @@ describe('tn-drawer focus capture (#227)', () => {
 
       expect(document.activeElement).toBe(trigger());
     });
+
+    /**
+     * Destroying a drawer that is still open — a route change, a `@if` around
+     * the container — is the other way focus leaves it, and it runs no close.
+     * The removal drops focus on `<body>`, and until #227 it was
+     * `CdkTrapFocus.ngOnDestroy` that put it back, off the back of the
+     * auto-capture that replaced.
+     */
+    it('returns focus to the trigger when a drawer is destroyed while open', async () => {
+      trigger().focus();
+      const opener = trigger();
+      await openByClick();
+      expect(document.activeElement).not.toBe(opener);
+
+      fixture.destroy();
+
+      expect(document.activeElement).toBe(opener);
+    });
   });
 
   describe('side mode, which is navigation', () => {

--- a/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
@@ -150,6 +150,28 @@ describe('tn-drawer focus capture (#227)', () => {
     });
 
     /**
+     * `@if (mode() === 'over')` destroys the panel focus is on, and the browser
+     * falls back to `<body>` when a focused element goes away. Nothing else in
+     * the component covers it: the drawer has not closed, so the close branch
+     * does not run, and `tnFocusOnOpen` only acts on an edge INTO modality.
+     * Until #227 `CdkTrapFocus.ngOnDestroy` restored here, off the back of the
+     * auto-capture that replaced — so this is a regression the removal opened
+     * rather than a case that never worked.
+     */
+    it('returns focus to the trigger when a switch to side destroys the panel holding it', async () => {
+      trigger().focus();
+      const opener = trigger();
+      await openByClick();
+      expect(document.activeElement).not.toBe(opener);
+
+      host.mode.set('side');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(opener);
+    });
+
+    /**
      * The other half, and the one an unconditional restore-on-destroy gets
      * wrong. This component has a standing route to it, which is why the case
      * is asserted here rather than only on `tn-side-panel`: an `over` open

--- a/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
@@ -30,6 +30,14 @@ import { TnDrawerComponent } from './drawer.component';
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <button type="button" id="trigger" (click)="opened.set(true)">Toggle</button>
+    <!--
+      Somewhere else on the page to be. A side-mode drawer is beside the
+      content rather than over it, so the user is free to work here while it is
+      open, and where focus is when the drawer goes away decides whether it
+      owes them a restore. No backticks in here: this is an inline template,
+      and one would end the template literal.
+    -->
+    <button type="button" id="elsewhere">Elsewhere</button>
     <tn-drawer-container>
       <tn-drawer ariaLabel="Datasets" [mode]="mode()" [(opened)]="opened">
         @if (withContent()) {
@@ -139,6 +147,32 @@ describe('tn-drawer focus capture (#227)', () => {
       fixture.destroy();
 
       expect(document.activeElement).toBe(opener);
+    });
+
+    /**
+     * The other half, and the one an unconditional restore-on-destroy gets
+     * wrong. This component has a standing route to it, which is why the case
+     * is asserted here rather than only on `tn-side-panel`: an `over` open
+     * records the opener, a breakpoint switches the drawer to `side` WITHOUT
+     * closing it — so nothing spends that record — and the user carries on
+     * using the page beside it. Destroying the drawer then, minutes later,
+     * must not throw them back to a button they pressed before the resize.
+     */
+    it('leaves focus alone on destroy when a switch to side left the opener unspent', async () => {
+      trigger().focus();
+      await openByClick();
+
+      host.mode.set('side');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const elsewhere = fixture.nativeElement.querySelector('#elsewhere') as HTMLElement;
+      elsewhere.focus();
+      expect(document.activeElement).toBe(elsewhere);
+
+      fixture.destroy();
+
+      expect(document.activeElement).toBe(elsewhere);
     });
   });
 

--- a/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-focus-capture.spec.ts
@@ -1,0 +1,157 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnDrawerContainerComponent } from './drawer-container.component';
+import { TnDrawerContentComponent } from './drawer-content.component';
+import { TnDrawerComponent } from './drawer.component';
+
+/**
+ * The drawer's half of #227: an `over` drawer is a modal dialog, so opening one
+ * must put focus inside it.
+ *
+ * The defect was reported against `tn-side-panel`, and the ticket asked for this
+ * component to be checked for the same thing rather than assumed clear —
+ * `tn-drawer` was written from the side panel and the two have now reached
+ * identical bugs three times (#214, #218, #227). It was NOT unaffected: it asked
+ * for the capture the same way, with `[cdkTrapFocusAutoCapture]="trapFocus()"`,
+ * and so had the same silent failure available to it — a drawer holding no
+ * tabbable element opens with focus left behind it, under `aria-modal="true"`.
+ * Both now go through `../a11y/initial-focus.ts`.
+ *
+ * What `side` mode must do is the opposite, and is asserted below: it is
+ * persistent navigation beside the page's content, not a dialog, and a
+ * navigation region that grabs focus when it appears is its own defect.
+ */
+
+@Component({
+  selector: 'tn-drawer-focus-host',
+  standalone: true,
+  imports: [TnDrawerContainerComponent, TnDrawerComponent, TnDrawerContentComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger" (click)="opened.set(true)">Toggle</button>
+    <tn-drawer-container>
+      <tn-drawer ariaLabel="Datasets" [mode]="mode()" [(opened)]="opened">
+        @if (withContent()) {
+          <button type="button" id="in-drawer">Pools</button>
+        } @else {
+          <p>Nothing to focus in here</p>
+        }
+      </tn-drawer>
+      <tn-drawer-content>
+        <p>Main content</p>
+      </tn-drawer-content>
+    </tn-drawer-container>
+  `,
+})
+class DrawerFocusHostComponent {
+  mode = signal<'side' | 'over'>('over');
+  opened = signal(false);
+  withContent = signal(true);
+}
+
+describe('tn-drawer focus capture (#227)', () => {
+  let fixture: ComponentFixture<DrawerFocusHostComponent>;
+  let host: DrawerFocusHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawerFocusHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DrawerFocusHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // The over-mode overlay is portaled to document.body and only removed on
+    // destroy, so without this the next fixture finds the previous one's panel.
+    fixture.destroy();
+  });
+
+  /** In `over` mode the panel lives in the portaled overlay, in `side` mode inline. */
+  function panel(): HTMLElement {
+    return document.querySelector('.tn-drawer__panel') as HTMLElement;
+  }
+
+  function trigger(): HTMLElement {
+    return fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+  }
+
+  /**
+   * Opens through the trigger and settles the render, which is what runs the
+   * `afterNextRender` the focus is deferred to — a closed drawer is `inert`, and
+   * focusing into an inert subtree does nothing. Nothing here touches focus
+   * itself; the component moving it is the assertion.
+   */
+  async function openByClick(): Promise<void> {
+    trigger().click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  describe('over mode, which is a modal dialog', () => {
+    it('moves focus onto the panel when it opens', async () => {
+      trigger().focus();
+      expect(document.activeElement).toBe(trigger());
+
+      await openByClick();
+
+      expect(document.activeElement).toBe(panel());
+      expect(panel().getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('moves focus in even when the drawer holds nothing tabbable', async () => {
+      host.withContent.set(false);
+      fixture.detectChanges();
+      trigger().focus();
+
+      await openByClick();
+
+      expect(panel().contains(document.activeElement)).toBe(true);
+    });
+
+    it('returns focus to the trigger on close, having really taken it away', async () => {
+      trigger().focus();
+      await openByClick();
+      expect(document.activeElement).not.toBe(trigger());
+
+      host.opened.set(false);
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(trigger());
+    });
+  });
+
+  describe('side mode, which is navigation', () => {
+    it('leaves focus where the user put it when it opens', async () => {
+      host.mode.set('side');
+      fixture.detectChanges();
+      trigger().focus();
+
+      await openByClick();
+
+      expect(document.activeElement).toBe(trigger());
+    });
+
+    /**
+     * A responsive drawer crossing its breakpoint while open: `side` to `over`
+     * makes it modal, and a modal surface the user is now inside owes them the
+     * same focus contract as one that just opened.
+     */
+    it('captures when a drawer already open switches from side to over', async () => {
+      host.mode.set('side');
+      fixture.detectChanges();
+      trigger().focus();
+      await openByClick();
+      expect(document.activeElement).toBe(trigger());
+
+      host.mode.set('over');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(panel());
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.html
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.html
@@ -48,7 +48,15 @@
       [class.tn-drawer__backdrop--visible]="opened()"
       (click)="onBackdropClick()"></div>
 
+    <!--
+      `cdkTrapFocus` keeps Tab inside the open drawer; what moves focus IN is
+      `tnFocusOnOpen` in the component, not `[cdkTrapFocusAutoCapture]`, which
+      used to be here and could silently do nothing for a drawer holding no
+      tabbable control (#227). `tabindex="-1"` is what makes this element the
+      target it focuses — see `../a11y/initial-focus.ts`.
+    -->
     <div
+      #overPanel
       tabindex="-1"
       tnTestIdType="drawer"
       [class]="drawerClasses()"
@@ -61,7 +69,6 @@
       [attr.aria-labelledby]="ariaLabelledby()"
       [tnTestId]="testId()"
       [cdkTrapFocus]="trapFocus()"
-      [cdkTrapFocusAutoCapture]="trapFocus()"
       (keydown)="onKeydown($event)"
       (transitionend)="onTransitionEnd($event)">
       <ng-container *ngTemplateOutlet="drawerContent" />

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -14,6 +14,7 @@ import {
   afterNextRender,
 } from '@angular/core';
 import { tnAccessibleName } from '../a11y/accessible-name';
+import { tnFocusOnOpen } from '../a11y/initial-focus';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 import { tnTransitionLifecycle } from '../utils/transition-lifecycle';
 
@@ -114,6 +115,13 @@ export class TnDrawerComponent implements OnDestroy {
   /** Reference to the overlay element (portaled to body in over mode) */
   protected overlayRef = viewChild<ElementRef>('overlay');
 
+  /**
+   * The `over`-mode panel, which is what focus moves to when a modal drawer
+   * opens. Optional rather than required: it lives inside an `@if` on the mode,
+   * so a `side` drawer never renders it.
+   */
+  private overPanelRef = viewChild<ElementRef<HTMLElement>>('overPanel');
+
   /** Focus trap should be active only in 'over' mode when open */
   protected trapFocus = computed(() => this.mode() === 'over' && this.opened());
 
@@ -168,6 +176,14 @@ export class TnDrawerComponent implements OnDestroy {
   );
 
   constructor() {
+    // Moves focus onto the panel when a MODAL drawer opens (#227) — `trapFocus`
+    // rather than `opened`, because a `side` drawer is navigation the page keeps
+    // beside its content and must not steal focus when it appears. This is the
+    // half `[cdkTrapFocusAutoCapture]` only kept when the drawer happened to
+    // hold a tabbable element; `../a11y/initial-focus.ts` holds the reasoning
+    // and the timing, and `restoreFocus` below is the return leg.
+    tnFocusOnOpen(this.trapFocus, () => this.overPanelRef()?.nativeElement);
+
     // Capture focus before opening in over mode, and restore it on close
     effect(() => {
       const opened = this.opened();

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -4,6 +4,7 @@ import type { OnDestroy } from '@angular/core';
 import {
   Component,
   ElementRef,
+  Injector,
   computed,
   effect,
   inject,
@@ -85,6 +86,9 @@ export class TnDrawerComponent implements OnDestroy {
    * question about both this and `overlayRef`.
    */
   private readonly hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /** For the `afterNextRender` an effect below schedules, outside injection context. */
+  private readonly injector = inject(Injector);
 
   /** Whether the drawer sits alongside content ('side') or overlays it ('over') */
   mode = input<TnDrawerMode>('side');
@@ -233,8 +237,51 @@ export class TnDrawerComponent implements OnDestroy {
         // `over` to `side` WHILE OPEN — a responsive layout crossing its
         // breakpoint — fails the first test without having closed, and would
         // otherwise have focus yanked out of it and back to whatever opened it.
+        // That switch owes a restore only in the one case where the teardown
+        // orphaned focus, which is the effect below, not this branch.
         this.restoreFocus();
       }
+    });
+
+    // A drawer that stops being MODAL while staying open owes the same restore
+    // a close owes, and by the same mechanism: `@if (mode() === 'over')` in the
+    // template destroys the panel that holds focus, which drops it on `<body>`.
+    // Until #227 `CdkTrapFocus.ngOnDestroy` covered this, off the back of the
+    // auto-capture that replaced — the trap was on the destroyed panel, so its
+    // teardown restored. Nothing else does: the close branch above is gated on
+    // `!opened` and the drawer has not closed, and `tnFocusOnOpen` only acts on
+    // an edge INTO modality.
+    //
+    // Read after the render rather than in the effect, because the teardown is
+    // what leaves the evidence, and only when focus was orphaned: `<body>` is
+    // what the browser falls back to when the focused element goes away, and a
+    // user who is somewhere else on the page is not to be moved.
+    let wasModal = false;
+    effect(() => {
+      const modal = this.trapFocus();
+      const lost = wasModal && !modal && this.opened();
+      wasModal = modal;
+      if (!lost) {
+        return;
+      }
+
+      afterNextRender(
+        () => {
+          const active = this.document.activeElement;
+          if (active && active !== this.document.body) {
+            return;
+          }
+
+          // Focused WITHOUT spending the saved element, which is why this is
+          // not `restoreFocus()`. `CdkTrapFocus` held a capture of its own, so
+          // before #227 this switch restored focus AND left the close's restore
+          // owed — two records, one each. There is one now, and both halves
+          // still have to come out of it. `drawer-a11y.spec.ts` asserts the
+          // second half.
+          this.previousFocus?.focus();
+        },
+        { injector: this.injector }
+      );
     });
 
     // Portal overlay to document.body in over mode to avoid clipping

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -222,6 +222,14 @@ export class TnDrawerComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.overlayRef()?.nativeElement?.remove();
+
+    // A drawer destroyed WHILE OPEN never runs the close branch of the effect
+    // above, so the restore has to happen here as well — and removing the
+    // overlay has just dropped focus onto `<body>`. `CdkTrapFocus.ngOnDestroy`
+    // used to cover this case, off the back of the auto-capture that #227
+    // replaced; it is the component's now. A no-op in `side` mode and after an
+    // ordinary close, neither of which leaves a `previousFocus` behind.
+    this.restoreFocus();
   }
 
   /** Open the drawer */

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -1,8 +1,9 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
-import type { ElementRef, OnDestroy } from '@angular/core';
+import type { OnDestroy } from '@angular/core';
 import {
   Component,
+  ElementRef,
   computed,
   effect,
   inject,
@@ -77,6 +78,13 @@ export const TN_DRAWER_DEFAULT_LABEL = 'Drawer';
 })
 export class TnDrawerComponent implements OnDestroy {
   private readonly document = inject(DOCUMENT);
+
+  /**
+   * The host, which contains the `side`-mode panel. The `over`-mode one is
+   * portaled out to `document.body`, so "does this drawer hold focus" is a
+   * question about both this and `overlayRef`.
+   */
+  private readonly hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /** Whether the drawer sits alongside content ('side') or overlays it ('over') */
   mode = input<TnDrawerMode>('side');
@@ -240,18 +248,28 @@ export class TnDrawerComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.overlayRef()?.nativeElement?.remove();
+    const overlay = this.overlayRef()?.nativeElement as HTMLElement | undefined;
 
     // A drawer destroyed WHILE OPEN never runs the close branch of the effect
-    // above, so the restore has to happen here as well — and removing the
-    // overlay has just dropped focus onto `<body>`. `CdkTrapFocus.ngOnDestroy`
-    // used to cover this case, off the back of the auto-capture that #227
-    // replaced; it is the component's now. A no-op unless an `over` open
-    // captured a `previousFocus` that no close has spent — so an ordinary close
-    // and a drawer that has only ever been `side` both reach here with nothing
-    // to do, while one that opened in `over` and was switched to `side` at a
-    // breakpoint still owes the restore, and does it.
-    this.restoreFocus();
+    // above, so the restore has to happen here as well — removing the overlay
+    // drops focus onto `<body>`, and `CdkTrapFocus.ngOnDestroy` used to cover
+    // that off the back of the auto-capture #227 replaced.
+    //
+    // Only when this drawer is what focus is being taken FROM, and read before
+    // the removal, which is the thing that takes it. Both places are asked,
+    // because the `over` panel is portaled out to `<body>` while the `side` one
+    // is inline in the host. Restoring unconditionally moves focus for a user
+    // who is somewhere else entirely — and this component has a standing way to
+    // reach that state: an `over` open captures `previousFocus`, a breakpoint
+    // switches the drawer to `side` without closing it, and the capture is
+    // still unspent however long the user then spends elsewhere on the page.
+    const active = this.document.activeElement;
+    const heldFocus = this.hostRef.nativeElement.contains(active) || !!overlay?.contains(active);
+    overlay?.remove();
+
+    if (heldFocus) {
+      this.restoreFocus();
+    }
   }
 
   /** Open the drawer */

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -227,8 +227,11 @@ export class TnDrawerComponent implements OnDestroy {
     // above, so the restore has to happen here as well — and removing the
     // overlay has just dropped focus onto `<body>`. `CdkTrapFocus.ngOnDestroy`
     // used to cover this case, off the back of the auto-capture that #227
-    // replaced; it is the component's now. A no-op in `side` mode and after an
-    // ordinary close, neither of which leaves a `previousFocus` behind.
+    // replaced; it is the component's now. A no-op unless an `over` open
+    // captured a `previousFocus` that no close has spent — so an ordinary close
+    // and a drawer that has only ever been `side` both reach here with nothing
+    // to do, while one that opened in `over` and was switched to `side` at a
+    // breakpoint still owes the restore, and does it.
     this.restoreFocus();
   }
 

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -42,6 +42,25 @@ export type TnDrawerPosition = 'start' | 'end';
  */
 export const TN_DRAWER_DEFAULT_LABEL = 'Drawer';
 
+/**
+ * A drawer, which is two different things by `mode`: in `side` it is
+ * persistent navigation beside the page's content, and in `over` it is a modal
+ * dialog with focus trapped in it.
+ *
+ * FOCUS ON OPEN, IN `over` MODE ONLY
+ * ----------------------------------
+ * An `over` drawer moves focus to the panel container when it opens, whatever
+ * you projected into it, so that a screen reader announces the dialog it has
+ * just entered before any control in it. A `side` drawer does not: navigation
+ * that appears beside the content must not take focus from the page.
+ *
+ * **`[cdkFocusInitial]` is not honoured** (#227). It used to be, through the
+ * CDK auto-capture this replaced, and `cdkTrapFocus` is still on the panel — so
+ * the marker looks like it should work and does not. To focus a control of your
+ * own, focus it yourself once the drawer is open; the component leaves focus
+ * alone as soon as it is inside the panel. `lib/a11y/initial-focus.ts` holds
+ * the reasoning for capturing the container rather than a control.
+ */
 @Component({
   selector: 'tn-drawer',
   standalone: true,

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-a11y.spec.ts
@@ -37,12 +37,18 @@ import { axeResult } from '../a11y/axe-testing';
  *
  * THE MODEL: MODAL
  * ----------------
- * The panel already trapped focus with `cdkTrapFocus`, auto-captured it on open,
- * closed on Escape and restored focus to the opener on close. `role="dialog"`
- * plus `aria-modal="true"` describes that, so this ticket implements no new
- * contract for it — it makes the existing one nameable and stops it reaching the
- * tab order while closed. Declaring a focus contract and not implementing it is
- * what the ticket calls worse than the current state; this is the other case.
+ * The panel already trapped focus with `cdkTrapFocus`, asked the CDK to capture
+ * it on open, closed on Escape and restored focus to the opener on close.
+ * `role="dialog"` plus `aria-modal="true"` describes that, so this ticket
+ * implements no new contract for it — it makes the existing one nameable and
+ * stops it reaching the tab order while closed. Declaring a focus contract and
+ * not implementing it is what the ticket calls worse than the current state;
+ * this is the other case.
+ *
+ * The capture half of that turned out not to hold: `[cdkTrapFocusAutoCapture]`
+ * did nothing at all for a panel with no tabbable content, and this file's
+ * restoration tests could not see it because they moved focus by hand first.
+ * #227 replaced it and `side-panel-focus-capture.spec.ts` owns it.
  */
 
 @Component({
@@ -145,6 +151,17 @@ describe('tn-side-panel accessibility (#214)', () => {
   function openPanel(): void {
     host.open.set(true);
     fixture.detectChanges();
+  }
+
+  /**
+   * Opens and lets the render settle, which is what runs the `afterNextRender`
+   * the panel defers its focus capture to (#227). The plain `openPanel` above is
+   * enough for the ARIA assertions, which read attributes written during change
+   * detection; anything about focus needs this one.
+   */
+  async function openPanelAndSettle(): Promise<void> {
+    openPanel();
+    await fixture.whenStable();
   }
 
   /** The elements the dialog rules can report on. */
@@ -290,8 +307,9 @@ describe('tn-side-panel accessibility (#214)', () => {
 
     it('raises no violation with no backdrop, which does not change the model', async () => {
       // A panel without a backdrop still traps focus — `cdkTrapFocus` is on the
-      // panel unconditionally and auto-captures on open — so `aria-modal="true"`
-      // still describes it, and the same rules have to run over it.
+      // panel unconditionally, and the component moves focus into it on open —
+      // so `aria-modal="true"` still describes it, and the same rules have to
+      // run over it.
       host.hasBackdrop.set(false);
       openPanel();
 
@@ -365,16 +383,17 @@ describe('tn-side-panel accessibility (#214)', () => {
      * transition fires no event, and the overlay is `inert` from the moment it
      * closes, so waiting for the event would leave focus on `<body>`.
      */
-    it('returns focus to the element that opened it, without waiting for a transition', () => {
+    it('returns focus to the element that opened it, without waiting for a transition', async () => {
       const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
       trigger.focus();
       expect(document.activeElement).toBe(trigger);
 
-      openPanel();
-      // Focus is moved off the trigger the way a real open does, so the
-      // restoration below is restoring something rather than asserting that
-      // focus never moved.
-      (overlay().querySelector('#inside') as HTMLElement).focus();
+      // The open moves focus off the trigger by itself (#227), so this restores
+      // something rather than asserting that focus never moved. It used to be a
+      // `.focus()` call here, with a comment saying that is what a real open
+      // does — and the panel it was standing in for was not doing it.
+      // `side-panel-focus-capture.spec.ts` owns that half.
+      await openPanelAndSettle();
       expect(document.activeElement).not.toBe(trigger);
 
       host.open.set(false);
@@ -383,13 +402,12 @@ describe('tn-side-panel accessibility (#214)', () => {
       expect(document.activeElement).toBe(trigger);
     });
 
-    it('does not restore focus a second time when the close transition ends', () => {
+    it('does not restore focus a second time when the close transition ends', async () => {
       const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
       const other = fixture.nativeElement.querySelector('#external-title') as HTMLElement;
       trigger.focus();
 
-      openPanel();
-      (overlay().querySelector('#inside') as HTMLElement).focus();
+      await openPanelAndSettle();
       host.open.set(false);
       fixture.detectChanges();
       expect(document.activeElement).toBe(trigger);

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -297,6 +297,40 @@ describe('tn-side-panel focus capture (#227)', () => {
   });
 
   /**
+   * A pending retry must not take focus off whatever has since claimed it.
+   *
+   * The case that matters is a SECOND modal surface opening inside the window —
+   * a nested panel, or a dialog raised from this one. Its own capture succeeds,
+   * and this panel's retry would then take focus straight back off it on the
+   * next frame, out of a surface the user has already moved on to. It is staged
+   * here as focus simply arriving somewhere else, because what the retry can
+   * see is only that focus is no longer where it was entitled to take it from.
+   */
+  it('gives up when focus has moved somewhere it has no claim on', async () => {
+    const target = panel();
+    jest.spyOn(target, 'focus').mockImplementation(() => undefined);
+
+    const pending: FrameRequestCallback[] = [];
+    jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+      pending.push(callback);
+      return pending.length;
+    });
+
+    trigger().focus();
+    await openByClick();
+    expect(pending).toHaveLength(1);
+
+    const elsewhere = fixture.nativeElement.querySelector('#elsewhere') as HTMLElement;
+    elsewhere.focus();
+
+    pending.shift()?.(0);
+
+    expect(document.activeElement).toBe(elsewhere);
+    // And it stopped: no further frame was asked for.
+    expect(pending).toHaveLength(0);
+  });
+
+  /**
    * The retry has to stop. A panel still refusing focus a full transition after
    * it opened is not mid-anything, and a callback that re-arms itself forever
    * is a leak on every open.

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -147,12 +147,16 @@ describe('tn-side-panel focus capture (#227)', () => {
    * close button instead would still satisfy the two tests above; this is the
    * one that says which was chosen.
    */
-  it('focuses the panel container itself, which is what names the dialog', async () => {
+  it('focuses the panel container itself, inside the element that names the dialog', async () => {
     await openByClick();
 
     expect(document.activeElement).toBe(panel());
     expect(panel().getAttribute('tabindex')).toBe('-1');
+    // The role, the modal flag and the name are on the OVERLAY here — the panel
+    // is a child of it, so focus landing on the panel is focus landing in the
+    // dialog, with no control of its own claiming the announcement.
     expect(overlay().getAttribute('aria-modal')).toBe('true');
+    expect(overlay().contains(panel())).toBe(true);
   });
 
   it('leaves focus alone while the panel stays closed', async () => {
@@ -215,5 +219,22 @@ describe('tn-side-panel focus capture (#227)', () => {
     fixture.detectChanges();
 
     expect(document.activeElement).toBe(trigger());
+  });
+
+  /**
+   * Destroying a panel that is still open — a `@if` around it, a route change —
+   * is the other way focus leaves it, and it runs no close. The removal drops
+   * focus on `<body>`, and until #227 it was `CdkTrapFocus.ngOnDestroy` that
+   * put it back, off the back of the auto-capture that replaced.
+   */
+  it('returns focus to the trigger when a panel is destroyed while open', async () => {
+    trigger().focus();
+    const opener = trigger();
+    await openByClick();
+    expect(document.activeElement).not.toBe(opener);
+
+    fixture.destroy();
+
+    expect(document.activeElement).toBe(opener);
   });
 });

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -89,6 +89,10 @@ describe('tn-side-panel focus capture (#227)', () => {
     // The overlay is portaled to document.body and only removed on destroy, so
     // without this the next fixture in this file finds the previous one's panel.
     fixture.destroy();
+    // Several tests below stub `focus` or `requestAnimationFrame` to stage a
+    // browser that declines a call. A stub that outlived its test would stage
+    // it for every test after it too.
+    jest.restoreAllMocks();
   });
 
   function overlay(): HTMLElement {
@@ -233,31 +237,57 @@ describe('tn-side-panel focus capture (#227)', () => {
    * The retry re-attempts until the move takes — and "focus is inside the
    * panel" is the move having taken, whoever put it there. A caller focusing
    * the first field of their form, or a user who has started typing in one,
-   * must not be pulled back to the container on the next frame.
+   * must not be pulled back to the container by a pending retry.
    *
-   * Staged like the test above: the component's own call goes nowhere, so a
-   * retry is pending when focus arrives inside by another route.
+   * TWO THINGS THIS TEST HAS TO GET RIGHT TO BE ABLE TO FAIL
+   * -------------------------------------------------------
+   * The retry's `focus()` must be REAL. Stubbing it for the whole test makes
+   * the final assertion true by construction — nothing is left that could move
+   * focus — and the test then passes with the guard deleted, which is what an
+   * earlier version of it did. So exactly the FIRST call is declined, to leave
+   * a retry pending, and every call after it goes through.
+   *
+   * And the retry must run at a known moment. `requestAnimationFrame` is
+   * stubbed to hand the callback back rather than schedule it, so the frame
+   * lands after the close button has taken focus rather than racing it —
+   * jsdom is otherwise free to serve a frame inside `whenStable`, and does.
    */
   it('leaves focus alone when it is already inside the panel', async () => {
-    trigger().focus();
     const target = panel();
-    let dropped = false;
+    const reallyFocus = HTMLElement.prototype.focus.bind(target);
+    let attempts = 0;
     jest.spyOn(target, 'focus').mockImplementation(() => {
-      dropped = true;
+      attempts++;
+      if (attempts > 1) {
+        reallyFocus();
+      }
     });
 
+    const pending: FrameRequestCallback[] = [];
+    jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+      pending.push(callback);
+      return pending.length;
+    });
+
+    trigger().focus();
     await openByClick();
-    expect(dropped).toBe(true);
+
+    // The component asked once, was declined, and has a retry waiting.
+    expect(attempts).toBe(1);
+    expect(pending).toHaveLength(1);
 
     (overlay().querySelector('.tn-icon-button') as HTMLElement).focus();
     const landed = document.activeElement;
     expect(target.contains(landed)).toBe(true);
     expect(landed).not.toBe(target);
 
-    await nextFrame();
-    await nextFrame();
+    pending.shift()?.(0);
 
+    // The retry saw focus already inside and did not spend its call. Reading
+    // that AFTER focusing, or comparing with `===` instead of `contains`,
+    // moves focus to the container here.
     expect(document.activeElement).toBe(landed);
+    expect(attempts).toBe(1);
   });
 
   /**

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -119,6 +119,15 @@ describe('tn-side-panel focus capture (#227)', () => {
     await fixture.whenStable();
   }
 
+  /**
+   * Lets one animation frame pass, which is what the capture's retry waits for.
+   * Our own callback is queued after it, so by the time this resolves the
+   * re-attempt has already run.
+   */
+  function nextFrame(): Promise<void> {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  }
+
   it('moves focus into the panel, for a panel whose only control is its × button', async () => {
     trigger().focus();
     expect(document.activeElement).toBe(trigger());
@@ -181,6 +190,68 @@ describe('tn-side-panel focus capture (#227)', () => {
     await openByClick();
 
     expect(document.activeElement).toBe(panel());
+  });
+
+  /**
+   * `focus()` is a request the browser may decline in silence, and CI measured
+   * it declining one: with the capture as a single deferred call, this panel
+   * opened with focus still on the trigger in Chromium while the panel
+   * containing a form captured normally. `../a11y/initial-focus.ts` therefore
+   * reads the move back and re-attempts it on animation frames.
+   *
+   * The decline is staged here rather than reproduced, because jsdom has no
+   * notion of an element being unfocusable for a moment — what is asserted is
+   * that a dropped first call is noticed and followed, which is the part that
+   * was missing.
+   */
+  it('tries again on the next frame when the first focus is silently dropped', async () => {
+    trigger().focus();
+    const target = panel();
+    const reallyFocus = HTMLElement.prototype.focus.bind(target);
+    let dropped = false;
+    jest.spyOn(target, 'focus').mockImplementation(() => {
+      // Exactly one call goes nowhere, the way the browser declines one.
+      if (!dropped) {
+        dropped = true;
+        return;
+      }
+      reallyFocus();
+    });
+
+    await openByClick();
+    expect(dropped).toBe(true);
+    expect(document.activeElement).not.toBe(target);
+
+    await nextFrame();
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  /**
+   * The retry has to stop. A panel still refusing focus a full transition after
+   * it opened is not mid-anything, and a callback that re-arms itself forever
+   * is a leak on every open.
+   *
+   * Asserted as "the attempts plateau" rather than against the frame budget
+   * itself, so that tuning the budget does not rewrite the test that says it
+   * terminates.
+   */
+  it('gives up rather than re-attempting forever', async () => {
+    trigger().focus();
+    const target = panel();
+    const focusSpy = jest.spyOn(target, 'focus').mockImplementation(() => undefined);
+
+    await openByClick();
+    for (let i = 0; i < 40; i++) {
+      await nextFrame();
+    }
+    const settled = focusSpy.mock.calls.length;
+
+    for (let i = 0; i < 10; i++) {
+      await nextFrame();
+    }
+
+    expect(focusSpy.mock.calls.length).toBe(settled);
   });
 
   /**

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -204,27 +204,60 @@ describe('tn-side-panel focus capture (#227)', () => {
    * that a dropped first call is noticed and followed, which is the part that
    * was missing.
    */
-  it('tries again on the next frame when the first focus is silently dropped', async () => {
+  it('tries again after a first focus that is silently dropped', async () => {
     trigger().focus();
     const target = panel();
     const reallyFocus = HTMLElement.prototype.focus.bind(target);
+    let attempts = 0;
+    jest.spyOn(target, 'focus').mockImplementation(() => {
+      attempts++;
+      // Exactly the first call goes nowhere, the way the browser declines one.
+      if (attempts > 1) {
+        reallyFocus();
+      }
+    });
+
+    await openByClick();
+    await nextFrame();
+
+    // Both halves matter, and neither on its own would fail against a single
+    // undeferred call: the count says a second attempt was made, and the
+    // active element says it was the attempt that worked. Which frame the
+    // retry lands on is not asserted — jsdom is free to serve one during
+    // `whenStable`, and it does, intermittently.
+    expect(attempts).toBeGreaterThan(1);
+    expect(document.activeElement).toBe(target);
+  });
+
+  /**
+   * The retry re-attempts until the move takes — and "focus is inside the
+   * panel" is the move having taken, whoever put it there. A caller focusing
+   * the first field of their form, or a user who has started typing in one,
+   * must not be pulled back to the container on the next frame.
+   *
+   * Staged like the test above: the component's own call goes nowhere, so a
+   * retry is pending when focus arrives inside by another route.
+   */
+  it('leaves focus alone when it is already inside the panel', async () => {
+    trigger().focus();
+    const target = panel();
     let dropped = false;
     jest.spyOn(target, 'focus').mockImplementation(() => {
-      // Exactly one call goes nowhere, the way the browser declines one.
-      if (!dropped) {
-        dropped = true;
-        return;
-      }
-      reallyFocus();
+      dropped = true;
     });
 
     await openByClick();
     expect(dropped).toBe(true);
-    expect(document.activeElement).not.toBe(target);
+
+    (overlay().querySelector('.tn-icon-button') as HTMLElement).focus();
+    const landed = document.activeElement;
+    expect(target.contains(landed)).toBe(true);
+    expect(landed).not.toBe(target);
 
     await nextFrame();
+    await nextFrame();
 
-    expect(document.activeElement).toBe(target);
+    expect(document.activeElement).toBe(landed);
   });
 
   /**
@@ -242,14 +275,24 @@ describe('tn-side-panel focus capture (#227)', () => {
     const focusSpy = jest.spyOn(target, 'focus').mockImplementation(() => undefined);
 
     await openByClick();
-    for (let i = 0; i < 40; i++) {
-      await nextFrame();
-    }
-    const settled = focusSpy.mock.calls.length;
 
-    for (let i = 0; i < 10; i++) {
+    // Run frames until a frame passes with no new attempt. Capped so that a
+    // capture which never gives up fails this test rather than hanging it, and
+    // counted in frames rather than assumed, because how long the window is
+    // worth in frames depends on how fast jsdom serves them.
+    const cap = 200;
+    let frames = 0;
+    let previous = -1;
+    while (focusSpy.mock.calls.length !== previous && frames < cap) {
+      previous = focusSpy.mock.calls.length;
       await nextFrame();
+      frames++;
     }
+    expect(frames).toBeLessThan(cap);
+
+    const settled = focusSpy.mock.calls.length;
+    await nextFrame();
+    await nextFrame();
 
     expect(focusSpy.mock.calls.length).toBe(settled);
   });

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -1,0 +1,219 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnSidePanelComponent } from './side-panel.component';
+
+/**
+ * Guards the half of the modal focus contract that opening a panel owes (#227):
+ * focus must be INSIDE the panel once it is open.
+ *
+ * WHAT WAS REPORTED
+ * -----------------
+ * Driving Storybook in a real browser, `side-panel--default` opened with
+ * `document.activeElement` still on the trigger behind it — 800ms after the
+ * click, well past the transition. `side-panel--with-actions`, which has a form
+ * in it, captured focus normally. `aria-modal="true"` had meanwhile told
+ * assistive technology to ignore everything outside the dialog, so the listener
+ * was left on a control their screen reader had just been told does not exist
+ * (WCAG 2.4.3, Focus Order).
+ *
+ * WHY NO SPEC CAUGHT IT
+ * ---------------------
+ * `side-panel-a11y.spec.ts` asserted focus RESTORATION, and to have something to
+ * restore it moved focus into the panel by hand — `(overlay().querySelector(
+ * '#inside')).focus()` — with a comment saying that is what a real open does.
+ * Nothing asserted it. Every focus assertion in that file sat downstream of that
+ * call, so the suite stayed green while `--default` captured nothing at all.
+ * Those two tests no longer call `.focus()`; they open the panel and let the
+ * component move focus, which is what makes them able to fail.
+ *
+ * WHAT JSDOM CAN AND CANNOT SHOW HERE
+ * -----------------------------------
+ * These assertions are meaningful under jsdom only because the fix does not
+ * depend on layout. The OLD path, `[cdkTrapFocusAutoCapture]`, searched the
+ * panel for the first element the CDK's `InteractivityChecker` calls tabbable,
+ * and that test reads `offsetWidth` / `getClientRects()` — which jsdom reports
+ * as zero and empty for everything. Measured on the unfixed component: focus
+ * stayed on the trigger under plain jsdom, and moved to the × button as soon as
+ * `getClientRects` was stubbed to return a rect. So jsdom failed that path
+ * unconditionally and passed it with a one-line stub, which is why it could
+ * neither reproduce the browser's behaviour nor be trusted about it.
+ *
+ * What is asserted below is the component's own guarantee: on open it focuses
+ * the panel container, which exists whatever the caller projected. The
+ * browser-level statement — that a real user clicking a real trigger ends up
+ * inside the dialog — is asserted where a browser runs it, in the `play`
+ * functions on `Default` and `WithActions` in `side-panel.stories.ts`, which CI
+ * runs under Playwright.
+ */
+
+@Component({
+  selector: 'tn-side-panel-focus-host',
+  standalone: true,
+  imports: [TnSidePanelComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger" (click)="open.set(true)">Open</button>
+    <tn-side-panel title="Edit dataset" [(open)]="open">
+      <p>Panel body</p>
+      @if (withForm()) {
+        <input id="name" type="text" />
+      }
+    </tn-side-panel>
+  `,
+})
+class SidePanelFocusHostComponent {
+  open = signal(false);
+  /**
+   * The two shapes the report distinguished: a panel whose only tabbable is its
+   * own × button, and one with a form in it. Both must end with focus inside.
+   */
+  withForm = signal(false);
+}
+
+describe('tn-side-panel focus capture (#227)', () => {
+  let fixture: ComponentFixture<SidePanelFocusHostComponent>;
+  let host: SidePanelFocusHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SidePanelFocusHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SidePanelFocusHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // The overlay is portaled to document.body and only removed on destroy, so
+    // without this the next fixture in this file finds the previous one's panel.
+    fixture.destroy();
+  });
+
+  function overlay(): HTMLElement {
+    return document.body.querySelector('.tn-side-panel__overlay') as HTMLElement;
+  }
+
+  function panel(): HTMLElement {
+    return overlay().querySelector('.tn-side-panel__panel') as HTMLElement;
+  }
+
+  function trigger(): HTMLElement {
+    return fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+  }
+
+  /**
+   * Opens the panel the way the user does — through the trigger's click handler
+   * — and settles the render. NOTHING here touches focus: the component moving
+   * it is the whole assertion.
+   *
+   * `whenStable()` is what runs the `afterNextRender` the focus is deferred to.
+   * That deferral is not an implementation detail to work around: a closed panel
+   * is `inert`, and focusing into an inert subtree does nothing, so the focus
+   * has to wait for the pass that removes the attribute to have written it.
+   */
+  async function openByClick(): Promise<void> {
+    trigger().click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  it('moves focus into the panel, for a panel whose only control is its × button', async () => {
+    trigger().focus();
+    expect(document.activeElement).toBe(trigger());
+
+    await openByClick();
+
+    expect(panel().contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).not.toBe(trigger());
+  });
+
+  it('moves focus into the panel when it contains a form', async () => {
+    host.withForm.set(true);
+    fixture.detectChanges();
+    trigger().focus();
+
+    await openByClick();
+
+    expect(panel().contains(document.activeElement)).toBe(true);
+  });
+
+  /**
+   * WHICH element, said out loud: the panel container, not its first tabbable.
+   * `../a11y/initial-focus.ts` holds the reasoning — it is the only target that
+   * exists whatever the caller projected, and a screen reader announces the
+   * dialog's name and role from it. A future change that moves focus to the
+   * close button instead would still satisfy the two tests above; this is the
+   * one that says which was chosen.
+   */
+  it('focuses the panel container itself, which is what names the dialog', async () => {
+    await openByClick();
+
+    expect(document.activeElement).toBe(panel());
+    expect(panel().getAttribute('tabindex')).toBe('-1');
+    expect(overlay().getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('leaves focus alone while the panel stays closed', async () => {
+    trigger().focus();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  /**
+   * The panel with nothing tabbable in it at all — no projected control, and the
+   * × button reduced to a non-tabbable element. This is the case the old path
+   * could not serve even in a browser: `focusFirstTabbableElement()` finds
+   * nothing, returns `false`, and nobody reads the `false`.
+   */
+  it('still moves focus in when the panel holds no tabbable element', async () => {
+    trigger().focus();
+    const closeButton = overlay().querySelector('.tn-icon-button') as HTMLElement;
+    closeButton.tabIndex = -1;
+
+    await openByClick();
+
+    expect(document.activeElement).toBe(panel());
+  });
+
+  /**
+   * Reopening after a close, because the effect that drives this only acts on a
+   * change INTO the open state — a second open is a second change, and a panel
+   * that captures once and never again is the same defect with a longer path to
+   * it.
+   */
+  it('captures again on a second open', async () => {
+    trigger().focus();
+    await openByClick();
+    expect(document.activeElement).toBe(panel());
+
+    host.open.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(document.activeElement).toBe(trigger());
+
+    await openByClick();
+
+    expect(document.activeElement).toBe(panel());
+  });
+
+  /**
+   * Capture and restoration are one contract read in two directions, and this is
+   * the version of the restoration test that does not stage its own precondition
+   * — the panel captures focus, the close puts it back, and neither step is the
+   * spec's doing.
+   */
+  it('returns focus to the trigger on close, having really taken it away', async () => {
+    trigger().focus();
+    await openByClick();
+    expect(document.activeElement).not.toBe(trigger());
+
+    host.open.set(false);
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(trigger());
+  });
+});

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -54,6 +54,12 @@ import { TnSidePanelComponent } from './side-panel.component';
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <button type="button" id="trigger" (click)="open.set(true)">Open</button>
+    <!--
+      Somewhere else on the page to be. A panel with no backdrop does not stop
+      the user reaching this while it is open, and where focus is when the panel
+      goes away decides whether the panel owes them a restore.
+    -->
+    <button type="button" id="elsewhere">Elsewhere</button>
     <tn-side-panel title="Edit dataset" [(open)]="open">
       <p>Panel body</p>
       @if (withForm()) {
@@ -380,5 +386,31 @@ describe('tn-side-panel focus capture (#227)', () => {
     fixture.destroy();
 
     expect(document.activeElement).toBe(opener);
+  });
+
+  /**
+   * The other half of that, and the half a restore-on-destroy gets wrong if it
+   * is unconditional: a restore is owed only when the destruction is what took
+   * the focus away.
+   *
+   * `hasBackdrop=false` is a supported configuration and does not stop the user
+   * reaching the page behind an open panel. Someone who has clicked into a
+   * field back there, and whose panel is then destroyed by a route change,
+   * would be thrown out of what they were typing in and back to a trigger they
+   * left minutes ago — a worse version of the bug this ticket is about, because
+   * this one moves focus while they are using the page rather than merely
+   * failing to.
+   */
+  it('leaves focus alone when a panel destroyed while open did not hold it', async () => {
+    trigger().focus();
+    await openByClick();
+
+    const elsewhere = fixture.nativeElement.querySelector('#elsewhere') as HTMLElement;
+    elsewhere.focus();
+    expect(document.activeElement).toBe(elsewhere);
+
+    fixture.destroy();
+
+    expect(document.activeElement).toBe(elsewhere);
   });
 });

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
@@ -40,13 +40,20 @@
     </div>
   }
 
-  <!-- Panel -->
+  <!--
+    Panel. `cdkTrapFocus` keeps Tab inside it while it is open; what moves focus
+    IN on open is `tnFocusOnOpen` in the component, not
+    `[cdkTrapFocusAutoCapture]`, which used to be here and could silently do
+    nothing (#227). `tabindex="-1"` is what makes this element the target it
+    focuses — see `../a11y/initial-focus.ts` for why the container and not the
+    first control inside it.
+  -->
   <div
+    #panel
     class="tn-side-panel__panel"
     tabindex="-1"
     cdkTrapFocus
     [style.width]="width()"
-    [cdkTrapFocusAutoCapture]="open()"
     (transitionend)="onTransitionEnd($event)"
     (keydown)="onKeydown($event)">
 

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -271,15 +271,26 @@ export class TnSidePanelComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.overlayRef().nativeElement.remove();
+    const overlay = this.overlayRef().nativeElement as HTMLElement;
 
     // A panel destroyed WHILE OPEN never runs the close branch of the effect
-    // above, so the restore has to happen here as well — and removing the
-    // overlay has just dropped focus onto `<body>`. `CdkTrapFocus.ngOnDestroy`
-    // used to cover this case, off the back of the auto-capture that #227
-    // replaced; it is the component's now. A no-op after an ordinary close,
-    // which clears `previouslyFocusedElement`.
-    this.restoreFocus();
+    // above, so the restore has to happen here as well — removing the overlay
+    // drops focus onto `<body>`, and `CdkTrapFocus.ngOnDestroy` used to cover
+    // that off the back of the auto-capture #227 replaced.
+    //
+    // Only when this panel is what focus is being taken FROM, and read before
+    // the removal, which is the thing that takes it. Restoring unconditionally
+    // moves focus for a user who is somewhere else entirely: a panel with
+    // `hasBackdrop=false` does not stop them clicking into the page behind it,
+    // and destroying it would then yank them out of whatever they were typing
+    // in and back to a trigger they left minutes ago. A no-op after an
+    // ordinary close either way, which clears `previouslyFocusedElement`.
+    const heldFocus = overlay.contains(this.document.activeElement);
+    overlay.remove();
+
+    if (heldFocus) {
+      this.restoreFocus();
+    }
   }
 
   protected dismiss(): void {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -69,6 +69,23 @@ export class TnSidePanelActionDirective {}
 })
 export class TnSidePanelHeaderActionDirective {}
 
+/**
+ * A modal side panel: `role="dialog"` with `aria-modal="true"`, focus trapped
+ * while it is open and restored to the opener when it closes.
+ *
+ * FOCUS ON OPEN
+ * -------------
+ * Opening moves focus to the panel container, whatever you projected into it,
+ * so that a screen reader announces the dialog it has just entered before any
+ * control in it. The first Tab then reaches the close button.
+ *
+ * **`[cdkFocusInitial]` is not honoured** (#227). It used to be, through the
+ * CDK auto-capture this replaced, and `cdkTrapFocus` is still on the panel — so
+ * the marker looks like it should work and does not. To focus a control of your
+ * own, focus it yourself once the panel is open; the component leaves focus
+ * alone as soon as it is inside the panel. `lib/a11y/initial-focus.ts` holds
+ * the reasoning for capturing the container rather than a control.
+ */
 @Component({
   selector: 'tn-side-panel',
   standalone: true,

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -255,6 +255,14 @@ export class TnSidePanelComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.overlayRef().nativeElement.remove();
+
+    // A panel destroyed WHILE OPEN never runs the close branch of the effect
+    // above, so the restore has to happen here as well — and removing the
+    // overlay has just dropped focus onto `<body>`. `CdkTrapFocus.ngOnDestroy`
+    // used to cover this case, off the back of the auto-capture that #227
+    // replaced; it is the component's now. A no-op after an ordinary close,
+    // which clears `previouslyFocusedElement`.
+    this.restoreFocus();
   }
 
   protected dismiss(): void {

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -10,6 +10,7 @@ import { mdiClose } from '@mdi/js';
 import { take } from 'rxjs';
 import type { Observable } from 'rxjs';
 import { tnAccessibleName } from '../a11y/accessible-name';
+import { tnFocusOnOpen } from '../a11y/initial-focus';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
@@ -85,6 +86,7 @@ export class TnSidePanelComponent implements OnDestroy {
   private destroyRef = inject(DestroyRef);
 
   private overlayRef = viewChild.required<ElementRef>('overlay');
+  private panelRef = viewChild.required<ElementRef<HTMLElement>>('panel');
   protected initialized = signal(false);
 
   // Two-way bindable via [(open)]
@@ -220,6 +222,14 @@ export class TnSidePanelComponent implements OnDestroy {
 
   constructor() {
     this.registerMdiIcons();
+
+    // Moves focus onto the panel when it opens (#227) — the other half of the
+    // focus contract `aria-modal="true"` declares, and the half
+    // `[cdkTrapFocusAutoCapture]` only kept when the panel happened to contain a
+    // tabbable element, which the default panel, whose only control is its own ×
+    // button, did not. `../a11y/initial-focus.ts` holds the reasoning and the
+    // timing; `restoreFocus` below is the return leg.
+    tnFocusOnOpen(this.open, () => this.panelRef().nativeElement);
 
     effect(() => {
       if (this.open()) {

--- a/projects/truenas-ui/src/stories/drawer.stories.ts
+++ b/projects/truenas-ui/src/stories/drawer.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expectOpeningMovesFocusInside } from './focus-capture';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
@@ -156,26 +156,17 @@ export const OverMode: Story = {
 
   /**
    * An `over` drawer is a modal dialog, so opening one must put focus inside it
-   * (#227). Asserted here rather than only in Jest because whether a real click
-   * ends up inside the panel depends on layout, the transition and `inert` —
-   * none of which jsdom implements. The panel is portaled to `document.body`, so
-   * it is found from the document rather than from `canvasElement`.
+   * (#227) — and this is the shape with nothing tabbable in it at all: the nav
+   * entries are `<a>` elements with no `href`. It failed in CI against the
+   * first version of the fix. `focus-capture.ts` holds the assertion, shared
+   * with `tn-side-panel`, whose bug this component has now repeated for the
+   * third time.
+   *
+   * Unlike the side panel, `role="dialog"` and `aria-modal` sit on the PANEL
+   * here rather than on a wrapping overlay, so the panel is the dialog.
    */
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
-
-    trigger.focus();
-    await userEvent.click(trigger);
-
-    const panel = document.querySelector('.tn-drawer__panel--over') as HTMLElement;
-    await expect(panel).toBeInTheDocument();
-
-    await waitFor(async () => {
-      await expect(panel.getAttribute('aria-modal')).toBe('true');
-      await expect(panel.contains(document.activeElement)).toBe(true);
-      await expect(document.activeElement).not.toBe(trigger);
-    });
+    await expectOpeningMovesFocusInside(canvasElement, 'Open Drawer', '.tn-drawer__panel--over');
   },
 };
 

--- a/projects/truenas-ui/src/stories/drawer.stories.ts
+++ b/projects/truenas-ui/src/stories/drawer.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
@@ -152,6 +153,30 @@ export const OverMode: Story = {
       imports: sharedImports,
     },
   }),
+
+  /**
+   * An `over` drawer is a modal dialog, so opening one must put focus inside it
+   * (#227). Asserted here rather than only in Jest because whether a real click
+   * ends up inside the panel depends on layout, the transition and `inert` —
+   * none of which jsdom implements. The panel is portaled to `document.body`, so
+   * it is found from the document rather than from `canvasElement`.
+   */
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
+
+    trigger.focus();
+    await userEvent.click(trigger);
+
+    const panel = document.querySelector('.tn-drawer__panel--over') as HTMLElement;
+    await expect(panel).toBeInTheDocument();
+
+    await waitFor(async () => {
+      await expect(panel.getAttribute('aria-modal')).toBe('true');
+      await expect(panel.contains(document.activeElement)).toBe(true);
+      await expect(document.activeElement).not.toBe(trigger);
+    });
+  },
 };
 
 export const EndPosition: Story = {

--- a/projects/truenas-ui/src/stories/focus-capture.ts
+++ b/projects/truenas-ui/src/stories/focus-capture.ts
@@ -42,17 +42,33 @@ export async function expectOpeningMovesFocusInside(
   trigger.focus();
   await userEvent.click(trigger);
 
-  const dialog = document.querySelector(dialogSelector) as HTMLElement | null;
-  await expect(dialog, `no element matched ${dialogSelector} after the click`).toBeInTheDocument();
+  const dialog = document.querySelector(dialogSelector);
+  // Thrown rather than asserted. `toBeInTheDocument()` on a `null` throws out
+  // of jest-dom's own type check before it reaches a matcher, taking the
+  // message with it — so the one assertion whose failure needs explaining is
+  // the one that cannot carry an explanation.
+  if (!(dialog instanceof HTMLElement)) {
+    throw new Error(`no element matched ${dialogSelector} after clicking the trigger`);
+  }
 
   await waitFor(async () => {
-    // Read first, so that both assertions below describe the SAME instant. The
-    // dialog check also proves the element found above is this story's open
-    // panel rather than a stale one left in the document by another story.
+    // Read once, so that every assertion below describes the SAME instant.
     const active = document.activeElement;
-    const modal = dialog?.getAttribute('aria-modal');
+    const modal = dialog.getAttribute('aria-modal');
 
+    // Also proves the element found above is this story's OPEN panel rather
+    // than a stale one another story left in the document.
     await expect(modal, `${dialogSelector} did not open: aria-modal is ${describe(modal)}`).toBe('true');
+
+    // Ordered before the `contains` check below, not after it, because both
+    // fail together in the case that matters and this one names it: the
+    // trigger sits in the canvas and the dialog is portaled to `document.body`,
+    // so focus being inside the dialog already implies it is not on the
+    // trigger. Read the other way round it is an assertion that cannot fail.
+    await expect(
+      active === trigger,
+      `focus never left the trigger, ${describeElement(trigger)}`
+    ).toBe(false);
 
     // The assertion the ticket measured as false. It failed in CI reading
     // "expected false to be true" and naming neither element, which is why it
@@ -60,20 +76,15 @@ export async function expectOpeningMovesFocusInside(
     // whole round to find out, and this file exists because of a test that
     // looked like it had checked something.
     await expect(
-      dialog?.contains(active),
+      dialog.contains(active),
       `focus is on ${describeElement(active)}, outside the open ${dialogSelector}`
     ).toBe(true);
-
-    await expect(
-      active === trigger,
-      `focus never left the trigger, ${describeElement(trigger)}`
-    ).toBe(false);
   });
 }
 
-/** `null` and `undefined` are the two answers worth telling apart in a message. */
-function describe(value: string | null | undefined): string {
-  return value === null ? 'absent' : value === undefined ? 'unreadable' : `"${value}"`;
+/** An absent attribute and an empty one read the same way otherwise. */
+function describe(value: string | null): string {
+  return value === null ? 'absent' : `"${value}"`;
 }
 
 /**

--- a/projects/truenas-ui/src/stories/focus-capture.ts
+++ b/projects/truenas-ui/src/stories/focus-capture.ts
@@ -1,0 +1,104 @@
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+/**
+ * The browser half of #227: opening a modal surface must put focus inside it.
+ *
+ * WHY THIS RUNS HERE AND NOT ONLY IN JEST
+ * ---------------------------------------
+ * A unit spec can assert what the component does — it calls `focus()` on the
+ * panel container, and `side-panel-focus-capture.spec.ts` and
+ * `drawer-focus-capture.spec.ts` own that. It cannot assert that the browser
+ * HONOURED the call: `focus()` reports nothing and is declined silently when
+ * the element is not focusable at that instant, and jsdom implements none of
+ * the layout, transition or `inert` behaviour that decides it. The reported
+ * symptom was invisible to the whole Jest suite and visible on the first click
+ * in a browser.
+ *
+ * WHY ONE FUNCTION FOR BOTH COMPONENTS
+ * ------------------------------------
+ * `tn-drawer` was written from `tn-side-panel` and the two have now reached
+ * identical bugs three times (#214, #218, #227) — the ticket says so itself.
+ * The fix is shared (`lib/a11y/initial-focus.ts`), so the browser assertion
+ * over it is too, and neither can be tightened without the other.
+ *
+ * Both panels are portaled to `document.body`, so the dialog is found from the
+ * document rather than from `canvasElement`.
+ *
+ * @param canvasElement The story root, which holds the trigger.
+ * @param triggerName Accessible name of the button that opens the surface.
+ * @param dialogSelector The element carrying `role="dialog"` and `aria-modal`.
+ *   That is the overlay in `tn-side-panel` and the panel itself in `tn-drawer`,
+ *   and it is what focus has to end up inside: `aria-modal="true"` tells
+ *   assistive technology to ignore everything outside THIS element.
+ */
+export async function expectOpeningMovesFocusInside(
+  canvasElement: HTMLElement,
+  triggerName: string | RegExp,
+  dialogSelector: string
+): Promise<void> {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole('button', { name: triggerName });
+
+  trigger.focus();
+  await userEvent.click(trigger);
+
+  const dialog = document.querySelector(dialogSelector) as HTMLElement | null;
+  await expect(dialog, `no element matched ${dialogSelector} after the click`).toBeInTheDocument();
+
+  await waitFor(async () => {
+    // Read first, so that both assertions below describe the SAME instant. The
+    // dialog check also proves the element found above is this story's open
+    // panel rather than a stale one left in the document by another story.
+    const active = document.activeElement;
+    const modal = dialog?.getAttribute('aria-modal');
+
+    await expect(modal, `${dialogSelector} did not open: aria-modal is ${describe(modal)}`).toBe('true');
+
+    // The assertion the ticket measured as false. It failed in CI reading
+    // "expected false to be true" and naming neither element, which is why it
+    // carries a message: a focus test that cannot say WHERE focus went costs a
+    // whole round to find out, and this file exists because of a test that
+    // looked like it had checked something.
+    await expect(
+      dialog?.contains(active),
+      `focus is on ${describeElement(active)}, outside the open ${dialogSelector}`
+    ).toBe(true);
+
+    await expect(
+      active === trigger,
+      `focus never left the trigger, ${describeElement(trigger)}`
+    ).toBe(false);
+  });
+}
+
+/** `null` and `undefined` are the two answers worth telling apart in a message. */
+function describe(value: string | null | undefined): string {
+  return value === null ? 'absent' : value === undefined ? 'unreadable' : `"${value}"`;
+}
+
+/**
+ * Enough of an element to recognise it in a CI log — tag, id, classes, and the
+ * accessible name where the usual sources carry one. Deliberately not
+ * `outerHTML`: a panel's worth of markup in an assertion message buries the
+ * one element the message is about.
+ */
+function describeElement(element: Element | null): string {
+  if (!element) {
+    return 'nothing (document.activeElement is null)';
+  }
+
+  const parts = [element.tagName.toLowerCase()];
+  if (element.id) {
+    parts.push(`#${element.id}`);
+  }
+  if (element.classList.length) {
+    parts.push(`.${Array.from(element.classList).join('.')}`);
+  }
+
+  const name = element.getAttribute('aria-label') ?? element.textContent?.trim();
+  if (name) {
+    parts.push(` "${name.slice(0, 40)}"`);
+  }
+
+  return parts.join('');
+}

--- a/projects/truenas-ui/src/stories/side-panel.stories.ts
+++ b/projects/truenas-ui/src/stories/side-panel.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expectOpeningMovesFocusInside } from './focus-capture';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
 import { tnIconMarker } from '../lib/icon/icon-marker';
@@ -17,39 +17,11 @@ const rowStyle = 'display: flex; justify-content: space-between; align-items: ce
 const textareaStyle = 'width: 100%; padding: 10px 12px; border: 1px solid var(--tn-lines); border-radius: 4px; background: var(--tn-bg1); color: var(--tn-fg1); box-sizing: border-box; font-size: 1rem; font-family: inherit; resize: vertical; min-height: 80px;';
 
 /**
- * Opens a panel by clicking its trigger and asserts that focus ends up inside
- * it — the browser half of #227, where the defect was found and where jsdom
- * cannot follow.
- *
- * A unit spec can only assert what the component does (it focuses the panel
- * container; `side-panel-focus-capture.spec.ts` owns that). Whether a real user
- * clicking a real trigger ends up inside the dialog depends on layout, the CSS
- * transition and `inert`, none of which jsdom implements — the reported symptom
- * was invisible to the whole Jest suite and visible on the first click here.
- *
- * The panel is portaled to `document.body`, so it is found from the document
- * rather than from `canvasElement`.
+ * `role="dialog"` and `aria-modal` are on the OVERLAY in this component, not on
+ * the panel — so the overlay is what focus has to end up inside. The panel is a
+ * child of it. `focus-capture.ts` holds the assertion, shared with `tn-drawer`.
  */
-async function expectFocusMovesIntoPanel(canvasElement: HTMLElement, triggerName: string | RegExp): Promise<void> {
-  const canvas = within(canvasElement);
-  const trigger = canvas.getByRole('button', { name: triggerName });
-
-  trigger.focus();
-  await userEvent.click(trigger);
-
-  const overlay = document.querySelector('.tn-side-panel__overlay') as HTMLElement;
-  await expect(overlay).toBeInTheDocument();
-
-  await waitFor(async () => {
-    await expect(overlay.getAttribute('aria-modal')).toBe('true');
-    // The assertion the ticket measured as false: `aria-modal` has told
-    // assistive technology to ignore everything outside this element, so focus
-    // being outside it means focus is on something the user has been told does
-    // not exist.
-    await expect(overlay.contains(document.activeElement)).toBe(true);
-    await expect(document.activeElement).not.toBe(trigger);
-  });
-}
+const SIDE_PANEL_DIALOG = '.tn-side-panel__overlay';
 
 const meta: Meta<TnSidePanelComponent> = {
   title: 'Components/Side Panel',
@@ -264,9 +236,10 @@ export const Default: Story = {
   }),
 
   // The story the defect was reported against: the only tabbable inside this
-  // panel is its own × button, which is the shape the capture failed for.
+  // panel is its own × button, which is the shape the capture failed for — in
+  // the original report, and again in CI against the first version of the fix.
   play: async ({ canvasElement }) => {
-    await expectFocusMovesIntoPanel(canvasElement, 'View Dataset Details');
+    await expectOpeningMovesFocusInside(canvasElement, 'View Dataset Details', SIDE_PANEL_DIALOG);
   },
 };
 
@@ -365,10 +338,11 @@ export const WithActions: Story = {
   }),
 
   // The other shape from the report — a panel with a form in it, which captured
-  // focus even before the fix. Kept as the control: it says the change did not
-  // trade one shape's behaviour for the other's.
+  // focus both before the fix and under the first version of it. Kept as the
+  // control: it says the change did not trade one shape's behaviour for the
+  // other's, and it is the reason the two are known to differ at all.
   play: async ({ canvasElement }) => {
-    await expectFocusMovesIntoPanel(canvasElement, 'Add User');
+    await expectOpeningMovesFocusInside(canvasElement, 'Add User', SIDE_PANEL_DIALOG);
   },
 };
 

--- a/projects/truenas-ui/src/stories/side-panel.stories.ts
+++ b/projects/truenas-ui/src/stories/side-panel.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
 import { tnIconMarker } from '../lib/icon/icon-marker';
@@ -14,6 +15,41 @@ const labelStyle = 'display: block; font-weight: 600; margin-bottom: 6px; color:
 const sectionStyle = 'padding: 16px; background: var(--tn-bg1); border-radius: 6px; border: 1px solid var(--tn-lines);';
 const rowStyle = 'display: flex; justify-content: space-between; align-items: center; padding: 14px 16px; border: 1px solid var(--tn-lines); border-radius: 6px;';
 const textareaStyle = 'width: 100%; padding: 10px 12px; border: 1px solid var(--tn-lines); border-radius: 4px; background: var(--tn-bg1); color: var(--tn-fg1); box-sizing: border-box; font-size: 1rem; font-family: inherit; resize: vertical; min-height: 80px;';
+
+/**
+ * Opens a panel by clicking its trigger and asserts that focus ends up inside
+ * it — the browser half of #227, where the defect was found and where jsdom
+ * cannot follow.
+ *
+ * A unit spec can only assert what the component does (it focuses the panel
+ * container; `side-panel-focus-capture.spec.ts` owns that). Whether a real user
+ * clicking a real trigger ends up inside the dialog depends on layout, the CSS
+ * transition and `inert`, none of which jsdom implements — the reported symptom
+ * was invisible to the whole Jest suite and visible on the first click here.
+ *
+ * The panel is portaled to `document.body`, so it is found from the document
+ * rather than from `canvasElement`.
+ */
+async function expectFocusMovesIntoPanel(canvasElement: HTMLElement, triggerName: string | RegExp): Promise<void> {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole('button', { name: triggerName });
+
+  trigger.focus();
+  await userEvent.click(trigger);
+
+  const overlay = document.querySelector('.tn-side-panel__overlay') as HTMLElement;
+  await expect(overlay).toBeInTheDocument();
+
+  await waitFor(async () => {
+    await expect(overlay.getAttribute('aria-modal')).toBe('true');
+    // The assertion the ticket measured as false: `aria-modal` has told
+    // assistive technology to ignore everything outside this element, so focus
+    // being outside it means focus is on something the user has been told does
+    // not exist.
+    await expect(overlay.contains(document.activeElement)).toBe(true);
+    await expect(document.activeElement).not.toBe(trigger);
+  });
+}
 
 const meta: Meta<TnSidePanelComponent> = {
   title: 'Components/Side Panel',
@@ -226,6 +262,12 @@ export const Default: Story = {
       </tn-side-panel>
     `,
   }),
+
+  // The story the defect was reported against: the only tabbable inside this
+  // panel is its own × button, which is the shape the capture failed for.
+  play: async ({ canvasElement }) => {
+    await expectFocusMovesIntoPanel(canvasElement, 'View Dataset Details');
+  },
 };
 
 export const WithActions: Story = {
@@ -321,6 +363,13 @@ export const WithActions: Story = {
       </tn-side-panel>
     `,
   }),
+
+  // The other shape from the report — a panel with a form in it, which captured
+  // focus even before the fix. Kept as the control: it says the change did not
+  // trade one shape's behaviour for the other's.
+  play: async ({ canvasElement }) => {
+    await expectFocusMovesIntoPanel(canvasElement, 'Add User');
+  },
 };
 
 export const NestedPanels: Story = {


### PR DESCRIPTION
Fixes #227.

## What was wrong

`tn-side-panel` and `tn-drawer` both asked the CDK for the focus capture a
`role="dialog"` with `aria-modal="true"` promises, with
`[cdkTrapFocusAutoCapture]`. That calls `FocusTrap.focusInitialElement()`,
which honours a `[cdkFocusInitial]` if the caller marked one and otherwise
falls through to `focusFirstTabbableElement()` — a walk for the first element
the CDK's `InteractivityChecker` considers tabbable, a test that reads layout
(`offsetWidth`, `getClientRects()`, computed `visibility`). Both return `false`,
silently, when they find nothing. Nobody reads that `false`.

So the guarantee was conditional on the caller's content. `side-panel--default`,
whose only control is the panel's own × button, opened with
`document.activeElement` still on the trigger behind it, as the ticket measured:
`aria-modal="true"` has told assistive technology to ignore everything outside
the dialog, so the listener is left on a control their screen reader has just
been told does not exist (WCAG 2.4.3, Focus Order).

## What changed

Both components move focus themselves now, through a new
`lib/a11y/initial-focus.ts`. Shared for the same reason `accessible-name.ts` and
`utils/transition-lifecycle.ts` are: `tn-drawer` was written from
`tn-side-panel`, and the two have now reached identical bugs three times (#214,
#218, this).

**Which element gets focus: the panel container**, which both already render
with `tabindex="-1"`. Written down in the helper, with the reasoning — it is the
only target that exists whatever the caller projected, focus arriving on it is
focus arriving in the dialog with no control of its own claiming the
announcement, and the first Tab still reaches the close button.

**The move is read back rather than assumed.** `HTMLElement.focus()` reports
nothing and the browser declines it in silence when the element is not focusable
at that instant — the same silence that hid the original bug. A single deferred
call is a guess about timing, and CI measured it wrong: with the capture as one
`focus()` in `afterNextRender`, `side-panel--default` and `drawer--over-mode`
opened with focus still outside the dialog under Chromium while
`side-panel--with-actions` captured. One code path, three shapes, two outcomes.
The capture now reads `document.activeElement` back and re-attempts on animation
frames, outside the Angular zone, for `TN_TRANSITION_FALLBACK_MS` — the constant
the transition lifecycle already derives from the same two stylesheets. When the
first call works, nothing after it runs.

It stops re-attempting on any of four conditions: the surface closes, focus
reaches the panel, focus reaches something the capture has no claim on (a second
modal opened inside the window — its capture is not to be undone), or the
window expires.

**What made the browser decline the call is not established**, and the comments
say so rather than guessing. See *What I could not run*.

`tn-drawer` was **not** unaffected — it asked for the capture the same way, so it
had the same silent failure available to it. It captures in `over` mode only; a
`side` drawer is navigation beside the page's content and must not take focus
when it appears.

### The three restores that came with removing auto-capture

`[cdkTrapFocusAutoCapture]` brought `CdkTrapFocus`'s own focus restoration with
it, and removing it removed three things that had nothing to do with the bug:

- **Destroy while open.** A panel or drawer destroyed rather than closed — an
  `@if`, a route change — runs no close branch, and removing the overlay drops
  focus on `<body>`. Both `ngOnDestroy`s do it now.
- **Only when the destroy is what took the focus.** Read before the removal.
  Restoring unconditionally moves focus for a user who is somewhere else:
  `hasBackdrop=false` does not stop them clicking into the page behind an open
  panel, and `tn-drawer` has a standing route to the same state — an `over` open
  records the opener, a breakpoint switches to `side` without closing, and the
  record stays unspent however long they then work beside the drawer.
- **`over` → `side` while open.** That switch destroys the over-mode panel
  through the template's `@if`, so it destroys the element focus is on.
  `tn-drawer` now puts focus back after the render, and only when it was
  orphaned onto `<body>` — **without spending the saved element**, because
  `CdkTrapFocus` held a capture of its own and the eventual close is still owed
  one. `drawer-a11y.spec.ts` has asserted that second half since #214 and passes
  unchanged.

### `[cdkFocusInitial]` no longer works, and both components now say so

It was honoured by the auto-capture this replaced, and `cdkTrapFocus` is still
on both elements, so the marker looks like it should keep working. It does not.
Both component classes document that and what to do instead — focus your own
control once the surface is open, which the capture leaves alone. Nothing in
this repository uses it. A supported input for it is worth its own ticket rather
than a guess here.

## Why the specs did not catch it, and what they do now

`side-panel-a11y.spec.ts` asserted focus *restoration*, and to have something to
restore it moved focus into the panel by hand — with a comment saying that is
what a real open does. Nothing asserted it, and every focus assertion in the
file sat downstream of that call, so the suite stayed green while `--default`
captured nothing. Those two tests no longer stage it.

`side-panel-focus-capture.spec.ts` and `drawer-focus-capture.spec.ts` assert the
capture without calling `.focus()` themselves, and now cover the retry: that a
declined first call is followed, that the follow-up leaves focus alone once it
is inside, that it stops when something else claims focus, that it terminates,
and both directions of the destroy-time and mode-switch restores. **Each of
those was checked by mutation** — the guard removed, or `contains` narrowed to
`===`, or the restore made unconditional — and each fails against the mutation.
One of them was written vacuously first and passed against two mutations; that
is why they are all checked this way now.

The `play` functions say WHERE focus went. The CI failure that cost a round read
`expected false to be true` and named neither element — the same defect in a
test that this ticket is about. They also share one assertion between the two
components, in `stories/focus-capture.ts`.

**What jsdom can carry here, and what it cannot.** The component-level
assertions are meaningful because the fix does not depend on layout. Measured on
the unfixed component: under plain jsdom focus stayed on the trigger, and
stubbing `getClientRects()` to return a rect moved it to the × button — so jsdom
failed the old path unconditionally and passed it with a one-line stub, and
could neither reproduce the browser's behaviour nor be trusted about it. The
browser-level statement is asserted where a browser runs it: `play` functions on
`Default`, `WithActions` (side panel) and `OverMode` (drawer).

## What I could not run

**No browser runs in this environment.** `libatk-1.0.so.0` and
`libxkbcommon.so.0` are both absent, `playwright install --with-deps` needs
root, and a plain `playwright install` stalled at ~10 MB over 25 minutes. So the
`play` functions are unexercised locally and the only evidence about the
browser is the CI log — which is what the diagnostics in them are for.

`yarn lint`, `yarn test` (2804), `yarn test:scripts` (42), `yarn build` and
`yarn build-storybook` all pass locally, after merging `main` at `c877a5f`.
`yarn lint` also reports 4 pre-existing `import/order` errors in
`input.component.ts` and `menu-panel.component.ts`, which this branch does not
touch and which CI does not report.

The last review round was run by a subagent rather than by the project's own
reviewer, which had exhausted this ticket's review budget — so a clean result
from it is weaker evidence than a clean run of the check itself. The six rounds
before it were the real reviewer or the same rubric applied to the full diff.

## Findings left unfixed

All LOW.

- **The retry chain has no `DestroyRef` teardown**, so after a destroy-while-open
  it keeps re-arming for the rest of the window. Probed: it does not throw, the
  element is detached so `focus()` is a no-op, and it stops at the deadline —
  wasted work rather than a wrong result.
- **The `play` helper finds the portaled dialog with `document.querySelector`**,
  which takes the first match in the document. Under autodocs every story
  portals an overlay to `<body>`, so a story could in principle assert against
  another story's panel. Not what failed in CI: the `aria-modal` assertion runs
  first on the same element and passed, which is only true of this story's open
  panel.
- **The side panel focuses a child of the element carrying `role="dialog"`** —
  the panel inside the overlay — where `tn-drawer` focuses the dialog element
  itself. Moving `tabindex="-1"` to the overlay would make the two match.
- **`expect(overlay().contains(panel())).toBe(true)`** in
  `side-panel-focus-capture.spec.ts` holds by construction, since `panel()` is a
  `querySelector` inside `overlay()`. The enclosing test can fail; that line
  carries no weight.
- **The restore-on-destroy half is not in the shared helper**, so there are two
  `ngOnDestroy` blocks and two `restoreFocus` implementations with slightly
  different guards. Extracting it means the helper owning `previousFocus` in both
  components, including the drawer's mode-switch rule — a bigger refactor than
  this fix.
- **`drawer-a11y.spec.ts` still stages focus by hand** in its restoration tests.
  It is no longer masking anything, because `drawer-focus-capture.spec.ts`
  asserts the capture it was standing in for.
