### PR TITLE
NAS-142475 / 27.0.0-BETA.1 / fix(themes): raise --tn-alt-fg1 opacity so muted text reaches AA

### DIFF
--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -18,7 +18,11 @@
   --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
-  --tn-alt-fg1: rgba(194,194,194,0.5);
+  /* Muted body text (placeholders, group labels, breadcrumb separators). At 0.5
+     it composited to #707070 and read 3.37:1 on --tn-bg1; 0.8 gives >=4.5:1 on
+     every dark surface it is drawn on: --tn-bg1 6.47:1, --tn-bg2 5.86:1,
+     --tn-bg3 5.15:1, --tn-alt-bg1 4.84:1 (the stepper draws it there). */
+  --tn-alt-fg1: rgba(194,194,194,0.8);
   --tn-alt-fg2: #e1e1e1;
   --tn-lines: #383838;
   --tn-yellow: #DED142;
@@ -80,7 +84,9 @@
   --tn-fg4: rgba(255,255,255,0.35);
   --tn-alt-bg1: #383838;
   --tn-alt-bg2: #545454;
-  --tn-alt-fg1: rgba(194,194,194,0.5);
+  /* Muted body text. 0.5 read 3.37:1 on --tn-bg1; 0.8 gives >=4.5:1 on every
+     dark surface it is drawn on — see the note in :root. */
+  --tn-alt-fg1: rgba(194,194,194,0.8);
   --tn-alt-fg2: #e1e1e1;
   --tn-lines: #4a4a4a;
   --tn-yellow: #DED142;


### PR DESCRIPTION
Fixes #231.

## Reproduced first

The report measures `--tn-alt-fg1` on `--tn-bg1` across all nine palettes. I re-derived
that table by parsing `themes.css` itself rather than trusting the numbers, and it
matches exactly — `:root` and `.tn-dark` at **3.37:1**, compositing to `#707070`,
which is the same value and ratio axe reported (3.36 after its own rounding). The
other eight palettes came back with the ratios the ticket lists, which is what gives
me confidence the measurement is right rather than coincidentally close.

## The change

One token, in the two palettes that carry the bad value:

```css
--tn-alt-fg1: rgba(194,194,194,0.5);   /* was */
--tn-alt-fg1: rgba(194,194,194,0.8);   /* now */
```

**Why 0.8 and not 0.7.** 0.7 is enough for the two surfaces the acceptance criteria
name (`--tn-bg1` 5.28:1, `--tn-bg2` 4.85:1) and is *not* enough for the surfaces this
token is actually drawn on. `stepper.component.scss:162-163` puts `--tn-alt-fg1` text
directly on `--tn-alt-bg1`, where 0.7 gives 4.10:1 — still failing. 0.8 is the first
0.05 step that clears every one:

| Surface | Ratio at 0.8 |
|---|---|
| `--tn-bg1` `#1E1E1E` | 6.47:1 |
| `--tn-bg2` `#282828` | 5.86:1 |
| `--tn-bg3` `#333333` | 5.15:1 |
| `--tn-alt-bg1` `#383838` | 4.84:1 |

Still visibly muted: `#a1a1a1` composited against `--tn-fg1`'s `#e0e0e0`, so
placeholders continue to read as placeholders.

The value keeps the `rgba` form the two palettes already used, so this stays a
one-token change rather than a re-typing of the token.

## Against the acceptance criteria

- [x] **`--tn-alt-fg1` measures at least 4.5:1 against `--tn-bg1` and `--tn-bg2`** — 6.47:1 and 5.86:1.
- [x] **Non-text uses checked for regression.** Every other use of this token in the
  library is a `color:` declaration. The single non-text use is
  `slide-toggle.component.scss:276`, a disabled track/thumb `border-color` inside a
  `@media (prefers-contrast: high)` block — raising the token's contrast can only serve
  that block's intent, so there is no regression to trade off.
- [x] **The other eight palettes are left unchanged** — they set `--tn-alt-fg1` to opaque
  colours of their own and are untouched; re-measured after the edit, all identical.
- [ ] **The 16 stories pass `yarn test-sb`** — *not verified here; see below.*

## Checks run locally

- `yarn test` — **115 suites, 2814 tests, 0 failures**
- `yarn test:scripts` — 42/42
- `yarn build` — succeeds
- `yarn lint` — runs, and reports **4 pre-existing `import/order` errors** in
  `input.component.ts` and `menu-panel.component.ts`. Neither file is in this diff, both
  are present on unmodified `main`, and CI's linter does not report them.
- **Storybook Interaction Tests — not run.** That check drives a real browser, which this
  host cannot provide, so **the one criterion I could not verify directly is the one the
  bug was reported through.** What I can say instead: the failure is a pure
  contrast-ratio computation over two colours, I reproduced the exact failing number from
  source and re-measured the fixed one the same way, and `build-storybook` runs
  `copy-assets` → `copy-themes`, so CI's Storybook job regenerates its themes copy from
  the file this diff changes. If a story still fails, the arithmetic above is where to
  look first.

Local review: the shared reviewer ran here and returned **nothing at or above MEDIUM**.

## What I did not change, and why

Three LOW findings from the local review, left for a reader to judge rather than folded
into this diff:

1. **`projects/truenas-ui/.storybook/public/themes.css` still holds the old `0.5`.** It is
   a tracked build artefact that `yarn copy-themes` overwrites from `src/styles/themes.css`
   on every `storybook`/`build-storybook` run, so it does not affect CI or local Storybook.
   I verified that copy path before deciding to leave it. It does mean the committed
   artefact now drifts from its source until the next build — a pre-existing property of
   checking a generated file in, and arguably worth its own ticket.
2. **No spec measures this token.** The 4.5:1 claim lives in a comment.
   `contrast-testing.ts` and `radio-error-contrast.spec.ts` provide an rgba-aware
   template that would make it enforceable. That is a real gap and a reasonable
   follow-up ticket; it is also a new test file rather than part of this fix.
3. **Keeping the alpha leaves the ratio surface-dependent.** The guarantee above is a
   hand-audit of the four surfaces the token is drawn on, and it holds only while that
   stays true — on `--tn-alt-bg2` `#545454` the token would composite to about 3.3:1.
   I checked, and no `--tn-alt-fg1` text is drawn on `--tn-alt-bg2` today: the
   `--tn-alt-bg2` surfaces are option/row hover states and badges, while this token's text
   uses are group labels, placeholders, breadcrumbs and the stepper circle. Making the
   token opaque would remove the dependency, and would also change its appearance on
   every surface — a bigger change than this ticket asks for.

One observation outside this ticket's scope: `.tn-solarized-dark` sets
`--tn-alt-fg1: #839496`, which measures **4.11:1 on its `--tn-bg2`** — a genuine AA
failure, though not one of the nine `--tn-bg1` rows the report tabulated. The ticket
scopes this fix to `:root`/`.tn-dark` and says explicitly to leave the other palettes
alone, so I have. Worth its own ticket if someone wants it.
