### PR TITLE
NAS-142487 / 27.0.0-BETA.1 / fix(a11y): make the table select-all cell a columnheader, not a checkbox

### DIFF
--- a/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
@@ -294,18 +294,65 @@ describe('tn-table selection accessibility', () => {
       ).checked).toBe(true);
     });
 
-    it('toggles select-all on Space from the checkbox', () => {
-      // Space on a focused checkbox is a native activation: the browser turns it
-      // into a click on the input, which is what this stands in for. jsdom does
-      // not implement that translation, so the click is dispatched directly.
+    it('leaves Space to the checkbox itself', () => {
+      // Space on a focused checkbox is a NATIVE activation — the browser turns the
+      // keypress into a click on the input — and jsdom implements neither half, so
+      // there is no way to assert the toggle here. What is assertable is the part
+      // that was a real hazard: the `<th>` this replaced bound `keydown.space` and
+      // called `preventDefault()` on it, which is exactly how a wrapper cancels the
+      // activation of the control it wraps. Nothing may intercept the key now.
+      // The toggle it produces is covered by the click test above, which is what
+      // the browser dispatches.
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+      const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+
+      input.dispatchEvent(event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(host.selectionEvents).toBe(0);
+    });
+  });
+
+  describe('with no rows', () => {
+    beforeEach(() => {
+      host.rows.set([]);
+      fixture.detectChanges();
+      host.selectionEvents = 0;
+    });
+
+    // Selecting all of nothing cannot change `isAllSelected()`, and the checkbox's
+    // `checked` is bound one way — so a click that the model does not follow would
+    // leave the box drawn checked over an empty selection.
+    it('disables the select-all checkbox', () => {
+      expect(el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      ).disabled).toBe(true);
+    });
+
+    it('does not toggle from the header cell padding', () => {
+      clickOn(el('.tn-table__header-row .tn-table__select-cell'));
+
+      expect(host.selectionEvents).toBe(0);
+      expect(el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      ).checked).toBe(false);
+    });
+
+    it('does not toggle on Enter', () => {
       const input = el<HTMLInputElement>(
         '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
       );
 
-      input.click();
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      );
       fixture.detectChanges();
 
-      expect(host.selectionEvents).toBe(1);
+      expect(host.selectionEvents).toBe(0);
+      expect(input.checked).toBe(false);
     });
   });
 

--- a/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
@@ -1,0 +1,326 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnTableTesting } from './table-testing';
+import { TnTableComponent } from './table.component';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+
+/**
+ * Guards the structure fixed for #236: the select-all header cell used to be a
+ * focusable `<th role="checkbox" tabindex="0">` wrapping a real `tn-checkbox`,
+ * which fails axe's `nested-interactive` rule and costs the column its
+ * `columnheader` semantics.
+ *
+ * `nested-interactive` is pure DOM structure, so axe evaluates it correctly
+ * under jsdom — verified by watching it report the violation before the fix, and
+ * held there by the positive control below. The same is not true of the
+ * Storybook run the ticket reproduced on: `yarn test-sb` needs a real browser.
+ */
+
+interface Row { id: number; name: string }
+
+const ROWS: Row[] = [
+  { id: 1, name: 'alpha' },
+  { id: 2, name: 'beta' },
+];
+
+@Component({
+  selector: 'tn-table-a11y-host',
+  standalone: true,
+  imports: [TnTableComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-table
+      [dataSource]="rows()"
+      [displayedColumns]="['id', 'name']"
+      [selectable]="true"
+      [clickable]="clickable()"
+      [mobileLayout]="mobileLayout()"
+      (rowClick)="rowClicks = rowClicks + 1"
+      (selectionChange)="selectionEvents = selectionEvents + 1" />
+  `,
+})
+class TestHostComponent {
+  rows = signal<Row[]>(ROWS);
+  clickable = signal(false);
+  mobileLayout = signal<'cards' | 'scroll'>('scroll');
+  rowClicks = 0;
+  selectionEvents = 0;
+}
+
+describe('tn-table selection accessibility', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let restoreResizeObserver: () => void;
+
+  const el = <T extends HTMLElement>(selector: string): T => {
+    const found = fixture.nativeElement.querySelector(selector) as T | null;
+    if (!found) { throw new Error(`no element matched ${selector}`); }
+    return found;
+  };
+
+  /** Everything inside `root` that the browser would stop at while tabbing. */
+  const tabStops = (root: HTMLElement): HTMLElement[] =>
+    Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+    );
+
+  /** Dispatches a bubbling click whose target is `element` itself. */
+  const clickOn = (element: HTMLElement): void => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    restoreResizeObserver = TnTableTesting.installResizeObserver();
+    await TestBed.configureTestingModule({ imports: [TestHostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    // A table emits one `selectionChange([])` of its own on first render — the
+    // constructor effect that clears the selection when `data` changes runs for the
+    // first time after `ngOnInit` has set `initialized`. It is not this ticket's, and
+    // it is not per-gesture, so the counter starts from after it.
+    host.selectionEvents = 0;
+  });
+
+  afterEach(() => {
+    restoreResizeObserver();
+  });
+
+  describe('the select-all header cell', () => {
+    it('is a columnheader with no role or tabindex of its own', () => {
+      const cell = el('.tn-table__header-row .tn-table__select-cell');
+
+      expect(cell.tagName).toBe('TH');
+      expect(cell.getAttribute('role')).toBeNull();
+      expect(cell.getAttribute('tabindex')).toBeNull();
+      expect(cell.getAttribute('aria-checked')).toBeNull();
+    });
+
+    it('leaves the checkbox as the cell\'s only tab stop', () => {
+      const cell = el('.tn-table__header-row .tn-table__select-cell');
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+
+      expect(tabStops(cell)).toEqual([input]);
+    });
+
+    it('reports no nesting or empty-header violation to axe', async () => {
+      const cell = el('.tn-table__header-row .tn-table__select-cell');
+      const checkbox = el('.tn-table__header-row .tn-table__select-cell .tn-table__checkbox');
+
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [cell, checkbox],
+        ['nested-interactive', 'empty-table-header']
+      );
+
+      expect(violated).toEqual([]);
+      // Proof the rules looked at this cell rather than passing vacuously.
+      expect(evaluated).toContain('empty-table-header');
+    });
+
+    it('positive control: the pre-#236 markup still fails nested-interactive', async () => {
+      // The shape this ticket removed, rebuilt by hand. Without it, a `violated`
+      // of `[]` above would also be what an axe upgrade that stopped matching
+      // this element looks like.
+      const table = document.createElement('table');
+      table.innerHTML =
+        '<thead><tr><th role="checkbox" tabindex="0" aria-checked="false">'
+        + '<input type="checkbox" aria-label="Select all rows">'
+        + '</th></tr></thead><tbody><tr><td>alpha</td></tr></tbody>';
+      document.body.appendChild(table);
+
+      try {
+        const { violated } = await axeResult(
+          table,
+          table.querySelector<HTMLElement>('th'),
+          ['nested-interactive']
+        );
+
+        expect(violated).toEqual(['nested-interactive']);
+      } finally {
+        table.remove();
+      }
+    });
+
+    it('announces the indeterminate state on the checkbox itself', () => {
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+
+      clickOn(el('.tn-table__row .tn-table__select-cell'));
+
+      expect(input.indeterminate).toBe(true);
+      expect(input.checked).toBe(false);
+    });
+  });
+
+  // The select-all header, the row cell, and card mode's two wrappers all pair a
+  // checkbox with a hit area around it. `.tn-table__checkbox` used to be
+  // `pointer-events: none` so that only the hit area could ever be clicked; with
+  // the checkbox clickable again, each of these has to toggle exactly once per
+  // gesture, wherever in the cell the pointer lands.
+  describe('one gesture, one toggle', () => {
+    it('toggles select-all from the header cell padding', () => {
+      clickOn(el('.tn-table__header-row .tn-table__select-cell'));
+
+      expect(host.selectionEvents).toBe(1);
+      expect(el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      ).checked).toBe(true);
+    });
+
+    it('toggles select-all once from the header checkbox itself', () => {
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+
+      input.click();
+      fixture.detectChanges();
+
+      expect(host.selectionEvents).toBe(1);
+      expect(input.checked).toBe(true);
+    });
+
+    it('toggles select-all once from the header checkbox label', () => {
+      const label = el('.tn-table__header-row .tn-table__select-cell .tn-checkbox__label');
+
+      clickOn(label);
+
+      expect(host.selectionEvents).toBe(1);
+    });
+
+    it('toggles a row from its cell padding', () => {
+      clickOn(el('.tn-table__row .tn-table__select-cell'));
+
+      expect(host.selectionEvents).toBe(1);
+      expect(el<HTMLInputElement>(
+        '.tn-table__row .tn-table__select-cell input[type="checkbox"]'
+      ).checked).toBe(true);
+    });
+
+    it('toggles a row once from its checkbox itself', () => {
+      const input = el<HTMLInputElement>(
+        '.tn-table__row .tn-table__select-cell input[type="checkbox"]'
+      );
+
+      input.click();
+      fixture.detectChanges();
+
+      expect(host.selectionEvents).toBe(1);
+      expect(input.checked).toBe(true);
+    });
+
+    it('does not activate a clickable row when its checkbox is clicked', () => {
+      host.clickable.set(true);
+      fixture.detectChanges();
+
+      el<HTMLInputElement>('.tn-table__row .tn-table__select-cell input[type="checkbox"]').click();
+      fixture.detectChanges();
+
+      expect(host.selectionEvents).toBe(1);
+      expect(host.rowClicks).toBe(0);
+    });
+
+    describe('in card mode', () => {
+      beforeEach(() => {
+        host.mobileLayout.set('cards');
+        fixture.detectChanges();
+        TnTableTesting.emitContainerWidth(320);
+        fixture.detectChanges();
+        host.selectionEvents = 0;
+      });
+
+      it('renders cards', () => {
+        expect(fixture.nativeElement.querySelector('.tn-table__cards')).not.toBeNull();
+      });
+
+      it('toggles select-all once from the toolbar checkbox itself', () => {
+        const input = el<HTMLInputElement>(
+          '.tn-table__cards-selectall input[type="checkbox"]'
+        );
+
+        input.click();
+        fixture.detectChanges();
+
+        expect(host.selectionEvents).toBe(1);
+        expect(input.checked).toBe(true);
+      });
+
+      it('toggles select-all from the toolbar hit area', () => {
+        clickOn(el('.tn-table__cards-selectall'));
+
+        expect(host.selectionEvents).toBe(1);
+      });
+
+      it('toggles a card once from its checkbox itself', () => {
+        const input = el<HTMLInputElement>('.tn-table__card-select input[type="checkbox"]');
+
+        input.click();
+        fixture.detectChanges();
+
+        expect(host.selectionEvents).toBe(1);
+        expect(input.checked).toBe(true);
+      });
+
+      it('toggles a card from its hit area', () => {
+        clickOn(el('.tn-table__card-select'));
+
+        expect(host.selectionEvents).toBe(1);
+      });
+    });
+  });
+
+  describe('keyboard', () => {
+    const press = (key: string): void => {
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+      input.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+      fixture.detectChanges();
+    };
+
+    it('toggles select-all on Enter from the checkbox', () => {
+      press('Enter');
+
+      expect(host.selectionEvents).toBe(1);
+      expect(el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      ).checked).toBe(true);
+    });
+
+    it('toggles select-all on Space from the checkbox', () => {
+      // Space on a focused checkbox is a native activation: the browser turns it
+      // into a click on the input, which is what this stands in for. jsdom does
+      // not implement that translation, so the click is dispatched directly.
+      const input = el<HTMLInputElement>(
+        '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+      );
+
+      input.click();
+      fixture.detectChanges();
+
+      expect(host.selectionEvents).toBe(1);
+    });
+  });
+
+  it('reports nothing anywhere in a selectable table', async () => {
+    // The probe, kept as a guard. `nested-interactive` on the select-all cell is
+    // what this ticket fixed and is pinned by name above; this is what catches the
+    // next rule the selection markup breaks, in either direction — the fix removed a
+    // role, and a `<th>` whose only content is a hidden-label checkbox is exactly the
+    // shape `empty-table-header` objects to.
+    const scan = await axeScan(fixture);
+
+    expect(scan.violations).toEqual([]);
+    // Not a pass: axe puts a rule it could not decide here, and reading only
+    // `violations` reports a defect as clean.
+    expect(scan.incomplete).toEqual([]);
+    expect(scan.passed.length).toBeGreaterThan(0);
+  });
+});

--- a/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-a11y.spec.ts
@@ -356,6 +356,47 @@ describe('tn-table selection accessibility', () => {
     });
   });
 
+  // `SelectionModel` stores selections in a `Set`, so selecting every row of
+  // `[a, a, b]` leaves TWO selections for THREE array entries. Counting rows as
+  // `data().length` therefore never reaches "all selected" — see `distinctRowCount`.
+  // The stuck toggle predates #236; what is new is that the box can now be clicked,
+  // so a click that the model does not follow leaves the DOM and the model disagreeing.
+  describe('with a row reference repeated in the data', () => {
+    const repeated: Row = { id: 1, name: 'alpha' };
+    const other: Row = { id: 2, name: 'beta' };
+
+    const headerBox = (): HTMLInputElement => el<HTMLInputElement>(
+      '.tn-table__header-row .tn-table__select-cell input[type="checkbox"]'
+    );
+
+    beforeEach(() => {
+      host.rows.set([repeated, repeated, other]);
+      fixture.detectChanges();
+      host.selectionEvents = 0;
+    });
+
+    it('checks the header box once every distinct row is selected', () => {
+      clickOn(headerBox());
+
+      expect(host.selectionEvents).toBe(1);
+      expect(headerBox().checked).toBe(true);
+      expect(headerBox().indeterminate).toBe(false);
+    });
+
+    it('clears the selection on the second click', () => {
+      clickOn(headerBox());
+      clickOn(headerBox());
+
+      expect(headerBox().checked).toBe(false);
+      expect(headerBox().indeterminate).toBe(false);
+      expect(
+        Array.from(fixture.nativeElement.querySelectorAll<HTMLInputElement>(
+          '.tn-table__row .tn-table__select-cell input[type="checkbox"]'
+        )).every((box) => !box.checked)
+      ).toBe(true);
+    });
+  });
+
   it('reports nothing anywhere in a selectable table', async () => {
     // The probe, kept as a guard. `nested-interactive` on the select-all cell is
     // what this ticket fixed and is pinned by name above; this is what catches the

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -8,13 +8,19 @@
           and nesting one label inside another is invalid. The visible text is
           passed through the checkbox's own `label` input so it stays associated.
 
-          The handler goes on THIS wrapper, not on <tn-checkbox>: the checkbox is
-          `pointer-events: none` (see `__checkbox` in the stylesheet), so it and its
-          subtree are outside hit testing and a real click lands here instead. A
-          handler bound on the checkbox is never in the event path — which is how the
-          label -> div change silently killed mouse and touch selection while keyboard
-          kept working, since Space on the hidden input dispatches its own bubbling
-          click. Table mode binds the same handler on its <td> for this reason.
+          Two activation paths, deliberately, and they are mutually exclusive. The
+          checkbox activates itself and reports through `(change)`; this wrapper is
+          only the hit area around it, so its handler stands down for anything that
+          started inside the checkbox — see `onSelectAllHitAreaClick`. Until #236 the
+          wrapper was the only path, because `.tn-table__checkbox` was
+          `pointer-events: none` and no real click could reach the control; that
+          shape is what forced a focusable `role="checkbox"` onto the table header's
+          <th>, nesting one widget inside another.
+
+          No `preventDefault()` here any more, and that is load-bearing rather than
+          tidiness: a click on the checkbox's own <label> bubbles to this wrapper, and
+          cancelling it cancels the label's default action — which is how the label
+          activates the input.
 
           The click/key and focusable lint rules are suppressed rather than satisfied:
           this wrapper is a pointer hit area around a control that is already
@@ -25,12 +31,13 @@
         <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
         <div
           class="tn-table__cards-selectall"
-          (click)="toggleSelectAll(); $event.preventDefault()">
+          (click)="onSelectAllHitAreaClick($event)">
           <tn-checkbox
             class="tn-table__checkbox"
             label="Select all"
             [checked]="isAllSelected()"
-            [indeterminate]="isIndeterminate()" />
+            [indeterminate]="isIndeterminate()"
+            (change)="toggleSelectAll()" />
         </div>
       }
       @if (sortableColumns().length > 0) {
@@ -156,7 +163,7 @@
             <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
             <div
               class="tn-table__card-select"
-              (click)="toggleRowSelection(row); $event.preventDefault(); $event.stopPropagation()">
+              (click)="onRowSelectHitAreaClick($event, row)">
               <!--
                 Named from the card's title, not "Select row N": with `hideLabel` this is the
                 checkbox's entire accessible name, and a card list has no visible row numbers
@@ -170,7 +177,8 @@
                   'Select ' + (getCellValue(row, cardTitleColumn()) ?? 'row ' + (rowIdx + 1))
                 "
                 [hideLabel]="true"
-                [checked]="isRowSelected(row)" />
+                [checked]="isRowSelected(row)"
+                (change)="toggleRowSelection(row)" />
             </div>
           }
           <span class="tn-table__card-title">
@@ -267,19 +275,31 @@
       <tr class="tn-table__header-row">
         @for (column of effectiveDisplayedColumns(); track $index) {
           @if (column === '__select') {
+            <!--
+              A plain <th>, so it keeps its implicit `columnheader` role. It used to
+              carry `role="checkbox"` and `tabindex="0"` of its own, with the real
+              checkbox inside it: two tab stops for one action, a widget nested in a
+              widget (axe `nested-interactive`), and a selection column that was no
+              longer a header at all (#236).
+
+              The cell is now only the hit area — the same arrangement card mode has
+              always used, and the same `(change)` + hit-area pair as the row cells
+              below. `onSelectAllHitAreaClick` stands down when the click started
+              inside the checkbox, which activates itself.
+
+              Enter is bound because the removed <th> handled it and a native checkbox
+              does not; Space needs no binding, being the checkbox's own key.
+            -->
             <th class="tn-table__header-cell tn-table__select-cell"
-              role="checkbox"
-              tabindex="0"
-              [attr.aria-checked]="isAllSelected()"
-              (click)="toggleSelectAll()"
-              (keydown.enter)="toggleSelectAll()"
-              (keydown.space)="toggleSelectAll(); $event.preventDefault()">
+              (click)="onSelectAllHitAreaClick($event)">
               <tn-checkbox
                 class="tn-table__checkbox"
                 label="Select all rows"
                 [hideLabel]="true"
                 [checked]="isAllSelected()"
-                [indeterminate]="isIndeterminate()" />
+                [indeterminate]="isIndeterminate()"
+                (change)="toggleSelectAll()"
+                (keydown.enter)="onSelectAllEnter($event)" />
             </th>
           } @else if (column === '__expand') {
             <th class="tn-table__header-cell tn-table__expand-cell">
@@ -357,12 +377,13 @@
           @for (column of effectiveDisplayedColumns(); track $index) {
             @if (column === '__select') {
               <td class="tn-table__cell tn-table__select-cell"
-                (click)="toggleRowSelection(row); $event.stopPropagation()">
+                (click)="onRowSelectHitAreaClick($event, row)">
                 <tn-checkbox
                   class="tn-table__checkbox"
                   [label]="'Select row ' + (rowIdx + 1)"
                   [hideLabel]="true"
-                  [checked]="isRowSelected(row)" />
+                  [checked]="isRowSelected(row)"
+                  (change)="toggleRowSelection(row)" />
               </td>
             } @else if (column === '__expand') {
               <td class="tn-table__cell tn-table__expand-cell"

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -35,6 +35,7 @@
           <tn-checkbox
             class="tn-table__checkbox"
             label="Select all"
+            [disabled]="!canSelectAll()"
             [checked]="isAllSelected()"
             [indeterminate]="isIndeterminate()"
             (change)="toggleSelectAll()" />
@@ -289,6 +290,8 @@
 
               Enter is bound because the removed <th> handled it and a native checkbox
               does not; Space needs no binding, being the checkbox's own key.
+
+              `disabled` on an empty table is not decoration — see `canSelectAll`.
             -->
             <th class="tn-table__header-cell tn-table__select-cell"
               (click)="onSelectAllHitAreaClick($event)">
@@ -296,6 +299,7 @@
                 class="tn-table__checkbox"
                 label="Select all rows"
                 [hideLabel]="true"
+                [disabled]="!canSelectAll()"
                 [checked]="isAllSelected()"
                 [indeterminate]="isIndeterminate()"
                 (change)="toggleSelectAll()"

--- a/projects/truenas-ui/src/lib/table/table.component.scss
+++ b/projects/truenas-ui/src/lib/table/table.component.scss
@@ -374,10 +374,6 @@
     cursor: pointer;
   }
 
-  &__checkbox {
-    pointer-events: none;
-  }
-
   // Deliberately not pinned. Pinning select + first data + actions already consumes most of a
   // 320px viewport; adding a fourth pinned column leaves no scrollable middle at all. The chevron
   // stays reachable by scrolling, and card mode gives it a dedicated "Details" control.

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -665,6 +665,22 @@ export class TnTableComponent<T = unknown> implements OnInit {
     return count > 0 && !this.isAllSelected();
   });
 
+  /**
+   * Whether the select-all control has anything to act on.
+   *
+   * Disabling it on an empty table is a correctness guard, not a nicety. Since #236
+   * the checkbox is a real control the user can click, and its `checked` binding is
+   * one-way: the DOM follows `isAllSelected()`, and Angular only writes the attribute
+   * back when that value CHANGES. With no rows, `isAllSelected()` is pinned false —
+   * selecting nothing leaves the count at zero — so a click would flip the input in
+   * the DOM, change no bound value, and leave a checked-looking box over an empty
+   * selection until something else re-rendered it.
+   *
+   * The hit area around the checkbox stands down for the same reason, so the two
+   * cannot disagree about whether the control is live.
+   */
+  canSelectAll = computed(() => this.data().length > 0);
+
   trackByFn = computed(() => {
     const custom = this.trackBy();
     if (custom) { return custom; }
@@ -983,6 +999,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * @param event The originating click.
    */
   onSelectAllHitAreaClick(event: Event): void {
+    if (!this.canSelectAll()) { return; }
     if (this.isSelectionCheckboxTarget(event)) { return; }
     this.toggleSelectAll();
   }
@@ -1000,6 +1017,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
   onSelectAllEnter(event: Event): void {
     // Enter inside a form submits it, and this control is often inside one.
     event.preventDefault();
+    if (!this.canSelectAll()) { return; }
     this.toggleSelectAll();
   }
 

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -946,6 +946,77 @@ export class TnTableComponent<T = unknown> implements OnInit {
   }
 
   // --- Selection methods ---
+  //
+  // Every selection surface — the header cell, a row cell, and card mode's toolbar
+  // and card wrappers — is a checkbox with a hit area around it. The checkbox is the
+  // widget: it is the only tab stop, it activates itself, and it reports through
+  // `(change)`. The wrapper exists so that clicking the cell's padding works too, and
+  // it stands down for any click that started inside the checkbox.
+  //
+  // Before #236 it was the other way round: `.tn-table__checkbox` was
+  // `pointer-events: none`, so the wrapper caught every click and the checkbox caught
+  // none. That is why the header <th> had to be `role="checkbox" tabindex="0"` — the
+  // only focusable, activatable thing in the cell was the cell — and why axe reported
+  // a widget nested in a widget.
+
+  /**
+   * Whether an event started inside a selection checkbox rather than on the hit area
+   * around it.
+   *
+   * Matched on the component's host class rather than through
+   * {@link isControlTarget}, because the element clicked is usually neither the input
+   * nor the host: `tn-checkbox` renders a `<label>` wrapping the input and its
+   * checkmark, and a click on the checkmark activates the input as the label's default
+   * action. `closest('input')` says no to that click, and the toggle would then happen
+   * twice — once here, once from the label's own activation.
+   *
+   * @param event The DOM event; its `currentTarget` is the hit area.
+   */
+  private isSelectionCheckboxTarget(event: Event): boolean {
+    const target = event.target as HTMLElement | null;
+    return !!target?.closest('.tn-table__checkbox');
+  }
+
+  /**
+   * Click on the hit area around a select-all checkbox, in either layout.
+   *
+   * @param event The originating click.
+   */
+  onSelectAllHitAreaClick(event: Event): void {
+    if (this.isSelectionCheckboxTarget(event)) { return; }
+    this.toggleSelectAll();
+  }
+
+  /**
+   * Enter on the select-all checkbox.
+   *
+   * A native checkbox answers to Space and not to Enter, and the `<th>` this replaced
+   * handled both. Bound on the header's checkbox only, which is where that behaviour
+   * existed — card mode's select-all never had it.
+   *
+   * @param event The originating keydown; typed as `Event` because Angular types
+   *   `$event` that way for the `keydown.enter` pseudo-event.
+   */
+  onSelectAllEnter(event: Event): void {
+    // Enter inside a form submits it, and this control is often inside one.
+    event.preventDefault();
+    this.toggleSelectAll();
+  }
+
+  /**
+   * Click on the hit area around a row's selection checkbox, in either layout.
+   *
+   * Propagation stops whichever path activates the checkbox: a row is clickable and a
+   * card is activatable, and selecting is not activating.
+   *
+   * @param event The originating click.
+   * @param row The row the cell or card belongs to.
+   */
+  onRowSelectHitAreaClick(event: Event, row: T): void {
+    event.stopPropagation();
+    if (this.isSelectionCheckboxTarget(event)) { return; }
+    this.toggleRowSelection(row);
+  }
 
   toggleSelectAll(): void {
     if (this.isAllSelected()) {

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -654,9 +654,20 @@ export class TnTableComponent<T = unknown> implements OnInit {
     () => this.effectiveDisplayedColumns().length + (this.rowActionsDef() ? 1 : 0)
   );
 
+  /**
+   * How many rows a select-all can actually select.
+   *
+   * `SelectionModel` stores selections in a `Set`, so `selection.selected.length`
+   * counts DISTINCT rows while `data().length` counts array entries. A `dataSource`
+   * holding the same row reference twice makes the two disagree, and every comparison
+   * of a selection count against a row count has to use this one to stay honest —
+   * see {@link isAllSelected}.
+   */
+  private distinctRowCount = computed(() => new Set(this.data()).size);
+
   isAllSelected = computed(() => {
     const numSelected = this.selectionCount();
-    const numRows = this.data().length;
+    const numRows = this.distinctRowCount();
     return numRows > 0 && numSelected === numRows;
   });
 
@@ -678,8 +689,12 @@ export class TnTableComponent<T = unknown> implements OnInit {
    *
    * The hit area around the checkbox stands down for the same reason, so the two
    * cannot disagree about whether the control is live.
+   *
+   * An empty table is the only case that has to be disabled rather than fixed: a
+   * repeated row reference produces the same DOM-versus-model divergence, and
+   * {@link distinctRowCount} resolves that one by making the control work.
    */
-  canSelectAll = computed(() => this.data().length > 0);
+  canSelectAll = computed(() => this.distinctRowCount() > 0);
 
   trackByFn = computed(() => {
     const custom = this.trackBy();

--- a/projects/truenas-ui/src/lib/table/table.harness.ts
+++ b/projects/truenas-ui/src/lib/table/table.harness.ts
@@ -222,8 +222,10 @@ export class TnTableHarness extends ComponentHarness {
   // selected", so these resolve the right selectors themselves.
   //
   // The click target is the WRAPPER in both layouts (the `<td>`, or the card's
-  // `<div>`): `.tn-table__checkbox` is `pointer-events: none`, so clicking the
-  // checkbox itself exercises a path no user can take.
+  // `<div>`) — the cell's padding, which is the larger part of the hit area. Since
+  // #236 the checkbox is clickable too, and both paths toggle exactly once; clicking
+  // the wrapper is simply the one that does not depend on where inside the cell a
+  // pointer lands.
 
   /** True when the container is narrow enough that card mode is rendered. */
   private async isCards(): Promise<boolean> {


### PR DESCRIPTION
Fixes #236.

## The defect, reproduced before anything changed

Mounted in jsdom against unmodified `main`, axe reported exactly what the Storybook run in the ticket did:

```
nested-interactive (serious) — "Interactive controls must not be nested"
  th[role="checkbox"]
  <th role="checkbox" tabindex="0" class="tn-table__header-cell tn-table__select-cell" aria-checked="false">
  Fix any of the following:
    Element has focusable descendants
```

Both halves of the ticket are one element: a focusable `role="checkbox"` wrapping a real focusable checkbox — two tab stops for one action, and an inner control assistive technology may flatten — and a `role` that overrode the cell's implicit `columnheader`, so the selection column stopped being a header.

## What forced that shape, and what replaces it

`.tn-table__checkbox` was `pointer-events: none`. With the checkbox outside hit testing, **the only thing in the cell that could be clicked was the cell**, which is why the `<th>` had to be given a role, a tabindex and key handlers of its own. The ticket asks for that workaround to be removed rather than worked around a second time, and it is: the rule is gone.

**All four selection surfaces now pair a self-activating checkbox with a hit area around it** — the header cell, a row cell, and card mode's toolbar and card wrappers. The checkbox is the widget: the only tab stop, activating itself and reporting through `(change)`. The wrapper is only there so that clicking the cell's padding works too, and it stands down for any click that started inside the checkbox. **One gesture, one toggle, wherever in the cell the pointer lands** — that invariant is what the new specs are mostly about, because getting it wrong produces a double toggle, which is a control that visibly does nothing.

Two details that are load-bearing rather than tidiness:

- **The card wrapper's `preventDefault()` is gone.** A click on the checkbox's own `<label>` bubbles to the wrapper, and cancelling it cancels the label's default action — which *is* how a label activates its input. Harmless while the checkbox could never be clicked; a dead checkbox now.
- **The guard matches `.tn-table__checkbox`, not `input`.** The element clicked is usually neither the input nor the host: `tn-checkbox` renders a `<label>` around the input and its checkmark, and a click on the checkmark reaches the input as the label's default action. `closest('input')` says no to that click, and the toggle then happens twice.

**Enter is bound explicitly on the header's checkbox**, because a native checkbox answers only to Space and the `<th>` this replaced handled both. Space needs no binding and must not have one — the removed `<th>` called `preventDefault()` on it, which is how a wrapper cancels the activation of the control it wraps.

## What making the checkbox clickable exposed

`checked` follows `isAllSelected()`, and Angular writes the DOM only when that bound value *changes*. So wherever `isAllSelected()` cannot become true, a click flips the input in the DOM, changes no bound value, and leaves the rendering and the model disagreeing until something else re-renders. **There are two ways to land there, and they need different answers.**

**A repeated row reference — fixed, by making the control work.** `SelectionModel` stores selections in a `Set`, so `selection.selected.length` counts distinct rows while `data().length` counts array entries. With `[a, a, b]`, selecting every row leaves 2 selections for 3 entries: `isAllSelected()` stayed false, `isIndeterminate()` masked it, and the second click re-selected instead of clearing — a header box rendering unchecked over a 2-of-3 selection with no way to clear it. `distinctRowCount` is now the row count every selection comparison uses. The stuck toggle predates this ticket; the DOM-versus-model divergence is new, because before this change `pointer-events: none` meant no native activation could flip the input at all. Raised by the review on this PR (`isAllSelected` was comparing against `data().length`, so the empty table below was one instance of a two-instance problem).

**An empty table — disabled, because there is nothing to fix.** Selecting nothing leaves the count at zero, so `isAllSelected()` is pinned false with no honest value to reach. Both select-all controls are disabled when the table has no rows, and their hit areas stand down with them so the two cannot disagree about whether the control is live. `canSelectAll` reads `distinctRowCount` too, so both paths agree on what a row is. This is new behaviour, not a restoration: it was unreachable before, because the checkbox could not be clicked.

## Testing

`table-a11y.spec.ts` is new and holds four things: the axe guard on the cell (`nested-interactive` and `empty-table-header`, the latter because removing a role is how a `<th>` whose only content is a hidden-label checkbox becomes an empty header), the one-gesture-one-toggle contract on all four surfaces in both layouts, the empty-table case, and the repeated-row-reference case above — the last of which fails on the previous commit of this branch in both directions (the box never checks, and the second click never clears). It carries a **positive control** — the pre-#236 markup rebuilt by hand — so that a green `nested-interactive` cannot also mean an axe upgrade stopped matching the element. A whole-tree `axeScan` guard sits alongside the named rules, for the next rule this markup breaks in either direction.

**`yarn test-sb` could not be run here.** The Storybook Interaction Tests check drives a real browser, and this host has neither one nor the system libraries to supply it — so the ticket's last acceptance criterion (the 3 stories passing with `a11y: { test: 'error' }`) is the one I cannot demonstrate, and the jsdom axe scan above is what stands in for it. That check is green on CI, which has run it. Note also that `a11y: { test: 'error' }` is **not** set in `.storybook/preview.ts` on `main`; turning it on is out of scope here, since the other open accessibility tickets would fail it immediately.

Run locally and green: `yarn lint`, `yarn test` (3084 passing, 326 of them table), `yarn test:scripts`, `yarn build`, `yarn build-storybook`. `yarn lint` also reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here — that is #251.

Three rounds of local review; the third returned nothing at or above MEDIUM.

## Not changed, and why

LOW findings from the final review round, recorded here rather than fixed — every fix is a new diff, and a new diff is unreviewed:

- **`isSelectionCheckboxTarget` keys off `.tn-table__checkbox`, a class this diff leaves with no SCSS rule behind it.** It is documented as a behaviour hook on the method that reads it, but a future styling cleanup could delete the class as unused; `closest('tn-checkbox')` would survive that.
- **`cursor: pointer` stays on the select cell and the card toolbar when select-all is disabled**, advertising a hit area that returns early.
- **Enter toggles select-all in table mode only** — card mode's select-all and both row checkboxes ignore it, so the keyboard contract differs across the four selection surfaces and the same control gains and loses a key with viewport width. Deliberate — Enter is bound where the removed `<th>` had it, and nothing else ever had it — but the asymmetry is real.
- **The Space spec asserts `selectionEvents` is 0**, which is jsdom's lack of native checkbox activation rather than a statement about browsers, where Space does toggle. The test asserts the part that was actually at risk (nothing intercepts the key) and says so at length, but the assertion reads oddly on its own.
- **There is no card-mode counterpart to the clickable-row test**, so `onRowSelectHitAreaClick`'s `stopPropagation` is unverified in the layout where the wrapper sits inside an activatable card.
- **The new disabled state has no harness accessor**, so a consumer asserting it needs a raw selector.

Separately, and outside this ticket: **a table emits one `selectionChange([])` of its own on first render.** The constructor effect that clears the selection when `data` changes runs for the first time *after* `ngOnInit` has set `initialized`, so every consumer bound to `selectionChange` gets a phantom "selection cleared" on mount. Observed while reproducing this ticket, unrelated to it, and left alone; the new specs zero their counter past it and say why.
