### PR TITLE
NAS-142477 / 27.0.0-BETA.1 / fix(tabs): put role=tablist on the header, not the wrapper holding the panels

### DIFF
--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
@@ -3,8 +3,9 @@
   tnTestIdType="tab-panel"
   [ngClass]="classes()"
   [tnTestId]="testId()"
+  [attr.id]="panelId()"
   [attr.aria-hidden]="!isActive()"
-  [attr.aria-labelledby]="'tab-' + index()"
+  [attr.aria-labelledby]="tabId()"
   [attr.tabindex]="isActive() ? 0 : -1"
 >
   @if (shouldRender()) {

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
@@ -5,7 +5,7 @@
   [tnTestId]="testId()"
   [attr.id]="panelId()"
   [attr.aria-hidden]="!isActive()"
-  [attr.aria-labelledby]="tabId()"
+  [attr.aria-labelledby]="hasTab() ? tabId() : null"
   [attr.tabindex]="isActive() ? 0 : -1"
 >
   @if (shouldRender()) {

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
@@ -2,7 +2,10 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import type { TemplateRef} from '@angular/core';
 import { Component, input, viewChild, ElementRef, inject, computed, signal } from '@angular/core';
+import { tabDomId, tabPanelDomId } from '../tabs/tab-ids';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+
+let nextUnownedGroupId = 0;
 
 @Component({
   selector: 'tn-tab-panel',
@@ -20,10 +23,23 @@ export class TnTabPanelComponent {
 
   // Internal properties set by parent TnTabsComponent (public signals for parent control)
   index = signal<number>(0);
+  /**
+   * Id namespace, set by the parent `tn-tabs` so that both ends of the tab↔panel wiring
+   * agree. Unique per instance by default, for the same reason as on `tn-tab`: a panel
+   * rendered outside a `tn-tabs` has no tab to be labelled by, and an id colliding with
+   * another group's panel would be worse than one matching nothing.
+   */
+  groupId = signal<string>(`tn-tab-panel-unowned-${nextUnownedGroupId++}`);
   isActive = signal<boolean>(false);
   hasBeenActive = signal<boolean>(false);
 
   elementRef = inject(ElementRef<HTMLElement>);
+
+  /** This panel's own id, which its tab points at with `aria-controls`. */
+  panelId = computed(() => tabPanelDomId(this.groupId(), this.index()));
+
+  /** The id of the tab that labels this panel, for `aria-labelledby`. */
+  tabId = computed(() => tabDomId(this.groupId(), this.index()));
 
   classes = computed(() => {
     const classes = ['tn-tab-panel'];

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
@@ -26,10 +26,18 @@ export class TnTabPanelComponent {
   /**
    * Id namespace, set by the parent `tn-tabs` so that both ends of the tab↔panel wiring
    * agree. Unique per instance by default, for the same reason as on `tn-tab`: a panel
-   * rendered outside a `tn-tabs` has no tab to be labelled by, and an id colliding with
-   * another group's panel would be worse than one matching nothing.
+   * rendered outside a `tn-tabs` still renders an `id`, and one colliding with another
+   * group's panel would be worse than one nothing points at.
    */
   groupId = signal<string>(`tn-tab-panel-unowned-${nextUnownedGroupId++}`);
+  /**
+   * Whether the parent has a tab at this panel's index, which is what decides whether
+   * `aria-labelledby` is rendered. The mirror of `hasPanel` on `tn-tab`, and for the same
+   * reason: more panels than tabs, or a panel outside a `tn-tabs`, would otherwise leave
+   * this pointing at an id nothing carries — which is what `aria-labelledby="tab-0"` did
+   * unconditionally before #232.
+   */
+  hasTab = signal<boolean>(false);
   isActive = signal<boolean>(false);
   hasBeenActive = signal<boolean>(false);
 

--- a/projects/truenas-ui/src/lib/tab/tab.component.html
+++ b/projects/truenas-ui/src/lib/tab/tab.component.html
@@ -4,6 +4,8 @@
   tnTestIdType="tab"
   [ngClass]="classes()"
   [tnTestId]="testId()"
+  [attr.id]="tabId()"
+  [attr.aria-controls]="panelId()"
   [attr.aria-selected]="isActive()"
   [attr.aria-disabled]="disabled()"
   [attr.tabindex]="tabIndex()"

--- a/projects/truenas-ui/src/lib/tab/tab.component.html
+++ b/projects/truenas-ui/src/lib/tab/tab.component.html
@@ -5,7 +5,7 @@
   [ngClass]="classes()"
   [tnTestId]="testId()"
   [attr.id]="tabId()"
-  [attr.aria-controls]="panelId()"
+  [attr.aria-controls]="hasPanel() ? panelId() : null"
   [attr.aria-selected]="isActive()"
   [attr.aria-disabled]="disabled()"
   [attr.tabindex]="tabIndex()"

--- a/projects/truenas-ui/src/lib/tab/tab.component.ts
+++ b/projects/truenas-ui/src/lib/tab/tab.component.ts
@@ -31,10 +31,17 @@ export class TnTabComponent implements AfterContentInit {
   /**
    * Id namespace, set by the parent `tn-tabs` so that both ends of the tab↔panel wiring
    * agree. The default is unique per instance rather than a constant, so a `tn-tab`
-   * rendered outside a `tn-tabs` mints an id that collides with nothing — it has no panel
-   * to point at either way, and a duplicate id is worse than an unmatched one.
+   * rendered outside a `tn-tabs` still renders an `id` that collides with nothing.
    */
   groupId = signal<string>(`tn-tab-unowned-${nextUnownedGroupId++}`);
+  /**
+   * Whether the parent has a panel at this tab's index, which is what decides whether
+   * `aria-controls` is rendered at all. `tn-tabs` walks its tabs and its panels
+   * independently, so a group given more tabs than panels — or a `tn-tab` used outside a
+   * `tn-tabs`, which is why this starts false — would otherwise point `aria-controls` at
+   * an id no element in the document carries.
+   */
+  hasPanel = signal<boolean>(false);
   isActive = signal<boolean>(false);
   tabsComponent?: {
     onKeydown: (event: KeyboardEvent, index: number) => void;

--- a/projects/truenas-ui/src/lib/tab/tab.component.ts
+++ b/projects/truenas-ui/src/lib/tab/tab.component.ts
@@ -3,7 +3,10 @@ import { CommonModule } from '@angular/common';
 import type { TemplateRef, AfterContentInit} from '@angular/core';
 import { Component, input, output, ElementRef, inject, contentChild, computed, signal } from '@angular/core';
 import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
+import { tabDomId, tabPanelDomId } from '../tabs/tab-ids';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
+
+let nextUnownedGroupId = 0;
 
 @Component({
   selector: 'tn-tab',
@@ -25,6 +28,13 @@ export class TnTabComponent implements AfterContentInit {
 
   // Internal properties set by parent TnTabsComponent (public signals for parent control)
   index = signal<number>(0);
+  /**
+   * Id namespace, set by the parent `tn-tabs` so that both ends of the tab↔panel wiring
+   * agree. The default is unique per instance rather than a constant, so a `tn-tab`
+   * rendered outside a `tn-tabs` mints an id that collides with nothing — it has no panel
+   * to point at either way, and a duplicate id is worse than an unmatched one.
+   */
+  groupId = signal<string>(`tn-tab-unowned-${nextUnownedGroupId++}`);
   isActive = signal<boolean>(false);
   tabsComponent?: {
     onKeydown: (event: KeyboardEvent, index: number) => void;
@@ -68,6 +78,12 @@ export class TnTabComponent implements AfterContentInit {
   tabIndex = computed(() => {
     return this.isActive() ? 0 : -1;
   });
+
+  /** This tab's own id, which its panel points back at with `aria-labelledby`. */
+  tabId = computed(() => tabDomId(this.groupId(), this.index()));
+
+  /** The id of the panel this tab controls, for `aria-controls`. */
+  panelId = computed(() => tabPanelDomId(this.groupId(), this.index()));
 
   hasIcon = computed(() => {
     return !!(this.hasIconContent() || this.iconTemplate() || this.icon());

--- a/projects/truenas-ui/src/lib/tabs/tab-ids.ts
+++ b/projects/truenas-ui/src/lib/tabs/tab-ids.ts
@@ -1,0 +1,21 @@
+/**
+ * The DOM ids that tie a tab to its panel, in one place because both ends have to agree:
+ * `tn-tab` renders `aria-controls` pointing at the panel and `tn-tab-panel` renders
+ * `aria-labelledby` pointing back at the tab. A second copy of either formula drifting
+ * leaves both attributes resolving to nothing, which is the state #232 found
+ * `aria-labelledby="tab-0"` in — an id no element in this library ever rendered.
+ *
+ * `group` is the namespace the owning `tn-tabs` hands down, so that two tab groups on one
+ * page — a Storybook docs page renders all ten Tabs stories at once — cannot both mint
+ * `tab-0` and cross-wire each other's panels.
+ */
+
+/** The id rendered on the `tn-tab` at `index` within `group`. */
+export function tabDomId(group: string, index: number): string {
+  return `${group}-tab-${index}`;
+}
+
+/** The id rendered on the `tn-tab-panel` at `index` within `group`. */
+export function tabPanelDomId(group: string, index: number): string {
+  return `${group}-panel-${index}`;
+}

--- a/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
@@ -1,0 +1,340 @@
+import { Component, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TnTabsComponent } from './tabs.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TnTabComponent } from '../tab/tab.component';
+import { TnTabPanelComponent } from '../tab-panel/tab-panel.component';
+
+/**
+ * Guards the tablist structure given to `tn-tabs` in #232.
+ *
+ * WHAT WAS REPORTED
+ * -----------------
+ * `role="tablist"` sat on `.tn-tabs`, the outer wrapper, which holds the tab
+ * header AND the panel content. Every rendered `role="tabpanel"` was therefore
+ * an owned child of the tablist, and all ten Tabs stories failed axe
+ * `aria-required-children` with "Element has children which are not allowed:
+ * [role=tabpanel]". The role moved down one level, onto `.tn-tabs__header`,
+ * whose only children are the tabs.
+ *
+ * WHY THE TAB/PANEL WIRING IS PART OF THE SAME FIX
+ * ------------------------------------------------
+ * Containment was the only thing tying a panel to its tab. Once the panels are
+ * outside the tablist, the association has to be explicit, and it was not:
+ * `tn-tab` carried no `aria-controls` at all, and `tn-tab-panel` carried
+ * `aria-labelledby="tab-{index}"` pointing at an id no element in the library
+ * ever rendered. Both directions are now real ids, namespaced per `tn-tabs`
+ * instance so that two tab groups on one page — a Storybook docs page renders
+ * ten — cannot collide on `tab-0`.
+ *
+ * WHY `evaluated` IS ASSERTED BESIDE EVERY EMPTY `violated`
+ * ---------------------------------------------------------
+ * An empty `violations` is also what axe returns when it looked at nothing, and
+ * "looked at nothing" is a live risk here: `aria-required-children` only reports
+ * on an element that HAS a role, so a regression that drops `role="tablist"`
+ * entirely would empty `violated` rather than fill it. `the structure this
+ * replaced` at the bottom is the other half of that guard — it rebuilds the
+ * pre-#232 markup and asserts the rule does fire on it.
+ */
+
+@Component({
+  selector: 'tn-tabs-a11y-host',
+  standalone: true,
+  imports: [TnTabsComponent, TnTabComponent, TnTabPanelComponent],
+  templateUrl: './test-hosts/a11y-host.component.html',
+})
+class TabsA11yHostComponent {
+  orientation = signal<'horizontal' | 'vertical'>('horizontal');
+  detailsDisabled = signal(false);
+}
+
+@Component({
+  selector: 'tn-tabs-a11y-multi-host',
+  standalone: true,
+  imports: [TnTabsComponent, TnTabComponent, TnTabPanelComponent],
+  templateUrl: './test-hosts/multi-tabs-host.component.html',
+})
+class TabsA11yMultiHostComponent {}
+
+/**
+ * The rules this structure can be wrong under.
+ *
+ * `aria-required-children` is the reported one — what the tablist is allowed to
+ * own. `aria-required-parent` is its mirror and is what fails if the role lands
+ * somewhere that leaves the tabs outside a tablist, which is the way this
+ * particular fix is most likely to be got wrong.
+ *
+ * `aria-valid-attr-value` is here for the wiring: it is the rule that resolves
+ * `aria-controls` and `aria-labelledby` against real ids. Measured on the
+ * pre-#232 markup, a dangling `aria-labelledby` lands in `incomplete` rather
+ * than `violations` — which `axeResult` throws on, so the rule still fails this
+ * spec if a reference stops resolving, just not by way of `violated`. Note it
+ * does NOT check an unselected tab's `aria-controls` at all — axe skips that
+ * one when `aria-selected="false"` — so `every tab points at its own panel`
+ * below reads the DOM as well rather than leaving it to axe.
+ *
+ * `aria-allowed-attr` covers `aria-orientation` moving with the role: it is
+ * allowed on `tablist` and not on a roleless `div`.
+ */
+const TABLIST_RULES = [
+  'aria-required-children',
+  'aria-required-parent',
+  'aria-valid-attr-value',
+  'aria-allowed-attr',
+  'aria-allowed-role',
+];
+
+describe('tn-tabs accessibility (#232)', () => {
+  let host: TabsA11yHostComponent;
+  let fixture: ComponentFixture<TabsA11yHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabsA11yHostComponent],
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document itself, which axe needs — it
+    // walks up to the document root to decide visibility, and treats a detached
+    // tree as hidden and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TabsA11yHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function root(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-tabs') as HTMLElement;
+  }
+
+  function tablist(): HTMLElement {
+    return fixture.nativeElement.querySelector('[role="tablist"]') as HTMLElement;
+  }
+
+  function tabs(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('[role="tab"]'));
+  }
+
+  function panels(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('[role="tabpanel"]'));
+  }
+
+  describe('the tablist owns the tabs and nothing else', () => {
+    it('puts the role on the header, not on the wrapper that holds the panels', () => {
+      expect(tablist().classList.contains('tn-tabs__header')).toBe(true);
+      expect(root().getAttribute('role')).toBeNull();
+    });
+
+    it('keeps every panel outside the tablist', () => {
+      expect(panels().length).toBe(3);
+      expect(panels().some((panel) => tablist().contains(panel))).toBe(false);
+    });
+
+    it('holds every tab directly inside the tablist', () => {
+      expect(tabs().length).toBe(3);
+      expect(tabs().every((tab) => tablist().contains(tab))).toBe(true);
+    });
+
+    /**
+     * `aria-orientation` describes the tablist, so it has to travel with the
+     * role rather than stay on the wrapper — where it would also be an
+     * attribute a roleless element is not allowed to carry.
+     */
+    it.each(['horizontal', 'vertical'] as const)(
+      'carries aria-orientation on the tablist (%s)',
+      (orientation) => {
+        host.orientation.set(orientation);
+        fixture.detectChanges();
+
+        expect(tablist().getAttribute('aria-orientation')).toBe(orientation);
+        expect(root().hasAttribute('aria-orientation')).toBe(false);
+      },
+    );
+
+    /**
+     * The highlight bar is measured against the header element in
+     * `updateHighlightBar`, so it stays inside it — and inside the tablist as a
+     * result. It is a roleless `div`, which `aria-required-children` treats as
+     * generic and lets through; the axe assertions below would not notice if it
+     * ever gained a role, so its position is asserted here.
+     */
+    it('leaves the highlight bar inside the header it is measured against', async () => {
+      // The bar renders only once `ngAfterViewInit`'s setTimeout(fn, 0) has run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      fixture.detectChanges();
+
+      const bar = fixture.nativeElement.querySelector('.tn-tabs__highlight-bar') as HTMLElement;
+
+      expect(bar.parentElement).toBe(tablist());
+      expect(bar.getAttribute('role')).toBeNull();
+    });
+  });
+
+  describe('axe over the tablist', () => {
+    function targets(): HTMLElement[] {
+      return [tablist(), ...tabs(), ...panels()];
+    }
+
+    it('raises no violation, and does evaluate the tablist rules', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, targets(), TABLIST_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+      expect(evaluated).toContain('aria-required-parent');
+    });
+
+    it('raises no violation in vertical orientation', async () => {
+      host.orientation.set('vertical');
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, targets(), TABLIST_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+    });
+
+    it('raises no violation with a disabled tab', async () => {
+      host.detailsDisabled.set(true);
+      fixture.detectChanges();
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, targets(), TABLIST_RULES
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+    });
+  });
+
+  describe('each tab and its panel point at each other', () => {
+    it('gives every tab and every panel an id', () => {
+      expect(tabs().every((tab) => tab.id !== '')).toBe(true);
+      expect(panels().every((panel) => panel.id !== '')).toBe(true);
+    });
+
+    /**
+     * Read from the DOM rather than left to `aria-valid-attr-value`, which
+     * skips `aria-controls` on an element carrying `aria-selected="false"` —
+     * two of the three tabs here. It would also be satisfied by a tab pointing
+     * at the WRONG panel, since any resolvable id passes it.
+     */
+    it('every tab points at its own panel, and every panel back at its own tab', () => {
+      tabs().forEach((tab, i) => {
+        expect(tab.getAttribute('aria-controls')).toBe(panels()[i].id);
+        expect(panels()[i].getAttribute('aria-labelledby')).toBe(tab.id);
+      });
+    });
+
+    it('resolves every reference to an element that is actually in the document', () => {
+      tabs().forEach((tab, i) => {
+        expect(document.getElementById(tab.getAttribute('aria-controls') as string))
+          .toBe(panels()[i]);
+        expect(document.getElementById(panels()[i].getAttribute('aria-labelledby') as string))
+          .toBe(tab);
+      });
+    });
+  });
+
+  /**
+   * The ids were `tab-{index}` before this change, which is unique within one
+   * tab group and duplicated across every other one on the page. A Storybook
+   * docs page renders all ten Tabs stories at once, so `tab-0` would have
+   * resolved to whichever came first in the document and every panel after the
+   * first would have been labelled by another group's tab.
+   */
+  describe('two tab groups on one page', () => {
+    it('gives every tab and panel an id unique across both groups', async () => {
+      await TestBed.resetTestingModule().configureTestingModule({
+        imports: [TabsA11yMultiHostComponent],
+      }).compileComponents();
+
+      const multi = TestBed.createComponent(TabsA11yMultiHostComponent);
+      multi.detectChanges();
+
+      const ids: string[] = Array.from(
+        multi.nativeElement.querySelectorAll('[role="tab"], [role="tabpanel"]') as
+          NodeListOf<HTMLElement>
+      ).map((el) => el.id);
+
+      expect(ids.length).toBe(8);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  /**
+   * Positive controls. Every `expect(violated).toEqual([])` above is also what
+   * axe returns when it evaluated nothing, so these rebuild the markup the fix
+   * replaced and assert the rules do fire on it.
+   */
+  describe('the structure this replaced', () => {
+    async function scan(html: string, target: string, rules: string[]) {
+      const previous = document.createElement('div');
+      previous.innerHTML = html;
+      document.body.appendChild(previous);
+
+      // `await` inside the try, not `return axeResult(...)` — returning the
+      // promise runs `finally` before axe has read anything, which detaches the
+      // tree mid-scan and is precisely the vacuous pass this is guarding.
+      try {
+        return await axeResult(previous, previous.querySelector(target), rules);
+      } finally {
+        previous.remove();
+      }
+    }
+
+    /** The reported defect itself: a tablist wrapping the panels it labels. */
+    it('still reports a tabpanel owned by the tablist', async () => {
+      const { violated } = await scan(
+        '<div role="tablist" class="tn-tabs" aria-orientation="horizontal">'
+        + '<div class="tn-tabs__header">'
+        + '<button role="tab" type="button" aria-selected="true">Overview</button>'
+        + '</div>'
+        + '<div class="tn-tabs__content">'
+        + '<div role="tabpanel" tabindex="0">Overview content</div>'
+        + '</div>'
+        + '</div>',
+        '[role="tablist"]',
+        ['aria-required-children'],
+      );
+
+      expect(violated).toEqual(['aria-required-children']);
+    });
+
+    /**
+     * The control for the wiring half: `aria-labelledby="tab-0"` with no
+     * element of that id anywhere, which is what every panel rendered before
+     * #232.
+     *
+     * Asserted by resolving the reference rather than by asking axe for a
+     * violation, because axe does not call this one: measured here, it puts a
+     * dangling `aria-labelledby` in `incomplete`. That is not nothing — the
+     * shared `axeResult` throws on `incomplete`, so the clean scans above would
+     * still fail if a reference stopped resolving — but it is not a `violated`
+     * entry, and writing this control as one would be asserting a verdict axe
+     * never gives.
+     */
+    it('leaves the reference unresolvable, which axe reports as undecided, not as a violation',
+      async () => {
+        const previous = document.createElement('div');
+        previous.innerHTML =
+          '<div class="tn-tabs__content">'
+          + '<div role="tabpanel" aria-labelledby="tab-0" tabindex="0">Overview content</div>'
+          + '</div>';
+        document.body.appendChild(previous);
+
+        try {
+          const panel = previous.querySelector('[role="tabpanel"]') as HTMLElement;
+
+          expect(document.getElementById(panel.getAttribute('aria-labelledby') as string))
+            .toBeNull();
+          await expect(axeResult(previous, panel, ['aria-valid-attr-value']))
+            .rejects.toThrow('could not decide aria-valid-attr-value');
+        } finally {
+          previous.remove();
+        }
+      });
+  });
+});

--- a/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
@@ -57,6 +57,15 @@ class TabsA11yHostComponent {
 })
 class TabsA11yMultiHostComponent {}
 
+/** Two groups, one with a tab too many and one with a panel too many. */
+@Component({
+  selector: 'tn-tabs-a11y-mismatched-host',
+  standalone: true,
+  imports: [TnTabsComponent, TnTabComponent, TnTabPanelComponent],
+  templateUrl: './test-hosts/mismatched-host.component.html',
+})
+class TabsA11yMismatchedHostComponent {}
+
 /**
  * The rules this structure can be wrong under.
  *
@@ -239,32 +248,6 @@ describe('tn-tabs accessibility (#232)', () => {
   });
 
   /**
-   * The ids were `tab-{index}` before this change, which is unique within one
-   * tab group and duplicated across every other one on the page. A Storybook
-   * docs page renders all ten Tabs stories at once, so `tab-0` would have
-   * resolved to whichever came first in the document and every panel after the
-   * first would have been labelled by another group's tab.
-   */
-  describe('two tab groups on one page', () => {
-    it('gives every tab and panel an id unique across both groups', async () => {
-      await TestBed.resetTestingModule().configureTestingModule({
-        imports: [TabsA11yMultiHostComponent],
-      }).compileComponents();
-
-      const multi = TestBed.createComponent(TabsA11yMultiHostComponent);
-      multi.detectChanges();
-
-      const ids: string[] = Array.from(
-        multi.nativeElement.querySelectorAll('[role="tab"], [role="tabpanel"]') as
-          NodeListOf<HTMLElement>
-      ).map((el) => el.id);
-
-      expect(ids.length).toBe(8);
-      expect(new Set(ids).size).toBe(ids.length);
-    });
-  });
-
-  /**
    * Positive controls. Every `expect(violated).toEqual([])` above is also what
    * axe returns when it evaluated nothing, so these rebuild the markup the fix
    * replaced and assert the rules do fire on it.
@@ -336,5 +319,126 @@ describe('tn-tabs accessibility (#232)', () => {
           previous.remove();
         }
       });
+  });
+});
+
+/**
+ * The ids were `tab-{index}` before #232, which is unique within one tab group
+ * and duplicated across every other one on the page. A Storybook docs page
+ * renders all ten Tabs stories at once, so `tab-0` would have resolved to
+ * whichever came first in the document and every panel after the first would
+ * have been labelled by another group's tab.
+ */
+describe('tn-tabs accessibility (#232): two tab groups on one page', () => {
+  let fixture: ComponentFixture<TabsA11yMultiHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabsA11yMultiHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabsA11yMultiHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('gives every tab and panel an id unique across both groups', () => {
+    const ids: string[] = Array.from(
+      fixture.nativeElement.querySelectorAll('[role="tab"], [role="tabpanel"]') as
+        NodeListOf<HTMLElement>
+    ).map((el) => el.id);
+
+    expect(ids.length).toBe(8);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('keeps each panel labelled by a tab in its own group', () => {
+    const groups: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('.tn-tabs'));
+
+    expect(groups.length).toBe(2);
+    groups.forEach((group) => {
+      const tabs: HTMLElement[] = Array.from(group.querySelectorAll('[role="tab"]'));
+      const panels: HTMLElement[] = Array.from(group.querySelectorAll('[role="tabpanel"]'));
+
+      panels.forEach((panel, i) => {
+        expect(panel.getAttribute('aria-labelledby')).toBe(tabs[i].id);
+        expect(group.contains(
+          document.getElementById(panel.getAttribute('aria-labelledby') as string) as HTMLElement
+        )).toBe(true);
+      });
+    });
+  });
+});
+
+/**
+ * Tabs and panels are separate content children paired only by position, so a
+ * consumer can hand `tn-tabs` more of one than the other. Neither cross-
+ * reference may be rendered without the element it names: an `aria-controls`
+ * resolving to nothing is the defect this fix would otherwise have introduced,
+ * on the way to removing the same defect from `aria-labelledby`.
+ */
+describe('tn-tabs accessibility (#232): more tabs than panels, and the reverse', () => {
+  let fixture: ComponentFixture<TabsA11yMismatchedHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabsA11yMismatchedHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabsA11yMismatchedHostComponent);
+    fixture.detectChanges();
+  });
+
+  function groups(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.tn-tabs'));
+  }
+
+  function tabsIn(group: HTMLElement): HTMLElement[] {
+    return Array.from(group.querySelectorAll('[role="tab"]'));
+  }
+
+  function panelsIn(group: HTMLElement): HTMLElement[] {
+    return Array.from(group.querySelectorAll('[role="tabpanel"]'));
+  }
+
+  it('omits aria-controls on the tab that has no panel', () => {
+    const tabs = tabsIn(groups()[0]);
+
+    expect(tabs.length).toBe(2);
+    expect(tabs[0].getAttribute('aria-controls')).toBe(panelsIn(groups()[0])[0].id);
+    expect(tabs[1].hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('omits aria-labelledby on the panel that has no tab', () => {
+    const panels = panelsIn(groups()[1]);
+
+    expect(panels.length).toBe(2);
+    expect(panels[0].getAttribute('aria-labelledby')).toBe(tabsIn(groups()[1])[0].id);
+    expect(panels[1].hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  it('leaves no reference that resolves to nothing', () => {
+    const referring: HTMLElement[] = Array.from(
+      fixture.nativeElement.querySelectorAll('[aria-controls], [aria-labelledby]')
+    );
+
+    expect(referring.length).toBe(4);
+    referring.forEach((el) => {
+      const id = el.getAttribute('aria-controls') ?? el.getAttribute('aria-labelledby') as string;
+      expect(document.getElementById(id)).not.toBeNull();
+    });
+  });
+
+  it('raises no violation on either group', async () => {
+    for (const group of groups()) {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [group.querySelector('[role="tablist"]') as HTMLElement,
+          ...tabsIn(group), ...panelsIn(group)],
+        TABLIST_RULES,
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+    }
   });
 });

--- a/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs-a11y.spec.ts
@@ -57,6 +57,17 @@ class TabsA11yHostComponent {
 })
 class TabsA11yMultiHostComponent {}
 
+/** A group whose tabs can be taken away while its panels stay. */
+@Component({
+  selector: 'tn-tabs-a11y-removable-host',
+  standalone: true,
+  imports: [TnTabsComponent, TnTabComponent, TnTabPanelComponent],
+  templateUrl: './test-hosts/removable-tabs-host.component.html',
+})
+class TabsA11yRemovableHostComponent {
+  showTabs = signal(true);
+}
+
 /** Two groups, one with a tab too many and one with a panel too many. */
 @Component({
   selector: 'tn-tabs-a11y-mismatched-host',
@@ -84,7 +95,10 @@ class TabsA11yMismatchedHostComponent {}
  * below reads the DOM as well rather than leaving it to axe.
  *
  * `aria-allowed-attr` covers `aria-orientation` moving with the role: it is
- * allowed on `tablist` and not on a roleless `div`.
+ * allowed on `tablist` and not on a roleless `div`. `aria-allowed-role` is the
+ * one about where the role may sit at all — it reports a role given to an
+ * element whose implicit semantics forbid it, which is the risk in moving a
+ * role from one element to another rather than in the role itself.
  */
 const TABLIST_RULES = [
   'aria-required-children',
@@ -366,6 +380,61 @@ describe('tn-tabs accessibility (#232): two tab groups on one page', () => {
         )).toBe(true);
       });
     });
+  });
+});
+
+/**
+ * Taking the tabs away is the mismatch below arriving by a different route, and
+ * it is the one a consumer reaches by accident: an `@if` around the tabs leaves
+ * the panels behind. What makes it worth its own fixture is that it is a
+ * TRANSITION — every panel has already been told it has a tab, so nothing is
+ * dangling until the moment the tabs go, and only a re-run of `initializeTabs`
+ * takes the reference back off.
+ */
+describe('tn-tabs accessibility (#232): the last tab removed', () => {
+  let host: TabsA11yRemovableHostComponent;
+  let fixture: ComponentFixture<TabsA11yRemovableHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabsA11yRemovableHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabsA11yRemovableHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function panels(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('[role="tabpanel"]'));
+  }
+
+  it('labels each panel while its tab is there', () => {
+    const tabs: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('[role="tab"]'));
+
+    expect(panels().map((panel) => panel.getAttribute('aria-labelledby')))
+      .toEqual(tabs.map((tab) => tab.id));
+  });
+
+  it('takes aria-labelledby back off when the tabs go', () => {
+    host.showTabs.set(false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('[role="tab"]').length).toBe(0);
+    expect(panels().length).toBe(2);
+    expect(panels().some((panel) => panel.hasAttribute('aria-labelledby'))).toBe(false);
+  });
+
+  it('puts it back when the tabs return', () => {
+    host.showTabs.set(false);
+    fixture.detectChanges();
+    host.showTabs.set(true);
+    fixture.detectChanges();
+
+    const tabs: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('[role="tab"]'));
+
+    expect(panels().map((panel) => panel.getAttribute('aria-labelledby')))
+      .toEqual(tabs.map((tab) => tab.id));
   });
 });
 

--- a/projects/truenas-ui/src/lib/tabs/tabs.component.html
+++ b/projects/truenas-ui/src/lib/tabs/tabs.component.html
@@ -1,5 +1,11 @@
-<div role="tablist" tnTestIdType="tabs" [ngClass]="classes()" [attr.aria-orientation]="orientation()" [tnTestId]="testId()">
-  <div #tabHeader class="tn-tabs__header">
+<div tnTestIdType="tabs" [ngClass]="classes()" [tnTestId]="testId()">
+  <!--
+    `role="tablist"` sits here rather than on the wrapper above, because a tablist may own
+    nothing but tabs and the wrapper also holds the panels — which failed axe
+    `aria-required-children` in every Tabs story (#232). `aria-orientation` describes the
+    tablist, so it travels with the role.
+  -->
+  <div #tabHeader role="tablist" class="tn-tabs__header" [attr.aria-orientation]="orientation()">
     <ng-content select="tn-tab" />
     @if (highlightBarVisible()) {
       <div class="tn-tabs__highlight-bar"

--- a/projects/truenas-ui/src/lib/tabs/tabs.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs.component.spec.ts
@@ -342,24 +342,26 @@ describe('TnTabsComponent', () => {
     });
   });
 
+  // The modifier classes are on the `.tn-tabs` root, which is NOT the tablist: since #232
+  // the role sits on the header inside it, so these read the root by class.
   describe('CSS classes', () => {
     it('should apply horizontal class by default', () => {
-      const tablist = fixture.nativeElement.querySelector('[role="tablist"]');
-      expect(tablist.classList.contains('tn-tabs--horizontal')).toBe(true);
+      const root = fixture.nativeElement.querySelector('.tn-tabs');
+      expect(root.classList.contains('tn-tabs--horizontal')).toBe(true);
     });
 
     it('should apply vertical class', () => {
       host.orientation.set('vertical');
       fixture.detectChanges();
 
-      const tablist = fixture.nativeElement.querySelector('[role="tablist"]');
-      expect(tablist.classList.contains('tn-tabs--vertical')).toBe(true);
-      expect(tablist.classList.contains('tn-tabs--horizontal')).toBe(false);
+      const root = fixture.nativeElement.querySelector('.tn-tabs');
+      expect(root.classList.contains('tn-tabs--vertical')).toBe(true);
+      expect(root.classList.contains('tn-tabs--horizontal')).toBe(false);
     });
 
     it('should apply highlight position class', () => {
-      const tablist = fixture.nativeElement.querySelector('[role="tablist"]');
-      expect(tablist.classList.contains('tn-tabs--highlight-bottom')).toBe(true);
+      const root = fixture.nativeElement.querySelector('.tn-tabs');
+      expect(root.classList.contains('tn-tabs--highlight-bottom')).toBe(true);
     });
 
     it('should apply active class to selected tab', () => {
@@ -445,15 +447,18 @@ describe('TnTabsComponent (lazy loading)', () => {
 class TabsTestIdHostComponent {}
 
 describe('TnTabs test-id prefixes', () => {
-  it('prefixes tablist (tabs-), tab (tab-), and panel (tab-panel-)', async () => {
+  // `tabs-` is on the `.tn-tabs` root rather than on the tablist. The two were the same
+  // element until #232 moved the role onto the header; the test id did not move with it,
+  // because it is the whole component a consumer selects by, not its header.
+  it('prefixes root (tabs-), tab (tab-), and panel (tab-panel-)', async () => {
     await TestBed.configureTestingModule({ imports: [TabsTestIdHostComponent] }).compileComponents();
     const fixture = TestBed.createComponent(TabsTestIdHostComponent);
     fixture.detectChanges();
 
-    const tablist = fixture.nativeElement.querySelector('[role="tablist"]') as HTMLElement;
+    const root = fixture.nativeElement.querySelector('.tn-tabs') as HTMLElement;
     const tab = fixture.nativeElement.querySelector('[role="tab"]') as HTMLElement;
     const panel = fixture.nativeElement.querySelector('[role="tabpanel"]') as HTMLElement;
-    expect(tablist.getAttribute('data-testid')).toBe('tabs-settings');
+    expect(root.getAttribute('data-testid')).toBe('tabs-settings');
     expect(tab.getAttribute('data-testid')).toBe('tab-general');
     expect(panel.getAttribute('data-testid')).toBe('tab-panel-general');
   });

--- a/projects/truenas-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs.component.ts
@@ -91,12 +91,12 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
 
     // Listen for tab changes
     effect(() => {
-      // Track tabs signal to react to changes
-      const tabs = this.tabs();
-      if (tabs.length > 0) {
-        this.initializeTabs();
-        this.updateHighlightBar();
-      }
+      // Runs on an empty tab set as well, because `initializeTabs` is what clears each
+      // panel's `hasTab`: skipping it when the last tab is removed would leave every panel
+      // pointing `aria-labelledby` at a tab that no longer exists, which is the dangling
+      // reference #232 removed. Both calls below no-op on their own when there are no tabs.
+      this.initializeTabs();
+      this.updateHighlightBar();
     });
   }
 

--- a/projects/truenas-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs.component.ts
@@ -125,10 +125,16 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
 
   private initializeTabs() {
     const currentIndex = this.internalSelectedIndex();
+    // Tabs and panels are separate content children and nothing pairs them up but their
+    // position, so a group can be given more of one than the other. Each side is told
+    // whether its opposite number exists, and renders its cross-reference only if it does.
+    const tabCount = this.tabs().length;
+    const panelCount = this.panels().length;
 
     this.tabs().forEach((tab, index) => {
       tab.index.set(index);
       tab.groupId.set(this.groupId);
+      tab.hasPanel.set(index < panelCount);
       tab.isActive.set(index === currentIndex);
       tab.tabsComponent = this;
 
@@ -141,6 +147,7 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
     this.panels().forEach((panel, index) => {
       panel.index.set(index);
       panel.groupId.set(this.groupId);
+      panel.hasTab.set(index < tabCount);
       panel.isActive.set(index === currentIndex);
     });
 

--- a/projects/truenas-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/truenas-ui/src/lib/tabs/tabs.component.ts
@@ -7,6 +7,8 @@ import { TnTabComponent } from '../tab/tab.component';
 import { TnTabPanelComponent } from '../tab-panel/tab-panel.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
+let nextGroupId = 0;
+
 export interface TabChangeEvent {
   index: number;
   tab: TnTabComponent;
@@ -30,10 +32,18 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
   orientation = input<'horizontal' | 'vertical'>('horizontal');
   highlightPosition = input<'left' | 'right' | 'top' | 'bottom'>('bottom');
   /**
-   * Test-id applied to the tablist root element. Rendered under whichever attribute name
-   * is configured via `TN_TEST_ATTR` (default `data-testid`).
+   * Test-id applied to the root element — the wrapper around the tablist and the panels,
+   * not the tablist itself, which is the header inside it. Rendered under whichever
+   * attribute name is configured via `TN_TEST_ATTR` (default `data-testid`).
    */
   testId = input<TnTestIdValue>(undefined);
+
+  /**
+   * Namespace for the ids this group hands to its tabs and panels, so that two `tn-tabs`
+   * on one page cannot both mint `tab-0` and cross-wire each other's `aria-controls` and
+   * `aria-labelledby`. See `tab-ids.ts`.
+   */
+  private readonly groupId = `tn-tabs-${nextGroupId++}`;
 
   selectedIndexChange = output<number>();
   tabChange = output<TabChangeEvent>();
@@ -118,6 +128,7 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
 
     this.tabs().forEach((tab, index) => {
       tab.index.set(index);
+      tab.groupId.set(this.groupId);
       tab.isActive.set(index === currentIndex);
       tab.tabsComponent = this;
 
@@ -129,6 +140,7 @@ export class TnTabsComponent implements AfterContentInit, AfterViewInit, OnDestr
 
     this.panels().forEach((panel, index) => {
       panel.index.set(index);
+      panel.groupId.set(this.groupId);
       panel.isActive.set(index === currentIndex);
     });
 

--- a/projects/truenas-ui/src/lib/tabs/test-hosts/a11y-host.component.html
+++ b/projects/truenas-ui/src/lib/tabs/test-hosts/a11y-host.component.html
@@ -1,0 +1,9 @@
+<tn-tabs [orientation]="orientation()">
+  <tn-tab label="Overview" />
+  <tn-tab label="Details" [disabled]="detailsDisabled()" />
+  <tn-tab label="Settings" />
+
+  <tn-tab-panel>Overview content</tn-tab-panel>
+  <tn-tab-panel>Details content</tn-tab-panel>
+  <tn-tab-panel>Settings content</tn-tab-panel>
+</tn-tabs>

--- a/projects/truenas-ui/src/lib/tabs/test-hosts/mismatched-host.component.html
+++ b/projects/truenas-ui/src/lib/tabs/test-hosts/mismatched-host.component.html
@@ -1,0 +1,13 @@
+<tn-tabs>
+  <tn-tab label="Overview" />
+  <tn-tab label="Details" />
+
+  <tn-tab-panel>Overview content</tn-tab-panel>
+</tn-tabs>
+
+<tn-tabs>
+  <tn-tab label="Alpha" />
+
+  <tn-tab-panel>Alpha content</tn-tab-panel>
+  <tn-tab-panel>Orphan content</tn-tab-panel>
+</tn-tabs>

--- a/projects/truenas-ui/src/lib/tabs/test-hosts/removable-tabs-host.component.html
+++ b/projects/truenas-ui/src/lib/tabs/test-hosts/removable-tabs-host.component.html
@@ -1,0 +1,17 @@
+<!--
+  One `@if` per tab, rather than one around the pair. A control-flow block is projected by
+  the selector of its SINGLE root node, so a block holding two `tn-tab`s matches no
+  `ng-content select="tn-tab"` at all — the tabs are then found by `contentChildren` and
+  never rendered, which is a different defect from the one this fixture is for.
+-->
+<tn-tabs>
+  @if (showTabs()) {
+    <tn-tab label="Overview" />
+  }
+  @if (showTabs()) {
+    <tn-tab label="Details" />
+  }
+
+  <tn-tab-panel>Overview content</tn-tab-panel>
+  <tn-tab-panel>Details content</tn-tab-panel>
+</tn-tabs>

--- a/projects/truenas-ui/src/stories/tabs.stories.ts
+++ b/projects/truenas-ui/src/stories/tabs.stories.ts
@@ -551,7 +551,7 @@ export const TabsComponentHarness: Story = {
 };
 
 /**
- * **Test IDs (default).** `tn-tabs` emits `tabs-<base>` on the tablist, each
+ * **Test IDs (default).** `tn-tabs` emits `tabs-<base>` on its root element, each
  * `tn-tab` emits `tab-<base>` on its header button, and each `tn-tab-panel`
  * emits `tab-panel-<base>`, under `data-testid` (default) / `data-test`.
  */


### PR DESCRIPTION
Fixes #232.

## What was wrong

`role="tablist"` sat on `.tn-tabs`, the outer wrapper, which holds the tab header **and** the panel content. A tablist may own nothing but tabs, so every rendered `role="tabpanel"` was an illegal child of it and all ten Tabs stories failed axe `aria-required-children` with *"Element has children which are not allowed: [role=tabpanel]"*.

## What changed

**The role moved down one level, onto `.tn-tabs__header`**, whose only children are the tabs and the highlight bar. `aria-orientation` travelled with it, since it describes the tablist.

**The tab↔panel wiring is now real.** Containment was the only thing tying a panel to its tab; with the panels outside the tablist the association has to be explicit, and it was not — `tn-tab` carried no `aria-controls` at all, and `tn-tab-panel` carried `aria-labelledby="tab-{index}"` pointing at an id no element in this library ever rendered. Both ends now use ids from `tabs/tab-ids.ts`, namespaced per `tn-tabs` instance so two tab groups on one page (a Storybook docs page renders ten) cannot both mint `tab-0` and cross-wire each other's panels.

**Neither cross-reference is rendered without the element it names.** Tabs and panels are separate content children paired only by position, so a group can be handed more of one than the other, and the tabs can be taken away while the panels stay. `hasPanel` on `tn-tab` and `hasTab` on `tn-tab-panel` are set in `initializeTabs`, and that effect no longer skips itself on an empty tab set — which is what clears the flag when the last tab goes.

**Two existing assertions in `tabs.component.spec.ts` now read `.tn-tabs` by class.** They looked up `[role="tablist"]` and meant the root; those were the same element until this change. The test id did not move with the role — `tabs-<base>` is on the root, which is what a consumer selects the component by — and `tabs.stories.ts`'s test-id note was corrected to say so.

## How it was checked

Reproduced first, in jsdom: `axeResult` over the live component with `aria-required-children` reported exactly the violation the ticket quotes. `tabs-a11y.spec.ts` (23 tests) now guards the structure, the wiring, the mismatched and emptied cases, and carries positive controls that rebuild the markup this replaced — the `aria-required-children` violation, and the unresolvable `aria-labelledby` (which axe reports as *undecided*, not as a violation; the shared `axeResult` throws on that, so a clean scan above it is not vacuous).

The `initializeTabs` fix was confirmed against the defect rather than assumed: with the old guard restored, `takes aria-labelledby back off when the tabs go` fails and everything else still passes.

Locally: `yarn lint` clean for these files (the 4 remaining `import/order` errors are pre-existing, in `input.component.ts` and `menu-panel.component.ts`, which this branch does not touch), `yarn test` 2837 passed, `yarn test:scripts` 42 passed, `yarn build` clean.

**`yarn test-sb` could not be run here** — Storybook interaction tests drive a real browser through Playwright and this host has neither the browser nor the system libraries to start one. That is the check the ticket was filed from, so it is the one to watch on this PR. What stands behind the claim in the meantime is that the same axe rule runs over the same DOM in jsdom, in `tabs-a11y.spec.ts`.

Three local review rounds were run; the third returned nothing at MEDIUM or above.

## What was not changed, and why

Five LOW findings were left, listed here so they are not lost:

- **The highlight bar is now an owned child of the tablist** and carries no `aria-hidden`. It is a roleless `div`, which `aria-required-children` treats as generic and permits — measured, and asserted by `leaves the highlight bar inside the header it is measured against`. `aria-hidden="true"` would state the intent explicitly.
- **Three module-level id counters** (in `tabs`, `tab` and `tab-panel`) implement one policy. Consolidating them in `tab-ids.ts`, or using the CDK's `_IdGenerator` for SSR stability, would be tidier.
- **`groupId`/`hasPanel`/`hasTab` are pushed imperatively from `initializeTabs`.** Injecting the parent and deriving them as computeds would shrink the mutable signal surface on the children. Pushing is what the existing `index`/`isActive` do, so this follows the file rather than adding a second pattern.
- **`tabs-a11y.spec.ts` reuses `multi-tabs-host.component.html`** (shared with `tabs.harness.spec.ts`) and hard-codes `toBe(8)`, so editing that fixture breaks this spec for an unrelated reason.
- **No test covers the standalone case** — a `tn-tab` or `tn-tab-panel` used outside a `tn-tabs`, which keeps its unowned `groupId` and omits the cross-reference.
