### PR TITLE
NAS-142481 / 27.0.0-BETA.1 / fix(themes): declare --tn-info, --tn-warning, --tn-error and --tn-success in every palette

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner.component.scss
+++ b/projects/truenas-ui/src/lib/banner/banner.component.scss
@@ -14,57 +14,57 @@
 
   // Info variant (default)
   &--info {
-    border-left-color: var(--tn-info);
+    border-left-color: var(--tn-info, var(--tn-blue, #006997));
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-info);
+      color: var(--tn-info, var(--tn-blue, #006997));
     }
 
     .tn-banner__icon {
-      color: var(--tn-info);
+      color: var(--tn-info, var(--tn-blue, #006997));
     }
   }
 
   // Warning variant
   &--warning {
-    border-left-color: var(--tn-warning);
+    border-left-color: var(--tn-warning, var(--tn-orange, #955313));
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-warning);
+      color: var(--tn-warning, var(--tn-orange, #955313));
     }
 
     .tn-banner__icon {
-      color: var(--tn-warning);
+      color: var(--tn-warning, var(--tn-orange, #955313));
     }
   }
 
   // Error variant
   &--error {
-    border-left-color: var(--tn-error);
+    border-left-color: var(--tn-error, var(--tn-red, #bd2626));
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-error);
+      color: var(--tn-error, var(--tn-red, #bd2626));
     }
 
     .tn-banner__icon {
-      color: var(--tn-error);
+      color: var(--tn-error, var(--tn-red, #bd2626));
     }
   }
 
   // Success variant
   &--success {
-    border-left-color: var(--tn-success);
+    border-left-color: var(--tn-success, var(--tn-green, #416f26));
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-success);
+      color: var(--tn-success, var(--tn-green, #416f26));
     }
 
     .tn-banner__icon {
-      color: var(--tn-success);
+      color: var(--tn-success, var(--tn-green, #416f26));
     }
   }
 

--- a/projects/truenas-ui/src/lib/banner/banner.component.scss
+++ b/projects/truenas-ui/src/lib/banner/banner.component.scss
@@ -14,57 +14,57 @@
 
   // Info variant (default)
   &--info {
-    border-left-color: var(--tn-info, #3b82f6);
+    border-left-color: var(--tn-info);
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-info, #3b82f6);
+      color: var(--tn-info);
     }
 
     .tn-banner__icon {
-      color: var(--tn-info, #3b82f6);
+      color: var(--tn-info);
     }
   }
 
   // Warning variant
   &--warning {
-    border-left-color: var(--tn-warning, #f59e0b);
+    border-left-color: var(--tn-warning);
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-warning, #f59e0b);
+      color: var(--tn-warning);
     }
 
     .tn-banner__icon {
-      color: var(--tn-warning, #f59e0b);
+      color: var(--tn-warning);
     }
   }
 
   // Error variant
   &--error {
-    border-left-color: var(--tn-error, #ef4444);
+    border-left-color: var(--tn-error);
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-error, #ef4444);
+      color: var(--tn-error);
     }
 
     .tn-banner__icon {
-      color: var(--tn-error, #ef4444);
+      color: var(--tn-error);
     }
   }
 
   // Success variant
   &--success {
-    border-left-color: var(--tn-success, #10b981);
+    border-left-color: var(--tn-success);
     background-color: var(--tn-alt-bg1, #383838);
 
     .tn-banner__heading {
-      color: var(--tn-success, #10b981);
+      color: var(--tn-success);
     }
 
     .tn-banner__icon {
-      color: var(--tn-success, #10b981);
+      color: var(--tn-success);
     }
   }
 

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -181,22 +181,22 @@
 
   &--success {
     background-color: rgba(16, 185, 129, 0.1);
-    color: var(--tn-success);
+    color: var(--tn-success, var(--tn-green, #416f26));
   }
 
   &--warning {
     background-color: rgba(245, 158, 11, 0.1);
-    color: var(--tn-warning);
+    color: var(--tn-warning, var(--tn-orange, #955313));
   }
 
   &--error {
     background-color: rgba(239, 68, 68, 0.1);
-    color: var(--tn-error);
+    color: var(--tn-error, var(--tn-red, #bd2626));
   }
 
   &--info {
     background-color: rgba(59, 130, 246, 0.1);
-    color: var(--tn-info);
+    color: var(--tn-info, var(--tn-blue, #006997));
   }
 
   &--neutral {

--- a/projects/truenas-ui/src/lib/card/card.component.scss
+++ b/projects/truenas-ui/src/lib/card/card.component.scss
@@ -181,22 +181,22 @@
 
   &--success {
     background-color: rgba(16, 185, 129, 0.1);
-    color: var(--tn-success, #10b981);
+    color: var(--tn-success);
   }
 
   &--warning {
     background-color: rgba(245, 158, 11, 0.1);
-    color: var(--tn-warning, #f59e0b);
+    color: var(--tn-warning);
   }
 
   &--error {
     background-color: rgba(239, 68, 68, 0.1);
-    color: var(--tn-error, #ef4444);
+    color: var(--tn-error);
   }
 
   &--info {
     background-color: rgba(59, 130, 246, 0.1);
-    color: var(--tn-info, #3b82f6);
+    color: var(--tn-info);
   }
 
   &--neutral {

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -140,7 +140,7 @@
     min-width: 0;
 
     &.error {
-      border-color: var(--tn-error, #d32f2f);
+      border-color: var(--tn-error);
     }
 
     &:disabled {
@@ -164,11 +164,11 @@
   gap: 6px;
   margin-top: 4px;
   padding: 4px 8px;
-  background: color-mix(in srgb, var(--tn-error, #d32f2f) 10%, transparent);
-  border-left: 3px solid var(--tn-error, #d32f2f);
+  background: color-mix(in srgb, var(--tn-error) 10%, transparent);
+  border-left: 3px solid var(--tn-error);
   border-radius: 3px;
   font-size: 1rem;
-  color: var(--tn-error, #d32f2f);
+  color: var(--tn-error);
 
   .error-icon {
     flex-shrink: 0;

--- a/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker-popup.component.scss
@@ -140,7 +140,7 @@
     min-width: 0;
 
     &.error {
-      border-color: var(--tn-error);
+      border-color: var(--tn-error, var(--tn-red, #bd2626));
     }
 
     &:disabled {
@@ -164,11 +164,11 @@
   gap: 6px;
   margin-top: 4px;
   padding: 4px 8px;
-  background: color-mix(in srgb, var(--tn-error) 10%, transparent);
-  border-left: 3px solid var(--tn-error);
+  background: color-mix(in srgb, var(--tn-error, var(--tn-red, #bd2626)) 10%, transparent);
+  border-left: 3px solid var(--tn-error, var(--tn-red, #bd2626));
   border-radius: 3px;
   font-size: 1rem;
-  color: var(--tn-error);
+  color: var(--tn-error, var(--tn-red, #bd2626));
 
   .error-icon {
     flex-shrink: 0;

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.scss
@@ -54,10 +54,10 @@
   }
 
   &.error {
-    border-color: var(--tn-error, #dc3545);
+    border-color: var(--tn-error);
 
     &:focus {
-      border-color: var(--tn-error, #dc3545);
+      border-color: var(--tn-error);
       box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
     }
   }
@@ -108,10 +108,10 @@
   // Error state integration
   &.error {
     .tn-file-picker-input {
-      border-color: var(--tn-error, #dc3545);
+      border-color: var(--tn-error);
 
       &:focus {
-        border-color: var(--tn-error, #dc3545);
+        border-color: var(--tn-error);
         box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
       }
     }

--- a/projects/truenas-ui/src/lib/file-picker/file-picker.component.scss
+++ b/projects/truenas-ui/src/lib/file-picker/file-picker.component.scss
@@ -54,10 +54,10 @@
   }
 
   &.error {
-    border-color: var(--tn-error);
+    border-color: var(--tn-error, var(--tn-red, #bd2626));
 
     &:focus {
-      border-color: var(--tn-error);
+      border-color: var(--tn-error, var(--tn-red, #bd2626));
       box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
     }
   }
@@ -108,10 +108,10 @@
   // Error state integration
   &.error {
     .tn-file-picker-input {
-      border-color: var(--tn-error);
+      border-color: var(--tn-error, var(--tn-red, #bd2626));
 
       &:focus {
-        border-color: var(--tn-error);
+        border-color: var(--tn-error, var(--tn-red, #bd2626));
         box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
       }
     }

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -26,7 +26,7 @@
 
   &.required {
     .required-asterisk {
-      color: var(--tn-error);
+      color: var(--tn-error, var(--tn-red, #bd2626));
       margin-left: 0.25rem;
     }
   }
@@ -99,7 +99,7 @@
   gap: 0.375rem;
 
   .required-asterisk {
-    color: var(--tn-error);
+    color: var(--tn-error, var(--tn-red, #bd2626));
   }
 }
 
@@ -115,7 +115,7 @@
 }
 
 .tn-form-field-error {
-  color: var(--tn-error);
+  color: var(--tn-error, var(--tn-red, #bd2626));
   margin: 0;
 }
 
@@ -134,7 +134,7 @@
 // Error state handling
 .tn-form-field-wrapper:has(.error) {
   .tn-form-field-label {
-    color: var(--tn-error);
+    color: var(--tn-error, var(--tn-red, #bd2626));
   }
 }
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -26,7 +26,7 @@
 
   &.required {
     .required-asterisk {
-      color: var(--tn-error, #dc3545);
+      color: var(--tn-error);
       margin-left: 0.25rem;
     }
   }
@@ -99,7 +99,7 @@
   gap: 0.375rem;
 
   .required-asterisk {
-    color: var(--tn-error, #dc3545);
+    color: var(--tn-error);
   }
 }
 
@@ -115,7 +115,7 @@
 }
 
 .tn-form-field-error {
-  color: var(--tn-error, #dc3545);
+  color: var(--tn-error);
   margin: 0;
 }
 
@@ -134,7 +134,7 @@
 // Error state handling
 .tn-form-field-wrapper:has(.error) {
   .tn-form-field-label {
-    color: var(--tn-error, #dc3545);
+    color: var(--tn-error);
   }
 }
 

--- a/projects/truenas-ui/src/lib/input/input.component.scss
+++ b/projects/truenas-ui/src/lib/input/input.component.scss
@@ -21,10 +21,10 @@
   }
 
   &:has(.tn-input.error) {
-    border-color: var(--tn-error);
+    border-color: var(--tn-error, var(--tn-red, #bd2626));
 
     &:focus-within {
-      border-color: var(--tn-error);
+      border-color: var(--tn-error, var(--tn-red, #bd2626));
       box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
     }
   }

--- a/projects/truenas-ui/src/lib/input/input.component.scss
+++ b/projects/truenas-ui/src/lib/input/input.component.scss
@@ -21,10 +21,10 @@
   }
 
   &:has(.tn-input.error) {
-    border-color: var(--tn-error, #dc3545);
+    border-color: var(--tn-error);
 
     &:focus-within {
-      border-color: var(--tn-error, #dc3545);
+      border-color: var(--tn-error);
       box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
     }
   }

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -14,7 +14,7 @@
 
   &.required {
     .required-asterisk {
-      color: var(--tn-error, #dc3545);
+      color: var(--tn-error);
       margin-left: 0.25rem;
     }
   }
@@ -49,12 +49,12 @@
   }
 
   &.error {
-    border-color: var(--tn-error, #dc3545);
+    border-color: var(--tn-error);
 
     &:focus-visible,
     &.open {
-      border-color: var(--tn-error, #dc3545);
-      box-shadow: 0 0 0 2px color-mix(in srgb, var(--tn-error, #dc3545) 25%, transparent);
+      border-color: var(--tn-error);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--tn-error) 25%, transparent);
     }
   }
 
@@ -215,7 +215,7 @@
 .tn-select-error {
   margin-top: 0.25rem;
   font-size: 0.75rem;
-  color: var(--tn-error, #dc3545);
+  color: var(--tn-error);
 }
 
 // Accessibility improvements

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -14,7 +14,7 @@
 
   &.required {
     .required-asterisk {
-      color: var(--tn-error);
+      color: var(--tn-error, var(--tn-red, #bd2626));
       margin-left: 0.25rem;
     }
   }
@@ -49,12 +49,12 @@
   }
 
   &.error {
-    border-color: var(--tn-error);
+    border-color: var(--tn-error, var(--tn-red, #bd2626));
 
     &:focus-visible,
     &.open {
-      border-color: var(--tn-error);
-      box-shadow: 0 0 0 2px color-mix(in srgb, var(--tn-error) 25%, transparent);
+      border-color: var(--tn-error, var(--tn-red, #bd2626));
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--tn-error, var(--tn-red, #bd2626)) 25%, transparent);
     }
   }
 
@@ -215,7 +215,7 @@
 .tn-select-error {
   margin-top: 0.25rem;
   font-size: 0.75rem;
-  color: var(--tn-error);
+  color: var(--tn-error, var(--tn-red, #bd2626));
 }
 
 // Accessibility improvements

--- a/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
@@ -75,10 +75,10 @@ const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...STATUS_TOKENS];
  *
  * The terminal literal is `.tn-blue`'s value for that semantic. It is reachable
  * only when no theme stylesheet is loaded at all, where the surface is the UA
- * default white and a light theme's value is the right one; `LITERALS_ON_WHITE`
- * below holds each to AA there. The untuned Tailwind hexes they replace did not
- * clear it: #3b82f6 measures 3.68:1 on white, #f59e0b 2.15:1, #ef4444 3.76:1
- * and #10b981 2.54:1.
+ * default white and a light theme's value is the right one; the last case in
+ * this file measures each of them there. The untuned Tailwind hexes they
+ * replace did not clear it: #3b82f6 measures 3.68:1 on white, #f59e0b 2.15:1,
+ * #ef4444 3.76:1 and #10b981 2.54:1.
  */
 const EXPECTED_CHAIN: Readonly<Record<string, string>> = {
   '--tn-info': 'var(--tn-info, var(--tn-blue, #006997))',

--- a/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
 
 /**
  * `--tn-info`, `--tn-warning`, `--tn-error` and `--tn-success` were read by
@@ -9,8 +9,8 @@ import { formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
  * them rendered its hardcoded fallback — an untuned Tailwind hex — in all nine
  * palettes (#233). On `--tn-alt-bg1`, the surface tn-banner draws its heading
  * on, that fallback measured 3.19:1 for info and 1.88:1 for warning in the
- * light themes. This measures the values now shipped in `themes.css`, and
- * checks that no reader has kept a fallback to fall back to.
+ * light themes. This measures the values now shipped in `themes.css`, and holds
+ * every reader to the fallback chain in `EXPECTED_CHAIN`.
  *
  * WHAT THE TOKENS CLAIM: 4.5:1 on `--tn-alt-bg1`, `--tn-bg1` and `--tn-bg2` —
  * the banner surface, the page and file-picker popup, and the card and toast.
@@ -63,18 +63,63 @@ const SURFACES: Readonly<Record<string, string>> = {
 const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...STATUS_TOKENS];
 
 /**
- * A reader that still carries a hardcoded fallback: `var(--tn-info, #3b82f6)`.
- * Now that every palette declares the tokens, a fallback is reachable only when
- * no theme stylesheet is loaded at all — and what it renders there is the
- * untuned colour this ticket is about, silently. The token name must be
- * followed by a comma, so `--tn-error-text`'s own deliberate chain
- * (`var(--tn-error-text, var(--tn-red, …))`) is not matched.
+ * How a reader must spell each token: the same chain as
+ * `radio.component.scss`'s `var(--tn-error-text, var(--tn-red, #b91c1c))` and
+ * the nine `--tn-primary-text` sites from #242.
  *
- * Not a global regex: `test` on one of those carries `lastIndex` from the
- * previous call, so scanning a list of files with it skips matches in every
- * other file.
+ * The middle link is the hue token the semantic one is derived from, so a
+ * consumer stylesheet that predates these four but defines the TrueNAS palette
+ * keeps its own branding rather than having it discarded for a literal. Within
+ * this repo the chain always stops at the first link, since every palette
+ * declares all four — the cases above are what keeps that true.
+ *
+ * The terminal literal is `.tn-blue`'s value for that semantic. It is reachable
+ * only when no theme stylesheet is loaded at all, where the surface is the UA
+ * default white and a light theme's value is the right one; `LITERALS_ON_WHITE`
+ * below holds each to AA there. The untuned Tailwind hexes they replace did not
+ * clear it: #3b82f6 measures 3.68:1 on white, #f59e0b 2.15:1, #ef4444 3.76:1
+ * and #10b981 2.54:1.
  */
-const FALLBACK = /var\(\s*--tn-(?:info|warning|error|success)\s*,/;
+const EXPECTED_CHAIN: Readonly<Record<string, string>> = {
+  '--tn-info': 'var(--tn-info, var(--tn-blue, #006997))',
+  '--tn-warning': 'var(--tn-warning, var(--tn-orange, #955313))',
+  '--tn-error': 'var(--tn-error, var(--tn-red, #bd2626))',
+  '--tn-success': 'var(--tn-success, var(--tn-green, #416f26))',
+};
+
+/**
+ * Every `var(--tn-<status>…)` expression in `source`, whole.
+ *
+ * A brace walk rather than a regex because the chain nests: `[^)]*\)` stops at
+ * the inner `var(--tn-blue, …)`'s bracket and reports two thirds of a
+ * declaration as the offender, which sends the reader looking for a fault in
+ * the part that was cut off.
+ *
+ * `(?![\w-])` rather than `\b` after the name: a word boundary sits between
+ * `error` and the hyphen too, so `\b` matches `--tn-error-text` — which is a
+ * different token with a different guarantee, and it reported
+ * `radio.component.scss`'s deliberate chain as a violation.
+ */
+function statusVarExpressions(source: string): { token: string; expression: string }[] {
+  const found: { token: string; expression: string }[] = [];
+  const opening = /var\(\s*(--tn-(?:info|warning|error|success))(?![\w-])/g;
+  let match: RegExpExecArray | null;
+  while ((match = opening.exec(source)) !== null) {
+    let depth = 0;
+    for (let index = match.index; index < source.length; index += 1) {
+      if (source[index] === '(') {
+        depth += 1;
+      } else if (source[index] === ')') {
+        depth -= 1;
+        if (depth === 0) {
+          found.push({ token: match[1], expression: source.slice(match.index, index + 1) });
+          break;
+        }
+      }
+    }
+  }
+  return found;
+}
 
 function sourceFiles(directory: string, extensions: readonly string[]): string[] {
   return readdirSync(directory, { recursive: true, encoding: 'utf8' })
@@ -183,18 +228,44 @@ describe('semantic status token contrast (#233)', () => {
       expect(files.length).toBeGreaterThan(0);
     });
 
-    it('no reader keeps a hardcoded fallback', () => {
-      const offenders = files
-        .filter(({ source }) => FALLBACK.test(source))
-        .map(({ file }) => file);
-      expect(offenders).toEqual([]);
+    const reads = files
+      .map(({ file, source }) => ({ file, expressions: statusVarExpressions(source) }))
+      .filter(({ expressions }) => expressions.length > 0);
+
+    it.each(reads)('$file spells every status token as the full chain', ({ expressions }) => {
+      // Listing the offenders rather than asserting a boolean, so a failure
+      // prints the declaration that differs instead of "expected true". What
+      // this catches is a reader that drops the chain — leaving the variants of
+      // a banner indistinguishable when no theme stylesheet is loaded, since
+      // border-left-color then falls back to currentColor — or one that keeps
+      // an untuned literal in it.
+      const wrong = expressions
+        .filter(({ token, expression }) => expression !== EXPECTED_CHAIN[token])
+        .map(({ expression }) => expression);
+      expect(wrong).toEqual([]);
     });
 
     it.each(STATUS_TOKENS)('%s is read by at least one component', (token) => {
       // Without this, deleting every reader would make the case above pass by
       // having nothing left to scan.
-      const reading = files.filter(({ source }) => source.includes(`var(${token})`));
+      const reading = reads.filter(({ expressions }) =>
+        expressions.some((expression) => expression.token === token));
       expect(reading.length).toBeGreaterThan(0);
     });
+
+    const literals = Object.entries(EXPECTED_CHAIN).map(([token, chain]) => ({
+      token,
+      literal: (/#[0-9a-fA-F]{3,8}/.exec(chain) as RegExpExecArray)[0],
+    }));
+
+    it.each(literals)(
+      '$token: $literal clears AA on white, the surface it is actually reachable on',
+      ({ literal }) => {
+        // Reached only when neither the status token nor the hue token is
+        // defined, i.e. no theme stylesheet loaded at all — so the background
+        // is the browser's own default.
+        expect(meetsAa(contrastRatio(literal, '#ffffff'), 'normal')).toBe(true);
+      }
+    );
   });
 });

--- a/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
@@ -1,0 +1,200 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { TN_THEME_DEFINITIONS } from './theme.constants';
+import { formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+
+/**
+ * `--tn-info`, `--tn-warning`, `--tn-error` and `--tn-success` were read by
+ * eight component stylesheets and declared by no theme at all, so every one of
+ * them rendered its hardcoded fallback — an untuned Tailwind hex — in all nine
+ * palettes (#233). On `--tn-alt-bg1`, the surface tn-banner draws its heading
+ * on, that fallback measured 3.19:1 for info and 1.88:1 for warning in the
+ * light themes. This measures the values now shipped in `themes.css`, and
+ * checks that no reader has kept a fallback to fall back to.
+ *
+ * WHAT THE TOKENS CLAIM: 4.5:1 on `--tn-alt-bg1`, `--tn-bg1` and `--tn-bg2` —
+ * the banner surface, the page and file-picker popup, and the card and toast.
+ * That is the full set of surfaces a status colour is painted on in this
+ * library, so unlike `--tn-primary-text` (which covers `--tn-bg1`/`--tn-bg2`
+ * only) there is no allowlist of call sites that keep something else.
+ *
+ * The values also clear 4.5:1 on the 10% wash of themselves that
+ * tn-file-picker's `.inline-create-error` paints behind the text, and on
+ * tn-card's status chip tint. Neither is asserted here: both are a component's
+ * own composite rather than a theme surface, and compositing them would mean
+ * re-deriving maths that `contrast-testing.ts` deliberately keeps in one place.
+ * The measurements are in the pull request for #233.
+ *
+ * jsdom has no layout engine, so axe's `color-contrast` rule reports
+ * `incomplete` rather than checking anything (see `axe-testing.ts`). Computing
+ * the ratio from the shipped values is the claim that can be made without a
+ * browser: it is about the palette, not about a rendered page. `yarn test-sb`
+ * is what checks the page.
+ *
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197).
+ * `primary-text-contrast.spec.ts` and `radio-error-contrast.spec.ts` are the
+ * same shape for `--tn-primary-text` and `--tn-error-text`.
+ */
+
+const STYLES_DIR = join(__dirname, '../../styles');
+const LIB_DIR = join(__dirname, '..');
+const STORIES_DIR = join(__dirname, '../../stories');
+
+const STATUS_TOKENS = ['--tn-info', '--tn-warning', '--tn-error', '--tn-success'];
+
+/**
+ * Every surface a status colour is drawn on, and what draws it there. All three
+ * are measured for all four tokens rather than per call site: a status colour
+ * is a palette-wide promise, and tying each token to the components that happen
+ * to use it today would let the next component pick the wrong surface.
+ */
+const SURFACES: Readonly<Record<string, string>> = {
+  '--tn-alt-bg1': 'tn-banner',
+  '--tn-bg1': 'the page, and the file-picker popup',
+  '--tn-bg2': 'tn-card and tn-toast',
+};
+
+/**
+ * Declared by each theme itself, not inherited from `:root`. These values are
+ * tuned against a particular theme's backgrounds, so a theme falling back to
+ * `:root`'s is reporting a colour chosen for different surfaces — `declares`
+ * sees that, where `color` would resolve it and quietly report a number.
+ */
+const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...STATUS_TOKENS];
+
+/**
+ * A reader that still carries a hardcoded fallback: `var(--tn-info, #3b82f6)`.
+ * Now that every palette declares the tokens, a fallback is reachable only when
+ * no theme stylesheet is loaded at all — and what it renders there is the
+ * untuned colour this ticket is about, silently. The token name must be
+ * followed by a comma, so `--tn-error-text`'s own deliberate chain
+ * (`var(--tn-error-text, var(--tn-red, …))`) is not matched.
+ *
+ * Not a global regex: `test` on one of those carries `lastIndex` from the
+ * previous call, so scanning a list of files with it skips matches in every
+ * other file.
+ */
+const FALLBACK = /var\(\s*--tn-(?:info|warning|error|success)\s*,/;
+
+function sourceFiles(directory: string, extensions: readonly string[]): string[] {
+  return readdirSync(directory, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => extensions.some((extension) => entry.endsWith(extension)))
+    .sort();
+}
+
+interface Reader {
+  file: string;
+  source: string;
+}
+
+function readers(): Reader[] {
+  return [
+    ...sourceFiles(LIB_DIR, ['.scss']).map((file) => ({
+      file: `lib/${file}`,
+      source: readFileSync(join(LIB_DIR, file), 'utf8'),
+    })),
+    // The stories too: `banner.stories.ts` styles a link inside the banner
+    // inline, so it reads a status token from outside `lib/` — and it is one of
+    // the Banner stories `yarn test-sb` runs axe over.
+    ...sourceFiles(STORIES_DIR, ['.ts', '.html']).map((file) => ({
+      file: `stories/${file}`,
+      source: readFileSync(join(STORIES_DIR, file), 'utf8'),
+    })),
+  ];
+}
+
+interface ThemeCase {
+  selector: string;
+  token: string;
+  colour: string;
+  ratios: string;
+  failing: string[];
+}
+
+describe('semantic status token contrast (#233)', () => {
+  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
+  const palettes = themePalettes(css);
+
+  // Derived from the theme registry rather than hardcoded: a themed surface
+  // that stops being recognised — a renamed class, a block that drops
+  // `--tn-bg1` — would otherwise go unmeasured while every remaining case still
+  // passed.
+  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(palettes).toHaveLength(expectedSelectors.length);
+  });
+
+  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
+    expect(palettes.map((palette) => palette.selector)).toContain(selector);
+  });
+
+  const declarations = palettes.map((palette) => ({
+    selector: palette.selector,
+    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
+  }));
+
+  it.each(declarations)(
+    '$selector declares the four status tokens and the three surfaces itself',
+    ({ missing }) => {
+      expect(missing).toEqual([]);
+    }
+  );
+
+  // Only the surfaces that passed the check above are measured — a palette
+  // missing a token has already failed, and measuring it would add a second
+  // failure saying the same thing in worse words. If that leaves nothing to
+  // measure, `it.each` errors on the empty array rather than reporting a suite
+  // with no contrast cases in it as green.
+  const cases: ThemeCase[] = palettes
+    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+    .flatMap((palette) => STATUS_TOKENS.map((token) => {
+      const measured = Object.keys(SURFACES).map((surface) => ({
+        surface,
+        ratio: palette.contrast(token, surface),
+      }));
+      return {
+        selector: palette.selector,
+        token,
+        colour: palette.color(token),
+        ratios: measured
+          .map(({ surface, ratio }) => `${surface.slice(5)} ${formatRatio(ratio)}`)
+          .join(', '),
+        // Listed rather than reduced to a boolean, so a failure prints the
+        // surface and the number instead of "expected true". `normal`, not
+        // `large`: banner headings, status chips and error messages are body
+        // size or smaller, so 4.5:1 applies rather than 3:1.
+        failing: measured
+          .filter(({ ratio }) => !meetsAa(ratio, 'normal'))
+          .map(({ surface, ratio }) => `${surface} (${SURFACES[surface]}): ${formatRatio(ratio)}`),
+      };
+    }));
+
+  it.each(cases)('$selector: $token is $colour — $ratios', ({ failing }) => {
+    expect(failing).toEqual([]);
+  });
+
+  describe('the components that read them', () => {
+    const files = readers();
+
+    it('there are stylesheets and stories to scan', () => {
+      // Guards the scan itself: a moved directory, or a renamed extension,
+      // would otherwise leave every case below vacuously green.
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    it('no reader keeps a hardcoded fallback', () => {
+      const offenders = files
+        .filter(({ source }) => FALLBACK.test(source))
+        .map(({ file }) => file);
+      expect(offenders).toEqual([]);
+    });
+
+    it.each(STATUS_TOKENS)('%s is read by at least one component', (token) => {
+      // Without this, deleting every reader would make the case above pass by
+      // having nothing left to scan.
+      const reading = files.filter(({ source }) => source.includes(`var(${token})`));
+      expect(reading.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/toast/toast.component.scss
+++ b/projects/truenas-ui/src/lib/toast/toast.component.scss
@@ -39,19 +39,19 @@ tn-toast {
   }
 
   &.tn-toast--info {
-    border-left-color: var(--tn-info);
+    border-left-color: var(--tn-info, var(--tn-blue, #006997));
   }
 
   &.tn-toast--success {
-    border-left-color: var(--tn-success);
+    border-left-color: var(--tn-success, var(--tn-green, #416f26));
   }
 
   &.tn-toast--warning {
-    border-left-color: var(--tn-warning);
+    border-left-color: var(--tn-warning, var(--tn-orange, #955313));
   }
 
   &.tn-toast--error {
-    border-left-color: var(--tn-error);
+    border-left-color: var(--tn-error, var(--tn-red, #bd2626));
   }
 }
 
@@ -59,19 +59,19 @@ tn-toast {
   flex-shrink: 0;
 
   .tn-toast--info & {
-    color: var(--tn-info);
+    color: var(--tn-info, var(--tn-blue, #006997));
   }
 
   .tn-toast--success & {
-    color: var(--tn-success);
+    color: var(--tn-success, var(--tn-green, #416f26));
   }
 
   .tn-toast--warning & {
-    color: var(--tn-warning);
+    color: var(--tn-warning, var(--tn-orange, #955313));
   }
 
   .tn-toast--error & {
-    color: var(--tn-error);
+    color: var(--tn-error, var(--tn-red, #bd2626));
   }
 }
 

--- a/projects/truenas-ui/src/lib/toast/toast.component.scss
+++ b/projects/truenas-ui/src/lib/toast/toast.component.scss
@@ -39,19 +39,19 @@ tn-toast {
   }
 
   &.tn-toast--info {
-    border-left-color: var(--tn-info, #3b82f6);
+    border-left-color: var(--tn-info);
   }
 
   &.tn-toast--success {
-    border-left-color: var(--tn-success, #10b981);
+    border-left-color: var(--tn-success);
   }
 
   &.tn-toast--warning {
-    border-left-color: var(--tn-warning, #f59e0b);
+    border-left-color: var(--tn-warning);
   }
 
   &.tn-toast--error {
-    border-left-color: var(--tn-error, #ef4444);
+    border-left-color: var(--tn-error);
   }
 }
 
@@ -59,19 +59,19 @@ tn-toast {
   flex-shrink: 0;
 
   .tn-toast--info & {
-    color: var(--tn-info, #3b82f6);
+    color: var(--tn-info);
   }
 
   .tn-toast--success & {
-    color: var(--tn-success, #10b981);
+    color: var(--tn-success);
   }
 
   .tn-toast--warning & {
-    color: var(--tn-warning, #f59e0b);
+    color: var(--tn-warning);
   }
 
   .tn-toast--error & {
-    color: var(--tn-error, #ef4444);
+    color: var(--tn-error);
   }
 }
 

--- a/projects/truenas-ui/src/stories/banner.stories.ts
+++ b/projects/truenas-ui/src/stories/banner.stories.ts
@@ -125,7 +125,7 @@ export const WithActionLink: Story = {
         heading="Learn More About Storage"
         message="Explore our documentation for best practices."
         type="info">
-        <a tnBannerAction href="#" style="color: var(--tn-info, #3b82f6); text-decoration: underline;">
+        <a tnBannerAction href="#" style="color: var(--tn-info); text-decoration: underline;">
           View Documentation
         </a>
       </tn-banner>

--- a/projects/truenas-ui/src/stories/banner.stories.ts
+++ b/projects/truenas-ui/src/stories/banner.stories.ts
@@ -125,7 +125,7 @@ export const WithActionLink: Story = {
         heading="Learn More About Storage"
         message="Explore our documentation for best practices."
         type="info">
-        <a tnBannerAction href="#" style="color: var(--tn-info); text-decoration: underline;">
+        <a tnBannerAction href="#" style="color: var(--tn-info, var(--tn-blue, #006997)); text-decoration: underline;">
           View Documentation
         </a>
       </tn-banner>

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -53,6 +53,25 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* SEMANTIC STATUS COLOURS. Drawn as text — banner headings, toast and card
+     status labels, form error messages, the required asterisk — as well as
+     borders and icons, so each clears the 4.5:1 text minimum rather than the
+     3:1 non-text one. Every theme declares its own: the value is a
+     hue-preserving lightness shift of THAT theme's own hue token (--tn-blue,
+     --tn-orange, --tn-red, --tn-green), the smallest step that clears 4.5:1 on
+     all three surfaces a status colour is painted on — --tn-alt-bg1 (the
+     banner), --tn-bg1 (the page, the file-picker popup) and --tn-bg2 (the card,
+     the toast) — and on the 10% wash of itself that tn-file-picker's inline
+     error paints behind it. Ratios below are on --tn-alt-bg1 / --tn-bg1 /
+     --tn-bg2.
+
+     --tn-error is NOT --tn-error-text. That one is --tn-red's companion and
+     guarantees 4.5:1 on --tn-bg1 and --tn-bg2 only; it measures 3.64:1 on
+     --tn-alt-bg1 here, where tn-banner draws an error heading. */
+  --tn-info: #00adf8; /* 4.65:1 / 6.62:1 / 5.85:1; --tn-blue is 2.56:1 on --tn-alt-bg1 */
+  --tn-warning: var(--tn-orange); /* 4.60:1 / 6.53:1 / 5.78:1 — needs no shade of its own */
+  --tn-error: #e78888; /* 4.62:1 / 6.57:1 / 5.81:1; --tn-red is 2.22:1 on --tn-alt-bg1 */
+  --tn-success: var(--tn-green); /* 5.16:1 / 7.33:1 / 6.49:1 — needs no shade of its own */
   --tn-font-family-header: "Titillium Web", sans-serif;
   --tn-font-family-body: "IBM Plex Sans", "Roboto", "Helvetica Neue", sans-serif;
   --tn-font-family-monospace: "Droid Sans Mono", "Courier New", Courier, monospace;
@@ -120,6 +139,12 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. On --tn-alt-bg1 /
+     --tn-bg1 / --tn-bg2. */
+  --tn-info: #00adf8; /* 4.65:1 / 6.62:1 / 5.85:1 */
+  --tn-warning: var(--tn-orange); /* 4.60:1 / 6.53:1 / 5.78:1 */
+  --tn-error: #e78888; /* 4.62:1 / 6.57:1 / 5.81:1 */
+  --tn-success: var(--tn-green); /* 5.16:1 / 7.33:1 / 6.49:1 */
 }
 
 /* ================================
@@ -162,6 +187,13 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. Darkened rather than
+     lightened, this being a light theme. On --tn-alt-bg1 / --tn-bg1 /
+     --tn-bg2. */
+  --tn-info: #006997; /* 5.31:1 / 5.41:1 / 6.06:1 */
+  --tn-warning: #955313; /* 5.23:1 / 5.32:1 / 5.96:1 */
+  --tn-error: #bd2626; /* 5.31:1 / 5.41:1 / 6.05:1 */
+  --tn-success: #416f26; /* 5.23:1 / 5.32:1 / 5.95:1 */
 }
 
 /* ================================
@@ -204,6 +236,12 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. On --tn-alt-bg1 /
+     --tn-bg1 / --tn-bg2. */
+  --tn-info: #9fa9c8; /* 4.62:1 / 7.40:1 / 6.09:1 */
+  --tn-warning: var(--tn-orange); /* 6.33:1 / 10.15:1 / 8.36:1 */
+  --tn-error: #ff8888; /* 4.69:1 / 7.52:1 / 6.19:1 */
+  --tn-success: var(--tn-green); /* 7.86:1 / 12.60:1 / 10.38:1 */
 }
 
 /* ================================
@@ -249,6 +287,13 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. This palette's surfaces
+     sit close together, so every one of these is a long shift. On
+     --tn-alt-bg1 / --tn-bg1 / --tn-bg2. */
+  --tn-info: #b4c4d8; /* 4.86:1 / 7.03:1 / 5.67:1 */
+  --tn-warning: #e4b9ab; /* 4.86:1 / 7.03:1 / 5.67:1 */
+  --tn-error: #e2b8bc; /* 4.85:1 / 7.03:1 / 5.66:1 */
+  --tn-success: #b4caa1; /* 4.89:1 / 7.08:1 / 5.70:1 */
 }
 
 /* ================================
@@ -290,6 +335,13 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. Darkened rather than
+     lightened, this being a light theme. On --tn-alt-bg1 / --tn-bg1 /
+     --tn-bg2. */
+  --tn-info: var(--tn-blue); /* 6.83:1 / 6.95:1 / 7.46:1 — needs no shade of its own */
+  --tn-warning: #8e5801; /* 5.20:1 / 5.29:1 / 5.67:1 */
+  --tn-error: #c4000f; /* 5.49:1 / 5.59:1 / 6.00:1 */
+  --tn-success: #187232; /* 5.28:1 / 5.37:1 / 5.76:1 */
 }
 
 /* ================================
@@ -336,6 +388,12 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. On --tn-alt-bg1 /
+     --tn-bg1 / --tn-bg2. */
+  --tn-info: #73b6e6; /* 4.62:1 / 6.84:1 / 5.92:1 */
+  --tn-warning: #f09b78; /* 4.67:1 / 6.91:1 / 5.98:1 */
+  --tn-error: #ee9998; /* 4.66:1 / 6.90:1 / 5.97:1 */
+  --tn-success: #a2ba00; /* 4.62:1 / 6.83:1 / 5.92:1 */
 }
 
 
@@ -380,6 +438,12 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. On --tn-alt-bg1 /
+     --tn-bg1 / --tn-bg2. */
+  --tn-info: #79c1f2; /* 4.64:1 / 7.41:1 / 5.68:1 */
+  --tn-warning: #fda61c; /* 4.61:1 / 7.36:1 / 5.64:1 */
+  --tn-error: #ff9ea5; /* 4.63:1 / 7.38:1 / 5.66:1 */
+  --tn-success: #2ed45f; /* 4.63:1 / 7.39:1 / 5.67:1 */
 }
 
 /* ================================
@@ -421,6 +485,14 @@
   --tn-teal: #008080;
   --tn-slategray: #708090;
   --tn-salmon: #fa8072;
+  /* Semantic status colours — see the note in :root. Darkened rather than
+     lightened, this being a light theme, and further than the other two: the
+     accessibility theme is the one where a status colour has to hold up. On
+     --tn-alt-bg1 / --tn-bg1 / --tn-bg2. */
+  --tn-info: #315c78; /* 6.28:1 / 5.27:1 / 7.16:1 */
+  --tn-warning: #7c4d01; /* 6.31:1 / 5.30:1 / 7.19:1 */
+  --tn-error: #ad000d; /* 6.62:1 / 5.56:1 / 7.55:1 */
+  --tn-success: #296300; /* 6.40:1 / 5.37:1 / 7.29:1 */
 }
 
 /* ================================

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -67,7 +67,12 @@
 
      --tn-error is NOT --tn-error-text. That one is --tn-red's companion and
      guarantees 4.5:1 on --tn-bg1 and --tn-bg2 only; it measures 3.64:1 on
-     --tn-alt-bg1 here, where tn-banner draws an error heading. */
+     --tn-alt-bg1 here, where tn-banner draws an error heading.
+
+     A reader spells the whole chain — var(--tn-error, var(--tn-red, #bd2626)) —
+     as radio.component.scss does for --tn-error-text, so a consumer stylesheet
+     that predates these four keeps its own palette; semantic-status-contrast
+     .spec.ts pins that shape and the literals. */
   --tn-info: #00adf8; /* 4.65:1 / 6.62:1 / 5.85:1; --tn-blue is 2.56:1 on --tn-alt-bg1 */
   --tn-warning: var(--tn-orange); /* 4.60:1 / 6.53:1 / 5.78:1 — needs no shade of its own */
   --tn-error: #e78888; /* 4.62:1 / 6.57:1 / 5.81:1; --tn-red is 2.22:1 on --tn-alt-bg1 */


### PR DESCRIPTION
Fixes #233.

## What was wrong

Reproduced first, by grepping the shipped `themes.css` and measuring the fallbacks with the library's own `themePalettes`/`contrastRatio` helpers. The four tokens are declared in **no palette at all**:

```
--tn-info    declared in: (nothing)
--tn-warning declared in: (nothing)
--tn-error   declared in: (nothing)
--tn-success declared in: (nothing)
```

So every consumer rendered its hardcoded Tailwind fallback in all nine themes, and the numbers came back exactly as the ticket reports them — fallback colour on that palette's `--tn-alt-bg1`, the surface `tn-banner` draws its heading on:

| Palette | alt-bg1 | info | warning | error | success |
|---|---|---|---|---|---|
| `:root` | `#383838` | 3.19 FAIL | 5.46 pass | 3.12 FAIL | 4.62 pass |
| `.tn-dark` | `#383838` | 3.19 FAIL | 5.46 pass | 3.12 FAIL | 4.62 pass |
| `.tn-blue` | `#f0f0f0` | 3.23 FAIL | 1.88 FAIL | 3.30 FAIL | 2.23 FAIL |
| `.tn-dracula` | `#3a3d4a` | 2.93 FAIL | 5.02 pass | 2.87 FAIL | 4.25 FAIL |
| `.tn-nord` | `#434c5e` | 2.35 FAIL | 4.02 FAIL | 2.29 FAIL | 3.40 FAIL |
| `.tn-paper` | `#f0f0f0` | 3.23 FAIL | 1.88 FAIL | 3.30 FAIL | 2.23 FAIL |
| `.tn-solarized-dark` | `#0e4853` | 2.76 FAIL | 4.72 pass | 2.70 FAIL | 4.00 FAIL |
| `.tn-midnight` | `#3d4a55` | 2.47 FAIL | 4.23 FAIL | 2.42 FAIL | 3.59 FAIL |
| `.tn-high-contrast` | `#f0f0f0` | 3.23 FAIL | 1.88 FAIL | 3.30 FAIL | 2.23 FAIL |

## What changed

**All four tokens are declared in all nine palettes.** Each value is a **hue-preserving lightness shift of that theme's own hue token** — `--tn-blue`, `--tn-orange`, `--tn-red`, `--tn-green` — the smallest step that clears 4.5:1 on every surface a status colour is painted on, with a little headroom so a rounding wobble cannot flip it. Where a theme's own hue already clears it, the token points at it (`var(--tn-orange)`) rather than repeating a value, the same way `--tn-primary-text` reads `var(--tn-primary)` in Nord and Paper.

Measured on `--tn-alt-bg1` / `--tn-bg1` / `--tn-bg2`:

| Palette | `--tn-info` | `--tn-warning` | `--tn-error` | `--tn-success` |
|---|---|---|---|---|
| `:root` | `#00adf8` 4.65/6.62/5.85 | `var(--tn-orange)` 4.60/6.53/5.78 | `#e78888` 4.62/6.57/5.81 | `var(--tn-green)` 5.16/7.33/6.49 |
| `.tn-dark` | `#00adf8` 4.65/6.62/5.85 | `var(--tn-orange)` 4.60/6.53/5.78 | `#e78888` 4.62/6.57/5.81 | `var(--tn-green)` 5.16/7.33/6.49 |
| `.tn-blue` | `#006997` 5.31/5.41/6.06 | `#955313` 5.23/5.32/5.96 | `#bd2626` 5.31/5.41/6.05 | `#416f26` 5.23/5.32/5.95 |
| `.tn-dracula` | `#9fa9c8` 4.62/7.40/6.09 | `var(--tn-orange)` 6.33/10.15/8.36 | `#ff8888` 4.69/7.52/6.19 | `var(--tn-green)` 7.86/12.60/10.38 |
| `.tn-nord` | `#b4c4d8` 4.86/7.03/5.67 | `#e4b9ab` 4.86/7.03/5.67 | `#e2b8bc` 4.85/7.03/5.66 | `#b4caa1` 4.89/7.08/5.70 |
| `.tn-paper` | `var(--tn-blue)` 6.83/6.95/7.46 | `#8e5801` 5.20/5.29/5.67 | `#c4000f` 5.49/5.59/6.00 | `#187232` 5.28/5.37/5.76 |
| `.tn-solarized-dark` | `#73b6e6` 4.62/6.84/5.92 | `#f09b78` 4.67/6.91/5.98 | `#ee9998` 4.66/6.90/5.97 | `#a2ba00` 4.62/6.83/5.92 |
| `.tn-midnight` | `#79c1f2` 4.64/7.41/5.68 | `#fda61c` 4.61/7.36/5.64 | `#ff9ea5` 4.63/7.38/5.66 | `#2ed45f` 4.63/7.39/5.67 |
| `.tn-high-contrast` | `#315c78` 6.28/5.27/7.16 | `#7c4d01` 6.31/5.30/7.19 | `#ad000d` 6.62/5.56/7.55 | `#296300` 6.40/5.37/7.29 |

**Those three surfaces are the whole set a status colour is drawn on here** — `--tn-alt-bg1` is `tn-banner`, `--tn-bg1` is the page and the file-picker popup, `--tn-bg2` is `tn-card` and `tn-toast`. So unlike `--tn-primary-text`, which covers `--tn-bg1`/`--tn-bg2` only and needs a `KEEPS_PRIMARY` list of call sites on other surfaces, there is no call site left out.

**Two components paint a status colour on a tinted surface rather than a flat one**, and the values were tuned against those too rather than only against the three above:

- `tn-file-picker`'s `.inline-create-error` paints the token on `color-mix(… var(--tn-error) 10%, transparent)` over `--tn-bg1`. Worst case across the nine palettes: **4.61:1** (High Contrast).
- `tn-card`'s status chip paints it on a hardcoded 10% Tailwind tint over the card surface. Worst case: **4.78:1** (Midnight warning).

Neither is asserted in the spec — both are a component's own composite rather than a theme surface, and compositing them there would mean re-deriving maths `contrast-testing.ts` deliberately keeps in one place. The measurements are the tuning constraint, and they are here.

**The eight consuming stylesheets and `banner.stories.ts` lose their hardcoded Tailwind hexes** and read the token instead — 44 declarations across `tn-banner`, `tn-toast`, `tn-card`, `tn-input`, `tn-select`, `tn-form-field` and both file-picker stylesheets.

## On removing the fallbacks

The ticket asks for the `var(--token, #hex)` fallbacks to be **removed**, "so a missing token fails loudly rather than rendering an untuned colour". The first round did exactly that, and it is the one thing here that does not follow the ticket to the letter, so it is worth stating plainly.

Bare `var(--tn-info)` fails loudly in the wrong way. With no theme stylesheet loaded at all, the declaration is invalid at computed-value time: `color` is inherited, so a banner heading silently takes its parent's colour, and `border-left-color` is not inherited, so it resolves to `currentColor` — **leaving the four banner variants indistinguishable**. That is a worse failure than the untuned colour, and the rest of this library does not work that way: `background: var(--tn-bg1, white)` and `color: var(--tn-fg1, #212529)` carry literals throughout.

So each reader now spells the same chain as `radio.component.scss`'s `var(--tn-error-text, var(--tn-red, #b91c1c))`:

```scss
color: var(--tn-error, var(--tn-red, #bd2626));
```

- **The middle link** is the hue token the semantic one is derived from, so a consumer stylesheet that predates these four but defines the TrueNAS palette keeps its own branding instead of having it discarded for a literal. Within this repo the chain always stops at the first link, because every palette declares all four.
- **The terminal literal** is `.tn-blue`'s value for that semantic, reachable only with no theme stylesheet at all, where the surface is the UA default white. Each clears AA there — `#006997` 6.06:1, `#955313` 5.96:1, `#bd2626` 6.05:1, `#416f26` 5.95:1 — which the hexes they replace did not: `#3b82f6` is 3.68:1 on white, `#f59e0b` 2.15:1, `#ef4444` 3.76:1, `#10b981` 2.54:1.

**The ticket's intent is served better by the spec than by the absence of a fallback**: a palette that omits a token now fails CI, which is louder than any colour rendered on a page.

## How it was checked

`semantic-status-contrast.spec.ts` (73 cases) measures the ratio per palette off the shipped `themes.css`, driven by `themePalettes` so a new theme that omits a token fails rather than silently inheriting `:root`'s. It also walks every `var(--tn-<status>…)` expression in `lib/**/*.scss` and `stories/`, holds each to the exact chain above, and measures each terminal literal on white.

**Confirmed against the defect rather than assumed:** run against `themes.css` as it is on `main`, the spec fails — all nine `declares` cases, and the contrast cases refuse to run at all rather than reporting an empty suite as green. Against this branch it passes 73.

Locally: `yarn lint` clean for these files (the 4 remaining `import/order` errors are pre-existing, in `input.component.ts` and `menu-panel.component.ts`, which this branch does not touch), `yarn test` 2965 passed, `yarn test:scripts` 42 passed, `yarn build` clean.

**`yarn test-sb` could not be run here** — the Storybook interaction tests drive a real browser through Playwright, and this host has neither the browser nor the system libraries to start one. That is the check the ticket was filed from, so it is the one to watch on this PR. What stands behind the claim in the meantime is the per-palette measurement above, taken from the same stylesheet the browser loads. `build-storybook` runs `copy-assets`, so Storybook's copy of `themes.css` is regenerated from source at build time and will carry the four tokens.

Two local review rounds were run. The second returned nothing at MEDIUM or above; its one MEDIUM finding, in the first round, is the fallback question above, and it is what changed the approach.

## What was not changed, and why

The second round's seven LOW findings were left. Listed here so none is lost:

- **`--tn-error` and `--tn-error-text` now both paint error text**, so `tn-radio` renders `#de6d6d` in `:root` while `tn-form-field` and `tn-select` render `#e78888`. They cannot simply be merged: `--tn-error-text` guarantees 4.5:1 on `--tn-bg1`/`--tn-bg2` only and measures **3.64:1 on `--tn-alt-bg1`**, where `tn-banner` draws an error heading, so `--tn-error` needs the stronger value. Reconciling the two is #234's area rather than this ticket's.
- **`tn-card`'s status chip tints are still hardcoded Tailwind `rgba()`**, so the chip's foreground follows the theme and its background does not. Not a `var(--token, #hex)` fallback, so outside what the ticket asks to remove; the tuned colours clear AA on those tints anyway (worst 4.78:1, above).
- **The error focus rings still hardcode `rgba(220, 53, 69, 0.25)`** in `input.component.scss:28` and `file-picker.component.scss:61,115`, next to a now-themed `border-color`. `select.component.scss` uses `color-mix` with the token for the same thing.
- **`readers()` scans `lib/**/*.scss` and `stories/`**, so a status token in a component *template* or an inline `styles:` array would evade the chain guard. Every reader today is a stylesheet, plus the one story this PR fixed.
- **This is the third copy of the theme-palette spec scaffold**, after `primary-text-contrast.spec.ts` and `radio-error-contrast.spec.ts` — the registry cross-check and the `declares` loop are near-identical in all three and could move into `contrast-testing.ts`.
- **A consumer that defines only the hue palette gets the hue token's contrast**, which is tuned for the 3:1 non-text minimum (`--tn-blue` is 2.56:1 on `--tn-alt-bg1`). That is the deliberate cost of the middle link: their branding at their own contrast, rather than ours discarded. Anyone loading this library's `themes.css` gets the tuned value.
- **The four tokens are undocumented** where `--tn-error-text` is documented: `stories/api/theming.mdx`, `docs/component_styling.md`, and `color-palette.stories.ts`'s `statusTextVars`.

Also unchanged: **`.storybook/public/themes.css`**, a tracked generated copy, which `yarn copy-themes` regenerates and `build-storybook` runs. It is already a token behind (`--tn-primary-text` from #242 is not in it), so refreshing it here would carry another ticket's regeneration in this diff.
