### PR TITLE
NAS-142483 / 27.0.0-BETA.1 / test(a11y): add axeScan, the probe half of the shared axe wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ This file helps coding agents quickly find the right documentation for working o
 | `component_creation_checklist.md` | Step-by-step component creation workflow | Creating any new component | ~200 lines |
 | `component_templates.md` | Copy-paste boilerplate code for all file types | Need template code for .ts/.html/.scss/.spec/.stories files | ~740 lines |
 | `component_styling.md` | CSS patterns, theme variables, responsive design | Working on styles or appearance | ~480 lines |
-| `component_testing.md` | Testing patterns, Jest examples, mocking | Writing or debugging tests | ~740 lines |
-| `component_conventions.md` | Naming rules, architecture decisions, patterns | Understanding project structure or design choices | ~510 lines |
+| `component_testing.md` | Testing patterns, Jest examples, accessibility scans, mocking | Writing or debugging tests | ~800 lines |
+| `component_conventions.md` | Naming rules, architecture decisions, patterns | Understanding project structure or design choices | ~610 lines |
 | `harness_documentation.md` | Auto-generating harness API docs in Storybook | Creating harness documentation or integrating into stories | ~570 lines |
 
 ## Common Usage Patterns

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -433,10 +433,19 @@ and `politeness()` from `lib/a11y/live-region-testing.ts`; see
 
 ### Running axe in a spec
 
-**Use `axeResult()` from `lib/a11y/axe-testing.ts`. Do not write another axe
-wrapper.** Three specs each grew a private near-copy and two of them were wrong
-in the direction that makes a test pass (#196). The correct version is subtle
-enough that writing it again from memory is how the lenient copy gets made.
+**Use `lib/a11y/axe-testing.ts`. Do not write another axe wrapper.** Three specs
+each grew a private near-copy and two of them were wrong in the direction that
+makes a test pass (#196); four cycles in one day then wrote the same throwaway
+probe from scratch (#252). The correct version is subtle enough that writing it
+again from memory is how the lenient copy gets made.
+
+**It exports two, and the choice is not a matter of taste.** `axeScan(fixture)`
+is the probe — it names no rule and no element, and reports everything axe found,
+which is what you want when you do not yet know what is wrong. `axeResult()` is
+the guard, and it is what belongs in a spec long-term: the rest of this section is
+about it. `docs/component_testing.md` has the worked example of the probe; a
+finding it turns up gets pinned down with `axeResult()` before it is committed as
+a regression test.
 
 **Never assert on `violations` alone.** An empty `violations` is also what axe
 returns when it evaluated nothing at all — a detached tree, an upgrade that

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -401,10 +401,16 @@ one comes back clean whatever the markup says. `TestBed.createComponent` attache
 the fixture for you, which is why the examples above just work — but `axeScan` and
 `axeResult` both check, and throw rather than let it pass.
 
-`axeScan` also throws on a root with no children and no text, which is what a host
-whose `detectChanges()` never ran looks like. That is asked of the tree rather
-than of axe's output, precisely so that the empty-but-rendered case above stays an
-ordinary result.
+`axeScan` also throws on a root with no children, no text **and** no `role` or
+`aria-*` attribute of its own, which is what a host whose `detectChanges()` never
+ran looks like. That is asked of the tree rather than of axe's output, precisely
+so that the empty-but-rendered case above stays an ordinary result.
+
+The `role`/`aria-*` part of that is for a component whose whole accessibility
+surface is host attributes — `tn-divider` has a 0-byte template and declares
+`role="separator"` and `aria-orientation` in `host: {}`. It renders childless and
+textless, and it is exactly the component a scan has most to say about, since the
+rules that match are the ones about those attributes. Scan it as usual.
 
 ## Edge Cases to Test
 

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -321,6 +321,70 @@ export const Primary: Story = {
 };
 ```
 
+## Accessibility Tests
+
+**Do not write your own axe wrapper.** `lib/a11y/axe-testing.ts` exports two, and
+between them they cover what an accessibility ticket needs. Four cycles in one day
+each wrote a throwaway probe spec inside `src/` because this section did not exist
+(#252).
+
+| You want | Use | It answers |
+|---|---|---|
+| "What does axe say about this component?" | `axeScan(fixture)` | everything, with nothing named in advance |
+| "Does this fix stay fixed?" | `axeResult(root, targets, rules)` | whether *these* rules object to *these* elements |
+
+Start with `axeScan` to find out what is wrong. Write the regression test with
+`axeResult`, which pins a named rule to a named element and is what belongs in a
+spec long-term. `component_conventions.md` has the rules for that half.
+
+### Scanning a component: `axeScan`
+
+```typescript
+import { axeScan } from '../a11y/axe-testing';
+
+it('has nothing for axe to report', async () => {
+  // A fixture or an element — axeScan takes either.
+  const { violations, incomplete, passed } = await axeScan(fixture);
+
+  expect(violations).toEqual([]);
+  expect(incomplete).toEqual([]);
+  expect(passed).toContain('nested-interactive');
+});
+```
+
+See `lib/chip/chip-a11y.spec.ts` for the whole call on a real fixture, across four
+component states.
+
+**Never assert on `violations` alone.** It is only what axe is *sure* about.
+A rule it looked at and could not decide lands in `incomplete`, and the gap
+between the two is where real defects sit: a `<button aria-labelledby="nope">`
+whose referenced id does not exist has no accessible name at all, and axe returns
+**zero violations** for it — the finding is `aria-valid-attr-value`, impact
+`critical`, in `incomplete`. So `expect(violations).toEqual([])` passes on it.
+Assert on both, every time.
+
+The other two fields exist so that nothing is silently missing:
+
+- **`passed`** — rule ids that matched a node and passed. An empty `violations`
+  means nothing without it. (`axeScan` also throws outright if axe attributed no
+  result to any node, so a fixture that never rendered fails loudly instead of
+  reporting itself clean.)
+- **`notRun`** — rules `axeScan` declined, with the reason. Always
+  `color-contrast`: jsdom has no layout engine, so axe can return no verdict on
+  it. **Measure colour with `lib/a11y/contrast-testing.ts` instead** — see
+  `lib/theme/error-text-contrast.spec.ts`.
+
+A fifth field, `undecided`, collects any rule axe could not decide *and* could not
+point at a node for. It is empty on everything measured so far; it exists so such
+a rule is reported rather than dropped.
+
+### The fixture must be in the document
+
+axe treats a detached tree as hidden and exempts every node in it, so a scan of
+one comes back clean whatever the markup says. `TestBed.createComponent` attaches
+the fixture for you, which is why the examples above just work — but `axeScan` and
+`axeResult` both check, and throw rather than let it pass.
+
 ## Edge Cases to Test
 
 ### Null/Undefined Values

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -372,9 +372,9 @@ Assert on both, every time.
 The other two fields exist so that nothing is silently missing:
 
 - **`passed`** — rule ids that matched a node and passed. An empty `violations`
-  means nothing without it. (`axeScan` also throws outright if axe attributed no
-  result to any node, so a fixture that never rendered fails loudly instead of
-  reporting itself clean.)
+  means nothing without it, which is why the snippet above asserts on it. A scan
+  that matched no rule at all returns `violations: []` too, and `passed` is the
+  only field that tells the two apart.
 - **`notRun`** — rules `axeScan` declined, with the reason. Always
   `color-contrast`: jsdom has no layout engine, so axe can return no verdict on
   it. **Measure colour with `lib/a11y/contrast-testing.ts` instead** — see
@@ -384,12 +384,27 @@ A fifth field, `undecided`, collects any rule axe could not decide *and* could n
 point at a node for. It is empty on everything measured so far; it exists so such
 a rule is reported rather than dropped.
 
+### An empty scan is a real answer for a presentational component
+
+If your component renders only `<div>`s, text and classes, expect **every bucket
+empty, `passed` included** — no rule in the ruleset matches that markup once
+`color-contrast` is declined. That is not a broken fixture and `axeScan` returns
+it normally. It does mean the snippet's `expect(passed).toContain(...)` has no
+rule to name, so drop that line rather than inventing one: there is nothing here
+for axe to check, and the accessibility question for such a component is answered
+by the component that consumes it.
+
 ### The fixture must be in the document
 
 axe treats a detached tree as hidden and exempts every node in it, so a scan of
 one comes back clean whatever the markup says. `TestBed.createComponent` attaches
 the fixture for you, which is why the examples above just work — but `axeScan` and
 `axeResult` both check, and throw rather than let it pass.
+
+`axeScan` also throws on a root with no children and no text, which is what a host
+whose `detectChanges()` never ran looks like. That is asked of the tree rather
+than of axe's output, precisely so that the empty-but-rendered case above stays an
+ordinary result.
 
 ## Edge Cases to Test
 

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -401,16 +401,29 @@ one comes back clean whatever the markup says. `TestBed.createComponent` attache
 the fixture for you, which is why the examples above just work — but `axeScan` and
 `axeResult` both check, and throw rather than let it pass.
 
-`axeScan` also throws on a root with no children, no text **and** no `role` or
-`aria-*` attribute of its own, which is what a host whose `detectChanges()` never
-ran looks like. That is asked of the tree rather than of axe's output, precisely
-so that the empty-but-rendered case above stays an ordinary result.
+`axeScan` also throws on a root with no children and no text, which is what a host
+whose `detectChanges()` never ran looks like. That is asked of the tree rather
+than of axe's output, precisely so that the empty-but-rendered case above stays an
+ordinary result.
 
-The `role`/`aria-*` part of that is for a component whose whole accessibility
-surface is host attributes — `tn-divider` has a 0-byte template and declares
-`role="separator"` and `aria-orientation` in `host: {}`. It renders childless and
-textless, and it is exactly the component a scan has most to say about, since the
-rules that match are the ones about those attributes. Scan it as usual.
+### A component that is its own host: `{ hostOnly: true }`
+
+`tn-divider` has a 0-byte template and declares `role="separator"` and
+`aria-orientation` in `host: {}`, so it renders childless and textless having done
+exactly what it was asked to — and it is worth scanning, since the rules that
+match are the ones about those attributes. Say so:
+
+```typescript
+const scan = await axeScan(fixture, { hostOnly: true });
+```
+
+The flag is required rather than inferred from the host's `role`, because a
+component whose whole template sits inside an `@if` that has not run yet looks
+identical: Angular applies a static host `role` at `createComponent`, before any
+change detection. Inferring the escape would report that one as a near-clean scan
+of a component that rendered none of itself. `hostOnly` relaxes the guard, it does
+not switch it off — a root with nothing inside it and no `role` or `aria-*` on it
+is still rejected.
 
 ## Edge Cases to Test
 

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -348,12 +348,18 @@ it('has nothing for axe to report', async () => {
 
   expect(violations).toEqual([]);
   expect(incomplete).toEqual([]);
-  expect(passed).toContain('nested-interactive');
+  // Name a rule YOUR component exercises — `button-name` for something that
+  // renders a button, `aria-valid-attr-value` for something with ARIA
+  // references. Print `passed` once to see what is available; copying a rule
+  // your markup never triggers just fails for a reason that is not about
+  // accessibility.
+  expect(passed).toContain('button-name');
 });
 ```
 
 See `lib/chip/chip-a11y.spec.ts` for the whole call on a real fixture, across four
-component states.
+component states — it names `nested-interactive`, the rule the chip's own fix was
+about.
 
 **Never assert on `violations` alone.** It is only what axe is *sure* about.
 A rule it looked at and could not decide lands in `incomplete`, and the gap

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
@@ -1,6 +1,25 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { axeResult, axeScan } from './axe-testing';
 import * as axeTesting from './axe-testing';
 import * as publicApi from '../../public-api';
+import { TnDividerComponent } from '../divider/divider.component';
+
+/**
+ * A host that carries a static `role` and renders its template only once a
+ * condition turns true — the shape `hostOnly` exists to keep distinguishable
+ * from a component that is genuinely all host. Local, because no component in
+ * the library is written this way today and the guard has to hold if one is.
+ */
+@Component({
+  selector: 'tn-conditional-template-host',
+  standalone: true,
+  template: '@if (show) {<div role="button" tabindex="0"><button type="button">x</button></div>}',
+  host: { 'role': 'status' },
+})
+class ConditionalTemplateHostComponent {
+  show = false;
+}
 
 /**
  * Guards `axeResult` itself, because every other a11y spec now trusts it and a
@@ -384,37 +403,75 @@ describe('axeScan', () => {
       await expect(axeScan(root)).resolves.toBeDefined();
     });
 
-    /**
-     * The host-attribute case, which is `tn-divider`: a 0-byte template and
-     * `role="separator"` plus `aria-orientation` declared in `host: {}`. It
-     * renders childless and textless, so a guard reading only the tree would
-     * reject a fixture that rendered correctly — and reject it on the one shape
-     * where the scan has the most to say, since the rules that match are the
-     * ones about those very attributes.
-     */
-    it('accepts a root whose whole accessibility surface is host attributes', async () => {
+  });
+
+  /**
+   * A component that IS its host: `tn-divider` has a 0-byte template and puts
+   * `role="separator"` and `aria-orientation` in `host: {}`, so it renders
+   * childless and textless having done exactly what it was asked to. The tree
+   * guard above cannot tell that from a fixture that never rendered — measured,
+   * a component whose template sits inside a false `@if` reaches it looking
+   * identical, static host `role` included — so the caller says which it has and
+   * both cases below are covered rather than one being traded for the other.
+   */
+  describe('a component whose whole surface is its host', () => {
+    it('scans it when hostOnly says the emptiness is expected', async () => {
       root.setAttribute('role', 'separator');
       root.setAttribute('aria-orientation', 'horizontal');
 
-      const scan = await axeScan(root);
+      const scan = await axeScan(root, { hostOnly: true });
 
       expect(scan.violations).toEqual([]);
-      // Non-vacuous: axe really did evaluate the host attributes, which is why
-      // rejecting this root would have cost a real answer rather than an empty
-      // one. `aria-allowed-attr` is the rule that matches `aria-orientation` on
-      // `role="separator"`.
+      // Non-vacuous, which is the whole reason this shape is worth scanning:
+      // `aria-allowed-attr` is the rule that matches `aria-orientation` on
+      // `role="separator"`, so a scan here has a real verdict to give.
       expect(scan.passed).toContain('aria-allowed-attr');
     });
 
-    // The same guard from the other side: a bare root carrying an `aria-*` and
-    // no `role` is still a rendered host, and axe has a verdict on it — here a
-    // real one, since `aria-orientation` is not allowed on a generic `<div>`.
-    it('accepts a root marked with aria-* alone, and reports what axe found', async () => {
+    it('reports a real finding on the host, not just passes', async () => {
       root.setAttribute('aria-orientation', 'horizontal');
 
-      const scan = await axeScan(root);
+      const scan = await axeScan(root, { hostOnly: true });
 
+      // `aria-orientation` is not allowed on a `<div>` with no role.
       expect(scan.violations.map((v) => v.rule)).toEqual(['aria-allowed-attr']);
+    });
+
+    it('still refuses a root with nothing inside it and nothing on it', async () => {
+      await expect(axeScan(root, { hostOnly: true }))
+        .rejects.toThrow('there is nothing here for a rule to match');
+    });
+
+    /**
+     * The end-to-end case, on the real component rather than hand-built markup,
+     * because the claim under test is about what Angular renders for a host-only
+     * component and not about axe attribution.
+     */
+    it('scans tn-divider, whose host is all there is', async () => {
+      TestBed.configureTestingModule({ imports: [TnDividerComponent] });
+      const fixture = TestBed.createComponent(TnDividerComponent);
+      fixture.detectChanges();
+
+      const scan = await axeScan(fixture, { hostOnly: true });
+
+      expect(scan.violations).toEqual([]);
+      expect(scan.incomplete).toEqual([]);
+      expect(scan.passed).toContain('aria-allowed-attr');
+    });
+
+    /**
+     * And the case `hostOnly` is kept explicit for. This host carries a static
+     * `role` — Angular applies those at `createComponent`, before any change
+     * detection — and its whole template is inside an `@if` that has not run, so
+     * it is indistinguishable from `tn-divider` by looking. Inferring the escape
+     * from `role` alone would report this as a near-clean scan of a component
+     * that rendered none of itself.
+     */
+    it('rejects a marked host that never rendered its template', async () => {
+      TestBed.configureTestingModule({ imports: [ConditionalTemplateHostComponent] });
+      const fixture = TestBed.createComponent(ConditionalTemplateHostComponent);
+
+      await expect(axeScan(fixture)).rejects.toThrow('Check the fixture rendered');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
@@ -336,8 +336,52 @@ describe('axeScan', () => {
      * measured, not assumed — so without this guard `axeScan` would report a
      * fixture that failed to render as perfectly accessible.
      */
-    it('rejects a tree axe attributed nothing to', async () => {
-      await expect(axeScan(root)).rejects.toThrow('evaluated nothing');
+    it('rejects an empty tree, which a fixture that never rendered is', async () => {
+      await expect(axeScan(root)).rejects.toThrow('the scanned root is empty');
+    });
+  });
+
+  /**
+   * The other side of that guard, and the reason it asks the TREE rather than
+   * axe's output. Both of these are rendered trees, so neither is the failure
+   * the block above is about — and a guard that could not tell them apart from
+   * an unrendered fixture would reject them.
+   */
+  describe('a rendered tree no rule applies to', () => {
+    /**
+     * These two markup samples are measured, not assumed: with `color-contrast`
+     * declined, each returns every bucket empty — no violation, no incomplete,
+     * nothing passed — because no rule in the ruleset matches a `<div>`, a `<p>`
+     * or a `<span>`. A guard keyed to "axe attributed nothing" would therefore
+     * throw here, telling a caller to check a fixture that rendered exactly what
+     * it was asked to. That is the first thing a probe is pointed at on a
+     * presentational component, so it has to be an ordinary answer.
+     */
+    it('comes back empty rather than throwing', async () => {
+      for (const markup of [
+        '<div class="tn-card"><div class="tn-card__content">Some text</div></div>',
+        '<div><p>Some text</p><span>more</span></div>',
+      ]) {
+        root.innerHTML = markup;
+
+        const scan = await axeScan(root);
+
+        expect(scan.violations).toEqual([]);
+        expect(scan.incomplete).toEqual([]);
+        // The empty `passed` is what says "no rule applied here" rather than
+        // "everything was checked and was fine" — which is the distinction a
+        // caller needs, and the reason this returns instead of throwing.
+        expect(scan.passed).toEqual([]);
+        expect(scan.notRun.map((r) => r.rule)).toEqual(['color-contrast']);
+      }
+    });
+
+    // Text alone is a rendered tree: a component whose host holds only projected
+    // text has no child elements, and the guard must not read that as unrendered.
+    it('accepts a root holding only text', async () => {
+      root.textContent = 'Some text';
+
+      await expect(axeScan(root)).resolves.toBeDefined();
     });
   });
 });

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
@@ -1,4 +1,4 @@
-import { axeResult } from './axe-testing';
+import { axeResult, axeScan } from './axe-testing';
 import * as axeTesting from './axe-testing';
 import * as publicApi from '../../public-api';
 
@@ -202,6 +202,142 @@ describe('axeResult', () => {
       } finally {
         elsewhere.remove();
       }
+    });
+  });
+});
+
+/**
+ * Guards `axeScan`, the probe half of this module.
+ *
+ * The claim it has to hold up is narrower than `axeResult`'s and more easily
+ * lost: that a caller reading `violations` alone is reading the wrong half. The
+ * `incomplete` test below is the whole reason the return type has four buckets
+ * instead of one array, so it is the one to keep if any of these ever have to go.
+ *
+ * Hand-built DOM again, for the reason the file already gives: the property
+ * under test is about what axe reports, and a component would only add ways for
+ * the test to fail that are not about it. The worked example on a real fixture
+ * is `chip-a11y.spec.ts`.
+ */
+describe('axeScan', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+  });
+
+  describe('what it reports', () => {
+    it('reports a violation with the rule, its impact and the node it is on', async () => {
+      root.innerHTML = '<div role="button" tabindex="0"><button type="button">x</button></div>';
+
+      const { violations } = await axeScan(root);
+
+      expect(violations.map((v) => v.rule)).toEqual(['nested-interactive']);
+      expect(violations[0].impact).toBe('serious');
+      expect(violations[0].help).toBe('Interactive controls must not be nested');
+      expect(violations[0].nodes).toEqual([
+        expect.objectContaining({ target: 'div[role="button"]' }),
+      ]);
+    });
+
+    /**
+     * THE test in this block, and the one criterion the ticket (#252) spells out.
+     *
+     * A dangling `aria-labelledby` is a real, critical defect — the control has
+     * no accessible name — and axe reports ZERO violations for it, because it
+     * cannot tell a reference into a not-yet-rendered part of the page from a
+     * broken one. Measured against axe-core 4.10.3 under jsdom, not assumed.
+     *
+     * So a probe written the obvious way, `expect(violations).toEqual([])`,
+     * passes on this markup. Both halves are asserted here, together, because
+     * the empty `violations` is what makes the populated `incomplete` mean
+     * something.
+     */
+    it('puts a dangling aria-labelledby in incomplete, where violations alone would miss it', async () => {
+      root.innerHTML = '<button type="button" aria-labelledby="not-a-real-id">x</button>';
+
+      const { violations, incomplete } = await axeScan(root);
+
+      expect(violations).toEqual([]);
+      expect(incomplete.map((v) => v.rule)).toContain('aria-valid-attr-value');
+      expect(incomplete.find((v) => v.rule === 'aria-valid-attr-value')!.nodes[0].summary)
+        .toContain('ARIA attribute element ID does not exist on the page');
+    });
+
+    it('names the rules that ran and passed, so an empty violations list is not vacuous', async () => {
+      root.innerHTML = '<button type="button">Save</button>';
+
+      const { violations, passed } = await axeScan(root);
+
+      expect(violations).toEqual([]);
+      expect(passed).toContain('button-name');
+    });
+
+    /**
+     * `color-contrast` is declined rather than run — it needs a layout engine
+     * jsdom does not have, so it can only ever come back undecided, and running
+     * it makes jsdom log a canvas error on every scan. What matters is that the
+     * gap is visible in the result: a rule that was never run is not a rule that
+     * passed, and a caller reading an empty `violations` needs to know which is
+     * which.
+     */
+    it('reports the rule it declined to run, rather than leaving the gap silent', async () => {
+      root.innerHTML = '<button type="button">Save</button>';
+
+      const { notRun, incomplete, undecided, passed } = await axeScan(root);
+
+      expect(notRun.map((r) => r.rule)).toEqual(['color-contrast']);
+      expect(notRun[0].reason).toContain('contrast-testing.ts');
+      // And it is genuinely absent from every bucket a caller would act on,
+      // rather than merely declared skipped.
+      expect(incomplete.map((v) => v.rule)).not.toContain('color-contrast');
+      expect(undecided).not.toContain('color-contrast');
+      expect(passed).not.toContain('color-contrast');
+    });
+
+    it('accepts a fixture as well as an element, so a caller can pass either', async () => {
+      root.innerHTML = '<div role="button" tabindex="0"><button type="button">x</button></div>';
+
+      const { violations } = await axeScan({ nativeElement: root });
+
+      expect(violations.map((v) => v.rule)).toEqual(['nested-interactive']);
+    });
+  });
+
+  /**
+   * The same premise as `axeResult`'s guards one level up: an empty result is
+   * also what a scan of nothing returns, and a probe reporting "no violations"
+   * from a scan that never looked is the failure this module exists for.
+   */
+  describe('refuses to report on nothing', () => {
+    it('rejects a root that is not in the document', async () => {
+      const orphan = document.createElement('div');
+      orphan.innerHTML = '<div role="button" tabindex="0"><button type="button">x</button></div>';
+
+      await expect(axeScan(orphan)).rejects.toThrow('not in the document');
+    });
+
+    it('rejects a null element, rather than treating it as an empty tree', async () => {
+      await expect(axeScan(root.querySelector('.absent'))).rejects.toThrow('no element to scan');
+    });
+
+    it('rejects a fixture whose host never rendered', async () => {
+      await expect(axeScan({ nativeElement: null as unknown as HTMLElement }))
+        .rejects.toThrow('no nativeElement');
+    });
+
+    /**
+     * An empty element really does come back with all three buckets empty —
+     * measured, not assumed — so without this guard `axeScan` would report a
+     * fixture that failed to render as perfectly accessible.
+     */
+    it('rejects a tree axe attributed nothing to', async () => {
+      await expect(axeScan(root)).rejects.toThrow('evaluated nothing');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.spec.ts
@@ -383,5 +383,38 @@ describe('axeScan', () => {
 
       await expect(axeScan(root)).resolves.toBeDefined();
     });
+
+    /**
+     * The host-attribute case, which is `tn-divider`: a 0-byte template and
+     * `role="separator"` plus `aria-orientation` declared in `host: {}`. It
+     * renders childless and textless, so a guard reading only the tree would
+     * reject a fixture that rendered correctly — and reject it on the one shape
+     * where the scan has the most to say, since the rules that match are the
+     * ones about those very attributes.
+     */
+    it('accepts a root whose whole accessibility surface is host attributes', async () => {
+      root.setAttribute('role', 'separator');
+      root.setAttribute('aria-orientation', 'horizontal');
+
+      const scan = await axeScan(root);
+
+      expect(scan.violations).toEqual([]);
+      // Non-vacuous: axe really did evaluate the host attributes, which is why
+      // rejecting this root would have cost a real answer rather than an empty
+      // one. `aria-allowed-attr` is the rule that matches `aria-orientation` on
+      // `role="separator"`.
+      expect(scan.passed).toContain('aria-allowed-attr');
+    });
+
+    // The same guard from the other side: a bare root carrying an `aria-*` and
+    // no `role` is still a rendered host, and axe has a verdict on it — here a
+    // real one, since `aria-orientation` is not allowed on a generic `<div>`.
+    it('accepts a root marked with aria-* alone, and reports what axe found', async () => {
+      root.setAttribute('aria-orientation', 'horizontal');
+
+      const scan = await axeScan(root);
+
+      expect(scan.violations.map((v) => v.rule)).toEqual(['aria-allowed-attr']);
+    });
   });
 });

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.ts
@@ -190,7 +190,14 @@ export interface AxeFinding {
   impact: string | null;
   /** axe's one-line description of the rule, e.g. "Interactive controls must not be nested". */
   help: string;
-  /** The nodes this rule reported on. Never empty — see `undecided`. */
+  /**
+   * The nodes this rule reported on.
+   *
+   * Never empty in `incomplete`, where a node-less result is moved to
+   * `undecided` instead. That rescue is `incomplete`-only: axe defines a
+   * violation and a pass by the nodes they were found on, so neither bucket
+   * produces a node-less entry to rescue.
+   */
   nodes: AxeFindingNode[];
 }
 
@@ -240,8 +247,10 @@ export interface AxeScan {
   /**
    * Rule ids that matched a node in the tree and passed.
    *
-   * The proof that an empty `violations` means something. See `axeResult`'s
-   * `evaluated` for the same idea applied to a named element.
+   * The proof that an empty `violations` means something, and the field to
+   * assert on when it has to: an empty `passed` says no rule applied to this
+   * tree at all, which a purely presentational component reaches legitimately.
+   * See `axeResult`'s `evaluated` for the same idea applied to a named element.
    */
   passed: string[];
 }
@@ -330,13 +339,20 @@ function toFinding(result: axe.Result): AxeFinding {
  * So `expect(scan.violations).toEqual([])` is a check that passes while the
  * defect stands. Assert on `incomplete` as well, every time.
  *
- * A SCAN THAT LOOKED AT NOTHING THROWS
- * ------------------------------------
- * Same premise as `axeResult`'s guards, arriving one level up: an empty result
- * is also what axe returns for a tree it walked and found no rule applicable to
- * — a detached fixture, which axe treats as hidden and exempts entirely. Both
- * that and "axe attributed nothing to any node" are errors here rather than a
- * clean bill of health.
+ * A SCAN OF NOTHING THROWS — AN EMPTY SCAN OF SOMETHING DOES NOT
+ * --------------------------------------------------------------
+ * Same premise as `axeResult`'s guards, arriving one level up: a scan that never
+ * looked at anything returns the same empty result as a clean one. So a root
+ * that is detached — axe treats it as hidden and exempts every node in it — and
+ * a root that is empty are both errors rather than a clean bill of health.
+ *
+ * A tree axe reported NOTHING about is a different thing and is returned, not
+ * thrown on. That is the ordinary answer for a presentational component: with
+ * `color-contrast` declined, `<div><p>Some text</p></div>` matches no rule in the
+ * ruleset, and every bucket comes back empty on markup that is entirely correct.
+ * `passed` is what tells the two apart — an empty one means no rule applied here,
+ * so assert `expect(passed.length).toBeGreaterThan(0)` in a spec where a rule
+ * genuinely should have.
  *
  * WHAT THIS STILL CANNOT DO
  * -------------------------
@@ -371,6 +387,21 @@ export async function axeScan(
       + 'clean scan whatever the markup says.'
     );
   }
+  // "Nothing rendered" is asked of the TREE, not of axe's output, because those
+  // are not the same question and the difference is a false alarm on the most
+  // ordinary use of this function. A tree axe reports nothing about is usually a
+  // presentational one — measured, `<div><p>Some text</p></div>` matches no rule
+  // in the ruleset once `color-contrast` is declined — and a probe that threw
+  // there would blame the fixture for markup that rendered perfectly. An
+  // unrendered host is what the guard is actually for, and it is visible here
+  // directly: it has no children and no text.
+  if (root.children.length === 0 && (root.textContent ?? '').trim() === '') {
+    throw new Error(
+      'axeScan: the scanned root is empty — no child elements and no text — so '
+      + 'a clean result from it would say nothing about the component. Check the '
+      + 'fixture rendered and that detectChanges() ran.'
+    );
+  }
 
   // No `runOnly`: naming nothing is the point of a probe, so this is every rule
   // axe ships minus `SKIPPED_RULES`.
@@ -385,25 +416,11 @@ export async function axeScan(
   });
 
   const hasNodes = (result: axe.Result): boolean => result.nodes.length > 0;
-  const scan: AxeScan = {
+  return {
     violations: results.violations.filter(hasNodes).map(toFinding),
     incomplete: results.incomplete.filter(hasNodes).map(toFinding),
     undecided: results.incomplete.filter((r) => !hasNodes(r)).map((r) => r.id),
     notRun: SKIPPED_RULES,
     passed: results.passes.filter(hasNodes).map((r) => r.id),
   };
-
-  if (
-    scan.violations.length === 0
-    && scan.incomplete.length === 0
-    && scan.passed.length === 0
-  ) {
-    throw new Error(
-      'axeScan: axe attributed no result to any node in this tree, so an empty '
-      + 'violations list here means it evaluated nothing rather than that the '
-      + 'markup is clean. Check the fixture rendered and that detectChanges() ran.'
-    );
-  }
-
-  return scan;
 }

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.ts
@@ -255,6 +255,22 @@ export interface AxeScan {
   passed: string[];
 }
 
+/** What a caller can tell `axeScan` that it cannot see for itself. */
+export interface AxeScanOptions {
+  /**
+   * The component renders nothing inside its host, and that is expected.
+   *
+   * `axeScan` throws on a childless, textless root, because that is what a
+   * fixture whose `detectChanges()` never ran looks like. A component that IS
+   * its host looks the same — `tn-divider` has a 0-byte template and declares
+   * `role="separator"` on the host — and nothing in the DOM tells the two apart,
+   * so the caller says which it has. The scan still has to find something: a
+   * root that is empty AND carries no `role` or `aria-*` is rejected whatever
+   * this says.
+   */
+  hostOnly?: boolean;
+}
+
 /**
  * The rules `axeScan` declines to run, each with the reason, because a rule
  * skipped for no stated reason is how a scan quietly becomes the lenient one.
@@ -345,10 +361,11 @@ function toFinding(result: axe.Result): AxeFinding {
  * looked at anything returns the same empty result as a clean one. So a root
  * that is detached — axe treats it as hidden and exempts every node in it — and
  * a root that is empty are both errors rather than a clean bill of health.
- * "Empty" means no children, no text AND no `role` or `aria-*` on the root: a
- * component whose whole accessibility surface is host attributes, `tn-divider`
- * being the one here, renders to exactly that and is scanned rather than
- * rejected.
+ *
+ * A component whose whole accessibility surface is its host renders to exactly
+ * that empty shape and is worth scanning — `tn-divider` has a 0-byte template
+ * and `role="separator"` + `aria-orientation` on the host, and a scan of it
+ * passes ten rules. Pass `{ hostOnly: true }` for it; see `AxeScanOptions`.
  *
  * A tree axe reported NOTHING about is a different thing and is returned, not
  * thrown on. That is the ordinary answer for a presentational component: with
@@ -371,6 +388,7 @@ function toFinding(result: axe.Result): AxeFinding {
  */
 export async function axeScan(
   target: HTMLElement | { nativeElement: HTMLElement } | null | undefined,
+  { hostOnly = false }: AxeScanOptions = {},
 ): Promise<AxeScan> {
   if (target === null || target === undefined) {
     throw new Error('axeScan: no element to scan');
@@ -400,22 +418,39 @@ export async function axeScan(
   // unrendered host is what the guard is actually for, and it is visible here
   // directly: it has no children and no text.
   //
-  // Except when the host itself carries the accessibility surface. `tn-divider`
-  // has a 0-byte template and puts `role="separator"` plus `aria-orientation` in
-  // `host: {}`, so it reaches here childless and textless having rendered exactly
-  // what it was asked to — and a scan of it is not vacuous, since
-  // `aria-allowed-attr` and `aria-valid-attr-value` both match those attributes.
-  // An unrendered host has no `role` and no `aria-*` either, so the two are
-  // distinguishable and the guard keeps its purpose.
+  // The one shape that is legitimately childless is a component that IS its host,
+  // and it cannot be told from an unrendered one by looking, which is why it is
+  // the caller who says so rather than a predicate here. Measured, both of these
+  // reach this line with `children.length === 0` and `role` already set:
+  //
+  //   - `TestBed.createComponent(TnDividerComponent)` + `detectChanges()` — a
+  //     0-byte template, `role="separator"` and `aria-orientation` on the host.
+  //   - a component whose whole template sits inside an `@if`, before the change
+  //     detection that would have made the condition true. Angular applies a
+  //     static host `role` at createComponent, so the host is marked either way.
+  //
+  // A `role`-based predicate would therefore let the second case through as a
+  // near-clean scan of a component that never rendered — the exact reading this
+  // module exists to prevent — so `hostOnly` is required, and the message says so.
   const bare = root.children.length === 0 && (root.textContent ?? '').trim() === '';
+  if (bare && !hostOnly) {
+    throw new Error(
+      'axeScan: the scanned root is empty — no child elements and no text — so '
+      + 'a clean result from it would say nothing about the component. Check the '
+      + 'fixture rendered and that detectChanges() ran. If the component IS its '
+      + 'host — tn-divider has a 0-byte template and declares role="separator" in '
+      + 'host: {} — pass { hostOnly: true } to say the emptiness is expected.'
+    );
+  }
+  // `hostOnly` relaxes the guard; it does not switch it off. A root with nothing
+  // inside it and nothing on it is vacuous however it is labelled.
   const marked = root.hasAttribute('role')
     || root.getAttributeNames().some((name) => name.startsWith('aria-'));
   if (bare && !marked) {
     throw new Error(
-      'axeScan: the scanned root is empty — no child elements, no text, and no '
-      + 'role or aria-* attribute on the root itself — so a clean result from it '
-      + 'would say nothing about the component. Check the fixture rendered and '
-      + 'that detectChanges() ran.'
+      'axeScan: hostOnly says the accessibility surface is on the root itself, '
+      + 'but the root carries no role and no aria-* attribute, and nothing is '
+      + 'rendered inside it — so there is nothing here for a rule to match.'
     );
   }
 

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.ts
@@ -345,6 +345,10 @@ function toFinding(result: axe.Result): AxeFinding {
  * looked at anything returns the same empty result as a clean one. So a root
  * that is detached — axe treats it as hidden and exempts every node in it — and
  * a root that is empty are both errors rather than a clean bill of health.
+ * "Empty" means no children, no text AND no `role` or `aria-*` on the root: a
+ * component whose whole accessibility surface is host attributes, `tn-divider`
+ * being the one here, renders to exactly that and is scanned rather than
+ * rejected.
  *
  * A tree axe reported NOTHING about is a different thing and is returned, not
  * thrown on. That is the ordinary answer for a presentational component: with
@@ -395,11 +399,23 @@ export async function axeScan(
   // there would blame the fixture for markup that rendered perfectly. An
   // unrendered host is what the guard is actually for, and it is visible here
   // directly: it has no children and no text.
-  if (root.children.length === 0 && (root.textContent ?? '').trim() === '') {
+  //
+  // Except when the host itself carries the accessibility surface. `tn-divider`
+  // has a 0-byte template and puts `role="separator"` plus `aria-orientation` in
+  // `host: {}`, so it reaches here childless and textless having rendered exactly
+  // what it was asked to — and a scan of it is not vacuous, since
+  // `aria-allowed-attr` and `aria-valid-attr-value` both match those attributes.
+  // An unrendered host has no `role` and no `aria-*` either, so the two are
+  // distinguishable and the guard keeps its purpose.
+  const bare = root.children.length === 0 && (root.textContent ?? '').trim() === '';
+  const marked = root.hasAttribute('role')
+    || root.getAttributeNames().some((name) => name.startsWith('aria-'));
+  if (bare && !marked) {
     throw new Error(
-      'axeScan: the scanned root is empty — no child elements and no text — so '
-      + 'a clean result from it would say nothing about the component. Check the '
-      + 'fixture rendered and that detectChanges() ran.'
+      'axeScan: the scanned root is empty — no child elements, no text, and no '
+      + 'role or aria-* attribute on the root itself — so a clean result from it '
+      + 'would say nothing about the component. Check the fixture rendered and '
+      + 'that detectChanges() ran.'
     );
   }
 

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.ts
@@ -373,10 +373,14 @@ export async function axeScan(
   }
 
   // No `runOnly`: naming nothing is the point of a probe, so this is every rule
-  // axe ships minus `SKIPPED_RULES`. `elementRef` is on for consistency with
-  // `axeResult` and so a caller can correlate a finding with a node it holds.
+  // axe ships minus `SKIPPED_RULES`.
+  //
+  // No `elementRef` either, unlike `axeResult`. That flag exists to attribute a
+  // result to an element the caller already holds, and a probe holds none — it
+  // reports what it finds, by selector and markup, to someone who does not yet
+  // know which element to ask about. Turning it on would put an `element` on
+  // every node result for nothing to read.
   const results = await axe.run(root, {
-    elementRef: true,
     rules: Object.fromEntries(SKIPPED_RULES.map(({ rule }) => [rule, { enabled: false }])),
   });
 

--- a/projects/truenas-ui/src/lib/a11y/axe-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/axe-testing.ts
@@ -1,15 +1,32 @@
 import axe from 'axe-core';
 
 /**
- * The one axe wrapper the a11y specs share, so that no copy of it can drift into
- * being the lenient one.
+ * The two axe wrappers the a11y specs share, so that no copy of either can drift
+ * into being the lenient one.
+ *
+ * `axeResult` is the GUARD: you name the rules and the elements, and it answers
+ * whether those rules objected to those elements. Every regression test in this
+ * library uses it.
+ *
+ * `axeScan` is the PROBE: you name nothing, and it reports everything axe found
+ * anywhere in a tree. It is what an accessibility ticket reaches for *before*
+ * there is a fix to guard — "what does axe say about this component?" — and it
+ * exists because four cycles in one day each wrote that scan from scratch,
+ * inside `src/`, ran it once and threw it away (#252).
+ *
+ * Both rest on one premise, which is the reason this file exists at all:
  *
  * WHY A SHARED WRAPPER, RATHER THAN A COPY PER SPEC
  * ------------------------------------------------
- * Three specs ran axe with three near-copies of this function, and two of them
+ * Three specs ran axe with three near-copies of `axeResult`, and two of them
  * were wrong in the direction that makes a test PASS. Duplication is not the
  * complaint; the complaint is that the correct version is subtle enough that
  * writing it a fourth time from memory is how the lenient copy gets made.
+ *
+ * ---
+ *
+ * The rest of this block is about `axeResult`. `axeScan` has its own, above the
+ * function, further down the file.
  *
  * WHAT THE SUBTLETY IS
  * --------------------
@@ -163,4 +180,226 @@ export async function axeResult(
     violated: results.violations.filter(touches).map((v) => v.id),
     evaluated: [...results.violations, ...results.passes].filter(touches).map((v) => v.id),
   };
+}
+
+/** One rule's report, and the nodes axe attributed it to. */
+export interface AxeFinding {
+  /** The axe rule id, e.g. `nested-interactive`. */
+  rule: string;
+  /** axe's own severity, or `null` for a rule it did not rate. */
+  impact: string | null;
+  /** axe's one-line description of the rule, e.g. "Interactive controls must not be nested". */
+  help: string;
+  /** The nodes this rule reported on. Never empty — see `undecided`. */
+  nodes: AxeFindingNode[];
+}
+
+/** One node a rule reported on, in the form a person reading a probe needs. */
+export interface AxeFindingNode {
+  /** axe's CSS selector for the node, flattened to one string. */
+  target: string;
+  /** The node's markup, as axe captured it. */
+  html: string;
+  /** axe's explanation of what to fix, or `''` for a rule that gave none. */
+  summary: string;
+}
+
+/** Everything axe said about a tree, with nothing named in advance. */
+export interface AxeScan {
+  /** Rules axe is sure are broken, somewhere in the scanned tree. */
+  violations: AxeFinding[];
+  /**
+   * Rules axe looked at a node for and could not decide.
+   *
+   * **Read these.** They are not passes — see the docblock on `axeScan`. A
+   * dangling `aria-labelledby` lands here and nowhere else.
+   */
+  incomplete: AxeFinding[];
+  /**
+   * Rule ids axe could not decide and could not attribute to any node.
+   *
+   * Separate from `incomplete` so that `expect(incomplete).toEqual([])` stays a
+   * usable assertion. A rule with no node to point at is the harmless shape —
+   * there is nothing to assert about it, and `evaluated` in `axeResult` already
+   * refuses to count it — but it is reported rather than dropped, because a
+   * verdict that silently vanished is the failure this module is about.
+   *
+   * Empty on every tree measured so far, now that `color-contrast` is declined
+   * up front. It is here for the next rule that behaves that way, not for a
+   * caller to assert on.
+   */
+  undecided: string[];
+  /**
+   * Rule ids `axeScan` did not run, and why it did not — see `SKIPPED_RULES`.
+   *
+   * Reported rather than merely documented: a rule that was never run is a gap
+   * in the scan, and a gap the caller cannot see is indistinguishable from a
+   * clean result. Always populated.
+   */
+  notRun: typeof SKIPPED_RULES;
+  /**
+   * Rule ids that matched a node in the tree and passed.
+   *
+   * The proof that an empty `violations` means something. See `axeResult`'s
+   * `evaluated` for the same idea applied to a named element.
+   */
+  passed: string[];
+}
+
+/**
+ * The rules `axeScan` declines to run, each with the reason, because a rule
+ * skipped for no stated reason is how a scan quietly becomes the lenient one.
+ *
+ * `color-contrast` is the only entry and needs to be, on both counts: it can
+ * return no verdict here, and running it is actively costly.
+ *
+ * It cannot decide, because jsdom has no layout engine — measured on axe-core
+ * 4.10.3, it comes back `incomplete` with an EMPTY node list on every tree that
+ * contains text, so it reaches no bucket a caller can act on. The same finding
+ * is why `theme/primary-text-contrast.spec.ts` and
+ * `theme/error-text-contrast.spec.ts` compute ratios by hand; contrast in this
+ * library is measured by `contrast-testing.ts`, not by axe.
+ *
+ * And running it makes jsdom log a `HTMLCanvasElement.prototype.getContext` is
+ * "not implemented" error, once per scan — axe uses a canvas to detect icon
+ * ligatures. Suppressing that in `setup-jest.ts` was the alternative, and it
+ * would have hidden the same error for `particle-progress-bar`, which is the one
+ * component that genuinely draws.
+ */
+export const SKIPPED_RULES = [
+  {
+    rule: 'color-contrast',
+    reason: 'jsdom has no layout engine; use contrast-testing.ts instead',
+  },
+] as const;
+
+/** Flattens axe's nested selector shape to the one string a reader wants. */
+function selectorText(target: unknown): string {
+  const flatten = (value: unknown): string[] =>
+    Array.isArray(value) ? value.flatMap(flatten) : [String(value)];
+  return flatten(target).join(' ');
+}
+
+function toFinding(result: axe.Result): AxeFinding {
+  return {
+    rule: result.id,
+    impact: result.impact ?? null,
+    help: result.help,
+    nodes: result.nodes.map((node) => ({
+      target: selectorText(node.target),
+      html: node.html,
+      summary: node.failureSummary ?? '',
+    })),
+  };
+}
+
+/**
+ * Run every axe rule over `target` and report everything, naming nothing.
+ *
+ * This is the PROBE, and `axeResult` above is the guard. Use this one when you
+ * do not yet know what is wrong — an accessibility ticket arrives saying a
+ * component fails axe, and the first thing anyone needs is what axe actually
+ * says. Then write the regression test with `axeResult`, which pins a named rule
+ * to a named element and is what belongs in a spec long-term.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Four developer cycles on one day each wrote this scan from scratch, as a
+ * throwaway spec inside `src/`, ran it once to read what axe reported, and then
+ * could not delete it (#252). Four implementations of one shape in a day, none
+ * of which survived the day. Nothing about the scan varies per ticket.
+ *
+ * `target` is a fixture or an element, because a caller has one or the other and
+ * `fixture.nativeElement` is the only thing this needs from Angular — taking
+ * both avoids importing `@angular/core/testing` into this module for one
+ * property access.
+ *
+ * VIOLATIONS ARE NOT THE WHOLE ANSWER
+ * -----------------------------------
+ * This is the trap the return type is shaped around, and it is why the buckets
+ * are separate rather than one array.
+ *
+ * `violations` is what axe is SURE about. `incomplete` is what it looked at and
+ * could not decide, and a probe that reads only the first reports a defect as
+ * clean. Measured on axe-core 4.10.3 under jsdom: a `<button aria-labelledby="nope">`,
+ * where the referenced id is not in the document, returns ZERO violations. The
+ * finding — `aria-valid-attr-value`, impact `critical`, "ARIA attribute element
+ * ID does not exist on the page" — is in `incomplete`, because axe cannot tell a
+ * reference into a not-yet-rendered part of the page from a broken one.
+ *
+ * So `expect(scan.violations).toEqual([])` is a check that passes while the
+ * defect stands. Assert on `incomplete` as well, every time.
+ *
+ * A SCAN THAT LOOKED AT NOTHING THROWS
+ * ------------------------------------
+ * Same premise as `axeResult`'s guards, arriving one level up: an empty result
+ * is also what axe returns for a tree it walked and found no rule applicable to
+ * — a detached fixture, which axe treats as hidden and exempts entirely. Both
+ * that and "axe attributed nothing to any node" are errors here rather than a
+ * clean bill of health.
+ *
+ * WHAT THIS STILL CANNOT DO
+ * -------------------------
+ * jsdom has no layout engine, so a rule that needs one gets no verdict here.
+ * `SKIPPED_RULES` names the one that is declined outright, and `notRun` repeats
+ * it on every result so the gap travels with the answer; use
+ * `contrast-testing.ts` for colour. And a clean scan is a statement about the
+ * rules axe ships, not about the component being usable.
+ *
+ * Not exported from `public-api.ts`, and must not be, for the reasons in the
+ * docblock at the top of this file.
+ */
+export async function axeScan(
+  target: HTMLElement | { nativeElement: HTMLElement } | null | undefined,
+): Promise<AxeScan> {
+  if (target === null || target === undefined) {
+    throw new Error('axeScan: no element to scan');
+  }
+  // A fixture is unwrapped rather than required, so a caller can pass whichever
+  // it is holding. `nativeElement` is `any` on Angular's ComponentFixture, so a
+  // fixture whose host never rendered would arrive here as null — checked, not
+  // assumed.
+  const root: HTMLElement | null | undefined =
+    'nativeElement' in target ? target.nativeElement : target;
+  if (!root) {
+    throw new Error('axeScan: the fixture has no nativeElement to scan');
+  }
+  if (!root.isConnected) {
+    throw new Error(
+      'axeScan: the scanned root is not in the document. axe treats a detached '
+      + 'tree as hidden and exempts every node in it, so this would report a '
+      + 'clean scan whatever the markup says.'
+    );
+  }
+
+  // No `runOnly`: naming nothing is the point of a probe, so this is every rule
+  // axe ships minus `SKIPPED_RULES`. `elementRef` is on for consistency with
+  // `axeResult` and so a caller can correlate a finding with a node it holds.
+  const results = await axe.run(root, {
+    elementRef: true,
+    rules: Object.fromEntries(SKIPPED_RULES.map(({ rule }) => [rule, { enabled: false }])),
+  });
+
+  const hasNodes = (result: axe.Result): boolean => result.nodes.length > 0;
+  const scan: AxeScan = {
+    violations: results.violations.filter(hasNodes).map(toFinding),
+    incomplete: results.incomplete.filter(hasNodes).map(toFinding),
+    undecided: results.incomplete.filter((r) => !hasNodes(r)).map((r) => r.id),
+    notRun: SKIPPED_RULES,
+    passed: results.passes.filter(hasNodes).map((r) => r.id),
+  };
+
+  if (
+    scan.violations.length === 0
+    && scan.incomplete.length === 0
+    && scan.passed.length === 0
+  ) {
+    throw new Error(
+      'axeScan: axe attributed no result to any node in this tree, so an empty '
+      + 'violations list here means it evaluated nothing rather than that the '
+      + 'markup is clean. Check the fixture rendered and that detectChanges() ran.'
+    );
+  }
+
+  return scan;
 }

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -238,10 +238,11 @@ describe('tn-chip accessibility (#188)', () => {
 
       expect(violations).toEqual([]);
       expect(incomplete).toEqual([]);
-      // `axeScan` throws rather than returning an empty scan, so this cannot go
-      // vacuous the way an unpaired `toEqual([])` can. Naming a rule the chip
-      // actually exercises says more than the count: it is the one the fix was
-      // about, and it is evaluated on the body button post-#188.
+      // This is what stops the two `toEqual([])` above going vacuous: a scan
+      // that matched no rule at all returns empty too, and only `passed` tells
+      // the two apart. Naming a rule the chip actually exercises says more than
+      // the count: it is the one the fix was about, and it is evaluated on the
+      // body button post-#188.
       expect(passed).toContain('nested-interactive');
     });
   });

--- a/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-a11y.spec.ts
@@ -4,7 +4,7 @@ import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TnChipComponent } from './chip.component';
-import { axeResult } from '../a11y/axe-testing';
+import { axeResult, axeScan } from '../a11y/axe-testing';
 
 /**
  * Guards the structure fixed for #188: the chip used to render a focusable
@@ -203,6 +203,47 @@ describe('tn-chip accessibility (#188)', () => {
     expect(evaluated).toContain('nested-interactive');
     expect(body().disabled).toBe(true);
     expect(close()!.disabled).toBe(true);
+  });
+
+  /**
+   * The whole-fixture sweep, and the worked example of `axeScan` — the probe
+   * half of `../a11y/axe-testing` (#252). The full call is here on purpose, so a
+   * cycle picking up an accessibility ticket can copy it rather than write its
+   * own scan.
+   *
+   * It is not a replacement for the `axeResult` guards above and does not try to
+   * be: those pin a named rule to a named element, which is what survives an axe
+   * upgrade that changes which nodes a rule selects. What this adds is the
+   * opposite property — it names nothing, so it covers the rules nobody thought
+   * to name. The docblock on "raises no ARIA violation when disabled" explains
+   * why `evaluated` there cannot honestly name the two `aria-*` rules; a sweep
+   * has no such problem, because it makes no claim about which element was
+   * looked at.
+   *
+   * Both buckets are asserted. `violations` alone would pass on a dangling
+   * `aria-labelledby`, which axe reports as `incomplete` — see
+   * `../a11y/axe-testing.spec.ts`, where that is measured.
+   */
+  describe('the whole chip, with no rule named in advance', () => {
+    it.each([
+      ['closable', () => { /* the default fixture */ }],
+      ['with an icon', () => host.icon.set('mdi:star')],
+      ['non-closable', () => host.closable.set(false)],
+      ['disabled', () => host.disabled.set(true)],
+    ])('has nothing for axe to report when %s', async (_name, arrange) => {
+      arrange();
+      fixture.detectChanges();
+
+      const { violations, incomplete, passed } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      // `axeScan` throws rather than returning an empty scan, so this cannot go
+      // vacuous the way an unpaired `toEqual([])` can. Naming a rule the chip
+      // actually exercises says more than the count: it is the one the fix was
+      // about, and it is evaluated on the body button post-#188.
+      expect(passed).toContain('nested-interactive');
+    });
   });
 
   describe('the close control', () => {


### PR DESCRIPTION
Fixes #252.

## What was missing

`lib/a11y/axe-testing.ts` already had a shared axe wrapper — but only the **guard** half. `axeResult(root, targets, rules)` needs the rules and the elements named in advance, which is precisely what an accessibility ticket does not yet know. So the four cycles the ticket names each wrote the other half from scratch, as a throwaway spec inside `src/`, ran it once to read what axe said, and then could not delete it.

This adds `axeScan`: takes a fixture or an element, names nothing, reports everything.

| You want | Use | It answers |
|---|---|---|
| "What does axe say about this component?" | `axeScan(fixture)` | everything, with nothing named in advance |
| "Does this fix stay fixed?" | `axeResult(root, targets, rules)` | whether *these* rules object to *these* elements |

The two are not interchangeable and the docs say so: probe to find out what is wrong, then pin it down with `axeResult`, which is what belongs in a spec long-term.

## The trap the return type is shaped around

**`violations` is only what axe is SURE about**, and a probe that reads only it reports a real defect as clean. This is the ticket's second acceptance criterion, and it is measured rather than assumed — against axe-core 4.10.3 under jsdom:

```
<button type="button" aria-labelledby="not-a-real-id">x</button>

violations: (none)
incomplete: aria-valid-attr-value  — impact critical
            "ARIA attribute element ID does not exist on the page"
```

The button has no accessible name at all, and `expect(violations).toEqual([])` passes on it. axe cannot tell a reference into a not-yet-rendered part of the page from a broken one, so it declines to decide. `incomplete` is a separate bucket for exactly this, and `axe-testing.spec.ts` asserts both halves together — the empty `violations` is what makes the populated `incomplete` mean something.

Three more fields exist so that nothing is silently missing:

- **`passed`** — rule ids that matched a node and passed. An empty `violations` means nothing without it, and it is also what distinguishes a scan that checked things and liked them from a scan that matched no rule at all.
- **`notRun`** — rules `axeScan` declined, each with its reason, repeated on every result so the gap travels with the answer.
- **`undecided`** — any rule axe could not decide *and* could not attribute to a node. Empty on everything measured; it is there so such a rule is reported rather than dropped by the filter.

## What "the scan looked at nothing" means, and what it does not

**An empty root throws. An empty *result* does not.** These are different failures and only the first one is a fault.

The guard is for a host whose `detectChanges()` never ran, which would otherwise report itself as perfectly accessible. That is asked of the **tree** — no child elements and no text — rather than of axe's output, because the two are not the same question:

```
<div class="tn-card"><div class="tn-card__content">Some text</div></div>
<div><p>Some text</p><span>more</span></div>

violations: (none)   incomplete: (none)   passed: (none)
```

Measured, on axe-core 4.10.3 with `color-contrast` declined: no rule in the ruleset matches a `div`, a `p` or a `span`, so a correctly-rendered presentational component comes back completely empty. Keying the guard to "axe attributed nothing" would throw there and blame the fixture for markup that rendered exactly what it was asked to — and that is the first thing the docs point a reader at, so it has to be an ordinary answer. Both samples are in the spec, as is a root holding only text, which has no child elements and must not read as unrendered.

A detached root still throws, separately and unambiguously: axe treats a detached tree as hidden and exempts every node in it.

### A component that IS its host: `axeScan(fixture, { hostOnly: true })`

`tn-divider` has a 0-byte template and declares `role="separator"` and `aria-orientation` in `host: {}`. It renders childless and textless having done exactly what it was asked to, and a scan of it is not vacuous — it passes ten rules, `aria-allowed-attr` and `aria-valid-attr-value` among them. The tree guard as first written rejected it, which is the HIGH round 2 of the required review raised.

**The flag is required rather than inferred**, and that is the one place this diff does not take the review's suggested predicate. The suggestion was to let a childless root through when it carries a `role` or an `aria-*`, on the reasoning that an unrendered host has neither. Measured against this repo, it has one:

```
TestBed.createComponent(TnDividerComponent)            children 0, attrs [id, role, ng-version, class]
  + detectChanges()                                    children 0, attrs [..., aria-orientation]

a host with role="status" whose template is one @if    children 0, attrs [id, role, ng-version]
  + detectChanges() with the condition true            children 1
```

Angular applies a **static** host `role` at `createComponent`, before any change detection, so a component whose whole template sits inside an `@if` is childless *and* marked — indistinguishable from `tn-divider` by looking. A `role`-based predicate would report it as a near-clean scan of a component that rendered none of itself, which is the exact reading this module exists to prevent. So the caller states the claim, and the guard's message names the flag, which is how the `tn-divider` case gets found.

`hostOnly` relaxes the guard rather than switching it off: a root with nothing inside it and no `role` or `aria-*` on it is still refused, because there is nothing there for a rule to match either way. Both directions are covered on real components — `tn-divider` scans and passes `aria-allowed-attr`; a local `@if`-template host with a static `role` is still refused.

## One judgement call: `color-contrast` is declined, not run

`axeScan` disables `color-contrast` up front, names it in the exported `SKIPPED_RULES`, and repeats it in every result's `notRun`.

Two reasons, both measured:

1. **It can return no verdict here.** jsdom has no layout engine, so it comes back `incomplete` with an **empty node list** on every tree containing text — it reaches no bucket a caller can act on. This is the same finding that made `theme/primary-text-contrast.spec.ts` and `theme/error-text-contrast.spec.ts` compute ratios by hand; contrast in this library is measured by `contrast-testing.ts`, not by axe.
2. **Running it is actively costly.** axe uses a canvas to detect icon ligatures, so jsdom logs `HTMLCanvasElement.prototype.getContext` is "not implemented" — a full stack trace, once per scan.

The alternative was suppressing that message in `setup-jest.ts`, which already has a list for expected test-environment errors. Rejected: it would hide the same error for `particle-progress-bar`, the one component that genuinely draws. Both of that component's specs mock `getContext` today, so nothing currently relies on seeing it — but a global suppression is a worse trade than declining one rule that cannot answer anyway.

Skipping a rule silently is the shape this module exists to prevent, which is why it is exported, named, reasoned, and present in the result rather than only in a comment.

## The worked example

`chip-a11y.spec.ts` gains the whole-fixture sweep across four component states, with the full call visible.

It **does not replace** the `axeResult` guards there and could not: those pin a named rule to a named element, which is what survives an axe upgrade that changes which nodes a rule selects. What the sweep adds is the opposite property — it names nothing, so it covers the rules nobody thought to name. That spec's own docblock on "raises no ARIA violation when disabled" explains at length why `evaluated` there cannot honestly name the two `aria-*` rules; a sweep has no such problem, because it makes no claim about which element was looked at.

Its `expect(passed).toContain('nested-interactive')` is what keeps the two `toEqual([])` beside it from going vacuous — a scan that matched no rule returns empty too.

## Docs

- `docs/component_testing.md` gains an **Accessibility Tests** section — the ticket's fourth criterion, so a cycle reading the testing guide finds this before writing its own probe. It had no mention of axe at all. It also says what an all-empty scan means for a presentational component, what to assert there instead, and when to reach for `{ hostOnly: true }`.
- `docs/component_conventions.md`'s "Running axe in a spec" opened with *"Use `axeResult()`… Do not write another axe wrapper"*, which this change makes incomplete. It now states which of the two to reach for and why the choice is not a matter of taste.
- `CLAUDE.md`'s file table: the `component_testing.md` line now mentions accessibility scans. Its two line-count figures were already stale before this branch (`~510` for a 603-line file); both are corrected to the current rounded values rather than left further out of date.

## How it was checked

`yarn lint`, `yarn test` (2997 passed, 118 suites) and `yarn build` all pass.

`yarn lint` reports the same **4 pre-existing `import/order` errors** in `input.component.ts` and `menu-panel.component.ts` that are open as #251, and nothing in any file this branch touches.

`yarn build-storybook` and `yarn test-sb` were **not** run. `test-sb` drives a real browser through Playwright and this host has neither the browser nor the system libraries to start one. Neither reads anything this branch changed — no story, template or component source is touched; the diff is two spec files, one test-only module, and three markdown files.

## Round log

**Round 1** — `axeScan` added. One local review round, clean at MEDIUM and above. Two LOWs it raised were both cases where the diff contradicted itself, so both were fixed rather than deferred: a dead `elementRef: true` whose comment claimed a caller could correlate a finding with a node it holds (removed; nothing read the field), and a `component_testing.md` snippet asserting `passed` contains `nested-interactive`, a chip-specific rule that most components never exercise (it now names `button-name` and tells the reader to pick their own).

**Round 2** — the required review returned a HIGH: the "axe attributed nothing" guard fired on correctly-rendered presentational markup. Confirmed by measurement before changing anything, and fixed by asking the tree instead. A second local review round on the full diff returned nothing at MEDIUM or above.

**Round 3** — the required review returned a second HIGH: the tree guard rejected `tn-divider`, whose whole surface is host attributes. Fixed with `{ hostOnly: true }` rather than with the suggested `role`-based predicate, for the measured reason in the section above — the local review round on that predicate raised it as a MEDIUM (an unrendered `@if` host carries a static `role` and would have slipped through), and the measurement confirmed it. The following local review round returned nothing at MEDIUM or above.

## Findings left unfixed, and why

All LOW, from round 3's clean local review. Recorded here rather than acted on, so a later ticket can take any of them:

- **Node-less `violations` and `passes` entries are dropped rather than rescued into `undecided`.** No input reaches it: axe defines a violation and a pass by the nodes they were found on. The `AxeFinding.nodes` docblock says the rescue is `incomplete`-only, so the prose and the code agree; widening the rescue would mean putting a rule axe *did* decide into a field documented as undecided, which is the larger change.
- **`SKIPPED_RULES` is honoured by `axeScan` only.** `axeResult` still accepts `color-contrast` as a named rule and returns an empty attribution for it, and `notRun` hands the caller the module's own array rather than a copy. Both are real; both widen the change beyond the probe this ticket asked for.
- **The `axeScan` docblock suggests `expect(passed.length).toBeGreaterThan(0)`** as the anti-vacuous assertion, where every real caller correctly uses `toContain(rule)` — which is the stronger form, and the one the #193 shape argues for.
- **`ConditionalTemplateHostComponent` never asserts that its host carries the `role`.** The test proves the rejection, which is the behaviour, but not the premise that makes it interesting — so removing the `role` from that fixture would leave the test green.
- **The two presentational markup samples are a `for` loop inside one `it()`**, so a failure does not say which sample failed; `it.each` is used elsewhere in this repo.
- **The chip sweep runs four full-ruleset axe scans** on top of the five targeted `axeResult` runs already in that file, and its `toEqual([])` pins the spec to axe's best-practice rules and to descendant components like `tn-icon`. An axe upgrade that adds a best-practice rule can turn it red for a reason unrelated to the chip. That is inherent to a sweep, and the reason `axeResult` exists beside it.
- **`toFinding` drops axe's `tags` and `helpUrl`**, so a probe reader cannot tell a WCAG failure from a best-practice opinion, or follow the fix guidance. A real gap in the output and a reasonable follow-up; it widens the return type rather than correcting it.

**Also inherent rather than a gap:** `axeScan` is a whole-tree sweep, so a violation it reports on a *descendant* — a `tn-icon` inside the component, say — is indistinguishable in its output from one on the component itself. That is exactly why `axeResult` takes targets; the split is the answer to it. Worth knowing before writing a sweep assertion over a component that composes several others.
