### PR TITLE
NAS-142514 / 27.0.0-BETA.1 / fix(lint): clear the pre-existing import/order errors on main

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -130,14 +130,18 @@ module.exports = [
       // Import ordering.
       //
       // internal/parent/sibling/index are deliberately ONE group, so a `./x`
-      // and a `../y` import sort against each other. Be aware of how the plugin
-      // compares those two: it splits both paths on '/', sees that the first
-      // segments differ ('.' vs '..'), stops comparing text there, and falls
-      // through to the tie-break — FEWER path segments first, equal counts tie
-      // (eslint-plugin-import 2.32.0, lib/rules/order.js). So `./size-conversion`
-      // sorts before `../enums/input-type.enum`, which reads backwards but is
-      // what this config asks for. Let `yarn lint:fix` decide the order rather
-      // than sorting imports by hand.
+      // and a `../y` import are sorted against each other. The plugin does not
+      // expect that: comparing those two, it splits both paths on '/', sees the
+      // first segments differ ('.' vs '..'), skips the text comparison as
+      // "different groups anyway", and falls through to a path-segment-count
+      // tie-break (eslint-plugin-import 2.32.0, lib/rules/order.js).
+      //
+      // The upshot is that the comparison is not a total order — `./a` can rank
+      // below `../b/c` while `../b/c` ranks below `../d/e/f`, and equal segment
+      // counts compare as equal — so which arrangement passes depends on the
+      // order the file already had, and an accepted file can look unsorted.
+      // Run `yarn lint:fix` and take what it gives you; sorting these by hand
+      // is guesswork.
       'import/order': [
         'error',
         {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,7 +127,17 @@ module.exports = [
         },
       ],
 
-      // Import ordering
+      // Import ordering.
+      //
+      // internal/parent/sibling/index are deliberately ONE group, so a `./x`
+      // and a `../y` import sort against each other. Be aware of how the plugin
+      // compares those two: it splits both paths on '/', sees that the first
+      // segments differ ('.' vs '..'), stops comparing text there, and falls
+      // through to the tie-break — FEWER path segments first, equal counts tie
+      // (eslint-plugin-import 2.32.0, lib/rules/order.js). So `./size-conversion`
+      // sorts before `../enums/input-type.enum`, which reads backwards but is
+      // what this config asks for. Let `yarn lint:fix` decide the order rather
+      // than sorting imports by hand.
       'import/order': [
         'error',
         {

--- a/projects/truenas-ui/src/lib/input/input.component.ts
+++ b/projects/truenas-ui/src/lib/input/input.component.ts
@@ -3,13 +3,13 @@ import type { ElementRef, AfterViewInit, OnDestroy} from '@angular/core';
 import { Component, viewChild, inject, input, output, computed, signal, linkedSignal, forwardRef } from '@angular/core';
 import type { ControlValueAccessor} from '@angular/forms';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { formatSize, parseSize, type SizeStandard } from './size-conversion';
 import { InputType } from '../enums/input-type.enum';
 import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import { tnIconMarker } from '../icon/icon-marker';
 import type { IconLibraryType } from '../icon/icon.component';
 import { TnIconComponent } from '../icon/icon.component';
 import { TnTestIdDirective, controlTestId, type TnTestIdValue } from '../test-id';
-import { formatSize, parseSize, type SizeStandard } from './size-conversion';
 
 // Module-level counter for deterministic, unique instance ids (matches the
 // tn-autocomplete convention). Deterministic ids are SSR/hydration-safe and

--- a/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
+++ b/projects/truenas-ui/src/lib/menu/menu-panel.component.ts
@@ -1,13 +1,13 @@
 import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, forwardRef, inject, input } from '@angular/core';
-import { TnIconComponent } from '../icon/icon.component';
 import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
 import { TnTestIdDirective, scopeTestId, type TnTestIdValue } from '../test-id';
 import { TnMenuActivateHoverDirective } from './menu-activate-hover.directive';
 import type { TnMenuItemComponent } from './menu-item.component';
 import type { TnMenuItem } from './menu.component';
 import { TnMenuComponent } from './menu.component';
+import { TnIconComponent } from '../icon/icon.component';
 
 /**
  * Renders one complete menu panel: the `<div cdkMenu>` container plus every


### PR DESCRIPTION
Fixes #251

## What was wrong

`yarn lint` on a clean checkout of `main` (`890be5e`) reported four `import/order`
errors in files no diff had touched:

```
projects/truenas-ui/src/lib/input/input.component.ts
  12:1  error  `./size-conversion` import should occur before import of `../enums/input-type.enum`

projects/truenas-ui/src/lib/menu/menu-panel.component.ts
  4:1  error  `../icon/icon.component` import should occur after import of `./menu.component`
  5:1  error  `../pipes/label-markup/label-markup.pipe` import should occur after import of `./menu.component`
  6:1  error  `../test-id` import should occur after import of `./menu.component`
```

Reproduced before changing anything. The ticket named a different set of four
(`axe-testing`, `side-panel.component`, `../a11y/axe-testing`); those are gone and
`menu-panel.component.ts` has taken their place, which matches the ticket's own
observation that the set drifts as the library grows.

## What changed

Three files. The four import statements were reordered by the rule's own fixer
(`eslint --fix`, scoped to the two files) rather than suppressed — no inline
`eslint-disable`, no rule exclusion. `yarn lint` now exits clean.

The third file is `eslint.config.js`, and it is a **comment only**, no config change.
It is there because the ordering the fixer produces reads backwards, and without a
note saying why, the next reader corrects it back and the errors return.

## Why the accepted order looks wrong

`internal`, `parent`, `sibling` and `index` are one group in this config, so `./x` and
`../y` are sorted against each other. eslint-plugin-import does not expect that. Its
comparator (2.32.0, `lib/rules/order.js`) splits both paths on `/`, sees the first
segments differ (`.` vs `..`), skips the text comparison — its own comment says the
paths "belong in different groups" — and falls through to a path-segment-count
tie-break, with equal counts comparing equal.

That comparison is not transitive, so no hand-sortable rule describes the result. In
`menu-panel.component.ts` a four-segment `../pipes/label-markup/label-markup.pipe`
now sits *above* a two-segment `./menu-activate-hover.directive` while a three-segment
`../icon/icon.component` sits *below* it — both in the arrangement lint accepts. Which
arrangement passes depends on the order the file already had. The comment says to run
`yarn lint:fix` and take its output.

## Considered and rejected: splitting the group

The durable fix looks like `groups: ['builtin', 'external', 'internal', 'parent',
'sibling', 'index']` — separate ranks mean the quirk never fires and ordering becomes
the intuitive parents-then-siblings. I tried it and measured the result: **134 errors**
across the repo, mostly `./testid-inspector.component` in story files. The codebase has
been written against the merged group throughout, so splitting it is a repo-wide
reformat and well outside this ticket. Recorded here so it is not re-derived.

## Checks

Run locally against the gating jobs in `.github/workflows/ci-cd.yml`:

- `yarn lint` — clean, zero errors (this is the acceptance criterion)
- `yarn test` — 3355 passed, 131 suites
- `yarn test:scripts` — 42 passed
- `yarn build` — library builds

`Storybook Interaction Tests` was **not** run locally — it drives a real browser and
this host has neither the browser nor the system libraries to supply one. It is the
one check here without local confirmation. Reordering import statements has no runtime
effect beyond module evaluation order, and the full Jest suite covers both touched
components.

## One thing a reviewer should weigh

The local review round flagged (LOW) that `../icon/icon.component` compares as
less-than both `../pipes/...` and `../test-id`, making its move to the bottom of the
list look like churn. It is not: those three lines were three of the four reported
errors, and this is where the fixer put them. But it is a fair reading, and it is the
same intransitivity described above — worth a second opinion rather than being buried.


## A caveat about what verified this

CI's own `Run Linter` job was **green on `890be5e`** — the same commit where the four
errors above reproduce locally, with the same `yarn lint`, the same eslint 9.39.2 and
the same eslint-plugin-import 2.32.0 that `yarn.lock` pins. So a green linter check on
this PR is not what confirms the fix; the local run is. I could not establish why the
two disagree: the job log is a 302 redirect this environment cannot follow, and the
versions I could compare all match.

Worth knowing for whoever reviews this, in two directions. If CI does not evaluate
`import/order` the way a local run does, then CI has never been the thing keeping these
files ordered, and the next four will arrive the same way. And if the divergence is
instead something about this deployment's checkout, then the errors are local-only and
this PR is churn — I do not believe that, because the arrangement CI accepts today
includes roughly 130 other files that order `./x` before `../y` in exactly the shape
this rule is being asked about, but it is the alternative and it is not ruled out.
