### PR TITLE
NAS-142495 / 27.0.0-BETA.1 / fix(stories): give demo markup real labels, heading order and theme tokens

### DIFF
--- a/projects/truenas-ui/src/stories/button-toggle.stories.ts
+++ b/projects/truenas-ui/src/stories/button-toggle.stories.ts
@@ -166,12 +166,12 @@ export const CustomCheckedColors: Story = {
         </div>
 
         <div>
-          <p style="margin: 0 0 8px;">Custom hex</p>
+          <p style="margin: 0 0 8px;">Accent color</p>
           <tn-button-toggle-group
             [ngModel]="'a'"
-            checkedBg="#71BF44"
-            checkedColor="#ffffff"
-            checkedBorder="#5fa036">
+            checkedBg="var(--tn-accent)"
+            checkedColor="var(--tn-accent-txt)"
+            checkedBorder="var(--tn-accent)">
             <tn-button-toggle value="a">Option A</tn-button-toggle>
             <tn-button-toggle value="b">Option B</tn-button-toggle>
             <tn-button-toggle value="c">Option C</tn-button-toggle>

--- a/projects/truenas-ui/src/stories/card.stories.ts
+++ b/projects/truenas-ui/src/stories/card.stories.ts
@@ -710,9 +710,9 @@ export const WithProjectedHeader: Story = {
         [bordered]="bordered"
         [background]="background">
         <div tnCardHeader style="display: flex; align-items: center; gap: 12px;">
-          <span style="width: 8px; height: 8px; border-radius: 50%; background: #10b981;"></span>
+          <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--tn-green);"></span>
           <h3 style="margin: 0; font-size: 1.125rem; font-weight: 600;">Custom Header Content</h3>
-          <span style="font-size: 0.75rem; color: #6b7280;">— with icon and subtitle</span>
+          <span style="font-size: 0.75rem; color: var(--tn-alt-fg1);">— with icon and subtitle</span>
         </div>
         <p>This card uses projected header content instead of a simple title string.</p>
         <p>You can put any content in the header using the <code>tnCardHeader</code> attribute.</p>

--- a/projects/truenas-ui/src/stories/icon.stories.ts
+++ b/projects/truenas-ui/src/stories/icon.stories.ts
@@ -336,19 +336,19 @@ export const LibraryComparison: Story = {
           <h4 style="margin-top: 0;">Material (Default)</h4>
           <tn-icon name="home" size="lg" tooltip="Material Home"></tn-icon>
           <div style="margin-top: 8px;">name="home"</div>
-          <div style="font-size: 12px; color: var(--text-secondary, #666);">Unicode fallback</div>
+          <div style="font-size: 12px; color: var(--tn-alt-fg1);">Unicode fallback</div>
         </div>
         <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
           <h4 style="margin-top: 0;">Lucide</h4>
           <tn-icon name="home" library="lucide" size="lg" tooltip="Lucide Home"></tn-icon>
           <div style="margin-top: 8px;">library="lucide"</div>
-          <div style="font-size: 12px; color: var(--text-secondary, #666);">Library parameter</div>
+          <div style="font-size: 12px; color: var(--tn-alt-fg1);">Library parameter</div>
         </div>
         <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
           <h4 style="margin-top: 0;">MDI</h4>
           <tn-icon name="folder" library="mdi" size="lg" tooltip="MDI Folder"></tn-icon>
           <div style="margin-top: 8px;">library="mdi"</div>
-          <div style="font-size: 12px; color: var(--text-secondary, #666);">Library parameter</div>
+          <div style="font-size: 12px; color: var(--tn-alt-fg1);">Library parameter</div>
         </div>
       </div>
     `,
@@ -412,7 +412,7 @@ export const FullSize: Story = {
     template: `
       <div style="padding: 20px;">
         <h4>Full Size Mode</h4>
-        <p style="margin-bottom: 16px; color: var(--text-secondary, #666);">
+        <p style="margin-bottom: 16px; color: var(--tn-alt-fg1);">
           When <code>[fullSize]="true"</code>, the icon expands to fill its container instead of using fixed dimensions.
           This is useful for logos, splash screens, or when you need the icon to scale with its parent element.
         </p>
@@ -446,7 +446,7 @@ export const FullSize: Story = {
               <tn-icon name="server" library="mdi" size="lg"></tn-icon>
             </div>
             <code style="display: block; margin-top: 8px; font-size: 11px;">size="lg"</code>
-            <div style="font-size: 12px; color: var(--text-secondary, #666);">Icon stays at fixed lg size</div>
+            <div style="font-size: 12px; color: var(--tn-alt-fg1);">Icon stays at fixed lg size</div>
           </div>
           <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
             <h5 style="margin-top: 0;">Full Size</h5>
@@ -454,7 +454,7 @@ export const FullSize: Story = {
               <tn-icon name="server" library="mdi" [fullSize]="true"></tn-icon>
             </div>
             <code style="display: block; margin-top: 8px; font-size: 11px;">[fullSize]="true"</code>
-            <div style="font-size: 12px; color: var(--text-secondary, #666);">Icon fills container</div>
+            <div style="font-size: 12px; color: var(--tn-alt-fg1);">Icon fills container</div>
           </div>
         </div>
       </div>
@@ -486,7 +486,7 @@ export const CustomSize: Story = {
     template: `
       <div style="padding: 20px;">
         <h4>Custom Size</h4>
-        <p style="margin-bottom: 16px; color: var(--text-secondary, #666);">
+        <p style="margin-bottom: 16px; color: var(--tn-alt-fg1);">
           Use <code>customSize</code> to set an explicit size using any valid CSS value.
           This overrides both <code>size</code> presets and <code>fullSize</code>.
         </p>

--- a/projects/truenas-ui/src/stories/patterns/progressive-disclosure.stories.html
+++ b/projects/truenas-ui/src/stories/patterns/progressive-disclosure.stories.html
@@ -15,7 +15,7 @@
           <!-- Step 1: Name -->
           <tn-step label="Name" [completed]="isStepCompleted(0)">
             <div style="padding: 20px 0;">
-              <h3 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Name Your Storage Pool</h3>
+              <h2 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Name Your Storage Pool</h2>
               <p style="margin: 0 0 20px 0; color: var(--tn-fg2, #666); font-size: 14px;">Choose a name that describes what you'll store here</p>
 
               <tn-form-field label="Pool Name" style="margin-bottom: 20px;">
@@ -37,7 +37,7 @@
           <!-- Step 2: Basic Settings -->
           <tn-step label="Basic Settings" [completed]="isStepCompleted(1)">
             <div style="padding: 20px 0;">
-              <h3 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Choose Your Protection Level</h3>
+              <h2 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Choose Your Protection Level</h2>
               <p style="margin: 0 0 20px 0; color: var(--tn-fg2, #666); font-size: 14px;">How safe should your data be if drives fail?</p>
 
               <div style="margin-bottom: 20px;">
@@ -138,7 +138,7 @@
           <!-- Step 3: Advanced Settings -->
           <tn-step label="Advanced Settings" [completed]="isStepCompleted(2)">
             <div style="padding: 20px 0;">
-              <h3 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Advanced Settings</h3>
+              <h2 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Advanced Settings</h2>
               <p style="margin: 0 0 20px 0; color: var(--tn-fg2, #666); font-size: 14px;">Optional optimizations and expert configurations - your pool works great with defaults!</p>
 
               <!-- Default Notice -->
@@ -154,7 +154,7 @@
 
               <!-- Optional Security Enhancement -->
               <div style="margin-bottom: 20px;">
-                <h4 style="margin: 0 0 12px 0; font-size: 1rem; font-weight: 500; color: var(--tn-fg1);">Security Enhancement</h4>
+                <h3 style="margin: 0 0 12px 0; font-size: 1rem; font-weight: 500; color: var(--tn-fg1);">Security Enhancement</h3>
 
                 <!-- Encryption -->
                 <div style="margin-bottom: 16px; padding: 12px; background: var(--tn-bg2, #ffffff); border-radius: 6px; border: 1px solid var(--tn-lines, #ddd);">
@@ -270,7 +270,7 @@
           <!-- Step 4: Review -->
           <tn-step label="Review" [completed]="isStepCompleted(3)">
             <div style="padding: 20px 0;">
-              <h3 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Review Your Storage Pool</h3>
+              <h2 style="margin: 0 0 8px 0; font-size: 18px; font-weight: 600; color: var(--tn-fg1);">Review Your Storage Pool</h2>
               <p style="margin: 0 0 20px 0; color: var(--tn-fg2, #666); font-size: 14px;">Final review of your storage configuration before creation</p>
 
               <!-- Storage Visualization -->

--- a/projects/truenas-ui/src/stories/side-panel.stories.ts
+++ b/projects/truenas-ui/src/stories/side-panel.stories.ts
@@ -157,7 +157,7 @@ export const Default: Story = {
 
         <div style="display: flex; flex-direction: column; gap: 24px;">
           <div>
-            <h4 style="margin: 0 0 12px 0; color: var(--tn-fg1);">Dataset: tank/media</h4>
+            <h3 style="margin: 0 0 12px 0; color: var(--tn-fg1);">Dataset: tank/media</h3>
             <p style="color: var(--tn-fg2); font-size: 1rem; margin: 0;">
               This dataset stores media files including photos, videos, and music. It uses LZ4 compression and has snapshots enabled.
             </p>
@@ -268,24 +268,24 @@ export const WithActions: Story = {
           </div>
 
           <div>
-            <label style="${labelStyle}">Full Name</label>
-            <input type="text" placeholder="e.g. John Doe" style="${inputStyle}" />
+            <label for="add-user-full-name" style="${labelStyle}">Full Name</label>
+            <input id="add-user-full-name" type="text" placeholder="e.g. John Doe" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Username</label>
-            <input type="text" placeholder="e.g. jdoe" style="${inputStyle}" />
+            <label for="add-user-username" style="${labelStyle}">Username</label>
+            <input id="add-user-username" type="text" placeholder="e.g. jdoe" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Email</label>
-            <input type="email" placeholder="e.g. john@example.com" style="${inputStyle}" />
+            <label for="add-user-email" style="${labelStyle}">Email</label>
+            <input id="add-user-email" type="email" placeholder="e.g. john@example.com" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Password</label>
-            <input type="password" placeholder="Enter password" style="${inputStyle}" />
+            <label for="add-user-password" style="${labelStyle}">Password</label>
+            <input id="add-user-password" type="password" placeholder="Enter password" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Confirm Password</label>
-            <input type="password" placeholder="Confirm password" style="${inputStyle}" />
+            <label for="add-user-confirm-password" style="${labelStyle}">Confirm Password</label>
+            <input id="add-user-confirm-password" type="password" placeholder="Confirm password" style="${inputStyle}" />
           </div>
 
           <div style="padding-bottom: 16px; border-bottom: 1px solid var(--tn-lines); padding-top: 8px;">
@@ -294,16 +294,16 @@ export const WithActions: Story = {
           </div>
 
           <div>
-            <label style="${labelStyle}">User ID</label>
-            <input type="number" value="1001" style="${inputStyle}" />
+            <label for="add-user-uid" style="${labelStyle}">User ID</label>
+            <input id="add-user-uid" type="number" value="1001" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Primary Group</label>
-            <input type="text" value="users" style="${inputStyle}" />
+            <label for="add-user-primary-group" style="${labelStyle}">Primary Group</label>
+            <input id="add-user-primary-group" type="text" value="users" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Auxiliary Groups</label>
-            <input type="text" placeholder="e.g. wheel, ftp, samba" style="${inputStyle}" />
+            <label for="add-user-aux-groups" style="${labelStyle}">Auxiliary Groups</label>
+            <input id="add-user-aux-groups" type="text" placeholder="e.g. wheel, ftp, samba" style="${inputStyle}" />
           </div>
 
           <div style="padding-bottom: 16px; border-bottom: 1px solid var(--tn-lines); padding-top: 8px;">
@@ -312,12 +312,12 @@ export const WithActions: Story = {
           </div>
 
           <div>
-            <label style="${labelStyle}">Home Directory</label>
-            <input type="text" value="/nonexistent" style="${inputStyle}" />
+            <label for="add-user-home-directory" style="${labelStyle}">Home Directory</label>
+            <input id="add-user-home-directory" type="text" value="/nonexistent" style="${inputStyle}" />
           </div>
           <div>
-            <label style="${labelStyle}">Shell</label>
-            <input type="text" value="/usr/bin/zsh" style="${inputStyle}" />
+            <label for="add-user-shell" style="${labelStyle}">Shell</label>
+            <input id="add-user-shell" type="text" value="/usr/bin/zsh" style="${inputStyle}" />
           </div>
 
           <div style="padding-bottom: 16px; border-bottom: 1px solid var(--tn-lines); padding-top: 8px;">
@@ -326,8 +326,8 @@ export const WithActions: Story = {
           </div>
 
           <div>
-            <label style="${labelStyle}">SSH Public Key</label>
-            <textarea placeholder="Paste public key here..." style="${textareaStyle}"></textarea>
+            <label for="add-user-ssh-key" style="${labelStyle}">SSH Public Key</label>
+            <textarea id="add-user-ssh-key" placeholder="Paste public key here..." style="${textareaStyle}"></textarea>
           </div>
         </div>
 
@@ -421,20 +421,20 @@ export const NestedPanels: Story = {
             </div>
 
             <div>
-              <label style="${labelStyle}">Share Name</label>
-              <input type="text" value="media" style="${inputStyle}" />
+              <label for="edit-share-name" style="${labelStyle}">Share Name</label>
+              <input id="edit-share-name" type="text" value="media" style="${inputStyle}" />
             </div>
             <div>
-              <label style="${labelStyle}">Path</label>
-              <input type="text" value="/mnt/tank/media" style="${inputStyle}" />
+              <label for="edit-share-path" style="${labelStyle}">Path</label>
+              <input id="edit-share-path" type="text" value="/mnt/tank/media" style="${inputStyle}" />
             </div>
             <div>
-              <label style="${labelStyle}">Description</label>
-              <input type="text" value="Media files share" style="${inputStyle}" />
+              <label for="edit-share-description" style="${labelStyle}">Description</label>
+              <input id="edit-share-description" type="text" value="Media files share" style="${inputStyle}" />
             </div>
             <div>
-              <label style="${labelStyle}">Purpose</label>
-              <input type="text" value="Default share parameters" style="${inputStyle}" />
+              <label for="edit-share-purpose" style="${labelStyle}">Purpose</label>
+              <input id="edit-share-purpose" type="text" value="Default share parameters" style="${inputStyle}" />
             </div>
 
             <div style="padding-bottom: 16px; border-bottom: 1px solid var(--tn-lines); padding-top: 8px;">
@@ -443,12 +443,12 @@ export const NestedPanels: Story = {
             </div>
 
             <div>
-              <label style="${labelStyle}">Allowed Hosts</label>
-              <textarea placeholder="One host per line..." style="${textareaStyle}"></textarea>
+              <label for="edit-share-allowed-hosts" style="${labelStyle}">Allowed Hosts</label>
+              <textarea id="edit-share-allowed-hosts" placeholder="One host per line..." style="${textareaStyle}"></textarea>
             </div>
             <div>
-              <label style="${labelStyle}">Denied Hosts</label>
-              <textarea placeholder="One host per line..." style="${textareaStyle}"></textarea>
+              <label for="edit-share-denied-hosts" style="${labelStyle}">Denied Hosts</label>
+              <textarea id="edit-share-denied-hosts" placeholder="One host per line..." style="${textareaStyle}"></textarea>
             </div>
 
             <div style="padding-bottom: 16px; border-bottom: 1px solid var(--tn-lines); padding-top: 8px;">
@@ -457,8 +457,8 @@ export const NestedPanels: Story = {
             </div>
 
             <div>
-              <label style="${labelStyle}">Auxiliary Parameters</label>
-              <textarea placeholder="smb.conf parameters..." style="${textareaStyle}"></textarea>
+              <label for="edit-share-aux-params" style="${labelStyle}">Auxiliary Parameters</label>
+              <textarea id="edit-share-aux-params" placeholder="smb.conf parameters..." style="${textareaStyle}"></textarea>
             </div>
           </div>
 

--- a/projects/truenas-ui/src/stories/tooltip.stories.ts
+++ b/projects/truenas-ui/src/stories/tooltip.stories.ts
@@ -303,7 +303,9 @@ export const OnDifferentElements: Story = {
           tnTooltip="Button tooltip">
         </tn-button>
 
+        <label for="tooltip-demo-input" style="color: var(--tn-fg1);">Server name</label>
         <input
+          id="tooltip-demo-input"
           type="text"
           placeholder="Hover for tooltip"
           tnTooltip="This input has a helpful tooltip"


### PR DESCRIPTION
Fixes #247.

The stories are what the a11y check actually runs against, so demo markup that fails axe measures the library against its own showcase. All seven reported failures are in story files. **No component source is touched** — the diff is six files, all under `src/stories/`.

## What changed

### Labels

Every `<label>` in the side panel demos was a bare `<label>` with no `for`, so each input was named only by its `placeholder` — and the four that carry a `value` instead of a placeholder (`User ID`, `Primary Group`, `Home Directory`, `Shell`) had no accessible name at all. That is why axe `label` fires on `side-panel.stories.ts:298` specifically and not on its neighbours. Each label is now paired to its control by `for`/`id`.

I fixed the `NestedPanels` form as well as the reported `WithActions` one. Its inputs (`Share Name`, `Path`, `Description`, `Purpose`) have the identical defect — `value`, no placeholder, unassociated label — and only escape the report because that inner panel is closed in the snapshot axe sees. The acceptance criterion is written per-file ("the Side Panel and Tooltip demo inputs get real labels"), and leaving half the file on the old pattern would have set two conventions in one story.

The tooltip demo input had no `<label>` at all and took its name from the tooltip's `aria-describedby`, which is what `label-title-only` is about. It now has a visible label.

### Heading order

- `Components/Side Panel > Default` — the projected `<h4>` sat under the panel's own `<h2>` title (`side-panel.component.html:68`), skipping a level. Now `<h3>`.
- `Patterns/Progressive Disclosure > StoragePoolWizard` — four `<h3>` step headings sat directly under the page `<h1>`. They are now `<h2>`, and the `Security Enhancement` `<h4>` nested inside one of them becomes `<h3>` so that subtree still steps by one.

**Only the tag changes.** Each heading keeps its inline `font-size`, so nothing moves visually.

### Colours

`--text-secondary` and its `#666` fallback appear seven times in `icon.stories.ts`. The token is defined in no theme — I checked all nine palettes in `themes.css` and it is absent from every one — so all seven render the fallback. All seven are replaced, including the four that do not currently fail, as the ticket asks.

The replacement is `--tn-alt-fg1`. `themes.css:40-54` is explicit that `--tn-fg3`/`--tn-fg4` are **non-text** tokens tuned for the 3:1 minimum and that muted *text* is `--tn-alt-fg1`, so this is the token the design system already nominates for exactly this use.

| | before | after |
|---|---|---|
| `icon.stories.ts` captions (×7) | `#666`, 2.90:1 | `--tn-alt-fg1`, 6.47:1 |
| `card.stories.ts:715` subtitle | `#6b7280`, 3.45:1 | `--tn-alt-fg1`, 6.47:1 |
| `button-toggle.stories.ts` checked fill | `#fff` on `#71BF44`, 2.27:1 | `--tn-accent-txt` on `--tn-accent`, 10.56:1 |

Ratios are against `--tn-bg1` in the default TN Dark theme, which is the theme the check runs in. The three "before" figures reproduce the ones in the report.

`card.stories.ts:713` also carried a decorative `#10b981` status dot; it is now `var(--tn-green)`, since the criterion asks the Card story to use tokens rather than hexes and leaving one hex two lines above a fixed one would just invite the next reader to fix it.

## How this was verified

`yarn lint`, `yarn test` (3355 tests, 131 suites), `yarn test:scripts` (42 tests), `yarn build` and `yarn build-storybook` all pass locally.

**`yarn test-sb` — the check that found these — could not be run here.** It drives a real browser through Playwright, and this host has neither the browser nor the ten system libraries it needs, on a read-only root that cannot receive them. So the story markup itself is not exercised locally and CI is the first place it runs.

What I could do instead was compute the ratios directly from `themes.css`, since contrast is arithmetic. That reproduces all three reported "before" figures to two decimal places (2.90, 3.45, 2.27), and confirms `--tn-accent-txt` on `--tn-accent` clears 4.5:1 in **all nine** palettes (worst case 4.75:1 on solarized-dark). The probe is a throwaway under `state/scratch/247/` and is not part of the diff.

`lint`, `test`, `build` and `build-storybook` do not exercise story a11y at all, so their passing says only that nothing was broken structurally — the a11y claim above rests on the arithmetic and on reading the axe rules, not on a green local run.

## What I did **not** change, and why

- **`a11y: { test: 'error' }` is not added to `preview.ts`.** The ticket names it as the setting the reporter used to surface these, not as a deliverable. Turning it on would fail CI immediately on #248, #249, #259, #261, #262 and #265, which are open against defects this ticket explicitly excludes.
- **`Components/Side Panel > Default` will still fail until #248 lands.** The ticket says so: that story shares an axe case with the `scrollable-region-focusable` defect filed separately. The heading half is fixed here; the story goes green when both do.
- **`--tn-alt-fg1` clears 4.5:1 on `--tn-bg1` in every palette, but on `--tn-bg2`/`--tn-bg3` it reads 4.11:1 and 3.57:1 in `.tn-solarized-dark`.** That is the token's own value in that one palette, which is #265's subject, and fixing it would mean editing `themes.css` — outside this ticket by its last criterion. The check runs in TN Dark, where the same pairs are 5.86:1 and 5.15:1.

## Local review

`local-review.py` ran the project's own reviewer and returned **0 — nothing at or above MEDIUM**. It raised six LOWs, which I am recording rather than acting on:

1. **`icon.stories.ts` also uses `var(--border-color, #ccc)`, another token defined nowhere**, on 10+ elements. Same phantom-token shape as `--text-secondary`, but the ticket names only `--text-secondary`, and these are borders — non-text, held to 3:1, which `#ccc` clears on the dark themes. Real, and proposed as its own ticket on #247.
2. Section titles in the side panel forms (`Identification`, `Directories`, …) are still styled `<div>`s, so the panel gains field labels but no heading structure. True, and a larger change to demo structure than this ticket describes.
3. `Advanced Configuration` in the wizard stayed a styled `<div>` while its sibling `Security Enhancement` is now an `<h3>`. Same shape as (2) — promoting it would add a heading the ticket did not ask for; leaving it keeps the diff to level corrections.
4. The status dot could use `--tn-success` rather than `--tn-green`. `--tn-success` does exist and resolves to `var(--tn-green)` in most palettes, so this is a semantics improvement on a decorative 8×8 dot with no contrast requirement.
5. The tooltip input keeps its `#ccc` border and a placeholder ("Hover for tooltip") that reads oddly beside its new label ("Server name"). The border was not reported and I left it rather than restyle an input the ticket did not name.
6. **Replacing `#71BF44` leaves `CustomCheckedColors` with no example of a literal CSS colour.** This one I think is a fair objection to the ticket rather than to the diff — the third group existed to show the inputs accept any colour, and it no longer does. The acceptance criterion is explicit ("use theme tokens instead of hardcoded hexes"), so I implemented what was asked and renamed the group from "Custom hex" to "Accent color" so the caption is not false. If the demo value is worth keeping, the fix is a hex that clears 4.5:1 with its label rather than reverting to `#71BF44`.
