### PR TITLE
NAS-142479 / 27.0.0-BETA.1 / fix(themes): add --tn-primary-text, a text-safe companion to --tn-primary

### DIFF
--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -78,7 +78,7 @@ a.storybook-button {
 .button-outline-primary {
   background-color: transparent;
   border: 1px solid var(--tn-primary);
-  color: var(--tn-primary);
+  color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
 }
 .button-outline-primary:hover {

--- a/projects/truenas-ui/src/lib/calendar/month-view.component.scss
+++ b/projects/truenas-ui/src/lib/calendar/month-view.component.scss
@@ -191,7 +191,7 @@
 // component withholds this class there rather than the two fighting in CSS.
 .tn-calendar-body-cell-content.tn-calendar-body-today-outline {
   border: 1px solid var(--tn-primary, #007bff);
-  color: var(--tn-primary, #007bff);
+  color: var(--tn-primary-text, var(--tn-primary, #0074a7));
 }
 
 .cdk-visually-hidden {

--- a/projects/truenas-ui/src/lib/calendar/multi-year-view.component.scss
+++ b/projects/truenas-ui/src/lib/calendar/multi-year-view.component.scss
@@ -91,7 +91,7 @@
 
 .tn-calendar-body-cell.tn-calendar-body-today:not(.tn-calendar-body-selected) .tn-calendar-body-cell-content {
   border: 1px solid var(--tn-primary, #007bff);
-  color: var(--tn-primary, #007bff);
+  color: var(--tn-primary-text, var(--tn-primary, #0074a7));
 }
 
 .tn-calendar-body-cell.tn-calendar-body-selected .tn-calendar-body-cell-content {

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -142,7 +142,7 @@
   transition: color 0.2s ease;
 
   &:hover {
-    color: var(--tn-primary, #2563eb);
+    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   }
 }
 
@@ -247,7 +247,7 @@
 .tn-card__footer-link {
   border: none;
   background: transparent;
-  color: var(--tn-primary, #2563eb);
+  color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
+++ b/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
@@ -107,7 +107,7 @@
     
     // The chevron is an <svg>, not text — 3:1 applies.
     .tn-expansion-panel__indicator {
-      color: var(--tn-primary);
+      color: var(--tn-primary, #3b82f6);
     }
 
     .tn-expansion-panel__header:hover:not(:disabled) {

--- a/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
+++ b/projects/truenas-ui/src/lib/expansion-panel/expansion-panel.component.scss
@@ -101,12 +101,13 @@
     .tn-expansion-panel__title {
       font-size: 1rem;
       font-weight: 400;
-      color: var(--tn-primary, #3b82f6);
+      color: var(--tn-primary-text, var(--tn-primary, #0074a7));
       text-decoration: none;
     }
     
+    // The chevron is an <svg>, not text — 3:1 applies.
     .tn-expansion-panel__indicator {
-      color: var(--tn-primary, #3b82f6);
+      color: var(--tn-primary);
     }
 
     .tn-expansion-panel__header:hover:not(:disabled) {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -45,7 +45,7 @@
   .breadcrumb-segment {
     background: transparent;
     border: none;
-    color: var(--tn-primary);
+    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
     cursor: pointer;
     padding: 4px 2px;
     border-radius: 4px;
@@ -150,6 +150,7 @@
     }
   }
 
+  // An icon, not text — 3:1 applies, which --tn-primary is tuned for.
   .creation-loading-icon {
     animation: spin 1s linear infinite;
     color: var(--tn-primary);
@@ -252,7 +253,7 @@ tn-table {
   flex-shrink: 0;
   line-height: 1;
 
-  // Folder color
+  // Folder color. An icon, not text — 3:1 applies.
   &.file-icon-folder {
     color: var(--tn-primary);
   }
@@ -332,6 +333,7 @@ tn-table {
   &:hover,
   &:focus-visible {
     background: var(--tn-bg3);
+    // The chevron is an icon, not text — 3:1 applies.
     color: var(--tn-primary);
   }
 }

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -46,7 +46,7 @@
   &:hover,
   &:focus-visible {
     // The button holds an icon and no text — 3:1 applies.
-    color: var(--tn-primary);
+    color: var(--tn-primary, #007bff);
   }
 
   &:focus-visible {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -45,7 +45,8 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--tn-primary, #007bff);
+    // The button holds an icon and no text — 3:1 applies.
+    color: var(--tn-primary);
   }
 
   &:focus-visible {
@@ -126,7 +127,7 @@
 // Focus state handling
 .tn-form-field-wrapper:has(:focus-visible) {
   .tn-form-field-label {
-    color: var(--tn-primary, #007bff);
+    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   }
 }
 

--- a/projects/truenas-ui/src/lib/form-section/form-section.component.scss
+++ b/projects/truenas-ui/src/lib/form-section/form-section.component.scss
@@ -58,7 +58,8 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--tn-primary, #007bff);
+    // The button holds an icon and no text — 3:1 applies.
+    color: var(--tn-primary);
   }
 
   &:focus-visible {

--- a/projects/truenas-ui/src/lib/form-section/form-section.component.scss
+++ b/projects/truenas-ui/src/lib/form-section/form-section.component.scss
@@ -59,7 +59,7 @@
   &:hover,
   &:focus-visible {
     // The button holds an icon and no text — 3:1 applies.
-    color: var(--tn-primary);
+    color: var(--tn-primary, #007bff);
   }
 
   &:focus-visible {

--- a/projects/truenas-ui/src/lib/menu/menu.component.scss
+++ b/projects/truenas-ui/src/lib/menu/menu.component.scss
@@ -93,7 +93,15 @@
   &.tn-menu-item--selected {
     background: var(--tn-alt-bg2, #e8f4fd);
     font-weight: 600;
-    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
+    // Left on --tn-primary deliberately. --tn-primary-text is tuned, and
+    // measured, against --tn-bg1 and --tn-bg2; this row paints on --tn-alt-bg2,
+    // where it measures 2.37:1 in :root and fails in six of the nine palettes.
+    // Reading it here would be claiming a guarantee the token does not make.
+    // --tn-alt-bg2 has no foreground that clears AA across the palettes at all
+    // — even --tn-fg1 is 1.45:1 on it in Solarized Dark — so this row needs the
+    // surface reconsidered rather than a different colour on it, which is a
+    // wider change than #242.
+    color: var(--tn-primary, #007bff);
   }
 
   &.disabled {

--- a/projects/truenas-ui/src/lib/menu/menu.component.scss
+++ b/projects/truenas-ui/src/lib/menu/menu.component.scss
@@ -93,7 +93,7 @@
   &.tn-menu-item--selected {
     background: var(--tn-alt-bg2, #e8f4fd);
     font-weight: 600;
-    color: var(--tn-primary, #007bff);
+    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   }
 
   &.disabled {

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.scss
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.scss
@@ -177,6 +177,10 @@
       border-color: var(--tn-primary);
     }
 
+    // Stays on --tn-primary: this is an <svg> tick, non-text content under the
+    // 3:1 minimum --tn-primary is tuned for, and the --accent/--warn variants
+    // below re-point --tn-primary to follow the toggle's colour. Reading
+    // --tn-primary-text here would make the tick ignore them.
     .tn-slide-toggle__check-icon {
       color: var(--tn-primary);
     }

--- a/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
@@ -1,0 +1,229 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { TN_THEME_DEFINITIONS } from './theme.constants';
+import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+
+/**
+ * `--tn-primary` is tuned for the 3:1 non-text minimum — fills, borders and
+ * focus rings — and measured 3.64:1 on `--tn-bg1` in `:root`, 2.79:1 in
+ * Solarized Dark. Anything reading it as `color:` on a themed surface inherited
+ * that (#242). `--tn-primary-text` is its text-safe companion, the same
+ * arrangement `--tn-error-text` already has for `--tn-red`, and this measures it
+ * against the values actually shipped in `themes.css`.
+ *
+ * jsdom has no layout engine, so axe's `color-contrast` rule cannot decide
+ * anything here — it reports `incomplete` rather than checking, and `axeResult`
+ * throws on that. Computing the ratio from the shipped values is the claim that
+ * can honestly be made without a browser: it is about the palette rather than
+ * about a rendered page. `yarn test-sb` is what checks the page.
+ *
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
+ * nothing is re-derived here. `radio-error-contrast.spec.ts` is the same shape
+ * for `--tn-error-text`.
+ */
+
+const STYLES_DIR = join(__dirname, '../../styles');
+const LIB_DIR = join(__dirname, '..');
+
+/**
+ * Declared by each theme itself, not inherited from `:root`. `--tn-primary-text`
+ * is tuned against a particular theme's backgrounds, so a theme falling back to
+ * `:root`'s value is reporting a colour chosen for different surfaces —
+ * `declares` sees that, where `color` would resolve it and quietly report a
+ * number.
+ */
+const REQUIRED_TOKENS = ['--tn-bg1', '--tn-bg2', '--tn-primary-text'];
+
+/**
+ * The literal each migrated declaration ends in. Reached only when no theme
+ * stylesheet is loaded at all, so the surface it renders on is the UA default:
+ * white.
+ */
+const FALLBACK_LITERAL = '#0074a7';
+
+/**
+ * `color:` declarations that legitimately still read `--tn-primary`, by the file
+ * they are in and the count in it. Every one paints an icon rather than text —
+ * an `<svg>` or a `<tn-icon>` — which is non-text content under WCAG 1.4.11 at
+ * 3:1, exactly what `--tn-primary` is tuned for. The tick in `tn-slide-toggle`
+ * has a second reason: `--accent` and `--warn` re-point `--tn-primary` locally
+ * to colour the whole toggle, and reading `--tn-primary-text` would make the
+ * tick ignore them.
+ *
+ * A count rather than a bare allowlist, so that a NEW `color: var(--tn-primary)`
+ * in one of these files is still caught. Adding a decorative icon means adding
+ * to a number here; adding text means using `--tn-primary-text`.
+ */
+const NON_TEXT_COLOR_USES: Readonly<Record<string, number>> = {
+  'expansion-panel/expansion-panel.component.scss': 1,
+  'file-picker/file-picker-popup.component.scss': 3,
+  'form-field/form-field.component.scss': 1,
+  'form-section/form-section.component.scss': 1,
+  'slide-toggle/slide-toggle.component.scss': 1,
+};
+
+/**
+ * A `color:` declaration reading `--tn-primary` directly. The `(^|[^-\w])` is
+ * load-bearing: `background-color: var(--tn-primary)` contains
+ * `color: var(--tn-primary)` as a substring, and it is a fill, which is
+ * *supposed* to read `--tn-primary`.
+ */
+const PRIMARY_AS_COLOR = /(?:^|[^-\w])color:\s*var\(\s*--tn-primary\s*[,)]/gm;
+
+function scssFiles(directory: string): string[] {
+  return readdirSync(directory, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.scss'))
+    .sort();
+}
+
+interface ThemeCase {
+  selector: string;
+  primaryText: string;
+  bg1: string;
+  bg2: string;
+  bg1Ratio: number;
+  bg2Ratio: number;
+  bg1RatioLabel: string;
+  bg2RatioLabel: string;
+}
+
+describe('--tn-primary-text contrast (#242)', () => {
+  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
+  const palettes = themePalettes(css);
+
+  // Derived from the theme registry rather than hardcoded: a themed surface that
+  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
+  // would otherwise go unmeasured while every remaining case still passed.
+  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(palettes).toHaveLength(expectedSelectors.length);
+  });
+
+  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
+    expect(palettes.map((palette) => palette.selector)).toContain(selector);
+  });
+
+  const declarations = palettes.map((palette) => ({
+    selector: palette.selector,
+    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
+  }));
+
+  it.each(declarations)('$selector declares --tn-bg1, --tn-bg2 and --tn-primary-text itself', ({ missing }) => {
+    expect(missing).toEqual([]);
+  });
+
+  // Only the surfaces that passed the check above are measured — a palette
+  // missing a token has already failed, and measuring it would add a second
+  // failure saying the same thing in worse words. If that leaves nothing to
+  // measure, `it.each` errors on the empty array rather than reporting a suite
+  // with no contrast cases in it as green.
+  const cases: ThemeCase[] = palettes
+    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+    .map((palette) => {
+      const bg1Ratio = palette.contrast('--tn-primary-text', '--tn-bg1');
+      const bg2Ratio = palette.contrast('--tn-primary-text', '--tn-bg2');
+      return {
+        selector: palette.selector,
+        primaryText: palette.color('--tn-primary-text'),
+        bg1: palette.color('--tn-bg1'),
+        bg2: palette.color('--tn-bg2'),
+        bg1Ratio,
+        bg2Ratio,
+        bg1RatioLabel: formatRatio(bg1Ratio),
+        bg2RatioLabel: formatRatio(bg2Ratio),
+      };
+    });
+
+  // `normal`, not `large`: the call sites are links, breadcrumbs, labels and
+  // calendar dates at body size or smaller, so 4.5:1 applies rather than 3:1.
+  // The measured ratio is in each case's title, so a failure names the colour
+  // and the number it came to as well as the theme it belongs to.
+  it.each(cases)(
+    '$selector: $primaryText on --tn-bg1 ($bg1) measures $bg1RatioLabel',
+    ({ bg1Ratio }) => {
+      expect(meetsAa(bg1Ratio, 'normal')).toBe(true);
+    }
+  );
+
+  it.each(cases)(
+    '$selector: $primaryText on --tn-bg2 ($bg2) measures $bg2RatioLabel',
+    ({ bg2Ratio }) => {
+      expect(meetsAa(bg2Ratio, 'normal')).toBe(true);
+    }
+  );
+
+  describe('the call sites that read it', () => {
+    const files = scssFiles(LIB_DIR).map((file) => ({
+      file,
+      scss: readFileSync(join(LIB_DIR, file), 'utf8'),
+    }));
+
+    it('there are component stylesheets to scan', () => {
+      // Guards the scan itself: a moved lib directory, or a renamed extension,
+      // would otherwise leave every case below vacuously green.
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    const remaining = files
+      .map(({ file, scss }) => ({
+        file,
+        count: (scss.match(PRIMARY_AS_COLOR) ?? []).length,
+        allowed: NON_TEXT_COLOR_USES[file] ?? 0,
+      }))
+      .filter(({ count, allowed }) => count > 0 || allowed > 0);
+
+    it.each(remaining)(
+      '$file paints $allowed non-text thing(s) with color: var(--tn-primary)',
+      ({ count, allowed }) => {
+        // Text reading --tn-primary is the defect; an icon reading it is
+        // correct. If this fails, either the declaration is text and wants
+        // --tn-primary-text, or it is an icon and belongs in
+        // NON_TEXT_COLOR_USES with a note saying which icon.
+        expect(count).toBe(allowed);
+      }
+    );
+
+    it('every allowlisted file still exists', () => {
+      // Without this a renamed or deleted component leaves a stale entry that
+      // nothing measures, and the case above passes it as 0 === 0.
+      const scanned = files.map(({ file }) => file);
+      expect(Object.keys(NON_TEXT_COLOR_USES).filter((file) => !scanned.includes(file))).toEqual([]);
+    });
+
+    // On the declaration, not on a bare `includes`: the comment above
+    // tn-slide-toggle's tick names the token to explain why it does NOT read it,
+    // and that file has no declaration to check.
+    const migrated = files.filter(({ scss }) => /color: var\(--tn-primary-text/.test(scss));
+
+    it('some component reads --tn-primary-text', () => {
+      expect(migrated.length).toBeGreaterThan(0);
+    });
+
+    it.each(migrated)(
+      '$file falls back through --tn-primary to a literal, for a consumer with no theme stylesheet',
+      ({ scss }) => {
+        // The same reasoning as radio.component.scss's
+        // `var(--tn-error-text, var(--tn-red, …))`: a consumer stylesheet that
+        // predates this token may still define --tn-primary, and discarding
+        // their branding for a literal would be worse than inheriting their
+        // tuning. Within this repo the chain always stops at the first link,
+        // because :root declares --tn-primary-text.
+        const expected = `color: var(--tn-primary-text, var(--tn-primary, ${FALLBACK_LITERAL}));`;
+        const uses = scss.match(/color: var\(--tn-primary-text[^;]*;/g) ?? [];
+        expect(uses.length).toBeGreaterThan(0);
+        // Listing the offenders rather than asserting a boolean, so a failure
+        // prints the declaration that differs instead of "expected true".
+        expect(uses.filter((use) => use !== expected)).toEqual([]);
+      }
+    );
+
+    it(`${FALLBACK_LITERAL} clears AA on white, the surface it is actually reachable on`, () => {
+      // Reached only when neither --tn-primary-text nor --tn-primary is
+      // defined, i.e. no theme stylesheet loaded at all — so the background is
+      // the browser's own default. The literals this replaced did not all clear
+      // it: #3b82f6 measures 3.68:1 there and #007bff 3.98:1.
+      expect(meetsAa(contrastRatio(FALLBACK_LITERAL, '#ffffff'), 'normal')).toBe(true);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
@@ -11,6 +11,13 @@ import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/cont
  * arrangement `--tn-error-text` already has for `--tn-red`, and this measures it
  * against the values actually shipped in `themes.css`.
  *
+ * WHAT THE TOKEN CLAIMS: 4.5:1 on `--tn-bg1` and on `--tn-bg2`, the page canvas
+ * and the card/panel surface, and nothing beyond that. It is NOT a
+ * general-purpose accent colour: on `--tn-alt-bg2` it measures 2.37:1 in
+ * `:root`. `KEEPS_PRIMARY` below is where a call site on some other surface is
+ * recorded, with the reason, rather than being migrated to a guarantee that
+ * does not cover it.
+ *
  * jsdom has no layout engine, so axe's `color-contrast` rule cannot decide
  * anything here — it reports `incomplete` rather than checking, and `axeResult`
  * throws on that. Computing the ratio from the shipped values is the claim that
@@ -42,24 +49,37 @@ const REQUIRED_TOKENS = ['--tn-bg1', '--tn-bg2', '--tn-primary-text'];
 const FALLBACK_LITERAL = '#0074a7';
 
 /**
- * `color:` declarations that legitimately still read `--tn-primary`, by the file
- * they are in and the count in it. Every one paints an icon rather than text —
- * an `<svg>` or a `<tn-icon>` — which is non-text content under WCAG 1.4.11 at
- * 3:1, exactly what `--tn-primary` is tuned for. The tick in `tn-slide-toggle`
- * has a second reason: `--accent` and `--warn` re-point `--tn-primary` locally
- * to colour the whole toggle, and reading `--tn-primary-text` would make the
- * tick ignore them.
+ * `color:` declarations that still read `--tn-primary`, by the file they are in,
+ * with the count in that file and why it is right there.
+ *
+ * Most are icons — an `<svg>` or a `<tn-icon>` — which are non-text content
+ * under WCAG 1.4.11 at 3:1, exactly what `--tn-primary` is tuned for. The one
+ * that is text is `tn-menu`'s selected row, and the reason is the surface: what
+ * `--tn-primary-text` guarantees, and what the cases above measure, is 4.5:1 on
+ * `--tn-bg1` and `--tn-bg2`. It says nothing about `--tn-alt-bg2`, where it
+ * measures 2.37:1 in `:root`.
  *
  * A count rather than a bare allowlist, so that a NEW `color: var(--tn-primary)`
  * in one of these files is still caught. Adding a decorative icon means adding
- * to a number here; adding text means using `--tn-primary-text`.
+ * to a number here; adding text on --tn-bg1/--tn-bg2 means using
+ * `--tn-primary-text`.
  */
-const NON_TEXT_COLOR_USES: Readonly<Record<string, number>> = {
-  'expansion-panel/expansion-panel.component.scss': 1,
-  'file-picker/file-picker-popup.component.scss': 3,
-  'form-field/form-field.component.scss': 1,
-  'form-section/form-section.component.scss': 1,
-  'slide-toggle/slide-toggle.component.scss': 1,
+const KEEPS_PRIMARY: Readonly<Record<string, { count: number; why: string }>> = {
+  'expansion-panel/expansion-panel.component.scss': { count: 1, why: 'the <svg> chevron' },
+  'file-picker/file-picker-popup.component.scss': {
+    count: 3,
+    why: 'the spinner, the folder icon and the chevron',
+  },
+  'form-field/form-field.component.scss': { count: 1, why: 'the icon-only help button' },
+  'form-section/form-section.component.scss': { count: 1, why: 'the icon-only help button' },
+  'menu/menu.component.scss': {
+    count: 1,
+    why: 'the selected row, which is text but paints on --tn-alt-bg2, not --tn-bg1/--tn-bg2',
+  },
+  'slide-toggle/slide-toggle.component.scss': {
+    count: 1,
+    why: 'the <svg> tick, which --accent and --warn re-colour by re-pointing --tn-primary',
+  },
 };
 
 /**
@@ -169,17 +189,19 @@ describe('--tn-primary-text contrast (#242)', () => {
       .map(({ file, scss }) => ({
         file,
         count: (scss.match(PRIMARY_AS_COLOR) ?? []).length,
-        allowed: NON_TEXT_COLOR_USES[file] ?? 0,
+        allowed: KEEPS_PRIMARY[file]?.count ?? 0,
+        why: KEEPS_PRIMARY[file]?.why ?? 'nothing',
       }))
       .filter(({ count, allowed }) => count > 0 || allowed > 0);
 
     it.each(remaining)(
-      '$file paints $allowed non-text thing(s) with color: var(--tn-primary)',
+      '$file keeps color: var(--tn-primary) on $allowed thing(s): $why',
       ({ count, allowed }) => {
-        // Text reading --tn-primary is the defect; an icon reading it is
-        // correct. If this fails, either the declaration is text and wants
-        // --tn-primary-text, or it is an icon and belongs in
-        // NON_TEXT_COLOR_USES with a note saying which icon.
+        // Body text on --tn-bg1/--tn-bg2 reading --tn-primary is the defect
+        // #242 is about. Anything else reading it may well be right. If this
+        // fails, either the declaration is such text and wants
+        // --tn-primary-text, or it belongs in KEEPS_PRIMARY with a `why`
+        // saying which thing it paints and on what.
         expect(count).toBe(allowed);
       }
     );
@@ -188,12 +210,13 @@ describe('--tn-primary-text contrast (#242)', () => {
       // Without this a renamed or deleted component leaves a stale entry that
       // nothing measures, and the case above passes it as 0 === 0.
       const scanned = files.map(({ file }) => file);
-      expect(Object.keys(NON_TEXT_COLOR_USES).filter((file) => !scanned.includes(file))).toEqual([]);
+      expect(Object.keys(KEEPS_PRIMARY).filter((file) => !scanned.includes(file))).toEqual([]);
     });
 
-    // On the declaration, not on a bare `includes`: the comment above
-    // tn-slide-toggle's tick names the token to explain why it does NOT read it,
-    // and that file has no declaration to check.
+    // On the declaration, not on a bare `includes`: the comments above
+    // tn-slide-toggle's tick and tn-menu's selected row name the token to
+    // explain why they do NOT read it, and neither file has a declaration to
+    // check.
     const migrated = files.filter(({ scss }) => /color: var\(--tn-primary-text/.test(scss));
 
     it('some component reads --tn-primary-text', () => {

--- a/projects/truenas-ui/src/lib/toast/toast.component.scss
+++ b/projects/truenas-ui/src/lib/toast/toast.component.scss
@@ -82,7 +82,7 @@ tn-toast {
 .tn-toast__action {
   background: none;
   border: none;
-  color: var(--tn-primary, #3b82f6);
+  color: var(--tn-primary-text, var(--tn-primary, #0074a7));
   font-family: inherit;
   font-size: 1rem;
   font-weight: 600;

--- a/projects/truenas-ui/src/stories/checkbox.stories.ts
+++ b/projects/truenas-ui/src/stories/checkbox.stories.ts
@@ -210,7 +210,7 @@ export const RichLabel: Story = {
           <span tnCheckboxLabel>
             I have read and agree to the
             <a href="https://example.com/terms" target="_blank"
-              style="color: var(--tn-primary); text-decoration: underline;">
+              style="color: var(--tn-primary-text); text-decoration: underline;">
               Terms of Service
             </a>
           </span>
@@ -220,12 +220,12 @@ export const RichLabel: Story = {
           <span tnCheckboxLabel>
             I accept the
             <a href="https://example.com/privacy" target="_blank"
-              style="color: var(--tn-primary); text-decoration: underline;">
+              style="color: var(--tn-primary-text); text-decoration: underline;">
               Privacy Policy
             </a>
             and
             <a href="https://example.com/cookies" target="_blank"
-              style="color: var(--tn-primary); text-decoration: underline;">
+              style="color: var(--tn-primary-text); text-decoration: underline;">
               Cookie Policy
             </a>
           </span>

--- a/projects/truenas-ui/src/stories/menu.stories.ts
+++ b/projects/truenas-ui/src/stories/menu.stories.ts
@@ -328,8 +328,8 @@ export const WithKeyboardShortcuts: Story = {
           Avoid single letters like H, K, T, F, B, L as they conflict with screen reader navigation.
           <br><br>
           <strong>Learn more:</strong>&nbsp;&nbsp;
-          <a href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html" target="_blank" rel="noopener" style="color: var(--tn-primary, #007bff);">WCAG 2.1.4 Character Key Shortcuts</a> •
-          <a href="https://webaim.org/techniques/keyboard/" target="_blank" rel="noopener" style="color: var(--tn-primary, #007bff);">WebAIM Keyboard Accessibility</a>
+          <a href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html" target="_blank" rel="noopener" style="color: var(--tn-primary-text, #0074a7);">WCAG 2.1.4 Character Key Shortcuts</a> •
+          <a href="https://webaim.org/techniques/keyboard/" target="_blank" rel="noopener" style="color: var(--tn-primary-text, #0074a7);">WebAIM Keyboard Accessibility</a>
         </div>
       </div>
     `,

--- a/projects/truenas-ui/src/stories/patterns/progressive-disclosure.stories.html
+++ b/projects/truenas-ui/src/stories/patterns/progressive-disclosure.stories.html
@@ -291,7 +291,7 @@
                         size="4TB"
                         [name]="getDriveName(driveIndex)"
                         [type]="DiskType.Ssd" />
-                      <div style="font-size: 9px; color: var(--tn-primary, #007bff); margin-top: 2px; font-weight: 500;">4TB SSD</div>
+                      <div style="font-size: 9px; color: var(--tn-primary-text, #0074a7); margin-top: 2px; font-weight: 500;">4TB SSD</div>
                     </div>
                   }
 

--- a/projects/truenas-ui/src/stories/side-panel.stories.ts
+++ b/projects/truenas-ui/src/stories/side-panel.stories.ts
@@ -604,7 +604,7 @@ export const WidePanel: Story = {
 
           <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px;">
             <div style="${sectionStyle} text-align: center;">
-              <div style="font-size: 2rem; font-weight: 700; color: var(--tn-primary);">24.10</div>
+              <div style="font-size: 2rem; font-weight: 700; color: var(--tn-primary-text);">24.10</div>
               <div style="font-size: 0.8125rem; color: var(--tn-fg2); margin-top: 4px;">TrueNAS Version</div>
             </div>
             <div style="${sectionStyle} text-align: center;">

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -4,6 +4,17 @@
 :root {
   --tn-primary: #007db3; /* WCAG fix #007db3 */
   --tn-primary-txt: #ffffff;
+  /* --tn-primary DRAWN AS TEXT. Not to be confused with --tn-primary-txt above,
+     which is the opposite pairing: text drawn ON a --tn-primary fill.
+
+     --tn-primary is tuned for the 3:1 non-text minimum (fills, borders, focus
+     rings) and is only 3.64:1 on --tn-bg1 here, so a link or an accent label
+     reading it as `color:` inherits a failure. This is the same companion-token
+     pattern as --tn-error-text below, and every theme declares its own: the
+     value is a hue-preserving lightness shift of that theme's --tn-primary,
+     chosen as the smallest step that clears 4.5:1 on both --tn-bg1 and
+     --tn-bg2. >=4.5:1 against both --tn-bg1 (5.22:1) and --tn-bg2 (4.62:1). */
+  --tn-primary-text: #0099db;
   --tn-btn-default-bg: #545454;
   --tn-btn-default-txt: #ffffff;
   --tn-topbar: #111111;
@@ -72,6 +83,9 @@
    ================================ */
 .tn-dark {
   --tn-primary: var(--tn-blue);
+  /* >=4.5:1 against both --tn-bg1 (5.22:1) and --tn-bg2 (4.62:1); --tn-primary
+     itself is only 3.64:1 on --tn-bg1 — see the note in :root. */
+  --tn-primary-text: #0099db;
   --tn-topbar: #111111;
   --tn-topbar-txt: rgba(255,255,255,0.85);
   --tn-accent: var(--tn-yellow);
@@ -114,6 +128,10 @@
 .tn-blue {
   --tn-primary: var(--tn-blue);
   --tn-primary-txt: #ffffff;
+  /* >=4.5:1 against both --tn-bg1 (4.62:1) and --tn-bg2 (5.18:1); --tn-primary
+     itself is only 4.09:1 on --tn-bg1. Darkened here rather than lightened —
+     this is a light theme. */
+  --tn-primary-text: #0074a7;
   --tn-topbar: #007db3;
   --tn-accent: #DED142;
   --tn-bg1: #f2f2f2;
@@ -152,6 +170,9 @@
 .tn-dracula {
   --tn-primary: #6272a4;
   --tn-primary-txt: #ffffff;
+  /* >=4.5:1 against both --tn-bg1 (5.60:1) and --tn-bg2 (4.61:1); --tn-primary
+     itself is only 3.67:1 on --tn-bg1. */
+  --tn-primary-text: #8592b8;
   --tn-topbar: #6272a4;
   --tn-topbar-txt: #efefef;
   --tn-accent: #bd93f9;
@@ -191,6 +212,11 @@
 .tn-nord {
   --tn-primary: #88c0d0;
   --tn-primary-txt: #333333;
+  /* --tn-primary already clears 4.5:1 here, against both --tn-bg1 (6.24:1) and
+     --tn-bg2 (5.03:1), so this theme needs no separate shade. Declared anyway
+     rather than left to inherit :root's — that value is tuned for :root's
+     surfaces, not these. */
+  --tn-primary-text: var(--tn-primary);
   --tn-topbar: #4c566a;
   --tn-topbar-txt: #eceff4;
   --tn-accent: #5e81aC;
@@ -231,6 +257,9 @@
 .tn-paper {
   --tn-primary: #0D5687;
   --tn-primary-txt: #ffffff;
+  /* --tn-primary already clears 4.5:1 here, against both --tn-bg1 (6.95:1) and
+     --tn-bg2 (7.46:1) — see the note in .tn-nord for why it is still declared. */
+  --tn-primary-text: var(--tn-primary);
   --tn-topbar: #0D5687;
   --tn-accent: #f0cb00;
   --tn-bg1: #F2F2F2;
@@ -269,6 +298,10 @@
 .tn-solarized-dark {
   --tn-primary: var(--tn-fg1);
   --tn-primary-txt: #ffffff;
+  /* >=4.5:1 against both --tn-bg1 (5.34:1) and --tn-bg2 (4.62:1); --tn-primary
+     itself is 2.79:1 on --tn-bg1, the worst of the nine, because it resolves to
+     --tn-fg1 (#586e75) rather than to a blue. */
+  --tn-primary-text: #879ea5;
   --tn-btn-default-bg: #0b4f60;
   --tn-btn-default-txt: var(--tn-fg2);
   --tn-topbar: var(--tn-fg1);
@@ -312,6 +345,9 @@
 .tn-midnight {
   --tn-primary: var(--tn-blue);
   --tn-primary-txt: #ffffff;
+  /* >=4.5:1 against both --tn-bg1 (6.02:1) and --tn-bg2 (4.61:1); --tn-primary
+     itself is only 2.90:1 on --tn-bg1. */
+  --tn-primary-text: #50afee;
   --tn-topbar: var(--tn-blue);
   --tn-topbar-txt: var(--tn-fg2);
   --tn-accent: var(--tn-violet);
@@ -351,6 +387,10 @@
    ================================ */
 .tn-high-contrast {
   --tn-primary: var(--tn-blue); /* WCAG fix try another shade of blue #007db3 or black #000000 */
+  /* >=4.5:1 against both --tn-bg1 (4.61:1) and --tn-bg2 (6.27:1); --tn-primary
+     itself is only 2.99:1 on --tn-bg1 — which, in the accessibility theme, is
+     the one worth noticing. Darkened, this being a light theme. */
+  --tn-primary-text: #366584;
   --tn-topbar: var(--tn-black);
   --tn-accent: var(--tn-magenta);
   --tn-bg1: #dddddd;


### PR DESCRIPTION
Fixes #242.

## What was wrong

`--tn-primary` is tuned for the 3:1 non-text minimum — fills, borders, focus rings — so anything reading it as `color:` inherited a contrast failure. Reproduced first, by measuring the shipped `themes.css` with the library's own `themePalettes`/`contrastRatio` helpers, and the numbers came back exactly as the ticket reports them:

| Palette | `--tn-primary` on `--tn-bg1` | on `--tn-bg2` |
|---|---|---|
| `:root` | 3.64 FAIL | 3.22 FAIL |
| `.tn-dark` | 3.64 FAIL | 3.22 FAIL |
| `.tn-blue` | 4.09 FAIL | 4.58 pass |
| `.tn-dracula` | 3.67 FAIL | 3.03 FAIL |
| `.tn-nord` | 6.24 pass | 5.03 pass |
| `.tn-paper` | 6.95 pass | 7.46 pass |
| `.tn-solarized-dark` | 2.79 FAIL | 2.42 FAIL |
| `.tn-midnight` | 2.90 FAIL | 2.22 FAIL |
| `.tn-high-contrast` | 2.99 FAIL | 4.07 FAIL |

## What changed

**`--tn-primary-text` is declared in all nine palettes**, the same companion-token arrangement `--tn-error-text` already has for `--tn-red`. Each value is a **hue-preserving lightness shift** of that theme's own `--tn-primary` — the smallest step away from the surface that clears 4.5:1 on both `--tn-bg1` and `--tn-bg2`, with a little headroom so a rounding wobble cannot flip it. Nord and Paper already clear 4.5:1, so they declare `var(--tn-primary)` rather than a second shade; they still declare it themselves, because inheriting `:root`'s would be inheriting a value tuned for different surfaces.

| Palette | `--tn-primary-text` | on `--tn-bg1` | on `--tn-bg2` |
|---|---|---|---|
| `:root` | `#0099db` | 5.22 | 4.62 |
| `.tn-dark` | `#0099db` | 5.22 | 4.62 |
| `.tn-blue` | `#0074a7` | 4.62 | 5.18 |
| `.tn-dracula` | `#8592b8` | 5.60 | 4.61 |
| `.tn-nord` | `var(--tn-primary)` | 6.24 | 5.03 |
| `.tn-paper` | `var(--tn-primary)` | 6.95 | 7.46 |
| `.tn-solarized-dark` | `#879ea5` | 5.34 | 4.62 |
| `.tn-midnight` | `#50afee` | 6.02 | 4.62 |
| `.tn-high-contrast` | `#366584` | 4.61 | 6.27 |

**Nine `color:` call sites migrate**, in `tn-button` (outline variant), `tn-card` (footer link and its hover), `tn-toast`, `tn-expansion-panel` (title link), `tn-form-field` (focused label), `tn-file-picker` (breadcrumb) and `tn-calendar` (the today cell, in both month and multi-year views). Seven inline `color:` styles across four story files move with them.

**`color:` declarations that do not paint body text on `--tn-bg1`/`--tn-bg2` stay on `--tn-primary`**, and each says why next to itself:

- Six icons — `<svg>` chevrons and ticks, `<tn-icon>` spinners and folder glyphs, icon-only help buttons. Those are non-text content under WCAG 1.4.11 at 3:1, which is what `--tn-primary` is for.
- `tn-slide-toggle`'s tick has a second reason: the `--accent` and `--warn` variants re-point `--tn-primary` locally to colour the whole toggle, so reading `--tn-primary-text` there would make the tick ignore them.
- **`tn-menu`'s selected row is text, and still stays.** It paints on `--tn-alt-bg2`, not on `--tn-bg1` or `--tn-bg2`, and `--tn-primary-text` measures **2.37:1** there in `:root`. Migrating it would have swapped one failing colour for another while the new spec stayed green. See *What was not changed* below — that row wants its surface reconsidered, which is wider than this ticket.

**The migrated declarations read `var(--tn-primary-text, var(--tn-primary, #0074a7))`** — the same shape as `radio.component.scss`'s `var(--tn-error-text, var(--tn-red, …))`. Within this repo the chain always stops at the first link, since `:root` declares the token; the rest is for a consumer stylesheet that predates it, whose own `--tn-primary` tuning should not be silently discarded. The terminal literal is reachable only with no theme stylesheet loaded at all, where the surface is the UA default white, and `#0074a7` measures 5.18:1 there. It replaces literals that did not: `#3b82f6` is 3.68:1 on white and `#007bff` is 3.98:1.

## How it was checked

`primary-text-contrast.spec.ts` (55 cases) measures the ratio per palette off the shipped `themes.css`, driven by `themePalettes` so a new theme that omits the token fails rather than silently inheriting `:root`'s. It also scans `lib/**/*.scss` and holds each file to a **count** of remaining `color: var(--tn-primary)` declarations with a reason for each, so a *new* one that is body text on the page or panel surface is caught.

**Confirmed against the defect rather than assumed:** run against `themes.css` as it is on `main`, the spec fails 11 cases; against this branch it passes 55.

Locally: `yarn lint` clean for these files (the 4 remaining `import/order` errors are pre-existing, in `input.component.ts` and `menu-panel.component.ts`, which this branch does not touch), `yarn test` 2892 passed, `yarn test:scripts` 42 passed, `yarn build` clean.

**`yarn test-sb` could not be run here** — Storybook interaction tests drive a real browser through Playwright, and this host has neither the browser nor the system libraries to start one. That is the check the ticket was filed from, so it is the one to watch on this PR. What stands behind the claim in the meantime is the per-palette measurement above, taken from the same stylesheet the browser loads. Note that `build-storybook` runs `copy-assets`, so the Storybook copy of `themes.css` is regenerated from source at build time and will carry the new token.

Two local review rounds were run; the second returned nothing at MEDIUM or above.

## What was not changed, and why

The second review round's five LOW findings were left, and there is one thing this change deliberately does not fix. Listed here so none of them is lost:

- **`tn-menu`'s selected row is still below AA** (`--tn-primary` on `--tn-alt-bg2`, 1.65:1 in `:root`) — it was before this branch too. It is not fixable by choosing a different foreground: `--tn-alt-bg2` has none that clears AA across the palettes, and even `--tn-fg1` measures 1.45:1 on it in Solarized Dark and 3.19:1 in Midnight. Proposed as its own ticket on #242.
- **The calendar today cell** reads `--tn-primary-text` but the cell can pick up `--tn-alt-bg2` on hover, the surface `tn-menu` was excluded for. The resting state, which is what axe measures, is on the panel surface.
- **The new token is undocumented** where `--tn-error-text` is documented: `stories/api/theming.mdx`, `docs/component_styling.md:46`, and `color-palette.stories.ts`'s `uiVars`/`statusTextVars`.
- **The regression scan covers `src/lib/**/*.scss` only**, so the four inline `color:` sites under `src/stories` this PR fixed are unguarded.
- **The story sites are not uniform**: bare `var(--tn-primary-text)` in `checkbox.stories.ts` and `side-panel.stories.ts`, `var(--tn-primary-text, #0074a7)` in `menu.stories.ts` and `progressive-disclosure.stories.html`. Each kept whatever fallback shape it already had.
- **`.storybook/public/themes.css`**, a tracked generated copy, is not refreshed here, unlike the `--tn-error-text` precedent in b33b0c6. `yarn copy-themes` regenerates it, and `build-storybook` runs it, so CI is unaffected.

## One thing worth flagging

The ticket names the token `--tn-primary-text`, and that is what this implements. It sits two characters away from the existing `--tn-primary-txt`, which means the **opposite** thing — text drawn *on* a `--tn-primary` fill, rather than `--tn-primary` drawn *as* text. The `:root` declaration carries a comment saying so, but a name that could not be confused would have been better.
