### PR TITLE
NAS-142491 / 27.0.0-BETA.1 / fix(chip): pair every chip label colour with the surface it sits on

### DIFF
--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -30,8 +30,8 @@ import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
  *    measurements of a hardcoded list, and a list is exactly as current as the
  *    last person to edit it: a new variant, or a `color:` moved to a different
  *    token, would leave all of the above green while measuring markup that no
- *    longer exists. `EXPECTED_*` reads the stylesheet and fails if it and this
- *    table have diverged in either direction.
+ *    longer exists. `scssRules` reads the stylesheet back and the pairing cases
+ *    fail if it and `CHIP_SURFACES` have diverged in either direction.
  *
  * NOT AXE'S `color-contrast` RULE, which needs a layout engine to find what is
  * really painted behind an element and reports `incomplete` under jsdom rather
@@ -233,8 +233,11 @@ describe('tn-chip label contrast (#238)', () => {
     const chipRule = rules.find((rule) => rule.selector === '.tn-chip');
 
     it('reads the stylesheet', () => {
-      // Without this a moved or renamed file leaves every scan below matching
-      // nothing, which passes as "no unexpected surface".
+      // A moved file throws in `readFileSync` and is loud on its own. This is
+      // for the quiet half: the wrapper renamed away from `.tn-chip`, which
+      // leaves a stylesheet that parses into rules none of the lookups below
+      // find, and a `chipRule` of `undefined` whose declarations are read with
+      // `?.` and compared against nothing.
       expect(chipRule).toBeDefined();
     });
 

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -79,8 +79,8 @@ const REQUIRED_TOKENS = [
 ].sort();
 
 /**
- * `color:` and `background-color:` values in `chip.component.scss` that name no
- * theme token, with why each one is not a surface this file measures.
+ * Backgrounds `chip.component.scss` paints that name no theme token, with why
+ * each one is not a label surface this file measures.
  *
  * A map rather than a bare list, because "this value is fine" and "this value
  * is fine FOR THIS REASON" rot differently: a wash that stops being decorative
@@ -88,31 +88,112 @@ const REQUIRED_TOKENS = [
  * disagree with.
  */
 const NOT_A_LABEL_SURFACE: Readonly<Record<string, string>> = {
-  inherit: 'the body button and the close glyph both take the chip wrapper\'s colour, which is what every pair above measures',
-  'rgba(255, 255, 255, 0.2)': 'the close circle, a wash over whatever the chip already paints — see the note below',
+  none: 'the body button, which is transparent over the wrapper the pairs above measure',
+  transparent: 'the <code> override, which puts a code span back on the chip\'s own surface after the label-markup mixin painted it --tn-bg2',
+  'rgba(255, 255, 255, 0.2)': 'the close circle, a wash over whatever the chip already paints — the × is a glyph on that wash, not the label, and is not measured here',
   'rgba(255, 255, 255, 0.3)': 'the same wash, on hover',
   'rgba(0, 0, 0, 0.2)': 'the same circle in TN Dark on --secondary, where a light wash would disappear',
   'rgba(0, 0, 0, 0.3)': 'the same dark wash, on hover',
 };
 
-/**
- * A `color:` declaration, but not `border-color:` or `background-color:`.
- *
- * The `(^|[^-\w])` is load-bearing and is the same guard
- * `primary-text-contrast.spec.ts` uses: `background-color: var(--tn-accent)`
- * contains `color: var(--tn-accent)` as a substring, and a border is not a
- * label.
- */
-const COLOR_DECLARATION = /(?:^|[^-\w])color:\s*([^;]+);/g;
-const BACKGROUND_COLOR_DECLARATION = /background-color:\s*([^;]+);/g;
+/** One rule in the stylesheet: its own declarations, and what it nests inside. */
+interface ScssRule {
+  selector: string;
+  declarations: Map<string, string>;
+  parent: ScssRule | null;
+}
 
-function declaredValues(scss: string, pattern: RegExp): string[] {
-  return [...scss.matchAll(pattern)].map((match) => match[1].trim());
+/**
+ * Every rule in `scss`, each pointing at the rule it nests inside.
+ *
+ * A brace walk rather than a regex, and the nesting is the reason. `color` and
+ * `background-color` are almost never declared together: `&--secondary:hover`
+ * repaints the background and inherits its label colour from `&--secondary`,
+ * one level up and on the same element. Scanning for the two properties
+ * independently — which is what this used to do — collects the right two SETS
+ * of tokens while saying nothing about which goes with which, so re-pairing an
+ * existing foreground with an existing surface passes: `--tn-alt-fg2` on
+ * `--tn-accent` is 1.45:1 in Solarized Dark and both halves are already in the
+ * table.
+ */
+function scssRules(scss: string): ScssRule[] {
+  // Both comment forms go first. `//` runs to end of line and `/* */` does not,
+  // and either can contain a brace or a semicolon that would otherwise be read
+  // as structure.
+  const source = scss.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  const rules: ScssRule[] = [];
+  const open: ScssRule[] = [];
+  let pending = '';
+
+  function absorb(rule: ScssRule, text: string): void {
+    for (const chunk of text.split(';')) {
+      const declaration = /^\s*([-\w]+)\s*:\s*([\s\S]+?)\s*$/.exec(chunk);
+      if (declaration) {
+        rule.declarations.set(declaration[1], declaration[2]);
+      }
+    }
+  }
+
+  for (const character of source) {
+    if (character === '{') {
+      // Everything after the last `;` is the prelude of the rule opening now;
+      // everything before it belongs to the rule already open.
+      const lastSemicolon = pending.lastIndexOf(';');
+      const enclosing = open[open.length - 1] ?? null;
+      if (enclosing) {
+        absorb(enclosing, pending.slice(0, lastSemicolon + 1));
+      }
+      const rule: ScssRule = {
+        selector: pending.slice(lastSemicolon + 1).trim(),
+        declarations: new Map(),
+        parent: enclosing,
+      };
+      open.push(rule);
+      rules.push(rule);
+      pending = '';
+    } else if (character === '}') {
+      const closing = open.pop();
+      if (closing === undefined) {
+        throw new Error('chip.component.scss: unbalanced braces — a } with nothing open');
+      }
+      absorb(closing, pending);
+      pending = '';
+    } else {
+      pending += character;
+    }
+  }
+  if (open.length > 0) {
+    throw new Error(`chip.component.scss: unbalanced braces — ${open.length} rule(s) left open`);
+  }
+  return rules;
+}
+
+/**
+ * The `color` in force on the element this rule matches: its own, or the
+ * nearest enclosing rule's.
+ *
+ * Nesting stands in for inheritance because of what the chip's selectors are.
+ * `&--secondary:hover` and `&--secondary` match the SAME element, so the outer
+ * `color` is the one that renders, not merely one that might cascade down.
+ */
+function labelColor(rule: ScssRule | null): string | undefined {
+  for (let current = rule; current !== null; current = current.parent) {
+    const own = current.declarations.get('color');
+    if (own !== undefined) {
+      return own;
+    }
+  }
+  return undefined;
 }
 
 /** `var(--tn-x)` -> `--tn-x`; anything else unchanged, to be judged as a literal. */
 function tokenOf(value: string): string {
   return /^var\(\s*(--[\w-]+)\s*\)$/.exec(value)?.[1] ?? value;
+}
+
+/** `--tn-alt-fg2 on --tn-alt-bg2`, the form both directions of the guard compare. */
+function pairing(foreground: string | undefined, background: string): string {
+  return `${foreground ?? 'no colour in force'} on ${background}`;
 }
 
 describe('tn-chip label contrast (#238)', () => {
@@ -131,51 +212,88 @@ describe('tn-chip label contrast (#238)', () => {
   });
 
   describe('the table above still describes chip.component.scss', () => {
+    const rules = scssRules(scss);
+    const chipRule = rules.find((rule) => rule.selector === '.tn-chip');
+
     it('reads the stylesheet', () => {
       // Without this a moved or renamed file leaves every scan below matching
-      // nothing, which passes as "no unexpected token".
-      expect(scss).toContain('.tn-chip');
+      // nothing, which passes as "no unexpected surface".
+      expect(chipRule).toBeDefined();
     });
 
-    const foregrounds = declaredValues(scss, COLOR_DECLARATION).map(tokenOf);
-    const backgrounds = declaredValues(scss, BACKGROUND_COLOR_DECLARATION).map(tokenOf);
+    /**
+     * Every (colour, background) the stylesheet actually puts together, read
+     * off the rule that paints the background. `background` as well as
+     * `background-color`, because the shorthand resets the longhand and is what
+     * the <code> override uses.
+     */
+    const painted = rules
+      .filter((rule) => rule.declarations.has('background-color') || rule.declarations.has('background'))
+      .map((rule) => {
+        const background = rule.declarations.get('background-color') ?? (rule.declarations.get('background') as string);
+        const foreground = labelColor(rule);
+        return {
+          selector: rule.selector,
+          background: tokenOf(background),
+          foreground: foreground === undefined ? undefined : tokenOf(foreground),
+        };
+      });
 
-    it('every color: it declares is either a measured foreground or an explained literal', () => {
-      const expected = new Set<string>(CHIP_SURFACES.map((surface) => surface.foreground));
-      expect(
-        [...new Set(foregrounds)].filter((value) => !expected.has(value) && !(value in NOT_A_LABEL_SURFACE))
-      ).toEqual([]);
+    it('paints something', () => {
+      expect(painted.length).toBeGreaterThan(0);
     });
 
-    it('every background-color: it declares is either a measured surface or an explained literal', () => {
-      const expected = new Set<string>(CHIP_SURFACES.map((surface) => surface.background));
-      expect(
-        [...new Set(backgrounds)].filter((value) => !expected.has(value) && !(value in NOT_A_LABEL_SURFACE))
-      ).toEqual([]);
+    const onATheme = painted.filter((surface) => surface.background.startsWith('--'));
+    const onALiteral = painted.filter((surface) => !surface.background.startsWith('--'));
+    const expectedPairs = new Set(CHIP_SURFACES.map((surface) => pairing(surface.foreground, surface.background)));
+    const paintedPairs = new Set(onATheme.map((surface) => pairing(surface.foreground, surface.background)));
+
+    it('every themed surface it paints is a pair the table measures', () => {
+      // The pairing, not the two halves separately: both `--tn-alt-fg2` and
+      // `--tn-accent` are already in the table, and putting them together is
+      // 1.45:1 in Solarized Dark.
+      expect([...paintedPairs].filter((pair) => !expectedPairs.has(pair)).sort()).toEqual([]);
     });
 
-    it.each(CHIP_SURFACES)('$name: the stylesheet still paints $background', ({ background }) => {
-      // The other direction: a pair deleted from the stylesheet but left in the
+    it('every pair the table measures is one the stylesheet still paints', () => {
+      // The other direction: a rule deleted from the stylesheet but left in the
       // table is measured forever, and the reader believes it is covered.
-      expect(backgrounds).toContain(background);
+      expect([...expectedPairs].filter((pair) => !paintedPairs.has(pair)).sort()).toEqual([]);
     });
 
-    it.each(CHIP_SURFACES)('$name: the stylesheet still labels it $foreground', ({ foreground }) => {
-      expect(foregrounds).toContain(foreground);
+    it('every background it paints that is not a theme token is explained', () => {
+      expect(
+        [...new Set(onALiteral.map((surface) => surface.background))].filter(
+          (value) => !(value in NOT_A_LABEL_SURFACE)
+        )
+      ).toEqual([]);
     });
 
     it('no rule reintroduces --tn-fg1 as the chip label', () => {
       // The specific value that failed. Named on its own so a regression says
       // what came back rather than only that something unexpected appeared.
-      expect(foregrounds).not.toContain('--tn-fg1');
+      expect(painted.map((surface) => surface.foreground)).not.toContain('--tn-fg1');
+    });
+
+    it('a <code> span in the label keeps the chip\'s own surface', () => {
+      // `label-markup.inline-code` paints <code> on --tn-bg2 and inherits the
+      // colour, which on a filled chip is a surface none of the pairs above
+      // describe: in TN Dark it is --tn-accent-txt (#1E1E1E) on #282828,
+      // 1.00:1. The mixin is included by ten components and is right for the
+      // other nine, so the chip overrides it rather than the mixin changing.
+      // The override lives in another file's mixin, so nothing above can see
+      // it going missing — this is what does.
+      const override = rules.find((rule) => rule.selector === '::ng-deep code');
+      expect(override?.declarations.get('background')).toBe('transparent');
     });
 
     it('the label is normal-size text, so 4.5:1 applies rather than 3:1', () => {
-      // AA's 3:1 large-text allowance starts at 24px, or 18.66px bold. Both
-      // declarations are on `.tn-chip` and inherited by `.tn-chip__label`; if
-      // either moves, the threshold every case below uses is the wrong one.
-      expect(scss).toContain('font-size: 14px;');
-      expect(scss).toContain('font-weight: 500;');
+      // AA's 3:1 large-text allowance starts at 24px, or 18.66px bold. Read off
+      // the `.tn-chip` rule itself rather than searched for in the file:
+      // `.tn-chip__close-icon` also declares `font-size: 14px`, so a substring
+      // search passes while the label moves into large-text size.
+      expect(chipRule?.declarations.get('font-size')).toBe('14px');
+      expect(chipRule?.declarations.get('font-weight')).toBe('500');
       expect(AA_MINIMUM.normal).toBe(4.5);
     });
   });

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -66,7 +66,7 @@ const CHIP_SURFACES: readonly ChipSurface[] = [
   { name: '--accent', foreground: '--tn-accent-txt', background: '--tn-accent' },
   // Hover moves the accent chip onto --tn-alt-bg2, so the label moves onto that
   // surface's companion rather than carrying --tn-accent-txt, which is tuned
-  // for the accent fill and measures 1.45:1 on the grey in Solarized Dark.
+  // for the accent fill and measures 1.93:1 on the grey in Solarized Dark.
   { name: '--accent:hover', foreground: '--tn-alt-fg2', background: '--tn-alt-bg2' },
 ];
 
@@ -113,7 +113,7 @@ interface ScssRule {
  * independently — which is what this used to do — collects the right two SETS
  * of tokens while saying nothing about which goes with which, so re-pairing an
  * existing foreground with an existing surface passes: `--tn-alt-fg2` on
- * `--tn-accent` is 1.45:1 in Solarized Dark and both halves are already in the
+ * `--tn-accent` is 2.58:1 in Solarized Dark and both halves are already in the
  * table.
  */
 function scssRules(scss: string): ScssRule[] {
@@ -251,7 +251,7 @@ describe('tn-chip label contrast (#238)', () => {
     it('every themed surface it paints is a pair the table measures', () => {
       // The pairing, not the two halves separately: both `--tn-alt-fg2` and
       // `--tn-accent` are already in the table, and putting them together is
-      // 1.45:1 in Solarized Dark.
+      // 2.58:1 in Solarized Dark.
       expect([...paintedPairs].filter((pair) => !expectedPairs.has(pair)).sort()).toEqual([]);
     });
 
@@ -275,14 +275,32 @@ describe('tn-chip label contrast (#238)', () => {
       expect(painted.map((surface) => surface.foreground)).not.toContain('--tn-fg1');
     });
 
+    it('nothing between the chip wrapper and the label sets a colour of its own', () => {
+      // Everything above reads the colour off the rule that paints the
+      // BACKGROUND, and walks outward from there. That is right for a variant
+      // and blind to a descendant: `.tn-chip__body` and `.tn-chip__label` sit
+      // between the wrapper and the text and paint no background at all, so a
+      // `color:` on either would repaint every label in every palette while
+      // every pair above still matched. They may say `inherit` and nothing
+      // else; a colour that belongs there belongs on the variant, next to the
+      // surface it goes with.
+      const between = rules.filter((rule) => rule.selector === '&__body' || rule.selector === '&__label');
+      expect(between.map((rule) => rule.selector).sort()).toEqual(['&__body', '&__label']);
+      expect(
+        between
+          .filter((rule) => (rule.declarations.get('color') ?? 'inherit') !== 'inherit')
+          .map((rule) => rule.selector)
+      ).toEqual([]);
+    });
+
     it('a <code> span in the label keeps the chip\'s own surface', () => {
       // `label-markup.inline-code` paints <code> on --tn-bg2 and inherits the
       // colour, which on a filled chip is a surface none of the pairs above
       // describe: in TN Dark it is --tn-accent-txt (#1E1E1E) on #282828,
-      // 1.00:1. The mixin is included by ten components and is right for the
+      // 1.13:1. The mixin is included by ten components and is right for the
       // other nine, so the chip overrides it rather than the mixin changing.
-      // The override lives in another file's mixin, so nothing above can see
-      // it going missing — this is what does.
+      // The wash comes from another file, so nothing above can see the
+      // override going missing — this is what does.
       const override = rules.find((rule) => rule.selector === '::ng-deep code');
       expect(override?.declarations.get('background')).toBe('transparent');
     });

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -191,9 +191,26 @@ function tokenOf(value: string): string {
   return /^var\(\s*(--[\w-]+)\s*\)$/.exec(value)?.[1] ?? value;
 }
 
-/** `--tn-alt-fg2 on --tn-alt-bg2`, the form both directions of the guard compare. */
+/** `--tn-alt-fg2 on --tn-alt-bg2`, the form the guard compares. */
 function pairing(foreground: string | undefined, background: string): string {
   return `${foreground ?? 'no colour in force'} on ${background}`;
+}
+
+/**
+ * How many times each pairing appears — a count, not a set.
+ *
+ * Two rules paint `--tn-alt-fg2` on `--tn-alt-bg2`: `--secondary:hover` and
+ * `--accent:hover`. Deduplicated into a set they are one entry, so deleting
+ * either rule leaves the other covering for it and the guard green while the
+ * table goes on claiming to measure a surface nothing paints. The count is what
+ * tells the two apart.
+ */
+function tally(pairings: readonly string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const pair of pairings) {
+    counts[pair] = (counts[pair] ?? 0) + 1;
+  }
+  return counts;
 }
 
 describe('tn-chip label contrast (#238)', () => {
@@ -245,20 +262,24 @@ describe('tn-chip label contrast (#238)', () => {
 
     const onATheme = painted.filter((surface) => surface.background.startsWith('--'));
     const onALiteral = painted.filter((surface) => !surface.background.startsWith('--'));
-    const expectedPairs = new Set(CHIP_SURFACES.map((surface) => pairing(surface.foreground, surface.background)));
-    const paintedPairs = new Set(onATheme.map((surface) => pairing(surface.foreground, surface.background)));
 
-    it('every themed surface it paints is a pair the table measures', () => {
-      // The pairing, not the two halves separately: both `--tn-alt-fg2` and
+    it('the stylesheet paints exactly the pairings the table measures, as many times each', () => {
+      // Both directions and the count, in one comparison.
+      //
+      // The PAIRING, not the two halves separately: both `--tn-alt-fg2` and
       // `--tn-accent` are already in the table, and putting them together is
-      // 2.58:1 in Solarized Dark.
-      expect([...paintedPairs].filter((pair) => !expectedPairs.has(pair)).sort()).toEqual([]);
-    });
-
-    it('every pair the table measures is one the stylesheet still paints', () => {
-      // The other direction: a rule deleted from the stylesheet but left in the
-      // table is measured forever, and the reader believes it is covered.
-      expect([...expectedPairs].filter((pair) => !paintedPairs.has(pair)).sort()).toEqual([]);
+      // 2.58:1 in Solarized Dark — a set of foregrounds and a set of surfaces
+      // would have nothing to say about it.
+      //
+      // The COUNT, not the set of pairings: `--secondary:hover` and
+      // `--accent:hover` paint the same pair, so one of them can go missing
+      // behind the other while the table still claims to measure both.
+      //
+      // And a pairing here that is not in the table catches the reverse — a
+      // rule deleted from the stylesheet is otherwise measured forever, and
+      // the reader believes it is covered.
+      expect(tally(onATheme.map((surface) => pairing(surface.foreground, surface.background))))
+        .toEqual(tally(CHIP_SURFACES.map((surface) => pairing(surface.foreground, surface.background))));
     });
 
     it('every background it paints that is not a theme token is explained', () => {

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { AA_MINIMUM, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
+
+/**
+ * Every surface `tn-chip` paints, measured against the label it paints on it,
+ * in all nine palettes (#238).
+ *
+ * WHAT WENT WRONG. The chip picked its `color` independently of its
+ * `background-color`, so a theme was free to move one and not the other. TN
+ * Dark did: `--tn-accent` resolves to `--tn-yellow` there while the accent
+ * label stayed `--tn-fg1`, giving near-white on #DED142 at 1.20:1. Six of the
+ * nine palettes failed on the accent variant, and two more failed on surfaces
+ * the Storybook run never reached — secondary in Solarized Dark at 1.40:1,
+ * whose `--tn-alt-fg2` was a near-black copied from a light theme, and primary
+ * in High Contrast at 4.07:1, which had never declared a `--tn-primary-txt` of
+ * its own and was inheriting `:root`'s white.
+ *
+ * WHAT THIS ASSERTS, IN THREE PARTS. The pairing is only as good as its weakest
+ * link, and each part below covers a different way it can rot:
+ *
+ * 1. Every chip surface has a companion foreground DECLARED BY THE PALETTE
+ *    ITSELF. `declares`, not `color`: a theme that omits one still renders, by
+ *    inheriting `:root`'s — which is precisely how High Contrast came to paint
+ *    white on its own lighter blue. A value tuned for `:root`'s surfaces is not
+ *    a value for these.
+ * 2. Every pair clears 4.5:1 on every palette.
+ * 3. The table below still describes `chip.component.scss`. Parts 1 and 2 are
+ *    measurements of a hardcoded list, and a list is exactly as current as the
+ *    last person to edit it: a new variant, or a `color:` moved to a different
+ *    token, would leave all of the above green while measuring markup that no
+ *    longer exists. `EXPECTED_*` reads the stylesheet and fails if it and this
+ *    table have diverged in either direction.
+ *
+ * NOT AXE'S `color-contrast` RULE, which needs a layout engine to find what is
+ * really painted behind an element and reports `incomplete` under jsdom rather
+ * than checking. This measures the values shipped in `themes.css` against the
+ * surface the stylesheet names — a claim about the palette rather than about a
+ * rendered page. `yarn test-sb` is what checks the page.
+ *
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197).
+ * `theme/primary-text-contrast.spec.ts` is the same shape for
+ * `--tn-primary-text`, and `theme/error-text-contrast.spec.ts` for
+ * `--tn-error-text`.
+ */
+
+const STYLES_DIR = join(__dirname, '../../styles');
+const CHIP_SCSS = join(__dirname, 'chip.component.scss');
+
+/**
+ * One thing the chip paints a label on: a `background-color` and the `color`
+ * that goes with it, as `chip.component.scss` declares them together.
+ */
+interface ChipSurface {
+  /** How it reads in a failure: `--accent:hover`. */
+  readonly name: string;
+  readonly foreground: string;
+  readonly background: string;
+}
+
+const CHIP_SURFACES: readonly ChipSurface[] = [
+  { name: '--primary', foreground: '--tn-primary-txt', background: '--tn-primary' },
+  { name: '--secondary', foreground: '--tn-alt-fg2', background: '--tn-alt-bg1' },
+  { name: '--secondary:hover', foreground: '--tn-alt-fg2', background: '--tn-alt-bg2' },
+  { name: '--accent', foreground: '--tn-accent-txt', background: '--tn-accent' },
+  // Hover moves the accent chip onto --tn-alt-bg2, so the label moves onto that
+  // surface's companion rather than carrying --tn-accent-txt, which is tuned
+  // for the accent fill and measures 1.45:1 on the grey in Solarized Dark.
+  { name: '--accent:hover', foreground: '--tn-alt-fg2', background: '--tn-alt-bg2' },
+];
+
+/**
+ * Both halves of every pair above, which is what each palette has to declare
+ * for itself. Sorted and de-duplicated so a failure reads in a stable order.
+ */
+const REQUIRED_TOKENS = [
+  ...new Set(CHIP_SURFACES.flatMap((surface) => [surface.foreground, surface.background])),
+].sort();
+
+/**
+ * `color:` and `background-color:` values in `chip.component.scss` that name no
+ * theme token, with why each one is not a surface this file measures.
+ *
+ * A map rather than a bare list, because "this value is fine" and "this value
+ * is fine FOR THIS REASON" rot differently: a wash that stops being decorative
+ * needs the reason revisited, and a reason recorded here is one a reader can
+ * disagree with.
+ */
+const NOT_A_LABEL_SURFACE: Readonly<Record<string, string>> = {
+  inherit: 'the body button and the close glyph both take the chip wrapper\'s colour, which is what every pair above measures',
+  'rgba(255, 255, 255, 0.2)': 'the close circle, a wash over whatever the chip already paints — see the note below',
+  'rgba(255, 255, 255, 0.3)': 'the same wash, on hover',
+  'rgba(0, 0, 0, 0.2)': 'the same circle in TN Dark on --secondary, where a light wash would disappear',
+  'rgba(0, 0, 0, 0.3)': 'the same dark wash, on hover',
+};
+
+/**
+ * A `color:` declaration, but not `border-color:` or `background-color:`.
+ *
+ * The `(^|[^-\w])` is load-bearing and is the same guard
+ * `primary-text-contrast.spec.ts` uses: `background-color: var(--tn-accent)`
+ * contains `color: var(--tn-accent)` as a substring, and a border is not a
+ * label.
+ */
+const COLOR_DECLARATION = /(?:^|[^-\w])color:\s*([^;]+);/g;
+const BACKGROUND_COLOR_DECLARATION = /background-color:\s*([^;]+);/g;
+
+function declaredValues(scss: string, pattern: RegExp): string[] {
+  return [...scss.matchAll(pattern)].map((match) => match[1].trim());
+}
+
+/** `var(--tn-x)` -> `--tn-x`; anything else unchanged, to be judged as a literal. */
+function tokenOf(value: string): string {
+  return /^var\(\s*(--[\w-]+)\s*\)$/.exec(value)?.[1] ?? value;
+}
+
+describe('tn-chip label contrast (#238)', () => {
+  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
+  const scss = readFileSync(CHIP_SCSS, 'utf8');
+  const palettes = themePalettes(css);
+
+  // Derived from the theme registry rather than hardcoded: a themed surface
+  // that stops being recognised — a renamed class, a block that drops
+  // `--tn-bg1` — would otherwise go unmeasured while every remaining case
+  // still passed.
+  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expectedSelectors].sort());
+  });
+
+  describe('the table above still describes chip.component.scss', () => {
+    it('reads the stylesheet', () => {
+      // Without this a moved or renamed file leaves every scan below matching
+      // nothing, which passes as "no unexpected token".
+      expect(scss).toContain('.tn-chip');
+    });
+
+    const foregrounds = declaredValues(scss, COLOR_DECLARATION).map(tokenOf);
+    const backgrounds = declaredValues(scss, BACKGROUND_COLOR_DECLARATION).map(tokenOf);
+
+    it('every color: it declares is either a measured foreground or an explained literal', () => {
+      const expected = new Set<string>(CHIP_SURFACES.map((surface) => surface.foreground));
+      expect(
+        [...new Set(foregrounds)].filter((value) => !expected.has(value) && !(value in NOT_A_LABEL_SURFACE))
+      ).toEqual([]);
+    });
+
+    it('every background-color: it declares is either a measured surface or an explained literal', () => {
+      const expected = new Set<string>(CHIP_SURFACES.map((surface) => surface.background));
+      expect(
+        [...new Set(backgrounds)].filter((value) => !expected.has(value) && !(value in NOT_A_LABEL_SURFACE))
+      ).toEqual([]);
+    });
+
+    it.each(CHIP_SURFACES)('$name: the stylesheet still paints $background', ({ background }) => {
+      // The other direction: a pair deleted from the stylesheet but left in the
+      // table is measured forever, and the reader believes it is covered.
+      expect(backgrounds).toContain(background);
+    });
+
+    it.each(CHIP_SURFACES)('$name: the stylesheet still labels it $foreground', ({ foreground }) => {
+      expect(foregrounds).toContain(foreground);
+    });
+
+    it('no rule reintroduces --tn-fg1 as the chip label', () => {
+      // The specific value that failed. Named on its own so a regression says
+      // what came back rather than only that something unexpected appeared.
+      expect(foregrounds).not.toContain('--tn-fg1');
+    });
+
+    it('the label is normal-size text, so 4.5:1 applies rather than 3:1', () => {
+      // AA's 3:1 large-text allowance starts at 24px, or 18.66px bold. Both
+      // declarations are on `.tn-chip` and inherited by `.tn-chip__label`; if
+      // either moves, the threshold every case below uses is the wrong one.
+      expect(scss).toContain('font-size: 14px;');
+      expect(scss).toContain('font-weight: 500;');
+      expect(AA_MINIMUM.normal).toBe(4.5);
+    });
+  });
+
+  describe('every palette declares both halves of every pair itself', () => {
+    const declarations = palettes.map((palette) => ({
+      selector: palette.selector,
+      missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
+    }));
+
+    it.each(declarations)('$selector declares every token the chip reads', ({ missing }) => {
+      // Inheriting `:root`'s value is not the same as having one: High
+      // Contrast rendered white on its own #4784ac at 4.07:1 for exactly that
+      // reason, and `color` would have resolved it and reported a number
+      // without complaint.
+      expect(missing).toEqual([]);
+    });
+  });
+
+  describe('every pair clears AA on every palette', () => {
+    // Only surfaces that passed the declaration check are measured — a palette
+    // missing a token has already failed, and measuring it would add a second
+    // failure saying the same thing in worse words. If that leaves nothing,
+    // `it.each` errors on an empty array rather than reporting a suite with no
+    // contrast cases in it as green.
+    const cases = palettes
+      .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+      .flatMap((palette) =>
+        CHIP_SURFACES.map((surface) => {
+          const ratio = palette.contrast(surface.foreground, surface.background);
+          return {
+            selector: palette.selector,
+            name: surface.name,
+            foreground: palette.color(surface.foreground),
+            background: palette.color(surface.background),
+            ratio,
+            ratioLabel: formatRatio(ratio),
+          };
+        })
+      );
+
+    it('there are pairs to measure', () => {
+      expect(cases).toHaveLength(expectedSelectors.length * CHIP_SURFACES.length);
+    });
+
+    it.each(cases)(
+      '$selector $name: $foreground on $background measures $ratioLabel',
+      ({ ratio }) => {
+        expect(meetsAa(ratio, 'normal')).toBe(true);
+      }
+    );
+  });
+});

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -142,6 +142,23 @@
   &__label {
     @include label-markup.inline-code;
 
+    // The mixin paints <code> on --tn-bg2 and leaves the colour inherited. On
+    // the other nine components that include it that is fine: their labels
+    // already sit on --tn-bg1 or --tn-bg2, so the wash is a near-neutral step
+    // off a surface the colour was chosen for. The chip is the one that labels
+    // a FILLED variant surface, so a <code> span in a chip label swaps the
+    // background out from under a colour paired with --tn-primary or
+    // --tn-accent — in TN Dark that is #1E1E1E on #282828, 1.00:1.
+    //
+    // So <code> keeps the chip's own surface, which is the one every pair
+    // above measures, and the monospace font and the border do the
+    // distinguishing instead. currentColor for the border because --tn-lines
+    // is a colour for the page, and on a filled chip it can vanish.
+    ::ng-deep code {
+      background: transparent;
+      border-color: currentColor;
+    }
+
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -142,18 +142,24 @@
   &__label {
     @include label-markup.inline-code;
 
-    // The mixin paints <code> on --tn-bg2 and leaves the colour inherited. On
-    // the other nine components that include it that is fine: their labels
+    // The mixin paints <code> on --tn-bg2 and leaves the colour inherited. For
+    // most of the ten components that include it that is fine: their labels
     // already sit on --tn-bg1 or --tn-bg2, so the wash is a near-neutral step
-    // off a surface the colour was chosen for. The chip is the one that labels
-    // a FILLED variant surface, so a <code> span in a chip label swaps the
-    // background out from under a colour paired with --tn-primary or
-    // --tn-accent — in TN Dark that is #1E1E1E on #282828, 1.13:1.
+    // off a surface the colour was chosen for. A chip label sits on a FILLED
+    // variant surface, so a <code> span in one swaps the background out from
+    // under a colour paired with --tn-primary or --tn-accent — in TN Dark that
+    // is #1E1E1E on #282828, 1.13:1.
     //
     // So <code> keeps the chip's own surface, which is the one every pair
     // above measures, and the monospace font and the border do the
     // distinguishing instead. currentColor for the border because --tn-lines
     // is a colour for the page, and on a filled chip it can vanish.
+    //
+    // The chip is not the only filled label in the library — .button-primary
+    // and .button-warn include the same mixin over their own fills, and have
+    // the same problem. Fixing them is not this ticket; #238 is the chip, and
+    // the mixin is right where it is used on the page's own surfaces. Filed as
+    // a proposed ticket on #238.
     ::ng-deep code {
       background: transparent;
       border-color: currentColor;

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -47,13 +47,13 @@
     border-color: var(--tn-primary);
 
     // No hover background. It used to swap to --tn-blue, which is a raw hue
-    // token rather than a themed surface and so has no companion foreground:
-    // the label stayed --tn-primary-txt and measured 3.14:1 in Nord and 3.68:1
-    // in Solarized Dark. The swap was also a no-op in five of the nine
-    // palettes, where --tn-primary already resolves to --tn-blue, which is how
-    // it survived — it did nothing at all in the themes anyone looked at.
-    // .button-primary, the filled button, likewise changes no colour on hover;
-    // the lift and shadow on .tn-chip:hover above are the affordance.
+    // token rather than a themed surface and so has no companion foreground.
+    // In seven of the nine palettes --tn-primary already resolves to the same
+    // colour as --tn-blue, so the swap did nothing at all — which is how it
+    // survived. The two where it did anything are the two it broke: Nord, at
+    // 3.14:1, and Solarized Dark, at 3.68:1. .button-primary, the filled
+    // button, likewise changes no colour on hover; the lift and shadow on
+    // .tn-chip:hover above are the affordance every variant shares.
   }
 
   &--secondary {
@@ -77,7 +77,7 @@
       // --tn-alt-bg2, not --tn-accent, is what this paints, so the label takes
       // that surface's companion — the same pair --secondary:hover uses.
       // Keeping --tn-accent-txt here would carry a colour tuned for the accent
-      // fill onto a grey one, which is 1.45:1 in Solarized Dark.
+      // fill onto a grey one, which is 1.93:1 in Solarized Dark.
       color: var(--tn-alt-fg2);
       border-color: var(--tn-alt-bg2);
     }
@@ -148,7 +148,7 @@
     // off a surface the colour was chosen for. The chip is the one that labels
     // a FILLED variant surface, so a <code> span in a chip label swaps the
     // background out from under a colour paired with --tn-primary or
-    // --tn-accent — in TN Dark that is #1E1E1E on #282828, 1.00:1.
+    // --tn-accent — in TN Dark that is #1E1E1E on #282828, 1.13:1.
     //
     // So <code> keeps the chip's own surface, which is the one every pair
     // above measures, and the monospace font and the border do the

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -33,15 +33,27 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
+  // Every variant below pairs its `color` with the token it paints as
+  // `background-color`, in the resting state and on hover alike. That pairing
+  // is the whole of #238: the label used to be chosen independently of the
+  // surface, so a theme was free to move one and not the other, and TN Dark
+  // did — --tn-accent resolves to yellow there while the label stayed --tn-fg1,
+  // at 1.20:1. chip-contrast.spec.ts measures each pair below in all nine
+  // palettes and is the reason a new surface here cannot repeat it.
+
   &--primary {
     background-color: var(--tn-primary);
     color: var(--tn-primary-txt);
     border-color: var(--tn-primary);
 
-    &:hover:not(.tn-chip--disabled) {
-      background-color: var(--tn-blue);
-      border-color: var(--tn-blue);
-    }
+    // No hover background. It used to swap to --tn-blue, which is a raw hue
+    // token rather than a themed surface and so has no companion foreground:
+    // the label stayed --tn-primary-txt and measured 3.14:1 in Nord and 3.68:1
+    // in Solarized Dark. The swap was also a no-op in five of the nine
+    // palettes, where --tn-primary already resolves to --tn-blue, which is how
+    // it survived — it did nothing at all in the themes anyone looked at.
+    // .button-primary, the filled button, likewise changes no colour on hover;
+    // the lift and shadow on .tn-chip:hover above are the affordance.
   }
 
   &--secondary {
@@ -57,11 +69,16 @@
 
   &--accent {
     background-color: var(--tn-accent);
-    color: var(--tn-fg1);
+    color: var(--tn-accent-txt);
     border-color: var(--tn-accent);
 
     &:hover:not(.tn-chip--disabled) {
       background-color: var(--tn-alt-bg2);
+      // --tn-alt-bg2, not --tn-accent, is what this paints, so the label takes
+      // that surface's companion — the same pair --secondary:hover uses.
+      // Keeping --tn-accent-txt here would carry a colour tuned for the accent
+      // fill onto a grey one, which is 1.45:1 in Solarized Dark.
+      color: var(--tn-alt-fg2);
       border-color: var(--tn-alt-bg2);
     }
   }

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -127,6 +127,7 @@ Each theme defines the following CSS custom properties:
 - `--tn-primary`: Primary brand color
 - `--tn-primary-txt`: Text color for primary backgrounds
 - `--tn-accent`: Accent color for highlights
+- `--tn-accent-txt`: Text color for accent backgrounds
 - `--tn-topbar`: Top navigation bar background
 - `--tn-topbar-txt`: Top navigation bar text
 

--- a/projects/truenas-ui/src/stories/color-palette.stories.ts
+++ b/projects/truenas-ui/src/stories/color-palette.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj;
 
 const fgVars = ['--tn-fg1', '--tn-fg2', '--tn-fg3', '--tn-fg4', '--tn-alt-fg1', '--tn-alt-fg2'];
 const bgVars = ['--tn-bg1', '--tn-bg2', '--tn-bg3', '--tn-alt-bg1', '--tn-alt-bg2'];
-const uiVars = ['--tn-primary', '--tn-primary-txt', '--tn-accent', '--tn-topbar', '--tn-topbar-txt', '--tn-lines'];
+const uiVars = ['--tn-primary', '--tn-primary-txt', '--tn-accent', '--tn-accent-txt', '--tn-topbar', '--tn-topbar-txt', '--tn-lines'];
 const statusVars = ['--tn-red', '--tn-green', '--tn-yellow', '--tn-orange', '--tn-blue', '--tn-cyan', '--tn-magenta', '--tn-violet'];
 const statusTextVars = ['--tn-error-text'];
 

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -280,11 +280,12 @@
   --tn-topbar-txt: #eceff4;
   --tn-accent: #5e81aC;
   /* Black, where every other theme uses one of its own surfaces. Nord's accent
-     sits mid-luminance and its whole Polar Night range is too light to clear
-     AA on it — the darkest, #2e3440, measures 3.10:1, and the lightest Snow
-     Storm 4.03:1. Nothing in the palette works, so the text is black. Retuning
-     --tn-accent itself would have been the alternative, and it is a border and
-     fill colour elsewhere. */
+     sits mid-luminance and the palette runs out at both ends before clearing
+     AA on it: the darkest Polar Night, #2e3440, measures 3.10:1, and the
+     lightest Snow Storm, #eceff4, 3.50:1. Nothing in the palette works, so the
+     text is black — 4.03:1 for pure white is still short. Retuning --tn-accent
+     itself would have been the alternative, and it is a border and fill colour
+     elsewhere. */
   --tn-accent-txt: #000000; /* 5.21:1 on --tn-accent */
   --tn-bg1: #2e3440;
   --tn-bg2: #3b4252;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -20,6 +20,16 @@
   --tn-topbar: #111111;
   --tn-topbar-txt: rgba(255,255,255,0.85);
   --tn-accent: #545454;
+  /* TEXT DRAWN ON A --tn-accent FILL — the companion --tn-accent never had, and
+     the same arrangement as --tn-primary / --tn-primary-txt above.
+
+     --tn-accent is a fill colour and nothing constrains its luminance: it is
+     #545454 here and #DED142 in TN Dark. A foreground picked once for both
+     cannot work, and tn-chip's accent label picked --tn-fg1, which measured
+     1.20:1 on the yellow and failed in six of the nine palettes (#238). Every
+     theme declares its own, chosen from that theme's own darkest or lightest
+     surface where one clears 4.5:1, and the measured ratio is on each. */
+  --tn-accent-txt: #ffffff; /* 7.57:1 on --tn-accent */
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
   --tn-bg3: #333333;
@@ -107,12 +117,16 @@
    ================================ */
 .tn-dark {
   --tn-primary: var(--tn-blue);
+  --tn-primary-txt: #ffffff; /* 4.58:1 on --tn-primary */
   /* >=4.5:1 against both --tn-bg1 (5.22:1) and --tn-bg2 (4.62:1); --tn-primary
      itself is only 3.64:1 on --tn-bg1 — see the note in :root. */
   --tn-primary-text: #0099db;
   --tn-topbar: #111111;
   --tn-topbar-txt: rgba(255,255,255,0.85);
   --tn-accent: var(--tn-yellow);
+  /* The yellow this resolves to is the brightest accent of the nine, so the
+     text on it is this theme's own --tn-bg1 rather than a light shade. */
+  --tn-accent-txt: #1E1E1E; /* 10.56:1 on --tn-accent */
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
   --tn-bg3: #333333;
@@ -164,6 +178,7 @@
   --tn-primary-text: #0074a7;
   --tn-topbar: #007db3;
   --tn-accent: #DED142;
+  --tn-accent-txt: #282a36; /* 9.02:1 on --tn-accent */
   --tn-bg1: #f2f2f2;
   --tn-bg2: #ffffff;
   --tn-bg3: #e8e8e8;
@@ -213,6 +228,7 @@
   --tn-topbar: #6272a4;
   --tn-topbar-txt: #efefef;
   --tn-accent: #bd93f9;
+  --tn-accent-txt: #282a36; /* 5.90:1 on --tn-accent */
   --tn-bg1: #181a26;
   --tn-bg2: #282a36;
   --tn-bg3: #343746;
@@ -263,6 +279,13 @@
   --tn-topbar: #4c566a;
   --tn-topbar-txt: #eceff4;
   --tn-accent: #5e81aC;
+  /* Black, where every other theme uses one of its own surfaces. Nord's accent
+     sits mid-luminance and its whole Polar Night range is too light to clear
+     AA on it — the darkest, #2e3440, measures 3.10:1, and the lightest Snow
+     Storm 4.03:1. Nothing in the palette works, so the text is black. Retuning
+     --tn-accent itself would have been the alternative, and it is a border and
+     fill colour elsewhere. */
+  --tn-accent-txt: #000000; /* 5.21:1 on --tn-accent */
   --tn-bg1: #2e3440;
   --tn-bg2: #3b4252;
   --tn-bg3: #454d5e;
@@ -312,6 +335,7 @@
   --tn-primary-text: var(--tn-primary);
   --tn-topbar: #0D5687;
   --tn-accent: #f0cb00;
+  --tn-accent-txt: #282a36; /* 8.98:1 on --tn-accent */
   --tn-bg1: #F2F2F2;
   --tn-bg2: #FAFAFA;
   --tn-bg3: #e8e8e8;
@@ -364,6 +388,7 @@
   --tn-topbar: var(--tn-fg1);
   --tn-topbar-txt: #cdcdcd;
   --tn-accent: var(--tn-cyan);
+  --tn-accent-txt: #002b36; /* 4.75:1 on --tn-accent */
   --tn-bg1: #002b36;
   --tn-bg2: #073642;
   --tn-bg3: #0a4050;
@@ -374,7 +399,10 @@
   --tn-alt-bg1: #0e4853;
   --tn-alt-bg2: #155a68;
   --tn-alt-fg1: #839496;
-  --tn-alt-fg2: #282a36;
+  /* Was #282a36 — near-black, copied from a light theme, and painted on this
+     theme's own --tn-alt-bg1 (1.40:1) and --tn-alt-bg2 (1.83:1), the only two
+     surfaces this token is ever drawn on. Solarized's base2 instead (#238). */
+  --tn-alt-fg2: #eee8d5; /* 8.28:1 on --tn-alt-bg1, 6.36:1 on --tn-alt-bg2 */
   --tn-lines: #586e75;
   --tn-yellow: #b58900;
   --tn-orange: #cb4b16;
@@ -414,6 +442,7 @@
   --tn-topbar: var(--tn-blue);
   --tn-topbar-txt: var(--tn-fg2);
   --tn-accent: var(--tn-violet);
+  --tn-accent-txt: #212a35; /* 4.92:1 on --tn-accent */
   --tn-bg1: #212a35;
   --tn-bg2: #303d48;
   --tn-bg3: #3d4a55;
@@ -456,12 +485,18 @@
    ================================ */
 .tn-high-contrast {
   --tn-primary: var(--tn-blue); /* WCAG fix try another shade of blue #007db3 or black #000000 */
+  /* Black, where the other eight themes put white or near-white on their
+     --tn-primary fill. This theme's --tn-blue is light enough that white
+     measures 4.07:1 on it — it was inheriting :root's #ffffff, having never
+     declared its own, and that is the value that failed (#238). */
+  --tn-primary-txt: #000000; /* 5.16:1 on --tn-primary */
   /* >=4.5:1 against both --tn-bg1 (4.61:1) and --tn-bg2 (6.27:1); --tn-primary
      itself is only 2.99:1 on --tn-bg1 — which, in the accessibility theme, is
      the one worth noticing. Darkened, this being a light theme. */
   --tn-primary-text: #366584;
   --tn-topbar: var(--tn-black);
   --tn-accent: var(--tn-magenta);
+  --tn-accent-txt: #000000; /* 5.75:1 on --tn-accent */
   --tn-bg1: #dddddd;
   --tn-bg2: #ffffff;
   --tn-bg3: #d0d0d0;

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -27,8 +27,10 @@
      #545454 here and #DED142 in TN Dark. A foreground picked once for both
      cannot work, and tn-chip's accent label picked --tn-fg1, which measured
      1.20:1 on the yellow and failed in six of the nine palettes (#238). Every
-     theme declares its own, chosen from that theme's own darkest or lightest
-     surface where one clears 4.5:1, and the measured ratio is on each. */
+     theme declares its own, preferring a colour already in that theme — its
+     own --tn-bg1, or the near-black its light surfaces use — and falling back
+     to plain white or black where the accent's luminance leaves the palette no
+     value that clears 4.5:1. The measured ratio is on each. */
   --tn-accent-txt: #ffffff; /* 7.57:1 on --tn-accent */
   --tn-bg1: #1E1E1E;
   --tn-bg2: #282828;
@@ -486,10 +488,11 @@
    ================================ */
 .tn-high-contrast {
   --tn-primary: var(--tn-blue); /* WCAG fix try another shade of blue #007db3 or black #000000 */
-  /* Black, where the other eight themes put white or near-white on their
-     --tn-primary fill. This theme's --tn-blue is light enough that white
-     measures 4.07:1 on it — it was inheriting :root's #ffffff, having never
-     declared its own, and that is the value that failed (#238). */
+  /* Black. Six of the other eight themes put white on their --tn-primary fill
+     and Nord puts #333333 on its pale one; this theme's --tn-blue is light
+     enough that white measures only 4.07:1. It was inheriting :root's #ffffff,
+     having never declared a --tn-primary-txt of its own, and that is the value
+     that failed (#238). */
   --tn-primary-txt: #000000; /* 5.16:1 on --tn-primary */
   /* >=4.5:1 against both --tn-bg1 (4.61:1) and --tn-bg2 (6.27:1); --tn-primary
      itself is only 2.99:1 on --tn-bg1 — which, in the accessibility theme, is


### PR DESCRIPTION
Fixes #238.

## The defect, reproduced before anything changed

Measured against unmodified `main` with `themePalettes` from `lib/a11y/contrast-testing.ts`, the ticket's table reproduces exactly — accent fails in six of the nine palettes, bottoming out at 1.20:1 in TN Dark, with secondary at 1.40:1 in Solarized Dark and primary at 4.07:1 in High Contrast.

The cause is one line of reasoning, not three bugs: **the chip chose its `color` independently of its `background-color`**, so a theme was free to move one and not the other. TN Dark moved `--tn-accent` to `--tn-yellow` and left the label on `--tn-fg1`.

## Each surface now carries its own foreground

- **`--tn-accent-txt`**, the companion `--tn-accent` never had, declared by all nine palettes with its measured ratio beside it — the arrangement `--tn-primary` / `--tn-primary-txt` already has. Values come from the theme where the theme has one that clears AA: `--tn-bg1` in TN Dark, the near-black the light themes use for text, Solarized's own base03. **Nord and High Contrast take plain black**, because their accents sit mid-luminance and the palette runs out at both ends — Nord's darkest Polar Night is 3.10:1 on it and its lightest Snow Storm 3.50:1.
- **`.tn-high-contrast` declares its own `--tn-primary-txt`.** It had none and was inheriting `:root`'s white onto its own lighter blue. `.tn-dark` also declares one now; its value was already right, and a palette that inherits is a palette that can be surprised.
- **`.tn-solarized-dark`'s `--tn-alt-fg2` was `#282a36`** — a near-black copied from a light theme, painted on that theme's own dark alt surfaces at 1.40:1 and 1.83:1. Now Solarized's base2. The token is read in three places and all three paint it on `--tn-alt-bg1` or `--tn-alt-bg2`, so nothing outside the chip regresses.

## Two hover states were the same defect

The ticket's table measures resting states. The hover rules paint different surfaces with the same labels, and one of them would have been made worse by the change above.

- **`--accent:hover` paints `--tn-alt-bg2`, so its label now takes that surface's companion** rather than carrying `--tn-accent-txt` onto grey, which is 1.93:1 in Solarized Dark. It is the pair `--secondary:hover` already uses.
- **`--primary:hover` no longer swaps its background to `--tn-blue`.** That is a raw hue token rather than a themed surface, and so has no text companion: the label stayed `--tn-primary-txt` and measured 3.14:1 in Nord and 3.68:1 in Solarized Dark. In **seven of the nine palettes `--tn-primary` already resolves to the same colour as `--tn-blue`**, so the swap did nothing at all — which is how it survived; the two palettes where it did anything are the two it broke. `.button-primary`, the filled button, likewise changes no colour on hover, and the lift and shadow on `.tn-chip:hover` are the affordance every variant shares.

**This is the one place the change alters appearance where nothing was broken.** In Nord, Paper, Dracula and Solarized Dark a primary chip no longer changes hue under the cursor. If that hover is wanted back, it needs a themed surface with a companion foreground rather than a hue token, which is a palette decision rather than a chip one.

## A `<code>` span in a chip label

Found by the review, and a regression this change would otherwise have introduced. `label-markup.inline-code` paints `<code>` on `--tn-bg2` and leaves the colour inherited. For most of the ten components that include it that is fine — their labels already sit on `--tn-bg1` or `--tn-bg2`. A chip label sits on a filled variant surface, so a code span swaps the background out from under a colour paired with `--tn-accent`: in TN Dark that is `#1E1E1E` on `#282828`, 1.13:1.

`<code>` in a chip label now keeps the chip's own surface — the one every pair here measures — with the monospace font and a `currentColor` border doing the distinguishing.

## The spec, and what makes it more than a list

`chip-contrast.spec.ts` measures all **45** label/background pairs, five surfaces across nine palettes, through `lib/a11y/contrast-testing.ts` (#197). Nothing about the maths is re-derived. It also asserts three things a plain measurement does not:

- **Every palette declares both halves of every pair itself.** `declares`, not `color` — a theme that omits a token still renders by inheriting `:root`'s, which is exactly how High Contrast came to paint white on its own blue.
- **The table still describes the stylesheet.** The spec brace-walks `chip.component.scss` and compares **pairings, with their counts**, in both directions. Pairings because both `--tn-alt-fg2` and `--tn-accent` are already in the table and putting them together is 2.58:1 in Solarized Dark; counts because `--secondary:hover` and `--accent:hover` paint the same pair, so a set would let one cover for the other. A hover rule's colour is taken from the rule it nests in, which is the same element.
- **Nothing between the wrapper and the label sets a colour of its own.** Everything above reads the colour off the rule that paints the *background* and walks outward, which is right for a variant and blind to a descendant: `.tn-chip__body` and `.tn-chip__label` paint no background, so a `color:` on either would repaint every label in every palette with every pair still matching.

## Testing

Run locally and green: `yarn lint`, `yarn test` (3177 passing), `yarn test:scripts`, `yarn build`, `yarn build-storybook`. `yarn lint` also reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here — that is #251.

**`yarn test-sb` could not be run here.** The Storybook Interaction Tests check drives a real browser and this host has neither one nor the system libraries to supply it, so the ticket's fourth criterion — the 2 failing Chip stories passing with `a11y: { test: 'error' }` — is the one I cannot demonstrate. The jsdom measurement above stands in for it, and is a claim about the palette rather than about a rendered page. Note also that `a11y: { test: 'error' }` is **not** set in `.storybook/preview.ts` on `main`, so nothing enforces it today; turning it on is out of scope here, since the other open accessibility tickets would fail it immediately. **And see the close button below** — it is a plausible reason that criterion still would not be met, and it is not this ticket's defect.

The stories themselves need no change: the fix is in the tokens and the stylesheet the stories compose.

**Five rounds of local review; the fourth returned nothing at or above MEDIUM.** Two of the five ran the project's own reviewer, which found the `<code>` regression and the two drift-guard gaps. The shared reviewer then became unavailable — one 420s timeout and three consecutive `API Error` responses — so rounds three and four were the same rubric applied by a subagent from the brief `local-review.py` writes for exactly that case. **A clean round from the brief is weaker evidence than a clean run of the check**, and it is what this one is.

## Not changed, and why

LOW findings recorded rather than fixed, since every fix is a new diff and a new diff is unreviewed. Two are worth their own ticket and are proposed on #238:

- **The close button's × fails AA on eight of the 27 variant/palette combinations, and always has.** `.tn-chip__close` paints `rgba(255,255,255,0.2)` over the chip's own background and the glyph inherits the label colour, so the wash lightens the surface out from under it: 3.31:1 for a primary chip in five palettes, 3.68:1 for secondary in Nord, 3.24:1 in Dracula. Every one of them clears the 3:1 non-text minimum and none clears 4.5:1, and axe reads a visible `×` as text. This change **improves** two of them and breaks none. It is the close button rather than the label, the ticket is scoped to the label, and the fix is a design decision about that circle — so it is proposed, with the measurements, rather than folded in.
- **`.button-primary` and `.button-warn` have the `<code>` problem the chip just fixed.** They include the same mixin over their own fills. Same shape, different component, out of scope here.
- **`.high-contrast .tn-chip` matches nothing.** The registered class is `tn-high-contrast`, so that block's 2px border and 3px focus ring have never applied. Pre-existing, untouched, and not a contrast defect.
- **`.tn-icon__text` at 3.03:1 inside a primary chip**, which the ticket itself records as lower priority. It is `aria-hidden`, and it is the icon component rather than the chip.
- **The spec is chip-local**, where `primary-text-contrast.spec.ts` sweeps the whole library for call sites of its token. `--tn-accent-txt` has exactly one consumer today and `--tn-accent` as a text background has exactly one call site, so there is nothing yet for a library-wide sweep to find; when a second component paints on the accent, that sweep is the thing to add.
- **The SCSS parser reads only `chip.component.scss`.** A colour arriving from a mixin in another file is invisible to it — which is how the `<code>` wash got in. The one such mixin the chip includes now has an explicit assertion of its own; a second would need the same.

Separately, and outside this ticket: **the committed `.storybook/public/themes.css` is behind `src/styles/themes.css`**, which `yarn copy-themes` regenerates on every Storybook build. Noticed because building Storybook dirties the working tree; reverted rather than committed, since the drift is nobody's change here. Already noted on #237.

## Correction to the commit log

The first commit's message says the removed primary hover swap was a no-op in **five** of the nine palettes. It is seven — the count was corrected in a later round and in every comment in the tree, but a landed commit message cannot be. The figure in this description and in `chip.component.scss` is the right one.
