### PR TITLE
NAS-142494 / 27.0.0-BETA.1 / fix(table): name a blank header and move the row's expanded state to a control

### DIFF
--- a/projects/truenas-ui/src/lib/table-column/table-column.directive.ts
+++ b/projects/truenas-ui/src/lib/table-column/table-column.directive.ts
@@ -36,6 +36,27 @@ export class TnTableColumnDirective {
   label = input<string | undefined>(undefined);
 
   /**
+   * Renders the header label for screen readers only, leaving the header cell
+   * visually blank. For a column whose purpose is obvious from its contents and
+   * whose heading would only add noise — a row-actions or icon column.
+   *
+   * A blank header is not the same thing as an unlabelled one: `<th>` with no
+   * text at all fails axe's `empty-table-header`, and a screen-reader user
+   * moving across the header row hears nothing where a column exists (#246). So
+   * the label is still rendered, inside the table's own `.cdk-visually-hidden`
+   * — the same treatment the built-in `__expand` and row-actions headers get.
+   *
+   * The text is `label`, falling back to the column `name`. A `tnHeaderCellDef`
+   * template is NOT rendered when this is set: the point is that nothing shows,
+   * and the class that hides it is scoped to the table's own view, so a
+   * consumer's projected markup could not use it anyway.
+   *
+   * Header-only. Card mode has no header row; use `cardHidden` to keep a column
+   * off the card.
+   */
+  hideLabel = input<boolean>(false);
+
+  /**
    * Relative importance of this column in card mode (see `mobileLayout` on
    * `tn-table`). Higher numbers render first; fields ranked beyond
    * `cardPrimaryCount` fold under a "More fields" disclosure. Defaults to `0`,

--- a/projects/truenas-ui/src/lib/table/table-expand-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-expand-a11y.spec.ts
@@ -1,0 +1,327 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TnTableTesting } from './table-testing';
+import { TnTableComponent } from './table.component';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+import {
+  TnCellDefDirective,
+  TnDetailRowDefDirective,
+  TnHeaderCellDefDirective,
+  TnTableColumnDirective,
+} from '../table-column/table-column.directive';
+
+/**
+ * Guards the two rules #246 reported against `tn-table`.
+ *
+ *   - `empty-table-header`, on a column whose header is deliberately blank —
+ *     the `actions` column of `Components/Table > ColumnWidths`, which reached
+ *     that state through an empty `tnHeaderCellDef`.
+ *   - `aria-conditional-attr`, on `<tr aria-expanded>` — `Components/Table >
+ *     ExpandOnRowClick`. The attribute is supported on a `treegrid` row and not
+ *     on a `table` row, so it announced nothing while reading as done work.
+ *
+ * The ticket reproduced both through `yarn test-sb`, which needs a real browser
+ * this deployment does not have. Neither rule needs one: `empty-table-header`
+ * reads text content and `aria-conditional-attr` reads the role/attribute pair,
+ * so axe decides both under jsdom. Both were watched failing here, with the same
+ * rule ids and messages the ticket quotes, before either fix went in — and the
+ * positive controls below are what keep a green run from meaning "axe stopped
+ * matching these elements".
+ */
+
+interface Row { id: number; name: string; email: string }
+
+const ROWS: Row[] = [
+  { id: 1, name: 'alpha', email: 'alpha@example.com' },
+  { id: 2, name: 'beta', email: 'beta@example.com' },
+];
+
+/** The `ColumnWidths` shape: a narrow trailing column that shows no heading. */
+@Component({
+  selector: 'tn-table-actions-column-host',
+  standalone: true,
+  imports: [
+    TnTableComponent,
+    TnTableColumnDirective,
+    TnHeaderCellDefDirective,
+    TnCellDefDirective,
+  ],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-table [dataSource]="rows()" [displayedColumns]="['id', 'name', 'actions']">
+      <ng-container tnColumnDef="id" width="60px">
+        <ng-template tnHeaderCellDef>ID</ng-template>
+        <ng-template let-row tnCellDef>{{ row.id }}</ng-template>
+      </ng-container>
+      <ng-container tnColumnDef="name">
+        <ng-template tnHeaderCellDef>Name</ng-template>
+        <ng-template let-row tnCellDef>{{ row.name }}</ng-template>
+      </ng-container>
+      <ng-container tnColumnDef="actions" width="48px" label="Actions" [hideLabel]="true">
+        <ng-template let-row tnCellDef>{{ row.email }}</ng-template>
+      </ng-container>
+    </tn-table>
+  `,
+})
+class ActionsColumnHostComponent {
+  rows = signal<Row[]>(ROWS);
+}
+
+/** The `ExpandOnRowClick` shape: the row itself is the expand trigger. */
+@Component({
+  selector: 'tn-table-expand-host',
+  standalone: true,
+  imports: [
+    TnTableComponent,
+    TnTableColumnDirective,
+    TnHeaderCellDefDirective,
+    TnCellDefDirective,
+    TnDetailRowDefDirective,
+  ],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-table
+      [dataSource]="rows()"
+      [displayedColumns]="['name', 'email']"
+      [expandable]="true"
+      [clickable]="true"
+      [expandOnRowClick]="true">
+      <ng-container tnColumnDef="name">
+        <ng-template tnHeaderCellDef>Name</ng-template>
+        <ng-template let-row tnCellDef>{{ row.name }}</ng-template>
+      </ng-container>
+      <ng-container tnColumnDef="email">
+        <ng-template tnHeaderCellDef>Email</ng-template>
+        <ng-template let-row tnCellDef>{{ row.email }}</ng-template>
+      </ng-container>
+      <ng-template let-row tnDetailRowDef>Status for {{ row.name }}</ng-template>
+    </tn-table>
+  `,
+})
+class ExpandHostComponent {
+  rows = signal<Row[]>(ROWS);
+}
+
+describe('tn-table blank headers and row expansion accessibility', () => {
+  let restoreResizeObserver: () => void;
+
+  beforeEach(() => {
+    restoreResizeObserver = TnTableTesting.installResizeObserver();
+  });
+
+  afterEach(() => {
+    restoreResizeObserver();
+  });
+
+  describe('a column whose header is deliberately blank', () => {
+    let fixture: ComponentFixture<ActionsColumnHostComponent>;
+
+    const el = <T extends HTMLElement>(selector: string): T => {
+      const found = fixture.nativeElement.querySelector(selector) as T | null;
+      if (!found) { throw new Error(`no element matched ${selector}`); }
+      return found;
+    };
+
+    const actionsHeader = (): HTMLElement =>
+      el('.tn-table__header-cell[data-column="actions"]');
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ActionsColumnHostComponent],
+      }).compileComponents();
+      fixture = TestBed.createComponent(ActionsColumnHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('names the header for screen readers rather than leaving it empty', () => {
+      const hidden = actionsHeader().querySelector('.cdk-visually-hidden');
+
+      expect(hidden).not.toBeNull();
+      expect(hidden!.textContent!.trim()).toBe('Actions');
+      // Hidden from sight, not from assistive tech — `aria-hidden` here would put
+      // the cell straight back to having no accessible name.
+      expect(hidden!.getAttribute('aria-hidden')).toBeNull();
+    });
+
+    it('renders no visible header text for that column', () => {
+      expect(actionsHeader().querySelector('.tn-table__header-text')).toBeNull();
+    });
+
+    it('leaves the labelled columns showing their text as before', () => {
+      const nameHeader = el('.tn-table__header-cell[data-column="name"]');
+
+      expect(nameHeader.querySelector('.tn-table__header-text')!.textContent!.trim())
+        .toBe('Name');
+      expect(nameHeader.querySelector('.cdk-visually-hidden')).toBeNull();
+    });
+
+    it('reports no empty-table-header violation to axe', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [actionsHeader()],
+        ['empty-table-header']
+      );
+
+      expect(violated).toEqual([]);
+      // Proof the rule looked at this cell rather than passing vacuously.
+      expect(evaluated).toContain('empty-table-header');
+    });
+
+    it('positive control: the pre-#246 markup still fails empty-table-header', async () => {
+      // What the column rendered before `hideLabel` existed: a sized <th> whose
+      // header template contributed no text. Without this, the `violated` of `[]`
+      // above would also be what an axe upgrade that stopped matching this
+      // element looks like.
+      const table = document.createElement('table');
+      table.innerHTML =
+        '<thead><tr><th>Name</th>'
+        + '<th data-column="actions" style="width: 48px;"><span></span></th></tr></thead>'
+        + '<tbody><tr><td>alpha</td><td>&#8942;</td></tr></tbody>';
+      document.body.appendChild(table);
+
+      try {
+        const { violated } = await axeResult(
+          table,
+          table.querySelector<HTMLElement>('th[data-column="actions"]'),
+          ['empty-table-header']
+        );
+
+        expect(violated).toEqual(['empty-table-header']);
+      } finally {
+        table.remove();
+      }
+    });
+
+    it('reports nothing anywhere in the table', async () => {
+      const scan = await axeScan(fixture);
+
+      expect(scan.violations).toEqual([]);
+      // Not a pass: axe puts a rule it could not decide here, and reading only
+      // `violations` reports a defect as clean.
+      expect(scan.incomplete).toEqual([]);
+      expect(scan.passed.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('a row that is its own expand trigger', () => {
+    let fixture: ComponentFixture<ExpandHostComponent>;
+
+    const el = <T extends HTMLElement>(selector: string): T => {
+      const found = fixture.nativeElement.querySelector(selector) as T | null;
+      if (!found) { throw new Error(`no element matched ${selector}`); }
+      return found;
+    };
+
+    const row = (index = 0): HTMLElement => el(`.tn-table__row[data-row-index="${index}"]`);
+    const chevron = (index = 0): HTMLButtonElement =>
+      el<HTMLButtonElement>(
+        `.tn-table__row[data-row-index="${index}"] .tn-table__expand-button`
+      );
+    const click = (element: HTMLElement): void => {
+      element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      fixture.detectChanges();
+    };
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ExpandHostComponent, NoopAnimationsModule],
+      }).compileComponents();
+      fixture = TestBed.createComponent(ExpandHostComponent);
+      fixture.detectChanges();
+    });
+
+    it('does not put aria-expanded on the row', () => {
+      expect(row().getAttribute('aria-expanded')).toBeNull();
+
+      click(row());
+
+      expect(row().classList).toContain('tn-table__row--expanded');
+      expect(row().getAttribute('aria-expanded')).toBeNull();
+    });
+
+    it('announces the state on the chevron inside the row instead', () => {
+      expect(chevron().getAttribute('aria-expanded')).toBe('false');
+
+      click(chevron());
+
+      expect(chevron().getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('keeps the chevron in step when the row itself is activated', () => {
+      click(row());
+
+      expect(chevron().getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('points the row and the chevron at the panel that opens', () => {
+      expect(row().getAttribute('aria-controls')).toBeNull();
+      expect(chevron().getAttribute('aria-controls')).toBeNull();
+
+      click(row());
+
+      const panel = el('.tn-table__detail-cell');
+      expect(panel.id).not.toBe('');
+      expect(row().getAttribute('aria-controls')).toBe(panel.id);
+      expect(chevron().getAttribute('aria-controls')).toBe(panel.id);
+    });
+
+    it('drops aria-controls again when the row collapses', () => {
+      click(row());
+      click(row());
+
+      expect(row().getAttribute('aria-controls')).toBeNull();
+      expect(chevron().getAttribute('aria-controls')).toBeNull();
+    });
+
+    it('reports no aria-conditional-attr violation on the row', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement,
+        [row(), row(1)],
+        ['aria-conditional-attr', 'aria-allowed-attr']
+      );
+
+      expect(violated).toEqual([]);
+      // The row still carries `aria-selected`, so `aria-allowed-attr` had
+      // something on these elements to look at — the scan was not vacuous.
+      expect(evaluated).toContain('aria-allowed-attr');
+    });
+
+    it('positive control: the pre-#246 markup still fails aria-conditional-attr', async () => {
+      const table = document.createElement('table');
+      table.innerHTML =
+        '<thead><tr><th>Name</th></tr></thead>'
+        + '<tbody><tr tabindex="0" aria-selected="false" aria-expanded="false">'
+        + '<td>alpha</td></tr></tbody>';
+      document.body.appendChild(table);
+
+      try {
+        const { violated } = await axeResult(
+          table,
+          table.querySelector<HTMLElement>('tbody tr'),
+          ['aria-conditional-attr']
+        );
+
+        expect(violated).toEqual(['aria-conditional-attr']);
+      } finally {
+        table.remove();
+      }
+    });
+
+    it('reports nothing anywhere in the table, collapsed or expanded', async () => {
+      const collapsed = await axeScan(fixture);
+      expect(collapsed.violations).toEqual([]);
+      expect(collapsed.incomplete).toEqual([]);
+      expect(collapsed.passed.length).toBeGreaterThan(0);
+
+      click(row());
+
+      const expanded = await axeScan(fixture);
+      expect(expanded.violations).toEqual([]);
+      // `aria-controls` now points at the detail cell. A dangling reference lands
+      // in `incomplete` and nowhere else, so this is what proves the id resolves.
+      expect(expanded.incomplete).toEqual([]);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/table/table.component.html
+++ b/projects/truenas-ui/src/lib/table/table.component.html
@@ -326,13 +326,30 @@
               (keydown.enter)="onSortHeaderKeydown(column, $event)"
               (keydown.space)="onSortHeaderKeydown(column, $event)">
               <span class="tn-table__sort-container">
-                <span class="tn-table__header-text">
-                  @if (getColumnDef(column)?.headerTemplate(); as tmpl) {
-                    <ng-container [ngTemplateOutlet]="tmpl" />
-                  } @else {
+                @if (getColumnDef(column)?.hideLabel()) {
+                  <!--
+                    A deliberately blank header still has to be announced: a <th>
+                    with no text fails axe `empty-table-header`, and the column
+                    goes unnamed for anyone reading the header row (#246). The
+                    hidden span is the same pattern the built-in `__expand` and
+                    row-actions headers use, and it lives here rather than in a
+                    consumer's `tnHeaderCellDef` because `.cdk-visually-hidden`
+                    is defined in this component's own stylesheet — projected
+                    markup carries the host's encapsulation attribute and would
+                    render the label visibly.
+                  -->
+                  <span class="cdk-visually-hidden">
                     {{ getColumnDef(column)?.label() ?? column }}
-                  }
-                </span>
+                  </span>
+                } @else {
+                  <span class="tn-table__header-text">
+                    @if (getColumnDef(column)?.headerTemplate(); as tmpl) {
+                      <ng-container [ngTemplateOutlet]="tmpl" />
+                    } @else {
+                      {{ getColumnDef(column)?.label() ?? column }}
+                    }
+                  </span>
+                }
                 @if (getColumnDef(column)?.sortable()) {
                   <!--
                     aria-hidden: the <th> has no aria-label, so its accessible name is
@@ -364,6 +381,16 @@
 
     <!-- Data Rows -->
     <tbody class="tn-table__body">
+      <!--
+        No `aria-expanded` here, unlike the card. `row` supports it only inside a
+        `treegrid`; on a plain `table` it is ignored, so the state it appeared to
+        publish reached nobody, while reading as though the work were done (axe
+        `aria-conditional-attr`, #246). The chevron in the `__expand` cell is the
+        control that carries it — a `button`, where the attribute is valid and
+        where a screen-reader user lands by tabbing. `aria-controls` is global
+        rather than role-conditional, so the row keeps pointing at the panel it
+        opens; that is the half of the association a row CAN hold.
+      -->
       @for (row of data(); track trackByFn()($index, row); let rowIdx = $index) {
         <tr
           class="tn-table__row"
@@ -374,7 +401,9 @@
           [class.tn-table__row--clickable]="clickable()"
           [attr.tabindex]="clickable() ? 0 : null"
           [attr.aria-selected]="clickable() ? isRowActive(row) : null"
-          [attr.aria-expanded]="isRowExpandTrigger(row) ? isRowExpanded(row) : null"
+          [attr.aria-controls]="isRowExpandTrigger(row) && isRowExpanded(row) && detailRowDef()
+            ? detailPanelId(rowIdx)
+            : null"
           (click)="onRowClick(row, $event)"
           (dblclick)="onRowDoubleClick(row, $event)"
           (keydown)="onRowKeydown($event, row)">
@@ -397,6 +426,7 @@
                     type="button"
                     class="tn-table__expand-button"
                     [attr.aria-expanded]="isRowExpanded(row)"
+                    [attr.aria-controls]="isRowExpanded(row) ? detailPanelId(rowIdx) : null"
                     [attr.aria-label]="isRowExpanded(row) ? 'Collapse row' : 'Expand row'"
                     (click)="toggleRowExpansion(row)">
                     <tn-icon
@@ -440,6 +470,7 @@
           <tr class="tn-table__detail-row" [@detailExpand]="'expanded'">
             <td
               class="tn-table__detail-cell"
+              [attr.id]="detailPanelId(rowIdx)"
               [attr.colspan]="totalColumnCount()">
               <ng-container
                 [ngTemplateOutlet]="detailRowDef()!.template"

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -715,28 +715,33 @@ describe('TnTableComponent', () => {
         expect(component.isRowExpanded(testData[0])).toBe(false);
       });
 
-      describe('row aria-expanded', () => {
+      // This fixture is a bare `tn-table` with no `tnDetailRowDef`, so it renders no
+      // `__expand` column and no detail panel — there is nothing for the row to point
+      // at. The chevron and `aria-controls` are asserted in `table-expand-a11y.spec.ts`,
+      // whose host supplies a detail template.
+      describe('the expanded state on a row', () => {
         const firstRow = (): HTMLElement =>
           fixture.nativeElement.querySelector('.tn-table__row') as HTMLElement;
 
-        it('announces the row as a collapsed expander, since the row is the control here', () => {
-          // Without this a screen-reader user who focuses the row and presses Enter hears nothing
-          // change: the state lives only on the chevron they never touched.
-          expect(firstRow().getAttribute('aria-expanded')).toBe('false');
-        });
+        it('never puts aria-expanded on the row, expanded or not', () => {
+          // The row used to carry it while `expandOnRowClick` was set. `aria-expanded`
+          // is supported on a `treegrid` row and ignored on a `table` row, so what
+          // looked like the state being announced reached nobody (#246, axe
+          // `aria-conditional-attr`). The chevron carries it instead.
+          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
 
-        it('flips to true once the row is expanded', () => {
           component.onRowClick(testData[0]);
           fixture.detectChanges();
 
-          expect(firstRow().getAttribute('aria-expanded')).toBe('true');
+          expect(component.isRowExpanded(testData[0])).toBe(true);
+          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
         });
 
-        it('stays off the row when only the chevron expands, which carries its own state', () => {
-          fixture.componentRef.setInput('expandOnRowClick', false);
+        it('leaves aria-controls off while there is no detail panel to point at', () => {
+          component.onRowClick(testData[0]);
           fixture.detectChanges();
 
-          expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+          expect(firstRow().getAttribute('aria-controls')).toBeNull();
         });
 
         it('stays off a row that is not activatable, since Enter never toggles it', () => {
@@ -744,6 +749,7 @@ describe('TnTableComponent', () => {
           fixture.detectChanges();
 
           expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+          expect(firstRow().getAttribute('aria-controls')).toBeNull();
         });
 
         it('stays off a row the predicate rejects, which never expands', () => {
@@ -751,6 +757,7 @@ describe('TnTableComponent', () => {
           fixture.detectChanges();
 
           expect(firstRow().getAttribute('aria-expanded')).toBeNull();
+          expect(firstRow().getAttribute('aria-controls')).toBeNull();
         });
       });
     });

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -251,6 +251,10 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * rows the `isRowExpandable` predicate rejects are unaffected, since `toggleRowExpansion` gates
    * on it. `rowClick` still emits, so a consumer can both expand and react to the click.
    *
+   * In table mode the expanded state is announced by the chevron, not by the row: `aria-expanded`
+   * is a `treegrid`-row attribute and a plain `table` row cannot hold it (#246). The row points at
+   * the open panel with `aria-controls`, which every role permits.
+   *
    * Applies in card mode too, where activating the card toggles its detail section. Both controls
    * report the state: the card carries `aria-expanded` while it is the trigger (`listitem` does
    * permit it, unlike `aria-selected`), and the "Details" button carries it unconditionally,
@@ -772,11 +776,17 @@ export class TnTableComponent<T = unknown> implements OnInit {
   }
 
   /**
-   * Whether the row element itself acts as the expand/collapse control, which is what makes an
-   * `aria-expanded` on it meaningful: a screen-reader user who focuses the row and presses Enter
-   * otherwise gets no announcement that anything expanded, since only the chevron carries the
-   * state. Also requires `clickable` — without it the row isn't activatable and
-   * {@link onRowClick} returns before toggling anything.
+   * Whether the row element itself acts as the expand/collapse control. Requires `clickable` —
+   * without it the row isn't activatable and {@link onRowClick} returns before toggling anything.
+   *
+   * A table row does NOT get `aria-expanded` from this. That attribute is only supported on a
+   * `treegrid` row; on a plain `table` it is ignored, so the state it seemed to publish reached
+   * nobody (#246). The chevron in the `__expand` cell carries it instead, on a `button`, where it
+   * is valid and where a screen-reader user lands by tabbing. What the row does take from this is
+   * `aria-controls`, which is global rather than role-conditional.
+   *
+   * Card mode is the case where the trigger element CAN hold the state — see
+   * {@link isCardExpandTrigger}.
    */
   isRowExpandTrigger(row: T): boolean {
     return this.expandOnRowClick() && this.clickable() && this.canExpandRow(row);
@@ -787,8 +797,8 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * template. Card mode renders no expansion affordance at all without one, so `aria-expanded`
    * on the card would advertise a state change that produces nothing.
    *
-   * Table mode deliberately keeps the looser check: its rows are asserted to carry
-   * `aria-expanded` from `expandOnRowClick` alone, and that predates this layout.
+   * `listitem` permits `aria-expanded`, which is what lets the card hold the state its table-row
+   * equivalent cannot.
    */
   isCardExpandTrigger(row: T): boolean {
     return this.isRowExpandTrigger(row) && !!this.detailRowDef();

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -660,8 +660,7 @@ export const ColumnWidths: Story = {
           <ng-template tnHeaderCellDef>Email</ng-template>
           <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
         </ng-container>
-        <ng-container tnColumnDef="actions" width="48px">
-          <ng-template tnHeaderCellDef></ng-template>
+        <ng-container tnColumnDef="actions" width="48px" label="Actions" [hideLabel]="true">
           <ng-template let-user tnCellDef>⋮</ng-template>
         </ng-container>
       </tn-table>
@@ -761,18 +760,24 @@ export const ExpandOnRowClick: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const rows = canvas.getAllByRole('row').filter((row) => row.classList.contains('tn-table__row'));
+    const chevron = (row: HTMLElement): HTMLElement =>
+      row.querySelector('.tn-table__expand-button') as HTMLElement;
 
-    // The row is the expand control here, so it must say so — a screen-reader user activating it
-    // otherwise gets no announcement that anything opened.
-    await expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
+    // The state is announced by the chevron, not by the row: `aria-expanded` is a treegrid-row
+    // attribute, so on this plain table the row could not publish it to anyone (#246).
+    await expect(rows[0]).not.toHaveAttribute('aria-expanded');
+    await expect(chevron(rows[0])).toHaveAttribute('aria-expanded', 'false');
 
     await userEvent.click(rows[0]);
-    await expect(rows[0]).toHaveAttribute('aria-expanded', 'true');
+    await expect(chevron(rows[0])).toHaveAttribute('aria-expanded', 'true');
+    // The row keeps the half of the association its role does allow.
+    await expect(rows[0]).toHaveAttribute('aria-controls');
 
     // singleExpand: opening the second row closes the first.
     await userEvent.click(rows[1]);
-    await expect(rows[1]).toHaveAttribute('aria-expanded', 'true');
-    await expect(rows[0]).toHaveAttribute('aria-expanded', 'false');
+    await expect(chevron(rows[1])).toHaveAttribute('aria-expanded', 'true');
+    await expect(chevron(rows[0])).toHaveAttribute('aria-expanded', 'false');
+    await expect(rows[0]).not.toHaveAttribute('aria-controls');
   },
 };
 


### PR DESCRIPTION
Fixes #246.

Two axe rules fired on `tn-table`. Both are markup, so both fail identically in every theme, and both reproduce under jsdom — the ticket found them in a real browser, but `empty-table-header` reads text content and `aria-conditional-attr` reads the role/attribute pair, and neither needs a layout engine.

## 1. `empty-table-header` — a blank header had no way to also be named

The failing cell is `.tn-table__header-cell[data-column="actions"]` in `Components/Table > ColumnWidths`. That is not the table's built-in row-actions header, which has carried `<span class="cdk-visually-hidden">Actions</span>` since #133 — it is a *consumer-declared* `tnColumnDef="actions"` whose `tnHeaderCellDef` is empty, which is the only way this API offered to get a heading that shows nothing.

The obvious fix — write the hidden label into the story's own `tnHeaderCellDef` — does not work. `.cdk-visually-hidden` is defined inside `table.component.scss` (the CDK's global a11y stylesheet is not shipped with this library), and the table uses emulated encapsulation, so markup projected from a consumer carries the *host's* encapsulation attribute and would not match. The label would render as visible text.

So the label is rendered by the table, in the table's own view, behind a new input:

```html
<ng-container tnColumnDef="actions" width="48px" label="Actions" [hideLabel]="true">
  <ng-template let-user tnCellDef>⋮</ng-template>
</ng-container>
```

`[hideLabel]` on `tnColumnDef` renders `label` (falling back to the column name) inside `.cdk-visually-hidden` instead of the visible `.tn-table__header-text` — the same treatment `__expand` and the row-actions header already get, which is what the ticket's acceptance criterion asks for. The sort affordance is untouched: the hidden span replaces the header text inside `.tn-table__sort-container`, so a sortable column with a hidden label still gets its icon and `aria-sort`.

The name is the one already used for this idea in this library (`tn-checkbox`'s `[hideLabel]`, which the table itself passes on its own checkboxes).

## 2. `aria-conditional-attr` — the row's `aria-expanded` announced nothing

`<tr aria-expanded>` is valid on a `treegrid` row and ignored on a `table` row. The attribute was set whenever the row was the expand trigger, with a comment explaining that it existed so a screen-reader user who focuses the row and presses Enter hears the state change. On a plain table it never did that — the state reached nobody, while the attribute read as though the work were done.

It is not simply deleted. The state moves to the control inside the row that supports it: the chevron in the `__expand` cell, a real `<button>`, which already carried `aria-expanded` and is what a screen-reader user reaches by tabbing. On top of that the disclosure association is now complete, matching what card mode has always done:

- the detail cell gets `id="<instance>-detail-<n>"` (`detailPanelId`, which already existed and was only used by card mode),
- the chevron gets `aria-controls` pointing at it while open,
- the **row** gets `aria-controls` too. That is the half a table row *can* hold — `aria-controls` is a global ARIA property, not role-conditional — so a user on the row still has a path to the panel it opened.

`treegrid` was the other option the ticket offered. It was not taken: it would change the table's keyboard interaction contract wholesale (full grid navigation), for two stories, which is far more than this defect is.

### Residual limitation, stated plainly

Activating a row by click or Enter leaves focus on the row, and the chevron's `aria-expanded` flip is not announced at that moment. That is a real gap — but it is the gap that was always there, since the row's own attribute was inert. Closing it properly means either a live region or `treegrid`, and both are larger than this ticket.

## Verification

Reproduced before either fix, in `table-expand-a11y.spec.ts`, with the same rule ids, impacts and failure summaries the ticket quotes:

```
empty-table-header   minor    Element does not have text that is visible to screen readers
aria-conditional-attr serious This attribute is supported with treegrid rows, but not table: aria-expanded
```

That file is now the regression guard for both, built on the shared `axeResult`/`axeScan` wrappers. Each defect gets a **positive control** that rebuilds the pre-fix markup by hand and asserts axe still objects to it — without those, a green run would also be what an axe upgrade that stopped matching these elements looks like.

Two existing assertions encoded the defect and were rewritten rather than deleted:

- `table.component.spec.ts` — the `row aria-expanded` block, now asserting the row never carries it and explaining why.
- `table.stories.ts` — `ExpandOnRowClick`'s play function, now reading the chevron's state and the row's `aria-controls`.

### Ran locally

| | |
|---|---|
| `yarn lint` | pass on every file this PR touches |
| `yarn test` | 3355 passing, 131 suites |
| `yarn test:scripts` | 42 passing |
| `yarn build` | pass |
| `yarn build-storybook` | pass |
| `yarn test-sb` | **not run — see below** |

**`Storybook Interaction Tests` could not be run on this machine.** It drives a real browser through Playwright, and the host is missing ten system libraries with a read-only `/`, so no package can supply them. That is the check the ticket reproduced on, and it is the one check here whose result I am predicting rather than reporting. What backs the prediction: both axe rules were reproduced and then cleared in jsdom against the same component markup, and `ColumnWidths` / `ExpandOnRowClick` are rendered by the same templates the specs exercise. The rewritten `ExpandOnRowClick` play function is the part that genuinely has not executed anywhere.

`yarn lint` also reports 4 pre-existing `import/order` errors in `input/input.component.ts` and `menu/menu-panel.component.ts`. They are untouched by this PR and are tracked as #251.

### Local review

The shared reviewer ran here in a separate process (same rubric and threshold as the required check) and returned **nothing at or above MEDIUM**.

## What I did not change, and why

Two LOW findings from that review, left for a reviewer to weigh rather than fixed — every fix is a new diff, and a new diff is unreviewed:

- **`table.harness.ts:98` — `getHeaderTexts()` reads `.tn-table__header-text`, which the `hideLabel` branch never renders, so a hidden-label column drops out of the returned array and shifts the indices after it.** No current caller is affected (nothing used `hideLabel` before this PR), but it is a trap for the first one that combines the two, and arguably the harness should return the hidden text. Worth its own ticket if a reviewer agrees.
- **`hideLabel` silently ignores a projected `tnHeaderCellDef` with no dev-mode warning.** Documented on the input, since the whole point is that nothing shows and the consumer's markup could not be hidden anyway — but it is undeniably silent.
