### PR TITLE
NAS-142492 / 27.0.0-BETA.1 / fix(disk-icon): drop the stray html wrapper from the template

### DIFF
--- a/projects/truenas-ui/src/lib/disk-icon/disk-icon.component.html
+++ b/projects/truenas-ui/src/lib/disk-icon/disk-icon.component.html
@@ -1,4 +1,3 @@
-<html>
 <svg id="disk-icon-large" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="72" height="80" viewBox="0 0 72 80">
   <defs>
     <clipPath id="clip-path">
@@ -42,4 +41,3 @@
     </g>
   </g>
 </svg>
-</html>

--- a/projects/truenas-ui/src/lib/disk-icon/disk-icon.component.spec.ts
+++ b/projects/truenas-ui/src/lib/disk-icon/disk-icon.component.spec.ts
@@ -1,0 +1,183 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { DiskIconComponent } from './disk-icon.component';
+import { axeScan } from '../a11y/axe-testing';
+import { DiskType } from '../enums/disk-type.enum';
+
+/**
+ * `disk-icon.component.html` was wrapped in a literal `<html>` element, left
+ * over from whatever exported the SVG (#239).
+ *
+ * Angular does not parse a template the way a browser parses a document: the
+ * compiler creates whatever element the tag names, so `<html>` becomes a real
+ * `<html>` node inside `<tn-disk-icon>` rather than being discarded as a
+ * duplicate document root. axe then evaluates that node AS a document root, so
+ * two document-level rules — `html-has-lang` and `landmark-one-main` — fire
+ * against a disk icon.
+ *
+ * The guards below are in the order the ticket's criteria are: the wrapper is
+ * gone, the icon still renders what it rendered, and no other template in the
+ * library carries the same leftover.
+ */
+
+const LIB_DIR = join(__dirname, '..');
+
+/**
+ * An opening or closing document-structure tag.
+ *
+ * The `(?=[\s/>])` lookahead is load-bearing: without it this matches the
+ * `<head` in `<header>`, which several templates in this library legitimately
+ * use.
+ */
+const DOCUMENT_TAG = /<\/?(?:html|head|body)(?=[\s/>])/i;
+
+/**
+ * A component's inline `template:`, for the handful that have one instead of a
+ * `.html` file.
+ *
+ * Three shipped components use an inline template today and all three are one
+ * line, so a regex is enough. It is deliberately non-greedy and quote-matched
+ * rather than a parser — and the sweep below asserts it found some, because a
+ * regex that silently stops matching would leave those three unscanned while
+ * every case still passed.
+ */
+const INLINE_TEMPLATE = /template:\s*(['"`])([\s\S]*?)\1/g;
+
+/**
+ * Files under `lib/`, by extension, excluding specs.
+ *
+ * Specs are excluded because their test hosts declare inline templates by the
+ * dozen — scanning them turns one guard into two hundred cases naming the same
+ * few files, and a test host is not markup this library ships.
+ */
+function libFiles(extension: string): string[] {
+  return readdirSync(LIB_DIR, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith(extension) && !entry.endsWith(`.spec${extension}`))
+    .sort();
+}
+
+describe('DiskIconComponent', () => {
+  let fixture: ComponentFixture<DiskIconComponent>;
+
+  async function render(type: DiskType, size = '16 TB', name = 'Disk 1'): Promise<HTMLElement> {
+    fixture = TestBed.createComponent(DiskIconComponent);
+    fixture.componentRef.setInput('size', size);
+    fixture.componentRef.setInput('type', type);
+    fixture.componentRef.setInput('name', name);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [DiskIconComponent] }).compileComponents();
+  });
+
+  describe('the template renders no document structure', () => {
+    it.each(Object.values(DiskType))('renders the <svg> as the host\'s only child, for %s', async (type) => {
+      const host = await render(type);
+
+      expect(Array.from(host.children).map((child) => child.tagName.toLowerCase())).toEqual(['svg']);
+    });
+
+    it.each(Object.values(DiskType))('renders no html, head or body element, for %s', async (type) => {
+      const host = await render(type);
+
+      // By tag name rather than by markup: this is the assertion the defect
+      // fails, and `querySelectorAll` finds the node wherever in the subtree it
+      // ends up rather than only at the root the leftover happened to sit at.
+      expect(Array.from(host.querySelectorAll('html, head, body')).map((el) => el.tagName.toLowerCase()))
+        .toEqual([]);
+    });
+
+    it.each(Object.values(DiskType))('reports no axe violation, for %s', async (type) => {
+      const host = await render(type);
+
+      const { violations, incomplete, passed } = await axeScan(host);
+
+      // Both buckets: axe puts a finding it cannot decide in `incomplete`, so a
+      // probe reading only `violations` reports a defect as clean.
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      // And proof the scan looked at something — an empty `violations` from a
+      // tree no rule matched is not a clean bill of health.
+      expect(passed.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('the icon itself is unchanged', () => {
+    it.each(Object.values(DiskType))('keeps the SVG root and its viewBox, for %s', async (type) => {
+      const host = await render(type);
+      const svg = host.querySelector('svg');
+
+      expect(svg?.id).toBe('disk-icon-large');
+      expect(svg?.getAttribute('viewBox')).toBe('0 0 72 80');
+      expect(svg?.getAttribute('width')).toBe('72');
+      expect(svg?.getAttribute('height')).toBe('80');
+      expect(svg?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    });
+
+    it('draws the hard disk glyph for HDD and not the SSD one', async () => {
+      const host = await render(DiskType.Hdd);
+
+      expect(host.querySelector('#harddisk')).not.toBeNull();
+      expect(host.querySelector('#ssd')).toBeNull();
+    });
+
+    it('draws the SSD glyph for SSD and not the hard disk one', async () => {
+      const host = await render(DiskType.Ssd);
+
+      expect(host.querySelector('#ssd')).not.toBeNull();
+      expect(host.querySelector('#harddisk')).toBeNull();
+    });
+
+    it.each(Object.values(DiskType))('labels the icon with its size and name, for %s', async (type) => {
+      const host = await render(type, '4 TiB', 'Disk 7');
+
+      expect(host.querySelector('#disk-size')?.textContent?.trim()).toBe('4 TiB');
+      expect(host.querySelector('#disk-identifier')?.textContent?.trim()).toBe('Disk 7');
+    });
+
+    it('re-renders the labels when the inputs change', async () => {
+      const host = await render(DiskType.Hdd, '1 TB', 'Disk 1');
+
+      fixture.componentRef.setInput('size', '18 TB');
+      fixture.componentRef.setInput('name', 'Disk 12');
+      fixture.detectChanges();
+
+      expect(host.querySelector('#disk-size')?.textContent?.trim()).toBe('18 TB');
+      expect(host.querySelector('#disk-identifier')?.textContent?.trim()).toBe('Disk 12');
+    });
+  });
+
+  /**
+   * The ticket's fourth criterion, as a guard rather than as a one-off grep: the
+   * leftover is the kind of thing that arrives again with the next exported SVG,
+   * and nothing else in the toolchain objects to it. eslint's Angular template
+   * rules do not, and neither does the compiler — an unknown element in a
+   * template is a warning at most, and `<html>` is not even unknown.
+   */
+  describe('no template in the library carries a document-structure tag', () => {
+    const templates = libFiles('.html').map((file) => ({
+      file,
+      html: readFileSync(join(LIB_DIR, file), 'utf8'),
+    }));
+
+    const inline = libFiles('.ts')
+      .flatMap((file) => Array.from(readFileSync(join(LIB_DIR, file), 'utf8').matchAll(INLINE_TEMPLATE))
+        .map((match) => ({ file, html: match[2] })));
+
+    it('there are templates to scan', () => {
+      // Guards the sweep itself: a moved lib directory or a renamed extension
+      // would otherwise leave every case below vacuously green.
+      expect(templates.length).toBeGreaterThan(0);
+      expect(inline.length).toBeGreaterThan(0);
+    });
+
+    it.each([...templates, ...inline])('$file', ({ html }) => {
+      expect(html).not.toMatch(DOCUMENT_TAG);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #239.

## The defect, reproduced before anything changed

The report is exact, and the template says so on its first and last lines: `disk-icon.component.html` opened with `<html>` and closed with `</html>`, wrapping the whole SVG.

**Angular does not parse a template the way a browser parses a document.** A browser discards a second `<html>` start tag as a duplicate document root; the Angular compiler creates whatever element the tag names, so this became a real `<html>` node inside `<tn-disk-icon>`. axe then evaluates it *as* a document root.

Measured on the unmodified template, through `axeScan` from `lib/a11y/axe-testing.ts`, under jsdom:

| rule | impact | node |
|---|---|---|
| `html-has-lang` — "`<html>` element must have a lang attribute" | serious | `#root0 > html` |
| `document-title` — "Documents must have `<title>` element to aid in navigation" | serious | `#root0 > html` |

`html-has-lang` is the ticket's own finding. `document-title` is a third document-level rule the report does not name; `landmark-one-main` is the report's second and does not fire under jsdom, which has no page for it to be the only main *of*. Two document-level rules firing on a disk icon is the same defect the report describes, observed here rather than read about.

## The fix

The wrapper is removed and nothing replaces it — the `<svg>` is a valid template root on its own. That is the whole change to shipped code: two deleted lines.

## The spec

`disk-icon.component.spec.ts` is new; the component had none. It guards the ticket's four criteria in their own order.

- **The wrapper is gone.** The host's only element child is the `<svg>`, and `querySelectorAll('html, head, body')` under the host is empty — by tag name rather than by markup, so the node is found wherever in the subtree a future leftover lands. Then the same `axeScan` that measured the defect, asserting `violations` **and** `incomplete` are empty, because axe puts a finding it cannot decide in the second bucket and a probe reading only the first reports a defect as clean.
- **The icon renders unchanged.** For both `DiskType`s: the SVG root keeps its id, `viewBox`, width, height and namespace; `#harddisk` draws for HDD and not SSD and `#ssd` the other way round; `#disk-size` and `#disk-identifier` carry the `size()` and `name()` they were given, and re-render when those inputs change.
- **No other template carries the same leftover.** A sweep over all 69 `.html` templates under `lib/`, plus the three inline `template:` strings, asserting none matches an opening or closing `html`/`head`/`body` tag. The `(?=[\s/>])` lookahead in that pattern is load-bearing: without it, `<head` matches the `<header>` several of those templates use.

The sweep is a guard rather than a one-off grep because nothing else in the toolchain objects to this. eslint's Angular template rules do not, and `<html>` is not an unknown element to the compiler — so the next exported SVG can arrive with the same wrapper and nothing will say so.

## Testing

Run locally and green: `yarn lint`, `yarn test` (3263 passing, 128 suites), `yarn test:scripts` (42 passing), `yarn build`, `yarn build-storybook`.

`yarn lint` also reports 4 pre-existing `import/order` errors in `input.component.ts` and `menu-panel.component.ts`, neither touched here — that is #251.

**`yarn test-sb` could not be run here.** The Storybook Interaction Tests check drives a real browser and this host has neither one nor the system libraries to supply it, so the ticket's third criterion — `Components/Disk Icon > DiskIcon` passing with `a11y: { test: 'error' }` — is the one I cannot demonstrate directly. The jsdom measurement above stands in for it: it is the same axe engine on the same rendered tree, minus a layout engine, and the two rules it reports are attributed to the node the fix removes. Note also that `a11y: { test: 'error' }` is **not** set in `.storybook/preview.ts` on `main`, so nothing enforces it today.

The story itself needs no change — nothing in it referenced the wrapper.

**One round of local review, and it returned nothing at or above MEDIUM.** That round ran the project's own reviewer — same rubric, same threshold, same parser as the required check — in a separate process, so this is the check's verdict rather than a substitute for it.

Separately: building Storybook dirties `projects/truenas-ui/.storybook/public/themes.css`, which `yarn copy-themes` regenerates from `src/styles/themes.css`. Reverted rather than committed; the drift is nobody's change here and is already noted on #237.

## Not changed, and why

Five LOW findings, recorded rather than fixed — every fix is a new diff, a new diff is unreviewed, and reviewing it starts another round. All five are on the spec; none is on the shipped change. My read on each:

- **The library-wide sweep lives in one component's spec**, so deleting or moving `disk-icon` silently drops the guard, and an unrelated template's failure reports as `DiskIconComponent`. Fair, and the fix is a home for it — a `lib/template-hygiene.spec.ts` or similar — which is a decision about where this library puts cross-cutting guards rather than part of this ticket.
- **`LIB_DIR` roots the sweep at `src/lib`**, leaving the 17 `.html` templates under `src/stories` unscanned while the `describe` says "in the library". The narrowness is real. **The ticket's fourth criterion is met regardless, and was checked independently of the spec**: a `git grep` for `</?(html|head|body)\b` across every `.html` in the repository matched `disk-icon.component.html` and nothing else. Widening the sweep is a change to executable code and belongs in a round of its own.
- **`INLINE_TEMPLATE` matches the text `template:` anywhere**, so a doc comment containing it followed by a backtick would capture prose; and `inline.length > 0` would pass having found one of the three known inline templates rather than all three. Both true. The comment above it claims only that the guard proves the regex found *some* — pinning the count to 3 would be the stronger assertion.
- **`expect(passed.length).toBeGreaterThan(0)` on a decorative SVG** couples the spec to axe incidentally matching a rule here; `axe-testing.ts` itself says a presentational tree can legitimately yield an empty `passed`. It is non-empty today, so the assertion is doing its job of proving the scan looked at something; it is a fair observation that this component is close to the case where it would not.
- **The assertions pin hardcoded global SVG ids** (`clip-path`, `BG_Fill`, `harddisk`), which cements a pre-existing collision: two `<tn-disk-icon>` on one page both define `#clip-path`, and `url(#clip-path)` resolves to the first. That is a real defect in the component and it predates this change — the ids are in the exported SVG, not added here. Worth its own ticket; not proposed as one from this cycle, since a fix means rewriting every id in the template and rechecking the render, which is more than a footnote.
