### PR TITLE
NAS-142474 / 27.0.0-BETA.1 / fix(chip-input): select the chip element that carries data-testid

### DIFF
--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -502,7 +502,7 @@ describe('TnChipInputComponent test ids', () => {
     const fixture = TestBed.createComponent(LabelledPrimitiveValueHostComponent);
     fixture.detectChanges();
 
-    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip .tn-chip');
     expect(chip?.getAttribute('data-testid')).toBe('chip-tags-united-states');
 
     const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -522,7 +522,7 @@ describe('TnChipInputComponent test ids', () => {
     fixture.detectChanges();
 
     const chipId = (): string | null | undefined => fixture.nativeElement
-      .querySelector('.tn-chip-input__chip [role="button"]')
+      .querySelector('.tn-chip-input__chip .tn-chip')
       ?.getAttribute('data-testid');
     expect(chipId()).toBe('chip-tags-us');
 
@@ -542,7 +542,7 @@ describe('TnChipInputComponent test ids', () => {
     const fixture = TestBed.createComponent(OptionTestIdKeyHostComponent);
     fixture.detectChanges();
 
-    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip .tn-chip');
     expect(chip?.getAttribute('data-testid')).toBe('chip-users-u-1');
 
     const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -562,7 +562,7 @@ describe('TnChipInputComponent test ids', () => {
     const fixture = TestBed.createComponent(UnnormalizableLabelHostComponent);
     fixture.detectChanges();
 
-    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip [role="button"]');
+    const chip = fixture.nativeElement.querySelector('.tn-chip-input__chip .tn-chip');
     expect(chip?.getAttribute('data-testid')).toBe('chip-tags-ja');
 
     const loader = TestbedHarnessEnvironment.loader(fixture);


### PR DESCRIPTION
Fixes #241.

## What was wrong

`yarn test` has failed on `main` for the last six merges, so pull requests touching no library code — #230 changed only `.github/ISSUE_TEMPLATE/*` and `CONTRIBUTE.md` — could not go green.

Reproduced on a clean `main` @ `5e3de28` before changing anything:

```
Test Suites: 1 failed, 114 passed, 115 total
Tests:       4 failed, 2810 passed, 2814 total
```

All four failures are in `chip-input.harness.spec.ts`, and all four are the same stale selector:

```
Expected: "chip-tags-united-states"
Received: undefined
```

This is a semantic merge conflict between two PRs, neither wrong on its own branch:

- **#191** removed the `role="button"` chip wrapper to fix axe's `nested-interactive`; `data-testid` now sits on the chip's outer `<div>`, which always carries `.tn-chip` (`chip.component.ts:47`).
- **#182** added these four assertions against the pre-#191 markup and merged without rebasing.

The two diffs share no files, so file-level CI signals could not catch it. The markup is correct as it stands.

## The change

Four occurrences of `.tn-chip-input__chip [role="button"]` → `.tn-chip-input__chip .tn-chip`. Nothing else; the diff is four lines in one spec file.

`.tn-chip` rather than the `[data-testid]` selector suggested in the issue: it is the element that actually carries `[tnTestId]`, it is already what the three *passing* assertions in this same block use (and what the comment at line 459 documents), and it selects the chip whether or not the attribute is present — so it cannot mask a regression that drops the id, which `[data-testid]` would.

Against the acceptance criteria:

- [x] The four assertions select the element that carries `data-testid` on current markup
- [x] `chip.component.html` is untouched — #191's sibling close button stays
- [x] `yarn test` passes: 115 suites, 2814 tests, zero failures
- [x] The behaviour #182 added is still asserted by exact expected value (`chip-tags-united-states`, `chip-tags-us` → `chip-tags-united-states`, `chip-users-u-1`, `chip-tags-ja`), not loosened to make the query match

## Checks run locally

- `yarn test` — **115 suites, 2814 tests, 0 failures** (was 4 failing)
- `yarn test:scripts` — 42/42
- `yarn build` — not run; this diff touches only a spec file and no library source
- `yarn lint` — runs, and reports **4 pre-existing `import/order` errors** in `input.component.ts` and `menu-panel.component.ts`. Neither file is in this diff; both errors are present on unmodified `main` and CI's linter does not report them.
- **Storybook Interaction Tests — not run.** That check needs a real browser, which this host cannot provide. No story or component markup changed here.

Local review: the shared reviewer ran and returned 0 findings.
