### PR TITLE
NAS-142473 / 27.0.0-BETA.1 / docs: add issue forms for bug reports and tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+# GitHub renders the issue title as a built-in field that takes no per-field
+# description, so the rule about titles is the first thing in the form body
+# instead. `title:` below only pre-fills it.
+#
+# No `labels:` key on purpose. Labels here are routing state applied during
+# triage from board-wide context (priority, bug, blocked, ...); a form that
+# stamped them would be deciding routing from inside a single ticket. The form
+# shapes the body, not the labels.
+name: Bug report
+description: Something the library does today is wrong, and you can make it happen.
+title: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### The title names the defect — no `type(scope):` prefix
+
+        Write what is broken, in plain words: *"[disabled] on tn-selection-list does not
+        disable its options"*. Not `fix(selection-list): ...`, and not `a11y(...)`.
+
+        A ticket title gets copied into the pull request that fixes it, and pull requests
+        here are squash-merged — so the PR title becomes the commit subject that
+        `.releaserc.json` reads. Only `feat`, `fix`, `perf` and `refactor` cut a release;
+        anything else merges, cuts no version and appears in no changelog. A prefix in a
+        ticket title is how that silent no-op gets started. Choosing the commit type is the
+        job of whoever writes the fix, not of whoever reports it.
+
+  - type: textarea
+    id: what_you_ran
+    attributes:
+      label: What you ran
+      description: >-
+        The smallest thing that shows the defect — a spec, a story, a template snippet, or
+        the steps you clicked through. Include the markup or component inputs involved.
+      placeholder: |
+        <tn-selection-list [disabled]="true">
+          <tn-list-option value="a">A</tn-list-option>
+        </tn-selection-list>
+
+        …rendered in Storybook and tabbed into.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What the library should have done, and where that expectation comes from if it is not obvious.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead
+      description: >-
+        What you actually observed. Paste the failure output, the rendered DOM, or the
+        violation the tool reported — not a summary of it.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: found_with
+    attributes:
+      label: How you found it
+      description: >-
+        The instrument matters. A jsdom test and a real browser disagree about what they
+        can see — layout, focus and computed accessibility all differ — so a fix aimed at
+        the wrong one passes the wrong check.
+      options:
+        - Jest unit test (jsdom)
+        - axe scan in a Jest test (jsdom)
+        - Storybook interaction test (real browser)
+        - Manually in Storybook
+        - Manually in a consuming application
+        - Screen reader or other assistive technology
+        - Reading the code
+        - Other — described above
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        What must be true for this to be closed, as things that can be checked. Whoever
+        fixes this writes a failing test first, so say what that test should assert.
+      placeholder: |
+        - [ ] A disabled tn-selection-list renders aria-disabled="true" on its options
+        - [ ] A disabled option is not reachable by keyboard
+    validations:
+      required: true
+
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: The `tn-` selector, if the defect belongs to one.
+      placeholder: tn-selection-list
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: The `truenas-ui` version you saw it in, or the commit on `main`.
+      placeholder: 27.0.0-BETA.1

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,10 @@ body:
 
         A ticket title gets copied into the pull request that fixes it, and pull requests
         here are squash-merged — so the PR title becomes the commit subject that
-        `.releaserc.json` reads. Only `feat`, `fix`, `perf` and `refactor` cut a release;
-        anything else merges, cuts no version and appears in no changelog. A prefix in a
+        `.releaserc.json` reads. Only `feat`, `fix`, `perf`, `refactor` and a revert cut a
+        release; `docs`, `style`, `test`, `build`, `ci` and `chore` merge, cut no version
+        and appear in no changelog — and an unrecognised type is worse still: it fails the
+        PR title check outright and blocks the fix from merging at all. A prefix in a
         ticket title is how that silent no-op gets started. Choosing the commit type is the
         job of whoever writes the fix, not of whoever reports it.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 # GitHub renders the issue title as a built-in field that takes no per-field
 # description, so the rule about titles is the first thing in the form body
-# instead. `title:` below only pre-fills it.
+# instead. There is no top-level `title:` either: it only pre-fills the box, and
+# anything pre-filled here would be a prefix of exactly the kind the rule warns off.
 #
 # No `labels:` key on purpose. Labels here are routing state applied during
 # triage from board-wide context (priority, bug, blocked, ...); a form that
@@ -8,7 +9,6 @@
 # shapes the body, not the labels.
 name: Bug report
 description: Something the library does today is wrong, and you can make it happen.
-title: ''
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# Without this, "Open a blank issue" sits under the two forms and makes every
+# required field on them optional again — which is the whole reason they are
+# forms rather than markdown templates.
+#
+# This applies to the web UI only. Issues created through the API carry a body
+# verbatim and never see a template, so automation that files tickets is
+# unaffected by this setting.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,9 +1,9 @@
-# Same two notes as bug_report.yml: the title rule lives in the first markdown
-# block because GitHub's built-in title field takes no description, and there is
-# no `labels:` key because labels are routing state applied at triage.
+# Same notes as bug_report.yml: the title rule lives in the first markdown block
+# because GitHub's built-in title field takes no description, nothing pre-fills
+# that field, and there is no `labels:` key because labels are routing state
+# applied at triage.
 name: Task
 description: Something the library should do and does not yet — a feature, a refactor, or infrastructure work.
-title: ''
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -15,8 +15,10 @@ body:
 
         A ticket title gets copied into the pull request that implements it, and pull
         requests here are squash-merged — so the PR title becomes the commit subject that
-        `.releaserc.json` reads. Only `feat`, `fix`, `perf` and `refactor` cut a release;
-        anything else merges, cuts no version and appears in no changelog. A prefix in a
+        `.releaserc.json` reads. Only `feat`, `fix`, `perf`, `refactor` and a revert cut a
+        release; `docs`, `style`, `test`, `build`, `ci` and `chore` merge, cut no version
+        and appear in no changelog — and an unrecognised type is worse still: it fails the
+        PR title check outright and blocks the change from merging at all. A prefix in a
         ticket title is how that silent no-op gets started. Choosing the commit type is the
         job of whoever writes the change, not of whoever asks for it.
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,82 @@
+# Same two notes as bug_report.yml: the title rule lives in the first markdown
+# block because GitHub's built-in title field takes no description, and there is
+# no `labels:` key because labels are routing state applied at triage.
+name: Task
+description: Something the library should do and does not yet — a feature, a refactor, or infrastructure work.
+title: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### The title names the change — no `type(scope):` prefix
+
+        Write what should be true when this is done, in plain words: *"Give an untitled
+        dialog an accessible name"*. Not `feat(dialog): ...`.
+
+        A ticket title gets copied into the pull request that implements it, and pull
+        requests here are squash-merged — so the PR title becomes the commit subject that
+        `.releaserc.json` reads. Only `feat`, `fix`, `perf` and `refactor` cut a release;
+        anything else merges, cuts no version and appears in no changelog. A prefix in a
+        ticket title is how that silent no-op gets started. Choosing the commit type is the
+        job of whoever writes the change, not of whoever asks for it.
+
+        **Reporting something that is already broken?** Use the bug report form instead —
+        it asks for the reproduction, which is the first thing that work needs.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What should exist
+      description: >-
+        The change itself: the API, the behaviour, or the file that should be there
+        afterwards. Concrete enough that two people would build the same thing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why — what it costs today
+      description: >-
+        What is being worked around in the meantime, and by whom. A cost that has already
+        been paid is the strongest case; an anticipated one should say what would trigger it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        What must be true for this to be closed, as things that can be checked. This is what
+        the work is reviewed against, so leave nothing to be inferred from the description.
+      placeholder: |
+        - [ ] tn-dialog without a heading gets aria-label from its `label` input
+        - [ ] No empty <h2> is rendered when there is no heading
+    validations:
+      required: true
+
+  - type: dropdown
+    id: found_with
+    attributes:
+      label: How this came up
+      description: >-
+        The instrument matters, the same way it does on a bug — a jsdom test and a real
+        browser disagree about what they can see, and a finding from one is not evidence
+        about the other.
+      options:
+        - A code review
+        - An audit or scan (say which, above)
+        - Building something that needed it
+        - A pattern repeated across components
+        - Following up on another ticket
+        - Other — described above
+    validations:
+      required: true
+
+  - type: input
+    id: component
+    attributes:
+      label: Component or area
+      description: The `tn-` selector or the directory this touches, if it is confined to one.
+      placeholder: tn-dialog

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -555,7 +555,11 @@ If you have questions or run into issues:
 
 - Check existing documentation
 - Search existing GitHub issues
-- Create a new issue with a detailed description
-- Tag it appropriately (bug, question, enhancement, etc.)
+- Open a new issue with the **Bug report** or **Task** form. What they ask for — a
+  reproduction, the tool you found it with, acceptance criteria — is what the work needs
+  before it can start, so filling them in is the difference between a ticket someone can
+  pick up and one that has to be sent back
+- Leave the labels off. Priority and routing labels are applied during triage, from
+  context about the rest of the board that a single ticket does not carry
 
 Thank you for contributing to TrueNAS-UI Components!


### PR DESCRIPTION
Fixes #229.

Adds `.github/ISSUE_TEMPLATE/` — a bug form, a task form, and a config that keeps the blank-issue route from making their required fields optional again.

## What each form asks for

**Both** open with the title rule, and both require acceptance criteria and the instrument the finding came from — a jsdom test and a real browser do not see the same things, so a fix aimed at the wrong one passes the wrong check.

**`bug_report.yml`** requires the reproduction as three separate fields — what you ran, what you expected, what happened instead — because that is what the work needs before it can start, and because whoever fixes it writes a failing test first. Component and version are optional.

**`task.yml`** requires what should exist and what it costs today, in place of the reproduction.

## The title rule, and why it is stated at that length

A ticket title gets copied into the PR that fixes it, PRs here are squash-merged, and the PR title becomes the commit subject `.releaserc.json` reads. So a `type(scope):` prefix on a *ticket* lands in a place that decides whether the fix cuts a version at all — `docs`, `style`, `test`, `build`, `ci` and `chore` merge and cut nothing, and a type `pr-title.yml` does not recognise (`a11y(...)`, the case in #229) fails the title check and does not merge. Both consequences are named in the form, because "style" is not the reason and a rule without its reason gets discarded.

## Decisions worth reviewing

- **Neither form sets `labels:`.** Labels here are routing state applied at triage from context about the rest of the board; a form that stamped `bug` or a priority would be deciding routing from inside a single ticket. The forms shape the body, not the labels — which is what #229 asks for. The reviewer's counterpoint is in the list below.
- **`blank_issues_enabled: false`.** Without it, "Open a blank issue" sits under both forms and makes every required field optional again. One line to reverse if it turns out to block more than it shapes. Issues filed through the API never see a template either way, so nothing automated is affected.
- **The title guidance is the first `markdown` block, not a field description.** GitHub renders the issue title as a built-in field that takes no per-field description; the top-level `title:` key only pre-fills the box. That is as close to "the title field says it in its own description" as the schema allows, and it is noted in a comment at the top of each file so the next reader does not go looking for the field.

## Checks

- **Validated the three files** against GitHub's form schema with a probe (`state/scratch/229/validate-forms.mjs`, outside this repo): parsed with the project's own `js-yaml`, then checked element types, per-type allowed attributes, required attributes, `validations` keys, duplicate ids, and that dropdowns carry more than one option. All three pass.
- **`yarn lint` run:** 4 errors, all `import/order` in `input.component.ts` and `menu-panel.component.ts` — pre-existing on `main`, in files this branch does not touch, and CI does not report them.
- **`yarn test` / `yarn test:scripts` not run.** This diff contains no TypeScript, HTML, SCSS or config the suites read; every gating job runs unchanged code. Say so plainly rather than implying they were run and passed.
- **Storybook interaction tests cannot run on this machine** (no browser, and no way to install one) — as for every branch here. Unaffected by a diff of two YAML forms and a docs bullet.
- **Local review: two rounds, both clean at MEDIUM and above**, using the shared reviewer from `ux-github-workflows@master` — the same one that runs as the required check, in a separate process.

## Findings left unfixed

All LOW, all from the review rounds above:

- **No `contact_links` beside `blank_issues_enabled: false`, so a question has no filing path.** Real, and deliberate for now: #229 asks for a bug form and a task form, and the right destination for questions is a decision about where support happens rather than a line of YAML. `CONTRIBUTE.md`'s "Questions or Issues?" section still points at both forms and at the docs.
- **The release-type rationale is duplicated verbatim between the two forms**, so a change to `.releaserc.json` has to find both copies. GitHub issue forms have no include mechanism; the alternative is a link to a doc, which is read less often than the paragraph it replaces.
- **The comment calls `bug` triage routing state, though the bug form is the one place that label is known with certainty.** A fair objection. Left as is because triage owns that label in this repo's loop, and a form that pre-applies it removes the distinction between a filer's claim and a triaged one.
- **The bug form takes a library version but not an Angular major or a browser.** Worth adding if a rendering defect ever needs a round-trip to establish them; four required fields already sit between a filer and the button.

The prose in both forms was corrected once after the second clean round — a claim about which commit types cut a release was right about six types and wrong about two neighbours. No executable code changed with it.
