### PR TITLE
NAS-142485 / 27.0.0-BETA.1 / fix(a11y): give the slider input and the selection list an accessible name

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -479,6 +479,30 @@ in `chip-a11y.spec.ts`, and the unlabelled checkbox in
 `slide-toggle-a11y.spec.ts`. It is the only assertion that shows axe failing
 rather than passing, and it doubles as the control for `axeResult()` itself.
 
+### Asserting an accessible name in a spec
+
+**An axe naming rule is a PRESENCE check and is not enough on its own.** `label`,
+`aria-input-field-name` and their siblings ask whether the element is named, not
+whether it is named *correctly* — `aria-label="_"` satisfies every one of them.
+So a fix that wires a control to the wrong label, or to a label that has not
+rendered, passes the whole suite (#235).
+
+**Pair the rule with `accessibleName()` from `lib/a11y/accessible-name-testing.ts`**,
+which resolves the string a screen reader would announce, and assert on that
+string. `slider-a11y.spec.ts` and `selection-list-name.spec.ts` are the worked
+examples: each asserts the name, that it follows the label when the label
+changes, and that the axe rule stays quiet.
+
+It implements the first three steps of the ARIA name calculation —
+`aria-labelledby`, `aria-label`, a native `<label>` — and deliberately no more.
+Add a step when a spec needs it, with the spec; a second unexercised
+implementation of a subtle algorithm is the failure the axe section above is
+about.
+
+**A dangling `aria-labelledby` comes back `null`, not `''`.** It is the case axe
+cannot report — a reference to a missing id lands in `incomplete`, never in
+`violations` — so this is the only assertion in a spec that catches it.
+
 ### Measuring colour contrast in a spec
 
 **Use `lib/a11y/contrast-testing.ts`. Do not write the formula again.** Three

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -332,10 +332,16 @@ each wrote a throwaway probe spec inside `src/` because this section did not exi
 |---|---|---|
 | "What does axe say about this component?" | `axeScan(fixture)` | everything, with nothing named in advance |
 | "Does this fix stay fixed?" | `axeResult(root, targets, rules)` | whether *these* rules object to *these* elements |
+| "What would a screen reader announce this AS?" | `accessibleName(el)` | the resolved name string, or `null` for none |
 
 Start with `axeScan` to find out what is wrong. Write the regression test with
 `axeResult`, which pins a named rule to a named element and is what belongs in a
 spec long-term. `component_conventions.md` has the rules for that half.
+
+`accessibleName` lives in `lib/a11y/accessible-name-testing.ts` and belongs
+alongside `axeResult` in any spec about naming: axe's naming rules only ask
+whether an element is named, so `aria-label="_"` passes them all. See
+`component_conventions.md`, "Asserting an accessible name in a spec".
 
 ### Scanning a component: `axeScan`
 

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
@@ -121,6 +121,25 @@ describe('accessibleName', () => {
     });
 
     /**
+     * A `<label for="…">` names the element `for` points at, even when it wraps
+     * a different one — so this input is unnamed, and saying otherwise would let
+     * a spec claim a name for markup a browser leaves silent.
+     */
+    it('names nothing when it wraps a control but points at another', () => {
+      const el = mount(
+        '<input id="other"><label for="other">Volume<input id="subject" type="range"></label>'
+      );
+
+      expect(accessibleName(el)).toBeNull();
+    });
+
+    it('still names the control it wraps when its for points back at it', () => {
+      const el = mount('<label for="subject">Volume<input id="subject" type="range"></label>');
+
+      expect(accessibleName(el)).toBe('Volume');
+    });
+
+    /**
      * A `<label>` names only a labelable element. Wrapping a `div` in one names
      * nothing, and reporting a name there would let a spec claim an accessible
      * name for markup a browser leaves unnamed.

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
@@ -158,11 +158,11 @@ describe('accessibleName', () => {
   });
 
   /**
-   * An id that a `label[for="…"]` selector would have to escape. Written as a
-   * selector it throws `ReferenceError: CSS is not defined` under jsdom — which
-   * is why the lookup compares the `for` attribute instead.
+   * An id full of CSS selector punctuation, which is where a lookup that builds
+   * a selector string goes wrong — the first version of this reached for
+   * `CSS.escape`, which is not defined under jsdom and threw.
    */
-  it('finds a label for an id a CSS selector would have to escape', () => {
+  it('finds a label for an id full of selector punctuation', () => {
     root.innerHTML = '<label for="a.b:c">Volume</label><input id="a.b:c" type="range">';
     const el = root.querySelector('input') as HTMLElement;
 

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.spec.ts
@@ -1,0 +1,152 @@
+import { accessibleName } from './accessible-name-testing';
+
+/**
+ * The spec for the naming helper the a11y specs share (#235).
+ *
+ * It exists for the same reason `axe-testing.spec.ts` does: this is an
+ * assertion other assertions rest on, so a bug in it is a bug that makes OTHER
+ * specs green. The cases below are the steps of the ARIA name calculation it
+ * implements and the two ways each of them can produce nothing.
+ */
+describe('accessibleName', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+  });
+
+  /** Renders `html` into the document and returns its `#subject` element. */
+  function mount(html: string): HTMLElement {
+    root.innerHTML = html;
+    return root.querySelector('#subject') as HTMLElement;
+  }
+
+  describe('aria-labelledby', () => {
+    it('resolves to the referenced element text', () => {
+      const el = mount('<span id="name">Speed Control</span><div id="subject" aria-labelledby="name"></div>');
+
+      expect(accessibleName(el)).toBe('Speed Control');
+    });
+
+    it('joins several references in the order they are listed', () => {
+      const el = mount(
+        '<span id="a">Fan</span><span id="b">Speed</span>'
+        + '<div id="subject" aria-labelledby="b a"></div>'
+      );
+
+      expect(accessibleName(el)).toBe('Speed Fan');
+    });
+
+    it('skips a reference that resolves to nothing', () => {
+      const el = mount('<span id="a">Fan</span><div id="subject" aria-labelledby="a gone"></div>');
+
+      expect(accessibleName(el)).toBe('Fan');
+    });
+
+    /**
+     * The case axe cannot report — a dangling IDREF lands in `incomplete`, never
+     * in `violations` — so this function is the only thing in a spec that
+     * catches it.
+     */
+    it('is null when every reference dangles and nothing follows', () => {
+      const el = mount('<div id="subject" aria-labelledby="gone"></div>');
+
+      expect(accessibleName(el)).toBeNull();
+    });
+
+    /**
+     * accname continues past a step that produced the empty string, so a
+     * browser announces the `aria-label` here. Returning null instead would put
+     * this function at odds with every screen reader on markup that works.
+     */
+    it('falls through to aria-label when every reference dangles', () => {
+      const el = mount('<div id="subject" aria-labelledby="gone" aria-label="Folders"></div>');
+
+      expect(accessibleName(el)).toBe('Folders');
+    });
+
+    it('wins over an aria-label when it resolves', () => {
+      const el = mount(
+        '<span id="name">Mailboxes</span>'
+        + '<div id="subject" aria-labelledby="name" aria-label="Folders"></div>'
+      );
+
+      expect(accessibleName(el)).toBe('Mailboxes');
+    });
+
+    it('is ignored when blank, as an attribute naming no element', () => {
+      const el = mount('<div id="subject" aria-labelledby="   " aria-label="Folders"></div>');
+
+      expect(accessibleName(el)).toBe('Folders');
+    });
+  });
+
+  describe('aria-label', () => {
+    it('is the name when present', () => {
+      const el = mount('<div id="subject" aria-label="Volume"></div>');
+
+      expect(accessibleName(el)).toBe('Volume');
+    });
+
+    /** Blank is not a name — the whole point of the components' own trimming. */
+    it.each(['', '   '])('is not a name when blank (%p)', (blank) => {
+      const el = mount(`<div id="subject" aria-label="${blank}"></div>`);
+
+      expect(accessibleName(el)).toBeNull();
+    });
+  });
+
+  describe('a native label', () => {
+    it('names a control it points at with for', () => {
+      const el = mount('<label for="subject">Volume</label><input id="subject" type="range">');
+
+      expect(accessibleName(el)).toBe('Volume');
+    });
+
+    it('names a control it wraps', () => {
+      const el = mount('<label>Volume<input id="subject" type="range"></label>');
+
+      expect(accessibleName(el)).toBe('Volume');
+    });
+
+    it('loses to an aria-label on the control', () => {
+      const el = mount('<label for="subject">Volume</label><input id="subject" aria-label="Brightness">');
+
+      expect(accessibleName(el)).toBe('Brightness');
+    });
+
+    /**
+     * A `<label>` names only a labelable element. Wrapping a `div` in one names
+     * nothing, and reporting a name there would let a spec claim an accessible
+     * name for markup a browser leaves unnamed.
+     */
+    it('names nothing when it wraps an element a label cannot name', () => {
+      const el = mount('<label>Volume<div id="subject" role="listbox"></div></label>');
+
+      expect(accessibleName(el)).toBeNull();
+    });
+  });
+
+  it('is null for an element with no naming route at all', () => {
+    const el = mount('<div id="subject"></div>');
+
+    expect(accessibleName(el)).toBeNull();
+  });
+
+  /**
+   * An id that a `label[for="…"]` selector would have to escape. Written as a
+   * selector it throws `ReferenceError: CSS is not defined` under jsdom — which
+   * is why the lookup compares the `for` attribute instead.
+   */
+  it('finds a label for an id a CSS selector would have to escape', () => {
+    root.innerHTML = '<label for="a.b:c">Volume</label><input id="a.b:c" type="range">';
+    const el = root.querySelector('input') as HTMLElement;
+
+    expect(accessibleName(el)).toBe('Volume');
+  });
+});

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
@@ -74,8 +74,16 @@ function nativeLabel(el: HTMLElement): string | null {
     ? Array.from(el.ownerDocument.querySelectorAll('label[for]'))
       .find((label) => label.getAttribute('for') === id) ?? null
     : null;
+  // A wrapping `<label for="…">` names the element that `for` points at, not the
+  // one it happens to contain — so a label pointing elsewhere names this control
+  // no more than a label somewhere else on the page does. Without the check, the
+  // `<label for="other">Volume<input></label>` shape reports a name for a
+  // control a browser leaves unnamed, which is the direction that makes a
+  // naming spec pass on markup that is broken.
   const wrapping = el.closest('label');
-  const text = (explicit ?? wrapping)?.textContent?.trim() ?? '';
+  const wraps = wrapping !== null
+    && (!wrapping.hasAttribute('for') || wrapping.getAttribute('for') === id);
+  const text = (explicit ?? (wraps ? wrapping : null))?.textContent?.trim() ?? '';
   return text !== '' ? text : null;
 }
 

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
@@ -31,12 +31,18 @@
  * `axe-testing.ts`'s own docblock is about. Add a step when a spec needs it, with
  * the spec.
  *
- * WHY A DANGLING REFERENCE IS `null` AND NOT `''`
- * -----------------------------------------------
- * `aria-labelledby="nope"` resolves to no text, so the element is unnamed —
- * which is the same outcome as having no naming attribute at all, and the
- * assertion should be the same. It matters because axe cannot report it: a
- * dangling IDREF lands in `incomplete`, not `violations` (see `axeScan`'s
+ * A DANGLING REFERENCE IS NOT AN ANSWER, IT IS A STEP THAT PRODUCED NOTHING
+ * -------------------------------------------------------------------------
+ * `aria-labelledby="nope"` resolves to no text, and accname says a step that
+ * yields the empty string does not end the computation — so the next step runs
+ * and an `aria-label` beside it is what the element is announced as. That is
+ * what a browser does, and reporting `null` there would have this function
+ * disagree with every screen reader on markup that works.
+ *
+ * With nothing after it to fall through to, the element really is unnamed and
+ * the result is `null` — not `''`, so that a dangling reference and a missing
+ * attribute assert identically. That case matters because axe cannot report it:
+ * a dangling IDREF lands in `incomplete`, not `violations` (see `axeScan`'s
  * docblock), so this function is the only thing in a spec that catches it.
  *
  * Not exported from `public-api.ts`, and must not be — the same rule as
@@ -59,12 +65,14 @@ function nativeLabel(el: HTMLElement): string | null {
   if (!LABELABLE.includes(el.tagName.toLowerCase())) {
     return null;
   }
-  // `labels` is the DOM's own answer and covers both forms at once, but it is
-  // only on labelable elements and jsdom leaves it null on some of them — so the
-  // two lookups are done by hand rather than trusted to be there.
+  // The explicit label is found by comparing `for` rather than by building a
+  // `label[for="…"]` selector, which would need `CSS.escape` for an id
+  // containing a `.` or a `:` — and `CSS` is simply not defined under jsdom, so
+  // that form throws `ReferenceError` on the ids it exists to handle.
   const id = el.getAttribute('id');
   const explicit = id !== null && id !== ''
-    ? el.ownerDocument.querySelector(`label[for="${CSS.escape(id)}"]`)
+    ? Array.from(el.ownerDocument.querySelectorAll('label[for]'))
+      .find((label) => label.getAttribute('for') === id) ?? null
     : null;
   const wrapping = el.closest('label');
   const text = (explicit ?? wrapping)?.textContent?.trim() ?? '';
@@ -82,15 +90,17 @@ function nativeLabel(el: HTMLElement): string | null {
 export function accessibleName(el: HTMLElement): string | null {
   const labelledby = attr(el, 'aria-labelledby');
   if (labelledby !== null) {
-    // Every id in the list, in order, skipping the ones that resolve to nothing
-    // — which is what makes a wholly dangling reference come back unnamed rather
-    // than named by the empty string.
+    // Every id in the list, in order, skipping the ones that resolve to nothing.
     const text = labelledby
       .split(/\s+/)
       .map((id) => el.ownerDocument.getElementById(id)?.textContent?.trim() ?? '')
       .filter((part) => part !== '')
       .join(' ');
-    return text !== '' ? text : null;
+    // A step that produced nothing does not end the computation — fall through
+    // to `aria-label`, which is what a browser announces here. See the docblock.
+    if (text !== '') {
+      return text;
+    }
   }
 
   return attr(el, 'aria-label') ?? nativeLabel(el);

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
@@ -65,10 +65,12 @@ function nativeLabel(el: HTMLElement): string | null {
   if (!LABELABLE.includes(el.tagName.toLowerCase())) {
     return null;
   }
-  // The explicit label is found by comparing `for` rather than by building a
-  // `label[for="…"]` selector, which would need `CSS.escape` for an id
-  // containing a `.` or a `:` — and `CSS` is simply not defined under jsdom, so
-  // that form throws `ReferenceError` on the ids it exists to handle.
+  // The explicit label is found by comparing `for` rather than by matching a
+  // `label[for="…"]` selector. A quoted attribute selector needs no escaping, so
+  // that form would have worked — but reaching for `CSS.escape` to build one
+  // does not: `CSS` is not defined under jsdom and the call throws
+  // `ReferenceError`. Comparing the attribute keeps the question in the DOM,
+  // where there is no selector syntax to get wrong in the first place.
   const id = el.getAttribute('id');
   const explicit = id !== null && id !== ''
     ? Array.from(el.ownerDocument.querySelectorAll('label[for]'))

--- a/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name-testing.ts
@@ -1,0 +1,97 @@
+/**
+ * Spec helper for asserting what a screen reader would announce an element AS.
+ *
+ * WHY THIS EXISTS ALONGSIDE `axe-testing.ts`
+ * ------------------------------------------
+ * axe answers "is this element named at all?" — `label` on a form control,
+ * `aria-input-field-name` on a listbox. That is a *presence* check, and it is
+ * satisfied by `aria-label="_"`. It cannot say the announced name is the one the
+ * consumer asked for, so a fix that wires an element to the WRONG label passes
+ * every axe rule in the suite (#235).
+ *
+ * So the two are complementary and both belong in a naming spec: `axeResult`
+ * pins the rule that must not object, and this resolves the string it would have
+ * objected about.
+ *
+ * WHAT IT IMPLEMENTS, AND WHAT IT DOES NOT
+ * ----------------------------------------
+ * The ARIA name computation is long, and only its first steps are reachable by
+ * this library's own markup. Implemented, in the order the spec applies them:
+ *
+ *   1. `aria-labelledby`, joining the referenced elements' text.
+ *   2. `aria-label`.
+ *   3. A native `<label>`, explicit (`for`) or wrapping, for a labelable control.
+ *
+ * NOT implemented, deliberately: `title`, the content-derived name a button or a
+ * link takes from its own text, and the recursion that lets an
+ * `aria-labelledby` target be named by its OWN `aria-label`. Each is a real step
+ * of the algorithm and none of them is reachable from the components this
+ * guards; adding one on speculation would be a second, unexercised
+ * implementation of a subtle algorithm — which is the failure
+ * `axe-testing.ts`'s own docblock is about. Add a step when a spec needs it, with
+ * the spec.
+ *
+ * WHY A DANGLING REFERENCE IS `null` AND NOT `''`
+ * -----------------------------------------------
+ * `aria-labelledby="nope"` resolves to no text, so the element is unnamed —
+ * which is the same outcome as having no naming attribute at all, and the
+ * assertion should be the same. It matters because axe cannot report it: a
+ * dangling IDREF lands in `incomplete`, not `violations` (see `axeScan`'s
+ * docblock), so this function is the only thing in a spec that catches it.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `live-region-testing.ts` and `axe-testing.ts`. It asserts an internal contract
+ * of this library's own markup; a consumer testing its own components has
+ * `dom-accessibility-api` and a real browser.
+ */
+
+/** Elements a `<label>` can name, per the HTML spec's "labelable element". */
+const LABELABLE = ['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea'];
+
+/** The trimmed value of `attr` on `el`, or `null` when it is absent or blank. */
+function attr(el: HTMLElement, name: string): string | null {
+  const value = el.getAttribute(name);
+  return value !== null && value.trim() !== '' ? value.trim() : null;
+}
+
+/** The text of the `<label>` naming `el`, explicit or wrapping, or `null`. */
+function nativeLabel(el: HTMLElement): string | null {
+  if (!LABELABLE.includes(el.tagName.toLowerCase())) {
+    return null;
+  }
+  // `labels` is the DOM's own answer and covers both forms at once, but it is
+  // only on labelable elements and jsdom leaves it null on some of them — so the
+  // two lookups are done by hand rather than trusted to be there.
+  const id = el.getAttribute('id');
+  const explicit = id !== null && id !== ''
+    ? el.ownerDocument.querySelector(`label[for="${CSS.escape(id)}"]`)
+    : null;
+  const wrapping = el.closest('label');
+  const text = (explicit ?? wrapping)?.textContent?.trim() ?? '';
+  return text !== '' ? text : null;
+}
+
+/**
+ * The accessible name a screen reader would announce for `el`, or `null` when it
+ * has none.
+ *
+ * `null` rather than `''` for an unnamed element, so that the two ways of being
+ * unnamed — no attribute, and an attribute that resolves to nothing — assert
+ * identically. See the docblock above.
+ */
+export function accessibleName(el: HTMLElement): string | null {
+  const labelledby = attr(el, 'aria-labelledby');
+  if (labelledby !== null) {
+    // Every id in the list, in order, skipping the ones that resolve to nothing
+    // — which is what makes a wholly dangling reference come back unnamed rather
+    // than named by the empty string.
+    const text = labelledby
+      .split(/\s+/)
+      .map((id) => el.ownerDocument.getElementById(id)?.textContent?.trim() ?? '')
+      .filter((part) => part !== '')
+      .join(' ');
+    return text !== '' ? text : null;
+  }
+
+  return attr(el, 'aria-label') ?? nativeLabel(el);
+}

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -267,6 +267,77 @@ describe('tn-selection-list accessible name (#235)', () => {
   });
 
   /**
+   * A name the consumer writes onto the host directly, as an ATTRIBUTE BINDING
+   * rather than through the input.
+   *
+   * This is the case that makes the naming attributes an effect rather than two
+   * host bindings. The `role="listbox"` is on the host, so this markup named the
+   * list before the input existed; measured on Angular 21, a host binding of the
+   * same attributes runs after the parent's and left the element with neither,
+   * so the list went silently from named to unnamed. The component now removes
+   * only attributes it wrote itself.
+   */
+  describe('a name bound onto the host by the parent template', () => {
+    @Component({
+      selector: 'tn-attr-bound-host',
+      standalone: true,
+      imports: [TnSelectionListComponent, TnListOptionComponent],
+      template: `<span id="heading">Mailboxes</span><tn-selection-list
+        [attr.aria-labelledby]="id()" [attr.aria-label]="label()"><tn-list-option
+        value="inbox">Inbox</tn-list-option></tn-selection-list>`
+    })
+    class AttrBoundHostComponent {
+      id = signal<string | null>(null);
+      label = signal<string | null>(null);
+    }
+
+    it('survives, when it is an aria-label', () => {
+      const fixture = TestBed.createComponent(AttrBoundHostComponent);
+      fixture.componentInstance.label.set('Folders');
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Folders');
+    });
+
+    it('survives, when it is an aria-labelledby', () => {
+      const fixture = TestBed.createComponent(AttrBoundHostComponent);
+      fixture.componentInstance.id.set('heading');
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+    });
+
+    /** And keeps surviving: the effect re-runs on every pass, not only the first. */
+    it('survives a later change-detection pass', () => {
+      const fixture = TestBed.createComponent(AttrBoundHostComponent);
+      fixture.componentInstance.label.set('Folders');
+      fixture.detectChanges();
+
+      fixture.componentInstance.id.set('heading');
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+      expect(list(fixture).getAttribute('aria-label')).toBe('Folders');
+    });
+
+    /**
+     * The other side of the ownership rule: a name this component DID write is
+     * still its to take back when the input that produced it goes away.
+     */
+    it('does not stop the component removing a name it wrote itself', () => {
+      const fixture = TestBed.createComponent(StandaloneHostComponent);
+      fixture.detectChanges();
+
+      expect(list(fixture).getAttribute('aria-label')).toBe('Mailboxes');
+
+      fixture.componentInstance.label.set(undefined);
+      fixture.detectChanges();
+
+      expect(list(fixture).hasAttribute('aria-label')).toBe(false);
+    });
+  });
+
+  /**
    * The sweep that names nothing, so a rule nobody thought of is still reported.
    */
   describe('the whole list, with nothing named in advance', () => {

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -321,6 +321,29 @@ describe('tn-selection-list accessible name (#235)', () => {
     });
 
     /**
+     * The write half of the ownership rule, which is the easier one to get
+     * wrong: inside a labelled field this component has a name to write on the
+     * very first pass, so a guard that covered only removal would overwrite the
+     * consumer's reference with the field's.
+     */
+    it('survives an enclosing form field having a label of its own', () => {
+      @Component({
+        selector: 'tn-attr-bound-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<span id="own-heading">Datasets</span><tn-form-field label="Mailboxes">
+          <tn-selection-list [attr.aria-labelledby]="'own-heading'"><tn-list-option
+          value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class AttrBoundInFieldHostComponent {}
+
+      const fixture = TestBed.createComponent(AttrBoundInFieldHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Datasets');
+    });
+
+    /**
      * The other side of the ownership rule: a name this component DID write is
      * still its to take back when the input that produced it goes away.
      */

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -395,6 +395,62 @@ describe('tn-selection-list accessible name (#235)', () => {
     });
 
     /**
+     * And the reverse, which is the case that made this a per-pass question
+     * rather than a `computed` one: withholding the field's label while the
+     * consumer's name stands has to STOP withholding when that name goes away.
+     * A `computed` cannot — a DOM attribute is not a signal, so nothing it read
+     * changed — and the list is left with no accessible name at all.
+     */
+    it('gives the field label back when the consumer clears their own', () => {
+      @Component({
+        selector: 'tn-clearable-attr-label-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-form-field label="Mailboxes"><tn-selection-list
+          [attr.aria-label]="label()"><tn-list-option
+          value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class ClearableAttrLabelHostComponent {
+        label = signal<string | null>('Folders');
+      }
+
+      const fixture = TestBed.createComponent(ClearableAttrLabelHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Folders');
+
+      fixture.componentInstance.label.set(null);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+    });
+
+    /** And takes it away again when the consumer names it once more. */
+    it('withholds the field label again when the consumer names it later', () => {
+      @Component({
+        selector: 'tn-late-attr-label-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-form-field label="Mailboxes"><tn-selection-list
+          [attr.aria-label]="label()"><tn-list-option
+          value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class LateAttrLabelHostComponent {
+        label = signal<string | null>(null);
+      }
+
+      const fixture = TestBed.createComponent(LateAttrLabelHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+
+      fixture.componentInstance.label.set('Folders');
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Folders');
+    });
+
+    /**
      * The other side of the ownership rule: a name this component DID write is
      * still its to take back when the input that produced it goes away.
      */

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -101,6 +101,32 @@ describe('tn-selection-list accessible name (#235)', () => {
     });
 
     /**
+     * The ordering the whole resolution exists to produce, and the case it is
+     * easiest to leave untested: an explicit name and a field label together.
+     *
+     * The explicit one wins, and the field's reference is WITHHELD rather than
+     * rendered beside it. Rendering both would announce the field's label —
+     * `aria-labelledby` beats `aria-label` wherever it resolves — so the second
+     * assertion is the one that catches a regression the first cannot see.
+     */
+    it('wins over an enclosing form field label', () => {
+      @Component({
+        selector: 'tn-named-in-field-list-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-form-field label="Mailboxes"><tn-selection-list aria-label="Folders">
+          <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class NamedInFieldHostComponent {}
+
+      const named = TestBed.createComponent(NamedInFieldHostComponent);
+      named.detectChanges();
+
+      expect(accessibleName(list(named))).toBe('Folders');
+      expect(list(named).hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    /**
      * A blank `aria-label` must not take the field's label away with it.
      * `injectTnFormFieldAria` suppresses the field whenever the explicit name is
      * TRUTHY, and `'   '` is truthy — so a list handing it the raw input ends up

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -39,7 +39,7 @@ class WrappedHostComponent {
   selector: 'tn-standalone-list-host',
   standalone: true,
   imports: [TnSelectionListComponent, TnListOptionComponent],
-  template: `<tn-selection-list [ariaLabel]="label()">
+  template: `<tn-selection-list [aria-label]="label()">
     <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
 })
 class StandaloneHostComponent {
@@ -98,6 +98,29 @@ describe('tn-selection-list accessible name (#235)', () => {
 
       expect(violated).toEqual([]);
       expect(evaluated).toContain('aria-input-field-name');
+    });
+
+    /**
+     * A blank `aria-label` must not take the field's label away with it.
+     * `injectTnFormFieldAria` suppresses the field whenever the explicit name is
+     * TRUTHY, and `'   '` is truthy — so a list handing it the raw input ends up
+     * with no `aria-label` (blank, dropped) and no `aria-labelledby`
+     * (suppressed), which is worse than either half alone.
+     */
+    it('still takes the field label when the explicit one is blank', () => {
+      @Component({
+        selector: 'tn-blank-in-field-list-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-form-field label="Mailboxes"><tn-selection-list aria-label="   ">
+          <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class BlankInFieldHostComponent {}
+
+      const blank = TestBed.createComponent(BlankInFieldHostComponent);
+      blank.detectChanges();
+
+      expect(accessibleName(list(blank))).toBe('Mailboxes');
     });
   });
 
@@ -177,7 +200,7 @@ describe('tn-selection-list accessible name (#235)', () => {
         standalone: true,
         imports: [TnSelectionListComponent, TnListOptionComponent],
         template: `<h2 id="mailboxes-heading">Mailboxes</h2><tn-selection-list
-          ariaLabel="Folders" ariaLabelledby="mailboxes-heading"><tn-list-option
+          aria-label="Folders" aria-labelledby="mailboxes-heading"><tn-list-option
           value="inbox">Inbox</tn-list-option></tn-selection-list>`
       })
       class BothNamesHostComponent {}
@@ -194,7 +217,7 @@ describe('tn-selection-list accessible name (#235)', () => {
         selector: 'tn-dangling-name-host',
         standalone: true,
         imports: [TnSelectionListComponent, TnListOptionComponent],
-        template: `<tn-selection-list ariaLabel="Folders" ariaLabelledby="not-here">
+        template: `<tn-selection-list aria-label="Folders" aria-labelledby="not-here">
           <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
       })
       class DanglingNameHostComponent {}
@@ -202,20 +225,23 @@ describe('tn-selection-list accessible name (#235)', () => {
       const fixture = TestBed.createComponent(DanglingNameHostComponent);
       fixture.detectChanges();
 
-      // `accessibleName` resolves the reference and finds nothing, so it reports
-      // the element as unnamed by that route; a real screen reader falls through
-      // to the `aria-label` that is still on the element, which is why emitting
-      // both is what keeps this markup usable rather than silent.
-      expect(list(fixture).getAttribute('aria-label')).toBe('Folders');
+      // The point of emitting both: a reference that resolves to nothing does
+      // not end the name computation, so the `aria-label` still on the element
+      // is what gets announced. Suppressing it beside a typo'd IDREF would
+      // leave the list silent in exactly the case where a name was supplied.
+      expect(accessibleName(list(fixture))).toBe('Folders');
     });
   });
 
   /**
-   * `ariaLabel="…"` as a static attribute, which is how a consumer names a list
-   * in a template and how `list.stories.ts` writes it. Unlike the slider's, this
-   * input is not aliased to an ARIA attribute name, so the leftover attribute
-   * Angular puts on the host is the inert `arialabel` rather than a second
-   * `aria-label` on an element with no role to carry it.
+   * `aria-label="…"` as a static attribute, which is how a consumer names a list
+   * in a template and how `list.stories.ts` writes it.
+   *
+   * This is the case the alias on the input exists for, and it is a REGRESSION
+   * test as much as a new one: the `role="listbox"` is on the host, so this
+   * markup named the list before the input existed, and the host binding added
+   * here rewrites that attribute on every pass. Without the alias the binding
+   * finds the input unset and strips the name.
    */
   describe('named by a static attribute, as a consumer writes it', () => {
     it('names the listbox and leaves nothing for axe', async () => {
@@ -223,7 +249,7 @@ describe('tn-selection-list accessible name (#235)', () => {
         selector: 'tn-static-label-list-host',
         standalone: true,
         imports: [TnSelectionListComponent, TnListOptionComponent],
-        template: `<tn-selection-list ariaLabel="Mailboxes">
+        template: `<tn-selection-list aria-label="Mailboxes">
           <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
       })
       class StaticLabelHostComponent {}

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -1,0 +1,261 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnSelectionListComponent } from './selection-list.component';
+import { accessibleName } from '../a11y/accessible-name-testing';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+import { TnFormFieldComponent } from '../form-field/form-field.component';
+import { TnListOptionComponent } from '../list-option/list-option.component';
+
+/**
+ * The listbox's accessible name (#235).
+ *
+ * `tn-selection-list` has carried `role="listbox"` from the start, which makes
+ * it an ARIA input field — and it had no route to a name of any kind: no
+ * `ariaLabel` input, and no wiring to an enclosing `tn-form-field`. Reproduced
+ * before the fix as `aria-input-field-name`, impact `serious`, on the host, both
+ * standalone and inside a labelled field.
+ *
+ * The options say what is IN the list. Nothing said what the list is for.
+ *
+ * Both axe and an `accessibleName` assertion, for the reason set out in
+ * `slider-a11y.spec.ts`: the rule is a presence check that `aria-label="_"`
+ * satisfies, so on its own it cannot tell a correct wiring from a wrong one.
+ */
+
+@Component({
+  selector: 'tn-wrapped-list-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+  // Held to three lines by @angular-eslint/component-max-inline-declarations.
+  template: `<tn-form-field [label]="label()"><tn-selection-list>
+    <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+})
+class WrappedHostComponent {
+  label = signal('Mailboxes');
+}
+
+@Component({
+  selector: 'tn-standalone-list-host',
+  standalone: true,
+  imports: [TnSelectionListComponent, TnListOptionComponent],
+  template: `<tn-selection-list [ariaLabel]="label()">
+    <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
+})
+class StandaloneHostComponent {
+  label = signal<string | undefined>('Mailboxes');
+}
+
+describe('tn-selection-list accessible name (#235)', () => {
+  function list(fixture: ComponentFixture<unknown>): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-selection-list') as HTMLElement;
+  }
+
+  describe('inside a tn-form-field', () => {
+    let fixture: ComponentFixture<WrappedHostComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WrappedHostComponent);
+      fixture.detectChanges();
+    });
+
+    /** The defect, stated as an assertion: this was `null` before the fix. */
+    it('takes its accessible name from the field label', () => {
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+    });
+
+    it('names the listbox through aria-labelledby rather than a copied string', () => {
+      expect(list(fixture).getAttribute('aria-labelledby')).not.toBeNull();
+      expect(list(fixture).hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('follows the field when its label changes', () => {
+      fixture.componentInstance.label.set('Datasets');
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Datasets');
+    });
+
+    /**
+     * A field with no label publishes `labelId: null`. Pointing at it anyway
+     * would leave a dangling IDREF, which names nothing and which axe reports as
+     * `incomplete` rather than a violation — quieter than the defect it replaces.
+     */
+    it('renders no aria-labelledby when the field has no label', () => {
+      fixture.componentInstance.label.set('');
+      fixture.detectChanges();
+
+      expect(list(fixture).hasAttribute('aria-labelledby')).toBe(false);
+      expect(accessibleName(list(fixture))).toBeNull();
+    });
+
+    it('raises no aria-input-field-name violation', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        list(fixture),
+        ['aria-input-field-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-input-field-name');
+    });
+  });
+
+  describe('standalone', () => {
+    let fixture: ComponentFixture<StandaloneHostComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(StandaloneHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('takes its accessible name from the ariaLabel input', () => {
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+    });
+
+    it('raises no aria-input-field-name violation', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        list(fixture),
+        ['aria-input-field-name']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-input-field-name');
+    });
+
+    /**
+     * A blank `aria-label` satisfies axe and announces nothing, so the attribute
+     * is dropped rather than emitted empty — which keeps the check red on a
+     * listbox that really is unnamed.
+     */
+    it.each(['', '   '])('renders no aria-label for a blank one (%p)', async (blank) => {
+      fixture.componentInstance.label.set(blank);
+      fixture.detectChanges();
+
+      expect(list(fixture).hasAttribute('aria-label')).toBe(false);
+      expect(accessibleName(list(fixture))).toBeNull();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement,
+        list(fixture),
+        ['aria-input-field-name']
+      );
+
+      expect(violated).toEqual(['aria-input-field-name']);
+    });
+
+    /**
+     * The positive control: with no name at all the rule really does fire on
+     * this element, so a `violated: []` elsewhere means the markup is right
+     * rather than that the rule stopped matching the host.
+     */
+    it('still fails the rule when nothing names it', async () => {
+      fixture.componentInstance.label.set(undefined);
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(
+        fixture.nativeElement,
+        list(fixture),
+        ['aria-input-field-name']
+      );
+
+      expect(violated).toEqual(['aria-input-field-name']);
+    });
+  });
+
+  /**
+   * `aria-labelledby` wins the ARIA name calculation where it resolves, so both
+   * attributes are emitted rather than one suppressing the other — a suppressed
+   * `aria-label` beside a typo'd IDREF would leave the list unnamed in exactly
+   * the case where a name was supplied.
+   */
+  describe('given both an ariaLabel and an ariaLabelledby', () => {
+    it('announces the referenced text and keeps the explicit label in the markup', () => {
+      @Component({
+        selector: 'tn-both-names-host',
+        standalone: true,
+        imports: [TnSelectionListComponent, TnListOptionComponent],
+        template: `<h2 id="mailboxes-heading">Mailboxes</h2><tn-selection-list
+          ariaLabel="Folders" ariaLabelledby="mailboxes-heading"><tn-list-option
+          value="inbox">Inbox</tn-list-option></tn-selection-list>`
+      })
+      class BothNamesHostComponent {}
+
+      const fixture = TestBed.createComponent(BothNamesHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+      expect(list(fixture).getAttribute('aria-label')).toBe('Folders');
+    });
+
+    it('falls back to the explicit label when the reference dangles', () => {
+      @Component({
+        selector: 'tn-dangling-name-host',
+        standalone: true,
+        imports: [TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-selection-list ariaLabel="Folders" ariaLabelledby="not-here">
+          <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
+      })
+      class DanglingNameHostComponent {}
+
+      const fixture = TestBed.createComponent(DanglingNameHostComponent);
+      fixture.detectChanges();
+
+      // `accessibleName` resolves the reference and finds nothing, so it reports
+      // the element as unnamed by that route; a real screen reader falls through
+      // to the `aria-label` that is still on the element, which is why emitting
+      // both is what keeps this markup usable rather than silent.
+      expect(list(fixture).getAttribute('aria-label')).toBe('Folders');
+    });
+  });
+
+  /**
+   * `ariaLabel="…"` as a static attribute, which is how a consumer names a list
+   * in a template and how `list.stories.ts` writes it. Unlike the slider's, this
+   * input is not aliased to an ARIA attribute name, so the leftover attribute
+   * Angular puts on the host is the inert `arialabel` rather than a second
+   * `aria-label` on an element with no role to carry it.
+   */
+  describe('named by a static attribute, as a consumer writes it', () => {
+    it('names the listbox and leaves nothing for axe', async () => {
+      @Component({
+        selector: 'tn-static-label-list-host',
+        standalone: true,
+        imports: [TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-selection-list ariaLabel="Mailboxes">
+          <tn-list-option value="inbox">Inbox</tn-list-option></tn-selection-list>`
+      })
+      class StaticLabelHostComponent {}
+
+      const fixture = TestBed.createComponent(StaticLabelHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Mailboxes');
+
+      const { violations, incomplete } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+    });
+  });
+
+  /**
+   * The sweep that names nothing, so a rule nobody thought of is still reported.
+   */
+  describe('the whole list, with nothing named in advance', () => {
+    it.each([
+      ['wrapped in a form field', () => TestBed.createComponent(WrappedHostComponent)],
+      ['standalone', () => TestBed.createComponent(StandaloneHostComponent)]
+    ])('has nothing for axe to report when %s', async (_case, create) => {
+      const fixture = create();
+      fixture.detectChanges();
+
+      const { violations, incomplete, passed } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      expect(passed).toContain('aria-input-field-name');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list-name.spec.ts
@@ -370,6 +370,31 @@ describe('tn-selection-list accessible name (#235)', () => {
     });
 
     /**
+     * Not being REMOVED is not enough — the field's label must not be added
+     * beside it either. `aria-labelledby` beats `aria-label` wherever it
+     * resolves, so a field reference added next to the consumer's name
+     * outranks it: the list keeps the attribute and still announces the wrong
+     * thing.
+     */
+    it('is not outranked by an enclosing form field label', () => {
+      @Component({
+        selector: 'tn-attr-label-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSelectionListComponent, TnListOptionComponent],
+        template: `<tn-form-field label="Mailboxes"><tn-selection-list
+          [attr.aria-label]="'Folders'"><tn-list-option
+          value="inbox">Inbox</tn-list-option></tn-selection-list></tn-form-field>`
+      })
+      class AttrLabelInFieldHostComponent {}
+
+      const fixture = TestBed.createComponent(AttrLabelInFieldHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(list(fixture))).toBe('Folders');
+      expect(list(fixture).hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    /**
      * The other side of the ownership rule: a name this component DID write is
      * still its to take back when the input that produced it goes away.
      */

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -33,7 +33,12 @@ export interface TnSelectionChange {
     '[class.tn-selection-list--dense]': 'dense()',
     '[class.tn-selection-list--disabled]': 'isDisabled()',
     'role': 'listbox',
-    // The naming attributes are NOT host bindings — see `applyName`.
+    // A `role="listbox"` is an ARIA input field, and one with no accessible name
+    // is announced as bare "listbox" — the options say what is IN the list,
+    // never what it is FOR (#235). What these two resolve to, and why they are
+    // methods rather than signals, is on `hostAriaLabel` / `hostAriaLabelledby`.
+    '[attr.aria-label]': 'hostAriaLabel()',
+    '[attr.aria-labelledby]': 'hostAriaLabelledby()',
     //
     // The listbox states its own disabled-ness rather than leaving assistive
     // technology to infer it from its children (#225). Inferring is not the same
@@ -110,37 +115,21 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   });
 
   /**
-   * The `aria-labelledby` this component supplies, or `null` when it supplies
-   * none — and the one place the precedence is decided.
+   * The explicit `ariaLabelledby` input, blank normalised away, or `null`.
    *
-   * The explicit reference comes first, so a consumer who points the list at
-   * their own visible text keeps it. An explicit `aria-label` comes next, and
-   * withholds the field's reference rather than rendering beside it: ARIA's name
-   * calculation prefers `aria-labelledby` wherever it resolves, so emitting both
-   * would announce the FIELD's label over the name written on the list.
-   *
-   * The field's label comes last, and only when nothing above has named the
-   * list. With none of the three, a list outside a field gets `null` and stays
-   * unnamed — deliberately: a generic fallback ("List") would satisfy axe while
-   * announcing nothing the user can act on, and only the consumer knows what
-   * this list holds.
+   * Kept apart from the field's label because the two rank differently against
+   * a name the consumer wrote on the host — see {@link hostAriaLabelledby}.
    */
-  private readonly resolvedAriaLabelledby = computed(() => {
+  private readonly explicitAriaLabelledby = computed(() => {
     const labelledby = this.ariaLabelledby();
-    if (labelledby !== undefined && labelledby.trim() !== '') {
-      return labelledby;
-    }
-    if (this.resolvedAriaLabel() !== null || this.namedByConsumer()) {
-      return null;
-    }
-    return this.fieldAria.labelledby();
+    return labelledby !== undefined && labelledby.trim() !== '' ? labelledby : null;
   });
 
   private readonly hostElement = inject(ElementRef<HTMLElement>).nativeElement;
 
   /**
    * The value this component last wrote for each naming attribute, so that it
-   * only ever rewrites or removes its own. See {@link applyName}.
+   * can tell its own from the consumer's. See {@link claim}.
    */
   private readonly written = new Map<string, string>();
 
@@ -217,39 +206,6 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   private onTouched = () => {};
 
   constructor() {
-    // The naming attributes, written here rather than as host bindings.
-    //
-    // A `role="listbox"` is an ARIA input field, and one with no accessible name
-    // is announced as bare "listbox" — the options say what is IN the list,
-    // never what it is FOR (#235).
-    //
-    // WHY NOT A HOST BINDING, WHICH IS WHAT EVERY OTHER ATTRIBUTE HERE USES
-    // ---------------------------------------------------------------------
-    // Because the role is on the HOST, `<tn-selection-list aria-label="…">` and
-    // `[attr.aria-labelledby]="…"` are valid markup that named this list before
-    // it had any naming input at all — and a host binding writes its attribute
-    // on every pass whether or not this component has a name to write. Measured
-    // on Angular 21: with `[attr.aria-label]` and `[attr.aria-labelledby]` bound
-    // in the PARENT template, a host binding of the same attributes ran last and
-    // left the element with neither, so the list went from named to unnamed and
-    // nothing said so. The parent's write reappeared only on a later pass, and
-    // only for the attribute whose bound value had changed.
-    //
-    // So the rule is ownership rather than precedence: this component writes an
-    // attribute when it has a name for it, and removes it only if the value it
-    // removes is one this component put there. Anything a consumer set by any
-    // route is left alone.
-    //
-    // Both attributes are written, rather than one suppressing the other,
-    // because ARIA prefers `aria-labelledby` only while it RESOLVES — dropping
-    // an explicit `aria-label` beside a dangling IDREF would leave the list
-    // unnamed in exactly the case where a name was supplied. Same reasoning as
-    // `a11y/accessible-name.ts`.
-    effect(() => {
-      this.applyName('aria-label', this.resolvedAriaLabel());
-      this.applyName('aria-labelledby', this.resolvedAriaLabelledby());
-    });
-
     // Push what the list decides for all of its options down onto each of them,
     // re-running both when the decision changes and when the set of options
     // does — an option added after the list was rendered has to arrive carrying
@@ -434,34 +390,48 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   }
 
   /**
-   * Whether the host already carries a name this component did not write.
+   * The `aria-label` the host should carry.
    *
-   * The ownership rule in {@link applyName} keeps such a name from being
-   * REMOVED. That is not enough on its own: a list inside a
-   * `<tn-form-field label="Mailboxes">` still had a field label to add, and
-   * adding it beside a consumer's `[attr.aria-label]="'Folders'"` announces
-   * "Mailboxes" — `aria-labelledby` wins the name calculation wherever it
-   * resolves, so the name the consumer wrote is outranked rather than removed.
-   * So a name from any route has to withhold the field's, exactly as an explicit
-   * input does.
-   *
-   * Read from the DOM rather than from an input because that is the only place
-   * this route exists: an `[attr.…]` binding in the parent template never
-   * reaches an input. It is read inside the effect, after Angular has applied
-   * that binding for the pass.
-   *
-   * WHAT THIS DOES NOT COVER, DELIBERATELY
-   * --------------------------------------
-   * A DOM attribute is not a signal, so this is answered when the surrounding
-   * computed re-runs and not when the attribute changes. A consumer whose
-   * `[attr.aria-label]` starts empty and fills in LATER, on a list that is
-   * inside a labelled field and has already been given the field's reference,
-   * keeps that reference until something else about the list changes. Closing
-   * that would mean observing the attribute — a `MutationObserver`, or a render
-   * hook running on every pass — which is a large mechanism for a narrow case,
-   * on a route (`[attr.…]` rather than the input) that already has a documented
-   * one that works. The input is the supported way to name this list.
+   * A METHOD rather than a signal, and that is the load-bearing part of this
+   * whole arrangement: a host binding re-evaluates on every change-detection
+   * pass, while a `computed` re-runs only when a signal it read has changed.
+   * These two answers depend on the host's CURRENT attributes, which are not
+   * signals — a consumer's `[attr.aria-label]` bound in the parent template
+   * never reaches an input and never notifies anything. Asked once per pass,
+   * the answer stays true; asked from a `computed`, it goes stale the moment
+   * the consumer's binding changes, and the list is left announcing the wrong
+   * name or no name at all.
    */
+  protected hostAriaLabel(): string | null {
+    return this.claim('aria-label', this.resolvedAriaLabel());
+  }
+
+  /**
+   * The `aria-labelledby` the host should carry — and the one place the naming
+   * precedence is decided.
+   *
+   * Most specific first: the `ariaLabelledby` input, then any name the consumer
+   * put on the host by another route, then the enclosing `tn-form-field`'s
+   * label. The field comes last because it is chrome the consumer did not write
+   * on this element, and it is WITHHELD rather than rendered alongside: ARIA
+   * prefers `aria-labelledby` wherever it resolves, so a field reference emitted
+   * beside a consumer's `aria-label` does not merely coexist with it — it
+   * outranks it, and the list announces the field's label instead.
+   *
+   * With none of the three, a list stays unnamed — deliberately: a generic
+   * fallback ("List") would satisfy axe while announcing nothing the user can
+   * act on, and only the consumer knows what this list holds.
+   */
+  protected hostAriaLabelledby(): string | null {
+    const explicit = this.explicitAriaLabelledby();
+    if (explicit !== null) {
+      return this.claim('aria-labelledby', explicit);
+    }
+    const named = this.resolvedAriaLabel() !== null || this.namedByConsumer();
+    return this.claim('aria-labelledby', named ? null : this.fieldAria.labelledby());
+  }
+
+  /** Whether the host already carries a non-blank name this component did not write. */
   private namedByConsumer(): boolean {
     return NAME_ATTRIBUTES.some((attribute) => {
       const current = this.hostElement.getAttribute(attribute);
@@ -470,37 +440,37 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   }
 
   /**
-   * Write one naming attribute to the host, or take back one this component
-   * previously wrote — and never touch one it did not.
+   * What to bind `attribute` to: this component's own `value` where it has one,
+   * and otherwise whatever is already on the host — so that a name the consumer
+   * set is preserved rather than overwritten by the `null` that means "nothing
+   * to say".
    *
-   * The guard covers WRITING as much as removing, and the write half is the
-   * easier one to get wrong: a list inside a `<tn-form-field label="…">` has a
-   * name to write on the very first pass, so guarding only the removal would
-   * still overwrite a `[attr.aria-labelledby]` the consumer bound in the parent
-   * template — the exact clobbering this method exists to stop, arriving from
-   * the other direction.
+   * That distinction is the reason this exists. `[attr.x]="null"` REMOVES the
+   * attribute, and the role is on the HOST here, so `<tn-selection-list
+   * aria-label="…">` and `[attr.aria-labelledby]="…"` are valid markup that
+   * named this list before it had any naming input at all. Measured on Angular
+   * 21, a plain host binding of these attributes ran after the parent's and left
+   * the element with NEITHER — named to unnamed, silently, with the parent's
+   * value reappearing only on a later pass and only for the one whose bound
+   * value had changed.
    *
-   * Ownership is checked against the value on the element rather than a flag,
-   * so it also lapses correctly: an attribute this component wrote and someone
-   * else has since changed is no longer its to rewrite or remove.
+   * Ownership is tracked by value rather than by a flag, so it also lapses
+   * correctly: an attribute this component wrote and something else has since
+   * changed is no longer this component's to rewrite or take away.
    */
-  private applyName(attribute: string, value: string | null): void {
+  private claim(attribute: string, value: string | null): string | null {
     const current = this.hostElement.getAttribute(attribute);
     const ours = this.written.get(attribute);
-    // Something is there that this component did not put there, or did not put
-    // there last. Whatever it names, it is the consumer's to manage.
-    if (current !== null && current !== ours) {
-      return;
-    }
     if (value !== null) {
-      this.hostElement.setAttribute(attribute, value);
       this.written.set(attribute, value);
-      return;
+      return value;
     }
-    if (ours !== undefined) {
-      this.hostElement.removeAttribute(attribute);
-      this.written.delete(attribute);
+    // Nothing of this component's to say. Anything there is the consumer's.
+    if (current !== null && current !== ours) {
+      return current;
     }
+    this.written.delete(attribute);
+    return null;
   }
 
   // ControlValueAccessor implementation

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -2,6 +2,7 @@
 import { Component, input, output, contentChildren, signal, computed, forwardRef, effect } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import { TnListOptionComponent } from '../list-option/list-option.component';
 import { TnTestIdDirective } from '../test-id';
 
@@ -29,6 +30,15 @@ export interface TnSelectionChange {
     '[class.tn-selection-list--dense]': 'dense()',
     '[class.tn-selection-list--disabled]': 'isDisabled()',
     'role': 'listbox',
+    // A `role="listbox"` is an ARIA input field, and an input field with no
+    // accessible name is announced as bare "listbox" — the options say what is
+    // in it, never what it is FOR (#235). Both attributes are emitted because
+    // ARIA's name calculation prefers `aria-labelledby` only while it RESOLVES:
+    // suppressing an explicit `aria-label` beside a dangling IDREF would leave
+    // the list unnamed in exactly the case where a name was supplied. Same
+    // reasoning as `a11y/accessible-name.ts`.
+    '[attr.aria-label]': 'resolvedAriaLabel()',
+    '[attr.aria-labelledby]': 'resolvedAriaLabelledby()',
     // The listbox states its own disabled-ness rather than leaving assistive
     // technology to infer it from its children (#225). Inferring is not the same
     // claim and is wrong in two ordinary cases: an empty disabled list has no
@@ -54,6 +64,54 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   disabled = input<boolean>(false);
   multiple = input<boolean>(true);
   color = input<'primary' | 'accent' | 'warn'>('primary');
+
+  /**
+   * Explicit accessible name for the listbox. Inside a `tn-form-field` with a
+   * label this is unnecessary — the field names the list automatically — but a
+   * list with neither is announced as an unlabelled listbox.
+   */
+  ariaLabel = input<string | undefined>(undefined);
+
+  /** Id of visible text naming the listbox. Wins over `ariaLabel` where it resolves. */
+  ariaLabelledby = input<string | undefined>(undefined);
+
+  /**
+   * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
+   * #235 is about the listbox having no accessible name, and the field's
+   * `describedby`/`invalid`/`required` are a separate question this list has
+   * never answered either way.
+   */
+  private readonly fieldAria = injectTnFormFieldAria(this.ariaLabel);
+
+  /**
+   * The `aria-label` to render, or `null` for none.
+   *
+   * Blank is `null` rather than passed through: `aria-label=""` names the
+   * listbox as emptily as no attribute at all, while satisfying axe's
+   * `aria-input-field-name` rule — a green check on a control a screen reader
+   * announces as "listbox".
+   */
+  protected readonly resolvedAriaLabel = computed(() => {
+    const label = this.ariaLabel();
+    return label !== undefined && label.trim() !== '' ? label : null;
+  });
+
+  /**
+   * The `aria-labelledby` to render, or `null` for none.
+   *
+   * The explicit input wins over the enclosing field, so a consumer who points
+   * the list at their own visible text keeps it. With neither, a list outside a
+   * field gets `null` and stays unnamed — deliberately: a generic fallback
+   * ("List") would satisfy axe while announcing nothing the user can act on, and
+   * only the consumer knows what this list holds.
+   */
+  protected readonly resolvedAriaLabelledby = computed(() => {
+    const labelledby = this.ariaLabelledby();
+    if (labelledby !== undefined && labelledby.trim() !== '') {
+      return labelledby;
+    }
+    return this.fieldAria.labelledby();
+  });
 
   selectionChange = output<TnSelectionChange>();
 

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, input, output, contentChildren, signal, computed, forwardRef, effect } from '@angular/core';
+import { Component, ElementRef, input, output, contentChildren, signal, computed, forwardRef, effect, inject } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { injectTnFormFieldAria } from '../form-field/form-field-context';
@@ -30,15 +30,8 @@ export interface TnSelectionChange {
     '[class.tn-selection-list--dense]': 'dense()',
     '[class.tn-selection-list--disabled]': 'isDisabled()',
     'role': 'listbox',
-    // A `role="listbox"` is an ARIA input field, and an input field with no
-    // accessible name is announced as bare "listbox" — the options say what is
-    // in it, never what it is FOR (#235). Both attributes are emitted because
-    // ARIA's name calculation prefers `aria-labelledby` only while it RESOLVES:
-    // suppressing an explicit `aria-label` beside a dangling IDREF would leave
-    // the list unnamed in exactly the case where a name was supplied. Same
-    // reasoning as `a11y/accessible-name.ts`.
-    '[attr.aria-label]': 'resolvedAriaLabel()',
-    '[attr.aria-labelledby]': 'resolvedAriaLabelledby()',
+    // The naming attributes are NOT host bindings — see `applyName`.
+    //
     // The listbox states its own disabled-ness rather than leaving assistive
     // technology to infer it from its children (#225). Inferring is not the same
     // claim and is wrong in two ordinary cases: an empty disabled list has no
@@ -110,11 +103,12 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    */
   private readonly fieldAria = injectTnFormFieldAria(this.explicitAriaLabel);
 
-  /** The `aria-label` to render, or `null` for none. */
-  protected readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
+  /** The `aria-label` this component supplies, or `null` when it supplies none. */
+  private readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
 
   /**
-   * The `aria-labelledby` to render, or `null` for none.
+   * The `aria-labelledby` this component supplies, or `null` when it supplies
+   * none.
    *
    * The explicit input wins over the enclosing field, so a consumer who points
    * the list at their own visible text keeps it. With neither, a list outside a
@@ -122,13 +116,21 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * ("List") would satisfy axe while announcing nothing the user can act on, and
    * only the consumer knows what this list holds.
    */
-  protected readonly resolvedAriaLabelledby = computed(() => {
+  private readonly resolvedAriaLabelledby = computed(() => {
     const labelledby = this.ariaLabelledby();
     if (labelledby !== undefined && labelledby.trim() !== '') {
       return labelledby;
     }
     return this.fieldAria.labelledby();
   });
+
+  private readonly hostElement = inject(ElementRef<HTMLElement>).nativeElement;
+
+  /**
+   * The naming attributes this component has written to the host, so that it
+   * only ever removes its own. See {@link applyName}.
+   */
+  private readonly written = new Set<string>();
 
   selectionChange = output<TnSelectionChange>();
 
@@ -203,6 +205,39 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   private onTouched = () => {};
 
   constructor() {
+    // The naming attributes, written here rather than as host bindings.
+    //
+    // A `role="listbox"` is an ARIA input field, and one with no accessible name
+    // is announced as bare "listbox" — the options say what is IN the list,
+    // never what it is FOR (#235).
+    //
+    // WHY NOT A HOST BINDING, WHICH IS WHAT EVERY OTHER ATTRIBUTE HERE USES
+    // ---------------------------------------------------------------------
+    // Because the role is on the HOST, `<tn-selection-list aria-label="…">` and
+    // `[attr.aria-labelledby]="…"` are valid markup that named this list before
+    // it had any naming input at all — and a host binding writes its attribute
+    // on every pass whether or not this component has a name to write. Measured
+    // on Angular 21: with `[attr.aria-label]` and `[attr.aria-labelledby]` bound
+    // in the PARENT template, a host binding of the same attributes ran last and
+    // left the element with neither, so the list went from named to unnamed and
+    // nothing said so. The parent's write reappeared only on a later pass, and
+    // only for the attribute whose bound value had changed.
+    //
+    // So the rule is ownership rather than precedence: this component writes an
+    // attribute when it has a name for it, and removes it only if the value it
+    // removes is one this component put there. Anything a consumer set by any
+    // route is left alone.
+    //
+    // Both attributes are written, rather than one suppressing the other,
+    // because ARIA prefers `aria-labelledby` only while it RESOLVES — dropping
+    // an explicit `aria-label` beside a dangling IDREF would leave the list
+    // unnamed in exactly the case where a name was supplied. Same reasoning as
+    // `a11y/accessible-name.ts`.
+    effect(() => {
+      this.applyName('aria-label', this.resolvedAriaLabel());
+      this.applyName('aria-labelledby', this.resolvedAriaLabelledby());
+    });
+
     // Push what the list decides for all of its options down onto each of them,
     // re-running both when the decision changes and when the set of options
     // does — an option added after the list was rendered has to arrive carrying
@@ -383,6 +418,27 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     const from = event.target as HTMLElement | null;
     if (from !== null && from.isConnected) {
       this.focusedOptionElement = null;
+    }
+  }
+
+  /**
+   * Write one naming attribute to the host, or take back one this component
+   * previously wrote — and never touch one it did not.
+   *
+   * The `written` guard is the whole point: without it, `value === null` means
+   * "remove", which removes a name the consumer put on the element directly.
+   * With it, `null` means "this component has nothing to say about this
+   * attribute", and whatever is there stays there. See the constructor.
+   */
+  private applyName(attribute: string, value: string | null): void {
+    if (value !== null) {
+      this.hostElement.setAttribute(attribute, value);
+      this.written.add(attribute);
+      return;
+    }
+    if (this.written.has(attribute)) {
+      this.hostElement.removeAttribute(attribute);
+      this.written.delete(attribute);
     }
   }
 

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -78,48 +78,57 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
 
   /**
-   * The `ariaLabel` input with a blank one normalised away.
+   * ARIA wiring from an enclosing `tn-form-field`, read for `labelledby` alone:
+   * #235 is about the listbox having no accessible name, and the field's
+   * `describedby`/`invalid`/`required` are a separate question this list has
+   * never answered either way.
+   *
+   * Called with NO argument, so it reports the field's label id unconditioned.
+   * Handing it the `ariaLabel` input would have it suppress the field itself —
+   * on truthiness, so a whitespace-only label would cancel the field while being
+   * dropped as no name, leaving nothing — and it would only do so while this
+   * field is initialised after the one it reads, since a signal captured before
+   * its own initialiser runs arrives as `undefined` and is swallowed by an
+   * optional call. The suppression is applied below instead, where the rest of
+   * the precedence is.
+   */
+  private readonly fieldAria = injectTnFormFieldAria();
+
+  /**
+   * The `aria-label` this component supplies, or `null` when it supplies none.
    *
    * Blank is not a name: `aria-label=""` names the listbox as emptily as no
    * attribute at all, while satisfying axe's `aria-input-field-name` rule — a
    * green check on a control a screen reader announces as "listbox".
-   *
-   * `injectTnFormFieldAria` reads THIS rather than the raw input, and that is
-   * load-bearing: it suppresses the field's label whenever the explicit one is
-   * truthy, and `'   '` is truthy — so passing the raw input would leave a
-   * whitespace-only `aria-label` inside a labelled field with no name from
-   * either side. Declared before `fieldAria` because that call captures it.
    */
-  private readonly explicitAriaLabel = computed(() => {
+  private readonly resolvedAriaLabel = computed(() => {
     const label = this.ariaLabel();
-    return label !== undefined && label.trim() !== '' ? label : undefined;
+    return label !== undefined && label.trim() !== '' ? label : null;
   });
 
   /**
-   * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
-   * #235 is about the listbox having no accessible name, and the field's
-   * `describedby`/`invalid`/`required` are a separate question this list has
-   * never answered either way.
-   */
-  private readonly fieldAria = injectTnFormFieldAria(this.explicitAriaLabel);
-
-  /** The `aria-label` this component supplies, or `null` when it supplies none. */
-  private readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
-
-  /**
    * The `aria-labelledby` this component supplies, or `null` when it supplies
-   * none.
+   * none — and the one place the precedence is decided.
    *
-   * The explicit input wins over the enclosing field, so a consumer who points
-   * the list at their own visible text keeps it. With neither, a list outside a
-   * field gets `null` and stays unnamed — deliberately: a generic fallback
-   * ("List") would satisfy axe while announcing nothing the user can act on, and
-   * only the consumer knows what this list holds.
+   * The explicit reference comes first, so a consumer who points the list at
+   * their own visible text keeps it. An explicit `aria-label` comes next, and
+   * withholds the field's reference rather than rendering beside it: ARIA's name
+   * calculation prefers `aria-labelledby` wherever it resolves, so emitting both
+   * would announce the FIELD's label over the name written on the list.
+   *
+   * The field's label comes last, and only when nothing above has named the
+   * list. With none of the three, a list outside a field gets `null` and stays
+   * unnamed — deliberately: a generic fallback ("List") would satisfy axe while
+   * announcing nothing the user can act on, and only the consumer knows what
+   * this list holds.
    */
   private readonly resolvedAriaLabelledby = computed(() => {
     const labelledby = this.ariaLabelledby();
     if (labelledby !== undefined && labelledby.trim() !== '') {
       return labelledby;
+    }
+    if (this.resolvedAriaLabel() !== null) {
+      return null;
     }
     return this.fieldAria.labelledby();
   });

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -69,11 +69,38 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * Explicit accessible name for the listbox. Inside a `tn-form-field` with a
    * label this is unnecessary — the field names the list automatically — but a
    * list with neither is announced as an unlabelled listbox.
+   *
+   * ALIASED to the attribute name, unlike the plain `ariaLabel` most controls in
+   * this library take, and the divergence is forced rather than chosen: this
+   * component's `role="listbox"` is on the HOST, so `<tn-selection-list
+   * aria-label="Mailboxes">` is valid markup that named the list before this
+   * input existed. The host binding below rewrites that attribute on every
+   * change-detection pass, so an unaliased input would silently STRIP a name
+   * that used to work. The alias makes the same markup set the input instead,
+   * and the binding writes it straight back.
    */
-  ariaLabel = input<string | undefined>(undefined);
+  ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
 
   /** Id of visible text naming the listbox. Wins over `ariaLabel` where it resolves. */
-  ariaLabelledby = input<string | undefined>(undefined);
+  ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
+
+  /**
+   * The `ariaLabel` input with a blank one normalised away.
+   *
+   * Blank is not a name: `aria-label=""` names the listbox as emptily as no
+   * attribute at all, while satisfying axe's `aria-input-field-name` rule — a
+   * green check on a control a screen reader announces as "listbox".
+   *
+   * `injectTnFormFieldAria` reads THIS rather than the raw input, and that is
+   * load-bearing: it suppresses the field's label whenever the explicit one is
+   * truthy, and `'   '` is truthy — so passing the raw input would leave a
+   * whitespace-only `aria-label` inside a labelled field with no name from
+   * either side. Declared before `fieldAria` because that call captures it.
+   */
+  private readonly explicitAriaLabel = computed(() => {
+    const label = this.ariaLabel();
+    return label !== undefined && label.trim() !== '' ? label : undefined;
+  });
 
   /**
    * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
@@ -81,20 +108,10 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * `describedby`/`invalid`/`required` are a separate question this list has
    * never answered either way.
    */
-  private readonly fieldAria = injectTnFormFieldAria(this.ariaLabel);
+  private readonly fieldAria = injectTnFormFieldAria(this.explicitAriaLabel);
 
-  /**
-   * The `aria-label` to render, or `null` for none.
-   *
-   * Blank is `null` rather than passed through: `aria-label=""` names the
-   * listbox as emptily as no attribute at all, while satisfying axe's
-   * `aria-input-field-name` rule — a green check on a control a screen reader
-   * announces as "listbox".
-   */
-  protected readonly resolvedAriaLabel = computed(() => {
-    const label = this.ariaLabel();
-    return label !== undefined && label.trim() !== '' ? label : null;
-  });
+  /** The `aria-label` to render, or `null` for none. */
+  protected readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
 
   /**
    * The `aria-labelledby` to render, or `null` for none.

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -127,10 +127,10 @@ export class TnSelectionListComponent implements ControlValueAccessor {
   private readonly hostElement = inject(ElementRef<HTMLElement>).nativeElement;
 
   /**
-   * The naming attributes this component has written to the host, so that it
-   * only ever removes its own. See {@link applyName}.
+   * The value this component last wrote for each naming attribute, so that it
+   * only ever rewrites or removes its own. See {@link applyName}.
    */
-  private readonly written = new Set<string>();
+  private readonly written = new Map<string, string>();
 
   selectionChange = output<TnSelectionChange>();
 
@@ -425,18 +425,31 @@ export class TnSelectionListComponent implements ControlValueAccessor {
    * Write one naming attribute to the host, or take back one this component
    * previously wrote — and never touch one it did not.
    *
-   * The `written` guard is the whole point: without it, `value === null` means
-   * "remove", which removes a name the consumer put on the element directly.
-   * With it, `null` means "this component has nothing to say about this
-   * attribute", and whatever is there stays there. See the constructor.
+   * The guard covers WRITING as much as removing, and the write half is the
+   * easier one to get wrong: a list inside a `<tn-form-field label="…">` has a
+   * name to write on the very first pass, so guarding only the removal would
+   * still overwrite a `[attr.aria-labelledby]` the consumer bound in the parent
+   * template — the exact clobbering this method exists to stop, arriving from
+   * the other direction.
+   *
+   * Ownership is checked against the value on the element rather than a flag,
+   * so it also lapses correctly: an attribute this component wrote and someone
+   * else has since changed is no longer its to rewrite or remove.
    */
   private applyName(attribute: string, value: string | null): void {
-    if (value !== null) {
-      this.hostElement.setAttribute(attribute, value);
-      this.written.add(attribute);
+    const current = this.hostElement.getAttribute(attribute);
+    const ours = this.written.get(attribute);
+    // Something is there that this component did not put there, or did not put
+    // there last. Whatever it names, it is the consumer's to manage.
+    if (current !== null && current !== ours) {
       return;
     }
-    if (this.written.has(attribute)) {
+    if (value !== null) {
+      this.hostElement.setAttribute(attribute, value);
+      this.written.set(attribute, value);
+      return;
+    }
+    if (ours !== undefined) {
       this.hostElement.removeAttribute(attribute);
       this.written.delete(attribute);
     }

--- a/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
+++ b/projects/truenas-ui/src/lib/selection-list/selection-list.component.ts
@@ -6,6 +6,9 @@ import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import { TnListOptionComponent } from '../list-option/list-option.component';
 import { TnTestIdDirective } from '../test-id';
 
+/** The attributes that can name the listbox host. */
+const NAME_ATTRIBUTES = ['aria-label', 'aria-labelledby'];
+
 export interface TnSelectionChange {
   source: TnSelectionListComponent;
   options: TnListOptionComponent[];
@@ -127,7 +130,7 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     if (labelledby !== undefined && labelledby.trim() !== '') {
       return labelledby;
     }
-    if (this.resolvedAriaLabel() !== null) {
+    if (this.resolvedAriaLabel() !== null || this.namedByConsumer()) {
       return null;
     }
     return this.fieldAria.labelledby();
@@ -428,6 +431,42 @@ export class TnSelectionListComponent implements ControlValueAccessor {
     if (from !== null && from.isConnected) {
       this.focusedOptionElement = null;
     }
+  }
+
+  /**
+   * Whether the host already carries a name this component did not write.
+   *
+   * The ownership rule in {@link applyName} keeps such a name from being
+   * REMOVED. That is not enough on its own: a list inside a
+   * `<tn-form-field label="Mailboxes">` still had a field label to add, and
+   * adding it beside a consumer's `[attr.aria-label]="'Folders'"` announces
+   * "Mailboxes" — `aria-labelledby` wins the name calculation wherever it
+   * resolves, so the name the consumer wrote is outranked rather than removed.
+   * So a name from any route has to withhold the field's, exactly as an explicit
+   * input does.
+   *
+   * Read from the DOM rather than from an input because that is the only place
+   * this route exists: an `[attr.…]` binding in the parent template never
+   * reaches an input. It is read inside the effect, after Angular has applied
+   * that binding for the pass.
+   *
+   * WHAT THIS DOES NOT COVER, DELIBERATELY
+   * --------------------------------------
+   * A DOM attribute is not a signal, so this is answered when the surrounding
+   * computed re-runs and not when the attribute changes. A consumer whose
+   * `[attr.aria-label]` starts empty and fills in LATER, on a list that is
+   * inside a labelled field and has already been given the field's reference,
+   * keeps that reference until something else about the list changes. Closing
+   * that would mean observing the attribute — a `MutationObserver`, or a render
+   * hook running on every pass — which is a large mechanism for a narrow case,
+   * on a route (`[attr.…]` rather than the input) that already has a documented
+   * one that works. The input is the supported way to name this list.
+   */
+  private namedByConsumer(): boolean {
+    return NAME_ATTRIBUTES.some((attribute) => {
+      const current = this.hostElement.getAttribute(attribute);
+      return current !== null && current.trim() !== '' && current !== this.written.get(attribute);
+    });
   }
 
   /**

--- a/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
@@ -1,0 +1,257 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnSliderThumbDirective } from './slider-thumb.directive';
+import { TnSliderComponent } from './slider.component';
+import { accessibleName } from '../a11y/accessible-name-testing';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+import { TnFormFieldComponent } from '../form-field/form-field.component';
+
+/**
+ * The range input's accessible name (#235).
+ *
+ * `tn-slider` projects the focusable `<input type="range">` through
+ * `<ng-content>` and, until this ticket, associated nothing with it: four
+ * Storybook stories failed axe's `label` rule, and the `Default` one failed
+ * while sitting inside a `<tn-form-field label="Speed Control">` — the field
+ * published its label id over `TN_FORM_FIELD_CONTEXT` and the slider was not
+ * listening. Reproduced here before the fix, as the identical violation in
+ * jsdom: `label`, impact `critical`, on the input.
+ *
+ * WHY BOTH AXE AND A NAME ASSERTION
+ * ---------------------------------
+ * axe's `label` rule is a PRESENCE check — `aria-label="_"` satisfies it. So it
+ * cannot tell a slider wired to its field's label from one wired to the wrong
+ * element, and a spec built on it alone would stay green through either. The
+ * `accessibleName` assertions are what pin the announced string; the axe ones
+ * are what keep the rule the browser check actually runs from objecting. See
+ * `a11y/accessible-name-testing.ts`.
+ */
+
+@Component({
+  selector: 'tn-wrapped-slider-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnSliderComponent, TnSliderThumbDirective],
+  // Held to three lines by @angular-eslint/component-max-inline-declarations.
+  template: `<tn-form-field [label]="label()"><tn-slider>
+    <input tnSliderThumb value="50"></tn-slider></tn-form-field>`
+})
+class WrappedHostComponent {
+  label = signal('Speed Control');
+}
+
+@Component({
+  selector: 'tn-standalone-slider-host',
+  standalone: true,
+  imports: [TnSliderComponent, TnSliderThumbDirective],
+  template: `<tn-slider [aria-label]="label()"><input tnSliderThumb value="50"></tn-slider>`
+})
+class StandaloneHostComponent {
+  label = signal<string | undefined>('Volume');
+}
+
+describe('tn-slider accessible name (#235)', () => {
+  function thumb(fixture: ComponentFixture<unknown>): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input[tnSliderThumb]') as HTMLInputElement;
+  }
+
+  describe('inside a tn-form-field', () => {
+    let fixture: ComponentFixture<WrappedHostComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WrappedHostComponent);
+      fixture.detectChanges();
+    });
+
+    /** The defect, stated as an assertion: this was `null` before the fix. */
+    it('takes its accessible name from the field label', () => {
+      expect(accessibleName(thumb(fixture))).toBe('Speed Control');
+    });
+
+    it('names the input through aria-labelledby rather than a copied string', () => {
+      // A copy would announce the same thing today and drift the moment the
+      // label changes — see the re-label case below, which a copy fails.
+      expect(thumb(fixture).getAttribute('aria-labelledby')).not.toBeNull();
+      expect(thumb(fixture).hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('follows the field when its label changes', () => {
+      fixture.componentInstance.label.set('Fan Speed');
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Fan Speed');
+    });
+
+    /**
+     * A field with no label publishes `labelId: null`, so there is nothing to
+     * point at — and a dangling `aria-labelledby` is worse than none: it names
+     * the input with nothing and axe reports it as `incomplete` rather than a
+     * violation, so the check goes quiet about a control that is still unnamed.
+     */
+    it('renders no aria-labelledby when the field has no label', () => {
+      fixture.componentInstance.label.set('');
+      fixture.detectChanges();
+
+      expect(thumb(fixture).hasAttribute('aria-labelledby')).toBe(false);
+      expect(accessibleName(thumb(fixture))).toBeNull();
+    });
+
+    it('raises no label violation', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        thumb(fixture),
+        ['label']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('label');
+    });
+  });
+
+  describe('standalone', () => {
+    let fixture: ComponentFixture<StandaloneHostComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(StandaloneHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('takes its accessible name from the slider aria-label input', () => {
+      expect(accessibleName(thumb(fixture))).toBe('Volume');
+    });
+
+    it('raises no label violation', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        thumb(fixture),
+        ['label']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('label');
+    });
+
+    /**
+     * A blank `aria-label` is a name to axe's `label` rule and to nobody else,
+     * so passing it through would turn the check green while leaving the input
+     * announced as a bare "slider" — the one outcome this ticket rules out.
+     * The attribute is dropped instead, which keeps the check red and honest.
+     */
+    it.each(['', '   '])('renders no aria-label for a blank one (%p)', async (blank) => {
+      fixture.componentInstance.label.set(blank);
+      fixture.detectChanges();
+
+      expect(thumb(fixture).hasAttribute('aria-label')).toBe(false);
+      expect(accessibleName(thumb(fixture))).toBeNull();
+
+      const { violated } = await axeResult(fixture.nativeElement, thumb(fixture), ['label']);
+
+      expect(violated).toEqual(['label']);
+    });
+
+    /**
+     * The positive control for the two assertions above: with no name at all,
+     * the rule this fix is about really does fire on this element. Without it,
+     * a `violated: []` elsewhere in this file could mean the rule stopped
+     * matching a hidden range input rather than that the markup is correct.
+     */
+    it('still fails the label rule when nothing names it', async () => {
+      fixture.componentInstance.label.set(undefined);
+      fixture.detectChanges();
+
+      const { violated } = await axeResult(fixture.nativeElement, thumb(fixture), ['label']);
+
+      expect(violated).toEqual(['label']);
+    });
+  });
+
+  /**
+   * A label written straight onto the projected input, which is the one naming
+   * route the slider does not own. It is read once in `ngOnInit` and re-emitted
+   * by the host binding, so the binding must not wipe it.
+   */
+  describe('a label set directly on the thumb input', () => {
+    it('survives the slider host binding', () => {
+      @Component({
+        selector: 'tn-thumb-label-host',
+        standalone: true,
+        imports: [TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-slider><input tnSliderThumb aria-label="Brightness" value="50"></tn-slider>`
+      })
+      class ThumbLabelHostComponent {}
+
+      const fixture = TestBed.createComponent(ThumbLabelHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Brightness');
+    });
+
+    it('loses to the slider input, which is the more specific instruction', () => {
+      @Component({
+        selector: 'tn-both-labels-host',
+        standalone: true,
+        imports: [TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-slider aria-label="Volume">
+          <input tnSliderThumb aria-label="Brightness" value="50"></tn-slider>`
+      })
+      class BothLabelsHostComponent {}
+
+      const fixture = TestBed.createComponent(BothLabelsHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Volume');
+    });
+  });
+
+  /**
+   * `aria-label="…"` written as a static attribute, which is how a consumer
+   * naming a slider in a template actually writes it — and how the four
+   * Storybook stories in #235 are written.
+   *
+   * It reaches the same input as a `[aria-label]` binding, but unlike a binding
+   * it ALSO leaves the attribute on the `tn-slider` host, where nothing has a
+   * role to carry it. That is a second element to check, and only this form
+   * produces it.
+   */
+  describe('named by a static attribute, as a consumer writes it', () => {
+    it('names the input and leaves nothing for axe on the host', async () => {
+      @Component({
+        selector: 'tn-static-label-host',
+        standalone: true,
+        imports: [TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-slider aria-label="Volume"><input tnSliderThumb value="50"></tn-slider>`
+      })
+      class StaticLabelHostComponent {}
+
+      const fixture = TestBed.createComponent(StaticLabelHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Volume');
+
+      const { violations, incomplete } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+    });
+  });
+
+  /**
+   * The sweep that names nothing, so a rule nobody thought of is still reported.
+   * `label` is what #235 was about; this is what would catch the next one.
+   */
+  describe('the whole slider, with nothing named in advance', () => {
+    it.each([
+      ['wrapped in a form field', () => TestBed.createComponent(WrappedHostComponent)],
+      ['standalone', () => TestBed.createComponent(StandaloneHostComponent)]
+    ])('has nothing for axe to report when %s', async (_case, create) => {
+      const fixture = create();
+      fixture.detectChanges();
+
+      const { violations, incomplete, passed } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      expect(passed).toContain('label');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
@@ -209,6 +209,48 @@ describe('tn-slider accessible name (#235)', () => {
       expect(accessibleName(thumb(fixture))).toBe('Brightness');
     });
 
+    /**
+     * The field's label is chrome the consumer did not write on the control, so
+     * it must not replace one they did. It would otherwise do so SILENTLY: both
+     * attributes render, and `aria-labelledby` beats `aria-label` in the name
+     * calculation, so the control announces "Speed Control" while the markup
+     * plainly says "Brightness".
+     */
+    it('beats an enclosing form field label', () => {
+      @Component({
+        selector: 'tn-thumb-label-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-form-field label="Speed Control"><tn-slider>
+          <input tnSliderThumb aria-label="Brightness" value="50"></tn-slider></tn-form-field>`
+      })
+      class ThumbLabelInFieldHostComponent {}
+
+      const fixture = TestBed.createComponent(ThumbLabelInFieldHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Brightness');
+      expect(thumb(fixture).hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    /** A reference written on the input is explicit too, and outranks the field. */
+    it('beats an enclosing form field label when it is a reference', () => {
+      @Component({
+        selector: 'tn-thumb-ref-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSliderComponent, TnSliderThumbDirective],
+        template: `<span id="own-label">Brightness</span><tn-form-field label="Speed Control">
+          <tn-slider><input tnSliderThumb aria-labelledby="own-label" value="50"></tn-slider>
+          </tn-form-field>`
+      })
+      class ThumbRefInFieldHostComponent {}
+
+      const fixture = TestBed.createComponent(ThumbRefInFieldHostComponent);
+      fixture.detectChanges();
+
+      expect(accessibleName(thumb(fixture))).toBe('Brightness');
+    });
+
     it('loses to the slider input, which is the more specific instruction', () => {
       @Component({
         selector: 'tn-both-labels-host',

--- a/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
@@ -106,6 +106,29 @@ describe('tn-slider accessible name (#235)', () => {
       expect(violated).toEqual([]);
       expect(evaluated).toContain('label');
     });
+
+    /**
+     * A blank `aria-label` must not take the field's label away with it.
+     * `injectTnFormFieldAria` suppresses the field whenever the explicit name is
+     * TRUTHY, and `'   '` is truthy — so a slider handing it the raw input ends
+     * up with no `aria-label` (blank, dropped) and no `aria-labelledby`
+     * (suppressed), which is worse than either half alone.
+     */
+    it('still takes the field label when the explicit one is blank', () => {
+      @Component({
+        selector: 'tn-blank-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-form-field label="Speed Control"><tn-slider aria-label="   ">
+          <input tnSliderThumb value="50"></tn-slider></tn-form-field>`
+      })
+      class BlankInFieldHostComponent {}
+
+      const blank = TestBed.createComponent(BlankInFieldHostComponent);
+      blank.detectChanges();
+
+      expect(accessibleName(thumb(blank))).toBe('Speed Control');
+    });
   });
 
   describe('standalone', () => {

--- a/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-a11y.spec.ts
@@ -108,6 +108,32 @@ describe('tn-slider accessible name (#235)', () => {
     });
 
     /**
+     * The ordering the whole resolution exists to produce, and the case it is
+     * easiest to leave untested: an explicit name and a field label together.
+     *
+     * The explicit one wins, and the field's reference is WITHHELD rather than
+     * rendered beside it. Rendering both would announce the field's label —
+     * `aria-labelledby` beats `aria-label` wherever it resolves — so the second
+     * assertion is the one that catches a regression the first cannot see.
+     */
+    it('loses to an explicit name on the slider', () => {
+      @Component({
+        selector: 'tn-named-in-field-host',
+        standalone: true,
+        imports: [TnFormFieldComponent, TnSliderComponent, TnSliderThumbDirective],
+        template: `<tn-form-field label="Speed Control"><tn-slider aria-label="Volume">
+          <input tnSliderThumb value="50"></tn-slider></tn-form-field>`
+      })
+      class NamedInFieldHostComponent {}
+
+      const named = TestBed.createComponent(NamedInFieldHostComponent);
+      named.detectChanges();
+
+      expect(accessibleName(thumb(named))).toBe('Volume');
+      expect(thumb(named).hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    /**
      * A blank `aria-label` must not take the field's label away with it.
      * `injectTnFormFieldAria` suppresses the field whenever the explicit name is
      * TRUTHY, and `'   '` is truthy — so a slider handing it the raw input ends

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -47,11 +47,12 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     value: () => number;
     labelPrefix: () => string;
     labelSuffix: () => string;
-    // The RESOLVED names, not the raw inputs: the slider is what folds in an
-    // enclosing `tn-form-field`'s label and drops a blank one, so a directive
-    // reading the inputs directly would miss the wrapped case entirely (#235).
+    // The naming values, blank-normalised by the slider — and the two sources of
+    // `aria-labelledby` kept apart, because they rank differently against a
+    // label written on this input. See ariaLabelledby().
     resolvedAriaLabel: () => string | null;
-    resolvedAriaLabelledby: () => string | null;
+    explicitAriaLabelledby: () => string | null;
+    fieldAriaLabelledby: () => string | null;
     updateValue: (value: number) => void;
     markTouched: () => void;
     getSliderRect: () => DOMRect;
@@ -280,18 +281,41 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   /**
-   * Resolve the accessible name for the range input: whatever the parent slider
-   * resolved — its own `aria-label`/`aria-labelledby` input, or an enclosing
-   * `tn-form-field`'s label (#235) — otherwise a value placed directly on the
-   * `<input tnSliderThumb>`. Returning the fallback keeps the host binding from
-   * wiping a directly-set label. Null removes the attribute.
+   * The `aria-label` for the range input: the parent slider's input when set,
+   * otherwise a value placed directly on the `<input tnSliderThumb>`. Returning
+   * the fallback keeps the host binding from wiping a directly-set label. Null
+   * removes the attribute.
    */
   ariaLabel(): string | null {
     return this.slider?.resolvedAriaLabel() ?? this.fallbackAriaLabel;
   }
 
+  /**
+   * The `aria-labelledby` for the range input — and the one place the precedence
+   * between an explicit name and an inherited one is decided.
+   *
+   * An explicit reference comes first, from the slider's input or from this
+   * input itself. **An enclosing `tn-form-field`'s label comes last, and only
+   * when nothing has named the control directly.** That ordering is the point:
+   * `aria-labelledby` beats `aria-label` in the ARIA name calculation whenever
+   * it resolves, so emitting the field's label beside an `aria-label` written on
+   * this input would render both attributes and announce the FIELD's label —
+   * silently replacing the name the consumer wrote on the control (#235).
+   *
+   * The slider's own `ariaLabel` input needs no such check here, because
+   * `injectTnFormFieldAria` already withholds the field's label whenever it is
+   * set; this covers the label that is written past the slider, onto the
+   * projected input, which the slider's inputs never see.
+   */
   ariaLabelledby(): string | null {
-    return this.slider?.resolvedAriaLabelledby() ?? this.fallbackAriaLabelledby;
+    const explicit = this.slider?.explicitAriaLabelledby() ?? this.fallbackAriaLabelledby;
+    if (explicit !== null) {
+      return explicit;
+    }
+    if (this.ariaLabel() !== null) {
+      return null;
+    }
+    return this.slider?.fieldAriaLabelledby() ?? null;
   }
 
   /**

--- a/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
+++ b/projects/truenas-ui/src/lib/slider/slider-thumb.directive.ts
@@ -3,6 +3,11 @@ import { ElementRef, Directive, forwardRef, signal, inject } from '@angular/core
 import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
+/** An attribute value that is absent or whitespace-only is not a name. */
+function blankToNull(value: string | null): string | null {
+  return value !== null && value.trim() !== '' ? value : null;
+}
+
 @Directive({
   selector: 'input[tnSliderThumb]',
   standalone: true,
@@ -42,8 +47,11 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
     value: () => number;
     labelPrefix: () => string;
     labelSuffix: () => string;
-    ariaLabel: () => string | undefined;
-    ariaLabelledby: () => string | undefined;
+    // The RESOLVED names, not the raw inputs: the slider is what folds in an
+    // enclosing `tn-form-field`'s label and drops a blank one, so a directive
+    // reading the inputs directly would miss the wrapped case entirely (#235).
+    resolvedAriaLabel: () => string | null;
+    resolvedAriaLabelledby: () => string | null;
     updateValue: (value: number) => void;
     markTouched: () => void;
     getSliderRect: () => DOMRect;
@@ -80,8 +88,11 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   ngOnInit() {
     // Make the native input visually hidden but still accessible
     const input = this.elementRef.nativeElement;
-    this.fallbackAriaLabel = input.getAttribute('aria-label');
-    this.fallbackAriaLabelledby = input.getAttribute('aria-labelledby');
+    // Blank is not a name, so it is not kept as a fallback: an `aria-label=""`
+    // left on the input would re-render as the same empty attribute, which
+    // satisfies axe's `label` rule while announcing nothing (#235).
+    this.fallbackAriaLabel = blankToNull(input.getAttribute('aria-label'));
+    this.fallbackAriaLabelledby = blankToNull(input.getAttribute('aria-labelledby'));
     input.style.opacity = '0';
     input.style.position = 'absolute';
     input.style.width = '100%';
@@ -269,17 +280,18 @@ export class TnSliderThumbDirective implements ControlValueAccessor, OnInit, OnD
   }
 
   /**
-   * Resolve the accessible name for the range input: the parent slider's
-   * `aria-label`/`aria-labelledby` input when set, otherwise a value placed
-   * directly on the `<input tnSliderThumb>`. Returning the fallback keeps the
-   * host binding from wiping a directly-set label. Null removes the attribute.
+   * Resolve the accessible name for the range input: whatever the parent slider
+   * resolved — its own `aria-label`/`aria-labelledby` input, or an enclosing
+   * `tn-form-field`'s label (#235) — otherwise a value placed directly on the
+   * `<input tnSliderThumb>`. Returning the fallback keeps the host binding from
+   * wiping a directly-set label. Null removes the attribute.
    */
   ariaLabel(): string | null {
-    return this.slider?.ariaLabel() ?? this.fallbackAriaLabel;
+    return this.slider?.resolvedAriaLabel() ?? this.fallbackAriaLabel;
   }
 
   ariaLabelledby(): string | null {
-    return this.slider?.ariaLabelledby() ?? this.fallbackAriaLabelledby;
+    return this.slider?.resolvedAriaLabelledby() ?? this.fallbackAriaLabelledby;
   }
 
   /**

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -70,44 +70,48 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
    * standalone `<tn-slider><input tnSliderThumb></tn-slider>` announces only
    * "slider".
    *
-   * The full precedence, most specific first: these two inputs, then a label
-   * written directly on the `input[tnSliderThumb]`, then an enclosing
-   * `tn-form-field`'s label. The field comes last because it is chrome the
-   * consumer did not write on the control — see
-   * `TnSliderThumbDirective.ariaLabelledby`, where that ordering is applied.
+   * Precedence is per attribute: each of `aria-label` and `aria-labelledby` is
+   * taken from the matching input here, else from one written directly on the
+   * `input[tnSliderThumb]`. Between the two attributes, ARIA's own rule decides
+   * — `aria-labelledby` wins wherever it resolves.
+   *
+   * An enclosing `tn-form-field`'s label comes after all of those, and only when
+   * nothing above has named the control: it is chrome the consumer did not write
+   * on the control. See `TnSliderThumbDirective.ariaLabelledby`, where the
+   * ordering is applied.
    */
   ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
   ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
 
   /**
-   * The `ariaLabel` input with a blank one normalised away.
+   * ARIA wiring from an enclosing `tn-form-field`, read for `labelledby` alone:
+   * #235 is about the range input having no accessible name, and the field's
+   * `describedby`/`invalid`/`required` are a separate question this slider has
+   * never answered either way.
+   *
+   * Called with NO argument, so it reports the field's label id unconditioned.
+   * Handing it the `ariaLabel` input would have it suppress the field itself —
+   * on truthiness, so a whitespace-only label would cancel the field while being
+   * dropped as no name, leaving nothing — and it would only do so while this
+   * field is initialised after the one it reads, since a signal captured before
+   * its own initialiser runs arrives as `undefined` and is swallowed by an
+   * optional call. The suppression is the thumb's, where the rest of the
+   * precedence already lives and where it is visible.
+   */
+  private readonly fieldAria = injectTnFormFieldAria();
+
+  /**
+   * The `aria-label` the thumb should render, or `null` for none.
    *
    * Blank is not a name: `aria-label=""` names the input as emptily as no
    * attribute at all, while satisfying axe's `label` rule — a green check on a
    * control a screen reader announces as "slider" (#235). Same reasoning as
    * `a11y/accessible-name.ts`, which the three progressbars share.
-   *
-   * `injectTnFormFieldAria` reads THIS rather than the raw input, and that is
-   * load-bearing: it suppresses the field's label whenever the explicit one is
-   * truthy, and `'   '` is truthy — so passing the raw input would leave a
-   * whitespace-only `aria-label` inside a labelled field with no name from
-   * either side. Declared before `fieldAria` because that call captures it.
    */
-  private readonly explicitAriaLabel = computed(() => {
+  readonly resolvedAriaLabel = computed(() => {
     const label = this.ariaLabel();
-    return label !== undefined && label.trim() !== '' ? label : undefined;
+    return label !== undefined && label.trim() !== '' ? label : null;
   });
-
-  /**
-   * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
-   * #235 is about the range input having no accessible name, and the field's
-   * `describedby`/`invalid`/`required` are a separate question this slider has
-   * never answered either way.
-   */
-  private readonly fieldAria = injectTnFormFieldAria(this.explicitAriaLabel);
-
-  /** The `aria-label` the thumb should render, or `null` for none. */
-  readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
 
   /**
    * The `ariaLabelledby` INPUT, blank normalised away, or `null` when unset.

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -66,10 +66,15 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
   /**
    * Accessible name forwarded to the inner range input — the focusable element
    * screen readers actually announce. Set this (or `aria-labelledby`) when the
-   * slider isn't already labelled by a `tn-form-field`/`<label>`, otherwise a
+   * slider isn't already inside a labelled `tn-form-field`, otherwise a
    * standalone `<tn-slider><input tnSliderThumb></tn-slider>` announces only
-   * "slider". A label set directly on the `input[tnSliderThumb]` is used as a
-   * fallback when neither is provided here.
+   * "slider".
+   *
+   * The full precedence, most specific first: these two inputs, then a label
+   * written directly on the `input[tnSliderThumb]`, then an enclosing
+   * `tn-form-field`'s label. The field comes last because it is chrome the
+   * consumer did not write on the control — see
+   * `TnSliderThumbDirective.ariaLabelledby`, where that ordering is applied.
    */
   ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
   ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
@@ -105,21 +110,25 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
   readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
 
   /**
-   * The `aria-labelledby` the thumb should render, or `null` for none.
+   * The `ariaLabelledby` INPUT, blank normalised away, or `null` when unset.
    *
-   * The explicit input wins over the enclosing field, so a consumer who points
-   * the slider at their own visible text keeps it. With neither, an unwrapped
-   * slider gets `null` and stays unnamed — deliberately: a generic fallback
-   * ("Slider") would satisfy axe while announcing nothing the user can act on,
-   * and only the consumer knows what this slider controls.
+   * Kept separate from {@link fieldAriaLabelledby} rather than folded into one
+   * resolved value, because the two rank differently against a label written on
+   * the projected input — see `TnSliderThumbDirective.ariaLabelledby`.
    */
-  readonly resolvedAriaLabelledby = computed(() => {
+  readonly explicitAriaLabelledby = computed(() => {
     const labelledby = this.ariaLabelledby();
-    if (labelledby !== undefined && labelledby.trim() !== '') {
-      return labelledby;
-    }
-    return this.fieldAria.labelledby();
+    return labelledby !== undefined && labelledby.trim() !== '' ? labelledby : null;
   });
+
+  /**
+   * The enclosing `tn-form-field`'s label id, or `null` outside one.
+   *
+   * With no field and no input, a slider stays unnamed — deliberately: a
+   * generic fallback ("Slider") would satisfy axe while announcing nothing the
+   * user can act on, and only the consumer knows what this slider controls.
+   */
+  readonly fieldAriaLabelledby = computed(() => this.fieldAria.labelledby());
 
   thumbDirective = contentChild.required(TnSliderThumbDirective);
   sliderContainer = viewChild.required<ElementRef<HTMLDivElement>>('sliderContainer');

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -75,25 +75,34 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
   ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
 
   /**
+   * The `ariaLabel` input with a blank one normalised away.
+   *
+   * Blank is not a name: `aria-label=""` names the input as emptily as no
+   * attribute at all, while satisfying axe's `label` rule — a green check on a
+   * control a screen reader announces as "slider" (#235). Same reasoning as
+   * `a11y/accessible-name.ts`, which the three progressbars share.
+   *
+   * `injectTnFormFieldAria` reads THIS rather than the raw input, and that is
+   * load-bearing: it suppresses the field's label whenever the explicit one is
+   * truthy, and `'   '` is truthy — so passing the raw input would leave a
+   * whitespace-only `aria-label` inside a labelled field with no name from
+   * either side. Declared before `fieldAria` because that call captures it.
+   */
+  private readonly explicitAriaLabel = computed(() => {
+    const label = this.ariaLabel();
+    return label !== undefined && label.trim() !== '' ? label : undefined;
+  });
+
+  /**
    * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
    * #235 is about the range input having no accessible name, and the field's
    * `describedby`/`invalid`/`required` are a separate question this slider has
    * never answered either way.
    */
-  private readonly fieldAria = injectTnFormFieldAria(this.ariaLabel);
+  private readonly fieldAria = injectTnFormFieldAria(this.explicitAriaLabel);
 
-  /**
-   * The `aria-label` the thumb should render, or `null` for none.
-   *
-   * Blank is `null` rather than passed through: `aria-label=""` names the input
-   * as emptily as no attribute at all, while satisfying axe's `label` rule — a
-   * green check on a control a screen reader announces as "slider" (#235). Same
-   * reasoning as `a11y/accessible-name.ts`, which the three progressbars share.
-   */
-  readonly resolvedAriaLabel = computed(() => {
-    const label = this.ariaLabel();
-    return label !== undefined && label.trim() !== '' ? label : null;
-  });
+  /** The `aria-label` the thumb should render, or `null` for none. */
+  readonly resolvedAriaLabel = computed(() => this.explicitAriaLabel() ?? null);
 
   /**
    * The `aria-labelledby` the thumb should render, or `null` for none.

--- a/projects/truenas-ui/src/lib/slider/slider.component.ts
+++ b/projects/truenas-ui/src/lib/slider/slider.component.ts
@@ -4,6 +4,7 @@ import { Component, contentChild, input, forwardRef, signal, computed, viewChild
 import type { ControlValueAccessor} from '@angular/forms';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TnSliderThumbDirective } from './slider-thumb.directive';
+import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 export type LabelType = 'none' | 'handle' | 'track' | 'both';
@@ -23,7 +24,20 @@ export type LabelType = 'none' | 'handle' | 'track' | 'both';
   styleUrl: './slider.component.scss',
   host: {
     'class': 'tn-slider',
-    '[attr.aria-disabled]': 'isDisabled()'
+    '[attr.aria-disabled]': 'isDisabled()',
+    // Both naming inputs are ALIASED to the attribute names, so a consumer
+    // writes `<tn-slider aria-label="Volume">` — a static attribute, which
+    // Angular reads into the input AND leaves on the host. The host has no
+    // role, where axe reports `aria-prohibited-attr`: "aria-label attribute is
+    // not well supported on a tn-slider with no valid role attribute" (#235).
+    // The name belongs on the projected range input, which is the focusable
+    // element and the one a screen reader announces, so it is forwarded there
+    // and removed from here. Binding `null` is what removes it: a host binding
+    // runs after the static attribute is written, and `null` means "no
+    // attribute". A `[aria-label]` property binding never leaves one behind and
+    // is unaffected.
+    '[attr.aria-label]': 'null',
+    '[attr.aria-labelledby]': 'null'
   }
 })
 /**
@@ -59,6 +73,44 @@ export class TnSliderComponent implements ControlValueAccessor, OnDestroy, After
    */
   ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
   ariaLabelledby = input<string | undefined>(undefined, { alias: 'aria-labelledby' });
+
+  /**
+   * ARIA wiring from an enclosing `tn-form-field`. Only `labelledby` is read:
+   * #235 is about the range input having no accessible name, and the field's
+   * `describedby`/`invalid`/`required` are a separate question this slider has
+   * never answered either way.
+   */
+  private readonly fieldAria = injectTnFormFieldAria(this.ariaLabel);
+
+  /**
+   * The `aria-label` the thumb should render, or `null` for none.
+   *
+   * Blank is `null` rather than passed through: `aria-label=""` names the input
+   * as emptily as no attribute at all, while satisfying axe's `label` rule — a
+   * green check on a control a screen reader announces as "slider" (#235). Same
+   * reasoning as `a11y/accessible-name.ts`, which the three progressbars share.
+   */
+  readonly resolvedAriaLabel = computed(() => {
+    const label = this.ariaLabel();
+    return label !== undefined && label.trim() !== '' ? label : null;
+  });
+
+  /**
+   * The `aria-labelledby` the thumb should render, or `null` for none.
+   *
+   * The explicit input wins over the enclosing field, so a consumer who points
+   * the slider at their own visible text keeps it. With neither, an unwrapped
+   * slider gets `null` and stays unnamed — deliberately: a generic fallback
+   * ("Slider") would satisfy axe while announcing nothing the user can act on,
+   * and only the consumer knows what this slider controls.
+   */
+  readonly resolvedAriaLabelledby = computed(() => {
+    const labelledby = this.ariaLabelledby();
+    if (labelledby !== undefined && labelledby.trim() !== '') {
+      return labelledby;
+    }
+    return this.fieldAria.labelledby();
+  });
 
   thumbDirective = contentChild.required(TnSliderThumbDirective);
   sliderContainer = viewChild.required<ElementRef<HTMLDivElement>>('sliderContainer');

--- a/projects/truenas-ui/src/stories/list.stories.ts
+++ b/projects/truenas-ui/src/stories/list.stories.ts
@@ -229,7 +229,7 @@ export const ListWithSelection: Story = {
       }
     },
     template: `
-      <tn-selection-list [dense]="dense" [disabled]="disabled" (selectionChange)="onSelectionChange($event)">
+      <tn-selection-list ariaLabel="Mailboxes" [dense]="dense" [disabled]="disabled" (selectionChange)="onSelectionChange($event)">
         <tn-list-option [value]="'inbox'" [selected]="false">
           <span tnListIcon>📥</span>
           <span tnListItemTitle>Inbox</span>

--- a/projects/truenas-ui/src/stories/list.stories.ts
+++ b/projects/truenas-ui/src/stories/list.stories.ts
@@ -229,7 +229,7 @@ export const ListWithSelection: Story = {
       }
     },
     template: `
-      <tn-selection-list ariaLabel="Mailboxes" [dense]="dense" [disabled]="disabled" (selectionChange)="onSelectionChange($event)">
+      <tn-selection-list aria-label="Mailboxes" [dense]="dense" [disabled]="disabled" (selectionChange)="onSelectionChange($event)">
         <tn-list-option [value]="'inbox'" [selected]="false">
           <span tnListIcon>📥</span>
           <span tnListItemTitle>Inbox</span>

--- a/projects/truenas-ui/src/stories/slider.stories.ts
+++ b/projects/truenas-ui/src/stories/slider.stories.ts
@@ -117,7 +117,7 @@ export const ReactiveForm: Story = {
     return {
       props: { control },
       template: `
-        <tn-slider [min]="0" [max]="100" [step]="5" labelType="both" labelSuffix="%">
+        <tn-slider aria-label="Volume" [min]="0" [max]="100" [step]="5" labelType="both" labelSuffix="%">
           <input tnSliderThumb [formControl]="control">
         </tn-slider>
         <p>Value: {{ control.value }}</p>
@@ -140,7 +140,7 @@ export const TestIds: Story = {
     props: args,
     template: `
       <tn-testid-inspector>
-        <tn-slider [min]="0" [max]="100" [testId]="testId">
+        <tn-slider aria-label="Volume" [min]="0" [max]="100" [testId]="testId">
           <input tnSliderThumb value="50">
         </tn-slider>
       </tn-testid-inspector>
@@ -159,7 +159,7 @@ export const ScopedTestIds: Story = {
     props: args,
     template: `
       <tn-testid-inspector>
-        <tn-slider [min]="0" [max]="100" [testId]="testId">
+        <tn-slider aria-label="Volume" [min]="0" [max]="100" [testId]="testId">
           <input tnSliderThumb value="50">
         </tn-slider>
       </tn-testid-inspector>


### PR DESCRIPTION
Fixes #235.

## The defect, reproduced before anything changed

Both components ship an interactive control with no accessible name. Mounted in jsdom against unmodified `main`, axe reported exactly what the Storybook run in the ticket did:

| Element | Rule | Impact |
|---|---|---|
| `input[tnSliderThumb]` | `label` — "Form elements must have labels" | critical |
| `tn-selection-list` (`role="listbox"`) | `aria-input-field-name` — "ARIA input fields must have an accessible name" | serious |

**And both failed while wrapped in a labelled `<tn-form-field>`.** That is what makes this a library bug rather than four stories forgetting a label: `tn-form-field` has published its label id over `TN_FORM_FIELD_CONTEXT` all along, and neither component was listening.

## What changed

**Both components now call `injectTnFormFieldAria`**, so wrapping either in a labelled field names it with no extra markup. `tn-selection-list` also gains the `aria-label` / `aria-labelledby` inputs it never had, for the standalone case; `tn-slider` already had them and now forwards them properly.

**Precedence, most specific first**, and it is the same on both: an explicit `aria-labelledby`, then an explicit `aria-label`, then (on the slider) a label written directly on the projected `input[tnSliderThumb]`, then the enclosing field's label. The field comes last because it is chrome the consumer did not write on the control.

The field's reference is **withheld** rather than rendered alongside an explicit name. That is not a style choice: `aria-labelledby` beats `aria-label` in the ARIA name calculation wherever it resolves, so emitting both does not merely coexist — it announces the field's label over the name the consumer wrote.

**A blank name is dropped, and an unnamed control stays unnamed.** `aria-label=""` announces nothing, and a generic fallback ("Slider", "List") would be a name only axe can hear. A control nobody named still fails the check, which is correct — that is a real defect in the consumer's markup.

**Three standalone slider stories and `ListWithSelection` get names of their own.** `Default` was already inside a form field and needed no story change — the component fix covers it.

## Two things measured rather than assumed

**The slider's naming inputs are aliased to the attribute names**, so `<tn-slider aria-label="Volume">` reaches the input *and* leaves the attribute on a host with no role, where axe reports `aria-prohibited-attr`. The first version of this fix traded one serious violation for another; the spec that caught it mounts the static-attribute form the stories actually use. The slider host now clears its own copy and forwards the name to the range input.

**The listbox's `role` is on the HOST**, so `<tn-selection-list aria-label="…">` and `[attr.aria-labelledby]="…"` are valid markup that named the list before this ticket. A plain host binding of those attributes, measured on Angular 21, ran after the parent's binding and left the element with **neither** — named to unnamed, silently. They are therefore bound to methods that return what the attribute should be rather than writing it, under an ownership rule: this component supplies a name when it has one, and otherwise leaves whatever is there alone. Methods and not `computed`s, because the answer depends on the host's current attributes, which are not signals — a `computed` went stale the moment a consumer's binding changed.

## Testing

Specs assert the **announced name**, not merely that axe is quiet, through a new `lib/a11y/accessible-name-testing.ts`. axe's naming rules are presence checks that `aria-label="_"` satisfies, so a fix wired to the *wrong* label passes every one of them. The helper implements the three steps of the ARIA name calculation these components can reach and no more, has its own spec — it is an assertion other assertions rest on — and both component specs carry a positive control proving the rule still fires on an unnamed control.

**`yarn test-sb` could not be run here.** The Storybook Interaction Tests check drives a real browser, and this host has neither one nor the system libraries to supply it. The five stories are covered instead by mounting their markup shapes in jsdom, including the static-attribute spelling they use. Note also that `a11y: { test: 'error' }` — the setting the ticket's repro used — is **not** set in `.storybook/preview.ts` on `main`, and turning it on is out of scope here: the other open accessibility tickets (#236–#249) would fail it immediately.

Run locally and green: `yarn lint`, `yarn test` (3060 passing), `yarn test:scripts`, `yarn build`. `yarn lint` also reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here — that is #251.

Eight rounds of local review; the last returned nothing at or above MEDIUM.

## Not changed, and why

Four LOW findings from the final review round, recorded here rather than fixed — every fix is a new diff, and a new diff is unreviewed:

- **Blank-name normalisation is written out in `slider.component.ts`, `selection-list.component.ts` and `slider-thumb.directive.ts`.** A shared helper beside `a11y/accessible-name.ts` would cover all three and the six existing callers of `injectTnFormFieldAria` too. Worth a ticket; it is a wider refactor than this fix.
- **`tn-slider` clears its host `aria-label`/`aria-labelledby` unconditionally**, where `tn-selection-list` preserves a consumer's. The asymmetry is deliberate — the slider host has no role, so the attribute is prohibited there and the name belongs on the range input — but a consumer's `[attr.aria-label]` on `<tn-slider>` is dropped without being forwarded. It named nothing before this change either, so nothing regresses; it could be forwarded.
- **`accessibleName` uses only the first `label[for]` pointing at a control**, where HTML-AAM concatenates all of them, and the docblock's list of deliberate omissions does not mention it.
- **No story shows a `tn-selection-list` inside a labelled `tn-form-field`**, which is the main new capability, and neither component's new naming inputs have `argTypes` entries.
