### PR TITLE
NAS-142513 / 27.0.0-BETA.1 / fix(table-pager): give each pager landmark a name of its own

### DIFF
--- a/projects/truenas-ui/src/lib/a11y/accessible-name.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name.ts
@@ -48,25 +48,32 @@ import type { Signal } from '@angular/core';
  * `live-region.ts`. It is how this library's own components agree with each
  * other; a consumer naming its own element has `aria-label`.
  *
- * WHAT THE SECOND BRANCH DEPENDS ON, AND THE ONE COMPONENT IT RULES OUT
- * --------------------------------------------------------------------
+ * WHAT THE SECOND BRANCH DEPENDS ON, AND THE ONE CALLER THAT CANNOT HAVE IT
+ * -------------------------------------------------------------------------
  * "Unnamed at least still fails loudly" is not a property of being unnamed. It
- * is a property of every caller here: an unnamed `role="progressbar"` fails
- * axe's `aria-progressbar-name`, and an unnamed dialog fails `aria-dialog-name`.
- * Withholding the fallback trades a masked dangling IDREF for a red check, which
- * is a good trade only while that red check exists.
+ * is a property of every caller here, and of two different mechanisms. An
+ * unnamed `role="progressbar"` fails axe's `aria-progressbar-name` and an
+ * unnamed `over` drawer fails `aria-dialog-name`; a `side` drawer is a
+ * `role="navigation"` landmark that axe reports only once there are two of them,
+ * and rests instead on the dev-mode warning below. That is why the rule and the
+ * warning are one function: taking the branch without one of the two leaves the
+ * loudness the branch assumes.
  *
- * It does not exist for a landmark. `tn-table-pager` is `role="navigation"`, and
- * axe's only landmark-naming rule is `landmark-unique`, which compares landmarks
- * against EACH OTHER — one unnamed navigation landmark on a page violates
- * nothing. So a pager given a typo'd `ariaLabelledby` would go silently unnamed,
- * which is the failure #249 reported made worse, not fixed. The pager therefore
- * names itself unconditionally and does not call this function; the reason is
- * written out at `resolvedTablePaginationLabel` in `table-pager.component.ts`.
+ * `tn-table-pager` (#249) is the caller that can have neither. It is
+ * `role="navigation"`, so no axe rule names it — `landmark-unique` compares
+ * landmarks against EACH OTHER, and one unnamed landmark violates nothing. And
+ * its fallback is a DESIGNED name the consumer configures through
+ * `TN_TABLE_PAGER_LABELS` rather than a last resort for a name someone forgot,
+ * so the warning would fire on the ordinary case and teach readers to ignore it
+ * where it means something. Withholding there would turn a typo'd
+ * `ariaLabelledby` into a pager that announces nothing and reports nothing —
+ * the failure #249 opened on, made worse. So the pager names itself
+ * unconditionally and does not call this function; the reasoning is written out
+ * at `resolvedTablePaginationLabel` in `table-pager.component.ts`.
  *
- * That is the exception rather than an invitation. Routing the pager through
- * here would be a regression, and any other caller that reaches for this
- * function needs to be able to name the axe rule that catches it when unnamed.
+ * That is an exception with a reason rather than an invitation. A caller
+ * reaching for this function should be able to say which of the two — an axe
+ * name rule, or the warning below — catches it when it ends up unnamed.
  */
 
 /** What a component needs to tell this function about itself. */

--- a/projects/truenas-ui/src/lib/a11y/accessible-name.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name.ts
@@ -1,4 +1,4 @@
-import { computed, effect, isDevMode } from '@angular/core';
+import { computed, effect, isDevMode, signal } from '@angular/core';
 import type { Signal } from '@angular/core';
 
 /**
@@ -47,7 +47,59 @@ import type { Signal } from '@angular/core';
  * Not exported from `public-api.ts`, and must not be — the same rule as
  * `live-region.ts`. It is how this library's own components agree with each
  * other; a consumer naming its own element has `aria-label`.
+ *
+ * THE RULE AND THE WARNING ARE SEPARATE FUNCTIONS
+ * ----------------------------------------------
+ * `tnResolvedAriaLabel` is the two-branch rule on its own; `tnAccessibleName` is
+ * that rule plus the dev-mode warning. The split exists for `tn-table-pager`
+ * (#249), which needs the rule and must not have the warning: its fallback is a
+ * DESIGNED name that a consumer configures through `TN_TABLE_PAGER_LABELS`, not
+ * a last resort for a name someone forgot, and a single unnamed pager announcing
+ * "Table pagination" is correct rather than a defect. Warning on it would fire
+ * on the ordinary case and teach readers to ignore the warning on the three
+ * progressbars and the two dialogs, where it means something.
+ *
+ * What is NOT split is the rule itself, which is the part that was getting
+ * copied wrong. A caller that opts out of the warning still cannot write its own
+ * version of the branches below.
  */
+
+/** The three signals the naming rule reads. */
+export interface TnAriaLabelConfig {
+  /** The component's `ariaLabel` input, or whatever plays that part. */
+  ariaLabel: Signal<string | null | undefined>;
+  /** The component's `ariaLabelledby` input, or whatever plays that part. */
+  ariaLabelledby: Signal<string | null | undefined>;
+  /**
+   * The name to render when the caller supplies neither.
+   *
+   * A signal rather than a string, because `tn-table-pager`'s fallback comes
+   * from the `TN_TABLE_PAGER_LABELS` token, which a consumer may provide as a
+   * signal so that a language change re-renders the label. `tnAccessibleName`
+   * wraps its plain-string `fallback` to reach this.
+   */
+  fallback: Signal<string>;
+}
+
+/**
+ * The name to render as `aria-label`, or `null` to render no `aria-label` at
+ * all. The rule, without the warning — see `tnAccessibleName` for the pair, and
+ * the docblock above for why a caller would want only this half.
+ */
+export function tnResolvedAriaLabel(config: TnAriaLabelConfig): Signal<string | null> {
+  // Blank is not a name. A whitespace-only `ariaLabel` names the element as
+  // emptily as no `ariaLabel`, and axe agrees, so it takes the fallback rather
+  // than being treated as an answer.
+  const hasLabelledby = computed(() => (config.ariaLabelledby() ?? '').trim() !== '');
+
+  return computed(() => {
+    const label = config.ariaLabel();
+    if ((label ?? '').trim() !== '') {
+      return label ?? null;
+    }
+    return hasLabelledby() ? null : config.fallback();
+  });
+}
 
 /** What a component needs to tell this function about itself. */
 export interface TnAccessibleNameConfig {
@@ -97,19 +149,18 @@ export interface TnAccessibleNameConfig {
  * for a copy of it to get wrong.
  */
 export function tnAccessibleName(config: TnAccessibleNameConfig): Signal<string | null> {
-  // Blank is not a name. A whitespace-only `ariaLabel` names the element as
-  // emptily as no `ariaLabel`, and axe agrees, so it takes the fallback and
-  // raises the warning rather than being treated as an answer.
-  const hasLabelledby = computed(() => (config.ariaLabelledby() ?? '').trim() !== '');
-  const named = computed(() => (config.ariaLabel() ?? '').trim() !== '' || hasLabelledby());
-
-  const resolved = computed(() => {
-    const label = config.ariaLabel();
-    if ((label ?? '').trim() !== '') {
-      return label;
-    }
-    return hasLabelledby() ? null : config.fallback;
+  const fallback = signal(config.fallback).asReadonly();
+  const resolved = tnResolvedAriaLabel({
+    ariaLabel: config.ariaLabel,
+    ariaLabelledby: config.ariaLabelledby,
+    fallback,
   });
+  // Blank is not a name, the same way it is not one to the rule above: a
+  // whitespace-only `ariaLabel` leaves the element as unnamed as no `ariaLabel`,
+  // so it raises the warning rather than being treated as an answer.
+  const named = computed(
+    () => (config.ariaLabel() ?? '').trim() !== '' || (config.ariaLabelledby() ?? '').trim() !== ''
+  );
 
   if (isDevMode()) {
     effect(() => {

--- a/projects/truenas-ui/src/lib/a11y/accessible-name.ts
+++ b/projects/truenas-ui/src/lib/a11y/accessible-name.ts
@@ -1,4 +1,4 @@
-import { computed, effect, isDevMode, signal } from '@angular/core';
+import { computed, effect, isDevMode } from '@angular/core';
 import type { Signal } from '@angular/core';
 
 /**
@@ -48,58 +48,26 @@ import type { Signal } from '@angular/core';
  * `live-region.ts`. It is how this library's own components agree with each
  * other; a consumer naming its own element has `aria-label`.
  *
- * THE RULE AND THE WARNING ARE SEPARATE FUNCTIONS
- * ----------------------------------------------
- * `tnResolvedAriaLabel` is the two-branch rule on its own; `tnAccessibleName` is
- * that rule plus the dev-mode warning. The split exists for `tn-table-pager`
- * (#249), which needs the rule and must not have the warning: its fallback is a
- * DESIGNED name that a consumer configures through `TN_TABLE_PAGER_LABELS`, not
- * a last resort for a name someone forgot, and a single unnamed pager announcing
- * "Table pagination" is correct rather than a defect. Warning on it would fire
- * on the ordinary case and teach readers to ignore the warning on the three
- * progressbars and the two dialogs, where it means something.
+ * WHAT THE SECOND BRANCH DEPENDS ON, AND THE ONE COMPONENT IT RULES OUT
+ * --------------------------------------------------------------------
+ * "Unnamed at least still fails loudly" is not a property of being unnamed. It
+ * is a property of every caller here: an unnamed `role="progressbar"` fails
+ * axe's `aria-progressbar-name`, and an unnamed dialog fails `aria-dialog-name`.
+ * Withholding the fallback trades a masked dangling IDREF for a red check, which
+ * is a good trade only while that red check exists.
  *
- * What is NOT split is the rule itself, which is the part that was getting
- * copied wrong. A caller that opts out of the warning still cannot write its own
- * version of the branches below.
+ * It does not exist for a landmark. `tn-table-pager` is `role="navigation"`, and
+ * axe's only landmark-naming rule is `landmark-unique`, which compares landmarks
+ * against EACH OTHER — one unnamed navigation landmark on a page violates
+ * nothing. So a pager given a typo'd `ariaLabelledby` would go silently unnamed,
+ * which is the failure #249 reported made worse, not fixed. The pager therefore
+ * names itself unconditionally and does not call this function; the reason is
+ * written out at `resolvedTablePaginationLabel` in `table-pager.component.ts`.
+ *
+ * That is the exception rather than an invitation. Routing the pager through
+ * here would be a regression, and any other caller that reaches for this
+ * function needs to be able to name the axe rule that catches it when unnamed.
  */
-
-/** The three signals the naming rule reads. */
-export interface TnAriaLabelConfig {
-  /** The component's `ariaLabel` input, or whatever plays that part. */
-  ariaLabel: Signal<string | null | undefined>;
-  /** The component's `ariaLabelledby` input, or whatever plays that part. */
-  ariaLabelledby: Signal<string | null | undefined>;
-  /**
-   * The name to render when the caller supplies neither.
-   *
-   * A signal rather than a string, because `tn-table-pager`'s fallback comes
-   * from the `TN_TABLE_PAGER_LABELS` token, which a consumer may provide as a
-   * signal so that a language change re-renders the label. `tnAccessibleName`
-   * wraps its plain-string `fallback` to reach this.
-   */
-  fallback: Signal<string>;
-}
-
-/**
- * The name to render as `aria-label`, or `null` to render no `aria-label` at
- * all. The rule, without the warning — see `tnAccessibleName` for the pair, and
- * the docblock above for why a caller would want only this half.
- */
-export function tnResolvedAriaLabel(config: TnAriaLabelConfig): Signal<string | null> {
-  // Blank is not a name. A whitespace-only `ariaLabel` names the element as
-  // emptily as no `ariaLabel`, and axe agrees, so it takes the fallback rather
-  // than being treated as an answer.
-  const hasLabelledby = computed(() => (config.ariaLabelledby() ?? '').trim() !== '');
-
-  return computed(() => {
-    const label = config.ariaLabel();
-    if ((label ?? '').trim() !== '') {
-      return label ?? null;
-    }
-    return hasLabelledby() ? null : config.fallback();
-  });
-}
 
 /** What a component needs to tell this function about itself. */
 export interface TnAccessibleNameConfig {
@@ -149,18 +117,19 @@ export interface TnAccessibleNameConfig {
  * for a copy of it to get wrong.
  */
 export function tnAccessibleName(config: TnAccessibleNameConfig): Signal<string | null> {
-  const fallback = signal(config.fallback).asReadonly();
-  const resolved = tnResolvedAriaLabel({
-    ariaLabel: config.ariaLabel,
-    ariaLabelledby: config.ariaLabelledby,
-    fallback,
+  // Blank is not a name. A whitespace-only `ariaLabel` names the element as
+  // emptily as no `ariaLabel`, and axe agrees, so it takes the fallback and
+  // raises the warning rather than being treated as an answer.
+  const hasLabelledby = computed(() => (config.ariaLabelledby() ?? '').trim() !== '');
+  const named = computed(() => (config.ariaLabel() ?? '').trim() !== '' || hasLabelledby());
+
+  const resolved = computed(() => {
+    const label = config.ariaLabel();
+    if ((label ?? '').trim() !== '') {
+      return label;
+    }
+    return hasLabelledby() ? null : config.fallback;
   });
-  // Blank is not a name, the same way it is not one to the rule above: a
-  // whitespace-only `ariaLabel` leaves the element as unnamed as no `ariaLabel`,
-  // so it raises the warning rather than being treated as an answer.
-  const named = computed(
-    () => (config.ariaLabel() ?? '').trim() !== '' || (config.ariaLabelledby() ?? '').trim() !== ''
-  );
 
   if (isDevMode()) {
     effect(() => {

--- a/projects/truenas-ui/src/lib/table-pager/table-pager-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager-a11y.spec.ts
@@ -1,0 +1,159 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnTablePagerComponent } from './table-pager.component';
+import { accessibleName } from '../a11y/accessible-name-testing';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the landmark naming fixed for #249: every `tn-table-pager` carries
+ * `role="navigation"`, and the name on it did not vary per instance — so two
+ * pagers on one page were one entry repeated in a screen reader's landmark list,
+ * both reading "Table pagination", with nothing to choose between them. axe
+ * reports it as `landmark-unique`.
+ *
+ * The ticket found it through `yarn test-sb` in a real browser. `landmark-unique`
+ * is pure DOM and axe evaluates it correctly under jsdom too — verified by
+ * watching it report the violation, on the same element and with the same
+ * summary as the browser run, before the fix. So this file holds the fix in place
+ * in a job that gates every PR, rather than only in the Storybook a11y run.
+ *
+ * Names are asserted with `accessibleName` alongside axe, because axe answers
+ * only "are these two the same?" — it is equally happy with two pagers named
+ * "a" and "b", which is not a fix. See `accessible-name-testing.ts`.
+ */
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnTablePagerComponent],
+  // The reported shape in miniature: two pagers in one view, each with the
+  // distinct `testId` such a view needs anyway so their child controls do not
+  // collide. The headings are what `ariaLabelledby` points at below — a table's
+  // visible name is the one a consumer should reach for first.
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <h4 id="storage-heading">Storage pools</h4>
+    <tn-table-pager
+      testId="storage"
+      [tablePaginationLabel]="firstLabel()"
+      [ariaLabelledby]="firstLabelledby()"
+      [totalItems]="247" />
+
+    <h4 id="snapshots-heading">Snapshots</h4>
+    <tn-table-pager
+      testId="snapshots"
+      [tablePaginationLabel]="secondLabel()"
+      [totalItems]="247" />
+  `,
+})
+class TwoPagersHostComponent {
+  firstLabel = signal<string | undefined>(undefined);
+  firstLabelledby = signal<string | undefined>(undefined);
+  secondLabel = signal<string | undefined>(undefined);
+}
+
+describe('tn-table-pager landmark naming (#249)', () => {
+  let host: TwoPagersHostComponent;
+  let fixture: ComponentFixture<TwoPagersHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TwoPagersHostComponent],
+    }).compileComponents();
+
+    // TestBed attaches the fixture to the document itself, which axe needs — it
+    // walks up to the document root to decide visibility, and treats a detached
+    // tree as hidden and therefore exempt from every rule below.
+    fixture = TestBed.createComponent(TwoPagersHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function pagers(): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('tn-table-pager'));
+  }
+
+  /**
+   * `evaluated` is asserted alongside every empty `violated`, because an empty
+   * `violations` is also what axe returns when it evaluated nothing at all. It is
+   * non-vacuous here: `landmark-unique` selects landmark elements, and both
+   * pagers carry `role="navigation"`.
+   */
+  async function landmarkUnique(): Promise<string[]> {
+    const { violated, evaluated } = await axeResult(
+      fixture.nativeElement,
+      pagers(),
+      ['landmark-unique'],
+    );
+    expect(evaluated).toContain('landmark-unique');
+    return violated;
+  }
+
+  describe('with neither pager named by the consumer', () => {
+    it('scopes each default name by the pager\'s own testId', () => {
+      expect(pagers().map((el) => el.getAttribute('aria-label')))
+        .toEqual(['Table pagination (storage)', 'Table pagination (snapshots)']);
+    });
+
+    it('leaves the two landmarks distinguishable', async () => {
+      const [first, second] = pagers().map((el) => accessibleName(el));
+      expect(first).not.toEqual(second);
+      expect(await landmarkUnique()).toEqual([]);
+    });
+  });
+
+  /**
+   * The positive control: `evaluated` proves the rule looked at these elements,
+   * not that it would object to the defect. Two pagers named identically are the
+   * pre-#249 shape rebuilt through the input, and axe has to report it — without
+   * this, the assertions above would stay green if `landmark-unique` stopped
+   * biting under jsdom, which is the way a guard goes quiet rather than red.
+   */
+  it('still reports two pagers a consumer names identically', async () => {
+    host.firstLabel.set('Table pagination');
+    host.secondLabel.set('Table pagination');
+    fixture.detectChanges();
+
+    expect(await landmarkUnique()).toEqual(['landmark-unique']);
+  });
+
+  describe('named by the consumer', () => {
+    it('takes tablePaginationLabel over the testId-scoped default', async () => {
+      host.firstLabel.set('Storage pool pagination');
+      fixture.detectChanges();
+
+      expect(accessibleName(pagers()[0])).toBe('Storage pool pagination');
+      expect(await landmarkUnique()).toEqual([]);
+    });
+
+    it('names a pager from the heading its ariaLabelledby points at', async () => {
+      host.firstLabelledby.set('storage-heading');
+      fixture.detectChanges();
+
+      const [first] = pagers();
+      expect(first.getAttribute('aria-labelledby')).toBe('storage-heading');
+      // The fallback is withheld beside a resolving `aria-labelledby` rather than
+      // rendered under it: a generic name there would be clean to axe and useless
+      // to a listener if the IDREF were the broken one. That rule is
+      // `tnResolvedAriaLabel`'s, shared with the progressbars and the dialogs.
+      expect(first.hasAttribute('aria-label')).toBe(false);
+      expect(accessibleName(first)).toBe('Storage pools');
+      expect(await landmarkUnique()).toEqual([]);
+    });
+
+    it('keeps an explicit label rendered beside an ariaLabelledby', async () => {
+      host.firstLabel.set('Storage pool pagination');
+      host.firstLabelledby.set('storage-heading');
+      fixture.detectChanges();
+
+      const [first] = pagers();
+      // Both attributes, and the IDREF wins the name — which is what a browser
+      // does. The `aria-label` survives so that a typo'd or not-yet-rendered
+      // IDREF leaves the pager named rather than silent.
+      expect(first.getAttribute('aria-label')).toBe('Storage pool pagination');
+      expect(accessibleName(first)).toBe('Storage pools');
+      expect(await landmarkUnique()).toEqual([]);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/table-pager/table-pager-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager-a11y.spec.ts
@@ -133,11 +133,10 @@ describe('tn-table-pager landmark naming (#249)', () => {
 
       const [first] = pagers();
       expect(first.getAttribute('aria-labelledby')).toBe('storage-heading');
-      // The fallback is withheld beside a resolving `aria-labelledby` rather than
-      // rendered under it: a generic name there would be clean to axe and useless
-      // to a listener if the IDREF were the broken one. That rule is
-      // `tnResolvedAriaLabel`'s, shared with the progressbars and the dialogs.
-      expect(first.hasAttribute('aria-label')).toBe(false);
+      // The IDREF wins the name — which is what a browser does — while the
+      // default `aria-label` stays rendered underneath it. See the next test for
+      // what that underneath is for.
+      expect(first.getAttribute('aria-label')).toBe('Table pagination (storage)');
       expect(accessibleName(first)).toBe('Storage pools');
       expect(await landmarkUnique()).toEqual([]);
     });
@@ -148,11 +147,26 @@ describe('tn-table-pager landmark naming (#249)', () => {
       fixture.detectChanges();
 
       const [first] = pagers();
-      // Both attributes, and the IDREF wins the name — which is what a browser
-      // does. The `aria-label` survives so that a typo'd or not-yet-rendered
-      // IDREF leaves the pager named rather than silent.
       expect(first.getAttribute('aria-label')).toBe('Storage pool pagination');
       expect(accessibleName(first)).toBe('Storage pools');
+      expect(await landmarkUnique()).toEqual([]);
+    });
+
+    /**
+     * The reason the `aria-label` is emitted beside an `ariaLabelledby` instead
+     * of being withheld under it. Nothing reports one unnamed navigation
+     * landmark — `landmark-unique` compares landmarks against each other, and
+     * axe has no `landmark-name` rule — so a pager that dropped its name here
+     * would announce nothing and fail no check, which is #249 made worse rather
+     * than fixed. Both pagers stay named and distinguishable through the typo.
+     */
+    it('stays named when its ariaLabelledby resolves to nothing', async () => {
+      host.firstLabelledby.set('storage-headnig');
+      fixture.detectChanges();
+
+      const [first, second] = pagers();
+      expect(accessibleName(first)).toBe('Table pagination (storage)');
+      expect(accessibleName(first)).not.toEqual(accessibleName(second));
       expect(await landmarkUnique()).toEqual([]);
     });
   });

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -297,9 +297,13 @@ export class TnTablePagerComponent {
    * when the caller supplies an IDREF, so a dangling IDREF surfaces as an
    * unnamed element instead of being masked by a name that says nothing. The
    * trade is only worth making where "unnamed" is itself caught: a progressbar
-   * fails `aria-progressbar-name`, a dialog fails `aria-dialog-name`. A
-   * `navigation` landmark fails neither, and `landmark-unique` compares
-   * landmarks against each other, so one unnamed pager violates nothing at all.
+   * fails `aria-progressbar-name`, an `over` drawer fails `aria-dialog-name`,
+   * and a `side` drawer — a landmark, like this — rests on that module's
+   * dev-mode warning instead. This pager has neither. `landmark-unique` compares
+   * landmarks against each other, so one unnamed pager violates nothing at all;
+   * and the warning is one it cannot take, because the fallback here is a name
+   * the consumer configures through `TN_TABLE_PAGER_LABELS` rather than one
+   * someone forgot, so it would fire on the ordinary case.
    *
    * Withholding here would therefore turn a typo in `ariaLabelledby` into a
    * pager that announces nothing and reports nothing — a worse version of the

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -18,7 +18,6 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { Observable, Subscription } from 'rxjs';
-import { tnResolvedAriaLabel } from '../a11y/accessible-name';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnSelectComponent, type TnSelectOption } from '../select/select.component';
 import { TN_TEST_ATTR, composeTestId, scopeTestId, writeTestId, type TnTestIdValue } from '../test-id';
@@ -240,11 +239,11 @@ export class TnTablePagerComponent {
    * IDREF naming the pager from text already on the page — the heading over the
    * table it pages, typically, which is the name the user can see.
    *
-   * Wins over `tablePaginationLabel` in the ARIA name computation while it
-   * resolves, so pass one or the other rather than both. An explicit
-   * `tablePaginationLabel` is still rendered beside it — see `tnResolvedAriaLabel`,
-   * which owns that rule for this library, and the reason it is safer than
-   * suppressing it.
+   * Wins over the `aria-label` in the ARIA name computation while it resolves,
+   * so pass one or the other rather than both. The `aria-label` is rendered
+   * beside it either way and is what the pager falls back to if the IDREF is
+   * typo'd or names an element that has not rendered yet — see
+   * `resolvedTablePaginationLabel`.
    */
   ariaLabelledby = input<string | undefined>(undefined);
 
@@ -257,9 +256,9 @@ export class TnTablePagerComponent {
   protected resolvedLastPageLabel = computed(() => this.lastPageLabel() ?? this.defaultLabels().lastPage);
 
   /**
-   * The landmark name a pager falls back to when the consumer names neither
-   * `tablePaginationLabel` nor `ariaLabelledby` — the DI default, scoped by
-   * `testId` when there is one.
+   * The landmark name a pager falls back to when the consumer sets no
+   * `tablePaginationLabel` — the DI default, scoped by `testId` when there is
+   * one.
    *
    * The scoping is what stops the DEFAULT from being the same string on every
    * pager, which is the shape #249 reported: two pagers, both announcing "Table
@@ -289,19 +288,30 @@ export class TnTablePagerComponent {
   });
 
   /**
-   * The name to render as `aria-label`, or `null` to render none.
+   * The name rendered as `aria-label`, always — the explicit
+   * `tablePaginationLabel` when there is one, the scoped default otherwise.
    *
-   * The rule lives in `../a11y/accessible-name`, shared with the progressbars and
-   * the dialogs, where both branches are set out: why an explicit label survives
-   * beside an `ariaLabelledby`, and why the generic fallback does not. This pager
-   * takes the rule WITHOUT that module's dev-mode warning — its fallback is a
-   * name the consumer configures through `TN_TABLE_PAGER_LABELS`, and a lone
-   * pager announcing "Table pagination" is correct rather than a defect.
+   * **It is emitted beside an `ariaLabelledby` rather than withheld under it**,
+   * which is where this differs from `../a11y/accessible-name`, the shared rule
+   * the progressbars and the dialogs take. That rule drops the generic fallback
+   * when the caller supplies an IDREF, so a dangling IDREF surfaces as an
+   * unnamed element instead of being masked by a name that says nothing. The
+   * trade is only worth making where "unnamed" is itself caught: a progressbar
+   * fails `aria-progressbar-name`, a dialog fails `aria-dialog-name`. A
+   * `navigation` landmark fails neither, and `landmark-unique` compares
+   * landmarks against each other, so one unnamed pager violates nothing at all.
+   *
+   * Withholding here would therefore turn a typo in `ariaLabelledby` into a
+   * pager that announces nothing and reports nothing — a worse version of the
+   * defect #249 opened on. So the pager keeps a name it can always fall back to,
+   * and accepts that a dangling IDREF is masked by a generic one.
    */
-  protected resolvedTablePaginationLabel = tnResolvedAriaLabel({
-    ariaLabel: this.tablePaginationLabel,
-    ariaLabelledby: this.ariaLabelledby,
-    fallback: this.defaultTablePaginationLabel,
+  protected resolvedTablePaginationLabel = computed(() => {
+    const label = this.tablePaginationLabel();
+    // Blank is not a name: `aria-label=" "` leaves the landmark as unnamed as no
+    // `aria-label` would, and axe reads it the same way, so it takes the default
+    // rather than being treated as an answer.
+    return (label ?? '').trim() === '' ? this.defaultTablePaginationLabel() : label;
   });
 
   /** Emits the new 1-based page number whenever the user navigates. */

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -18,6 +18,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { Observable, Subscription } from 'rxjs';
+import { tnResolvedAriaLabel } from '../a11y/accessible-name';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnSelectComponent, type TnSelectOption } from '../select/select.component';
 import { TN_TEST_ATTR, composeTestId, scopeTestId, writeTestId, type TnTestIdValue } from '../test-id';
@@ -144,6 +145,7 @@ export interface TnTableDataProvider {
     'class': 'tn-table-pager',
     'role': 'navigation',
     '[attr.aria-label]': 'resolvedTablePaginationLabel()',
+    '[attr.aria-labelledby]': 'ariaLabelledby() || null',
   },
 })
 export class TnTablePagerComponent {
@@ -222,7 +224,29 @@ export class TnTablePagerComponent {
   previousPageLabel = input<string | undefined>(undefined);
   nextPageLabel = input<string | undefined>(undefined);
   lastPageLabel = input<string | undefined>(undefined);
+
+  /**
+   * Accessible name for the pager's `navigation` landmark — what a screen
+   * reader user picking this pager out of a landmark list hears.
+   *
+   * **Name every pager on a page that has more than one.** Two pagers both
+   * announcing the DI default are one landmark repeated as far as that list is
+   * concerned, which is what #249 was: `landmark-unique` fails and the user has
+   * nothing to choose between them.
+   */
   tablePaginationLabel = input<string | undefined>(undefined);
+
+  /**
+   * IDREF naming the pager from text already on the page — the heading over the
+   * table it pages, typically, which is the name the user can see.
+   *
+   * Wins over `tablePaginationLabel` in the ARIA name computation while it
+   * resolves, so pass one or the other rather than both. An explicit
+   * `tablePaginationLabel` is still rendered beside it — see `tnResolvedAriaLabel`,
+   * which owns that rule for this library, and the reason it is safer than
+   * suppressing it.
+   */
+  ariaLabelledby = input<string | undefined>(undefined);
 
   /** Resolved labels: explicit input takes precedence over the DI default. */
   protected resolvedItemsPerPageLabel = computed(() => this.itemsPerPageLabel() ?? this.defaultLabels().itemsPerPage);
@@ -231,9 +255,54 @@ export class TnTablePagerComponent {
   protected resolvedPreviousPageLabel = computed(() => this.previousPageLabel() ?? this.defaultLabels().previousPage);
   protected resolvedNextPageLabel = computed(() => this.nextPageLabel() ?? this.defaultLabels().nextPage);
   protected resolvedLastPageLabel = computed(() => this.lastPageLabel() ?? this.defaultLabels().lastPage);
-  protected resolvedTablePaginationLabel = computed(
-    () => this.tablePaginationLabel() ?? this.defaultLabels().tablePagination,
-  );
+
+  /**
+   * The landmark name a pager falls back to when the consumer names neither
+   * `tablePaginationLabel` nor `ariaLabelledby` — the DI default, scoped by
+   * `testId` when there is one.
+   *
+   * The scoping is what stops the DEFAULT from being the same string on every
+   * pager, which is the shape #249 reported: two pagers, both announcing "Table
+   * pagination", indistinguishable in a landmark list. `testId` is the only
+   * per-instance identity the pager already has, and a page with two pagers
+   * needs distinct ones anyway — without them the pagers' own child controls
+   * collide on `select-page-size` / `button-first-page` (see the **Multiple
+   * Pagers** story), so the multi-pager case that trips this rule is exactly the
+   * case that already sets it.
+   *
+   * **It is a fallback and not the good answer.** A test id is a developer-facing
+   * token: it is not translated, and `storage` reads as the word rather than as
+   * "Storage pools". A pager whose name matters names itself with
+   * `tablePaginationLabel`, or points at the table's visible heading with
+   * `ariaLabelledby`; this only keeps the unnamed case from being ambiguous as
+   * well as generic.
+   *
+   * Appended in parentheses rather than woven into the sentence, because the
+   * base string comes from `TN_TABLE_PAGER_LABELS` and may be in any language —
+   * there is no word order here to get right, only a translated name and a
+   * scope after it.
+   */
+  private defaultTablePaginationLabel = computed(() => {
+    const base = this.defaultLabels().tablePagination;
+    const scope = composeTestId(undefined, this.testId());
+    return scope === '' ? base : `${base} (${scope})`;
+  });
+
+  /**
+   * The name to render as `aria-label`, or `null` to render none.
+   *
+   * The rule lives in `../a11y/accessible-name`, shared with the progressbars and
+   * the dialogs, where both branches are set out: why an explicit label survives
+   * beside an `ariaLabelledby`, and why the generic fallback does not. This pager
+   * takes the rule WITHOUT that module's dev-mode warning — its fallback is a
+   * name the consumer configures through `TN_TABLE_PAGER_LABELS`, and a lone
+   * pager announcing "Table pagination" is correct rather than a defect.
+   */
+  protected resolvedTablePaginationLabel = tnResolvedAriaLabel({
+    ariaLabel: this.tablePaginationLabel,
+    ariaLabelledby: this.ariaLabelledby,
+    fallback: this.defaultTablePaginationLabel,
+  });
 
   /** Emits the new 1-based page number whenever the user navigates. */
   pageChange = output<number>();

--- a/projects/truenas-ui/src/stories/table-pager.stories.ts
+++ b/projects/truenas-ui/src/stories/table-pager.stories.ts
@@ -223,22 +223,33 @@ export const TestIds: Story = {
 /**
  * **Multiple pagers in one view.** Two pagers without a `testId` base would both
  * emit `select-page-size` / `button-first-page` — duplicate, ambiguous selectors.
- * Give each a distinct `testId` base and every child id is scoped uniquely:
- * `select-storage-page-size` vs `select-snapshots-page-size`, etc. The live
- * tables below show the two disjoint id sets.
+ * Give each a distinct `testId` base (`storage` and `snapshots` below) and every
+ * child id is scoped uniquely: `select-storage-page-size` vs
+ * `select-snapshots-page-size`, etc. The live tables below show the two disjoint
+ * id sets.
+ *
+ * **Name them too.** Each pager is a `navigation` landmark, and two landmarks
+ * with the same accessible name are one entry repeated in a screen reader's
+ * landmark list — nothing to choose between them. The pager scopes its default
+ * name by `testId` when you give it one, so these would read "Table pagination
+ * (storage)" and "Table pagination (snapshots)" with no naming inputs at all; a
+ * test id is a developer's token rather than user-facing copy, though, so name
+ * them properly. Both routes are shown: the storage pager points
+ * `ariaLabelledby` at the heading above it, and the snapshots pager sets
+ * `tablePaginationLabel` directly.
  */
 export const MultiplePagers: Story = {
   render: () => ({
     props: { total: 247 },
     template: `
-      <h4 style="margin:0 0 8px;font:600 13px/1 sans-serif;">Pager testId="storage"</h4>
+      <h4 id="pager-story-storage" style="margin:0 0 8px;font:600 13px/1 sans-serif;">Storage pools</h4>
       <tn-testid-inspector>
-        <tn-table-pager testId="storage" [totalItems]="total" />
+        <tn-table-pager testId="storage" ariaLabelledby="pager-story-storage" [totalItems]="total" />
       </tn-testid-inspector>
 
-      <h4 style="margin:24px 0 8px;font:600 13px/1 sans-serif;">Pager testId="snapshots"</h4>
+      <h4 style="margin:24px 0 8px;font:600 13px/1 sans-serif;">Snapshots</h4>
       <tn-testid-inspector>
-        <tn-table-pager testId="snapshots" [totalItems]="total" />
+        <tn-table-pager testId="snapshots" tablePaginationLabel="Snapshots pagination" [totalItems]="total" />
       </tn-testid-inspector>
     `,
   }),


### PR DESCRIPTION
Fixes #249.

## The defect

Every `tn-table-pager` carries `role="navigation"` on its host and took its
`aria-label` from `resolvedTablePaginationLabel()`, which did not vary per
instance. Two pagers on one page were therefore one entry repeated in a screen
reader's landmark list — both reading "Table pagination" — and axe reports it as
`landmark-unique`.

**Reproduced before anything was changed.** The ticket found it in a real browser
via `yarn test-sb`; `landmark-unique` is pure DOM structure and axe evaluates it
under jsdom too. Scanning a fixture with two pagers returned the same rule, on
the same element, with the same summary as the browser run in the ticket:

```
landmark-unique (moderate)
  tn-table-pager[testid="storage"]
  <tn-table-pager role="navigation" testid="storage" class="tn-table-pager"
                  data-testid="storage" aria-label="Table pagination">
  The landmark must have a unique aria-label, aria-labelledby, or title to make
  landmarks distinguishable
```

and `accessibleName()` on the two hosts returned `['Table pagination', 'Table
pagination']`.

## The fix

Three naming routes, in the order ARIA resolves them:

| Route | For |
|---|---|
| **`ariaLabelledby`** — new input | The table already has a visible heading naming it. Points at it; the heading is the name the user can see |
| **`tablePaginationLabel`** — already existed | An explicit name, e.g. `"Snapshots pagination"` |
| The `TN_TABLE_PAGER_LABELS` default, **now scoped by `testId`** | Neither of the above — `"Table pagination (storage)"` |

The `testId` scoping is what stops the *default* from being one string on every
pager. A page with two pagers needs distinct test ids anyway or the pagers' own
child controls collide on `select-page-size` / `button-first-page`, so the case
that trips `landmark-unique` is the case that already carries the identity to fix
it.

**It is a fallback, not the good answer, and the code says so.** A test id is a
developer's token: it is not translated, and `storage` reads as the word rather
than as "Storage pools". The two consumer-facing routes are what a pager whose
name matters should use. A pager with no `testId` is unchanged — still exactly
`"Table pagination"`, which is what the existing host-a11y specs assert.

### The pager names itself unconditionally, and does not take the shared rule

`aria-label` is **always** emitted — the explicit `tablePaginationLabel` when
there is one, the scoped default otherwise — and `aria-labelledby` is passed
through beside it. A resolving IDREF wins the announced name, which is what a
browser does; a non-resolving one falls through to the `aria-label`.

That is deliberately *not* what `../a11y/accessible-name` does, and round 1 of
this PR got it wrong. That module withholds the generic fallback when the caller
supplies an `ariaLabelledby`, so a dangling IDREF surfaces as an unnamed element
rather than being masked by a name that says nothing. The trade buys a signal
only where being unnamed is itself caught — by an axe name rule
(`aria-progressbar-name` on the three progressbars, `aria-dialog-name` on an
`over` drawer), or by that module's dev-mode warning (which is what a `side`
drawer, also a `navigation` landmark, rests on).

`tn-table-pager` has neither. `landmark-unique` compares landmarks against each
other, so one unnamed pager violates nothing; and the warning is one this
component cannot take, because its fallback is a name the consumer configures
through `TN_TABLE_PAGER_LABELS` rather than one somebody forgot — it would fire
on the ordinary case and teach readers to ignore it where it means something. So
withholding here would turn a typo in `ariaLabelledby` into a pager that
announces nothing and reports nothing: the defect this ticket opened on, made
worse.

The shared module is therefore unchanged from `main` except for its docblock,
which now records what the withholding branch depends on and why this one caller
is the exception — so the next reader does not "tidy" the pager back into it.

## Acceptance criteria

- [x] **Two instances expose distinct accessible names** — from `ariaLabelledby`,
      from `tablePaginationLabel`, or from the `testId`-scoped default.
- [x] **The name is settable by the consumer** — `tablePaginationLabel`
      (pre-existing) and `ariaLabelledby` (new), both taking precedence over the
      generated scope.
- [x] **A single pager still gets a sensible default** — unchanged at `"Table
      pagination"` with no `testId`; `"Table pagination (storage)"` with one. No
      counter, so nothing reads `"Table pagination 1"`.
- [x] **`aria-labelledby` is supported** — new input, host binding, and the
      `MultiplePagers` story now points the storage pager at the heading above it.
- [ ] **`Components/Table Pager > MultiplePagers` passes `yarn test-sb`** — see
      below.

## Checks

**This round** re-ran `yarn lint`, the full jest suite (`3362` passing, 132
suites) and `yarn build` — all pass. Lint reports 4 pre-existing `import/order`
errors in `input.component.ts` and `menu-panel.component.ts`, neither of which
this touches (that is #251).

`yarn test:scripts` and `yarn build-storybook` passed in round 1 and were not
re-run: this round touches neither the scripts nor the stories, only
`accessible-name.ts` (not exported from `public-api.ts`), the pager component
and the pager's spec. Both are gating jobs on this PR and will run there.

**`yarn test-sb` could not be run here** — the Storybook interaction tests drive a
real browser through Playwright, and this machine has neither the browser nor the
system libraries to start one. So the last acceptance criterion is argued rather
than observed: `MultiplePagers` renders two pagers whose accessible names are now
`"Storage pools"` (from the heading it is pointed at) and `"Snapshots pagination"`,
and `landmark-unique` compares exactly those names. The equivalent assertion runs
under jsdom in `table-pager-a11y.spec.ts` and passes; the browser run is what the
`Storybook Interaction Tests` job on this PR will confirm.

## Tests

`projects/truenas-ui/src/lib/table-pager/table-pager-a11y.spec.ts` — new, and it
guards the fix in a job that gates every PR rather than only in the Storybook
a11y panel:

- the two default names are `"Table pagination (storage)"` and `"Table pagination
  (snapshots)"`, and `landmark-unique` is quiet on both hosts;
- a **positive control**: two pagers a consumer names *identically* still make axe
  object. `evaluated` proves the rule looked; only this proves it would still
  bite, which is how a guard goes quiet instead of red;
- `tablePaginationLabel` beats the `testId`-scoped default;
- `ariaLabelledby` names the pager from the heading, with the default
  `aria-label` still rendered underneath it;
- an explicit label is rendered beside an `ariaLabelledby` too, and the IDREF wins
  the announced name;
- **a dangling `ariaLabelledby` leaves the pager named and still distinguishable
  from its neighbour** — the case the round-2 fix above is about.

Names are asserted with `accessibleName()` alongside axe, because axe only
answers "are these two the same?" and is equally happy with two pagers named "a"
and "b".

## What I did not change

The local review's last round returned nothing at MEDIUM or above. These are the
LOWs, recorded rather than acted on, per the round rules — each is defensible as
a follow-up:

1. **The `testId` scope applies unconditionally**, so an existing single-pager
   consumer that sets `testId` starts announcing a developer token. Deliberate,
   and the tradeoff is written into the code: the alternative is to scope only
   when a second pager exists, which needs cross-instance coordination and would
   make one pager's name depend on another pager's existence. The `testId`
   input's own docs do not mention that it can reach the a11y tree — worth a line
   there.
2. **Two pagers with *no* `testId` still collide.** True. There is no
   per-instance identity to derive from in that case, and the remaining fix would
   be a generated counter — which acceptance criterion 3 rules out by name ("does
   not regress to something like 'Table pagination 1'").
3. **The pager emits no dev-mode warning when it is unnamed**, unlike every other
   naming route in the library. That is the point of the section above rather
   than an oversight: the pager is never unnamed by default. What no longer has a
   signal is a *dangling* `ariaLabelledby` — masked here by the fallback, and
   equally unreported for the drawers and progressbars, where axe files it as
   `incomplete` rather than a violation. A dev-mode check that resolves the IDREF
   would cover all of them and belongs in `accessible-name.ts`, not here.
4. **`resolvedTablePaginationLabel` infers `string | undefined`** — the blank
   check reads `(label ?? '').trim()`, which TypeScript cannot use to narrow
   `label`, so the signal's type is wider than its behaviour. It cannot be
   `undefined` at runtime; the fix is a narrowing rewrite of executable code and
   is left for a follow-up rather than pushed unreviewed.
5. **No `ariaLabel` input beside `ariaLabelledby`.** `tablePaginationLabel` is
   this component's `ariaLabel`, named for the labels token it defaults from; a
   consumer writing `ariaLabel` on a `tn-table-pager` is writing an input that has
   never existed here.
6. **`TnTablePagerHarnessFilters` is still empty** — a name filter would let
   harness tests pick between two pagers. A real improvement and a separate
   change to the harness API.
