### PR TITLE
NAS-142515 / 27.0.0-BETA.1 / fix(a11y): stop listbox containers owning children ARIA forbids

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -461,6 +461,27 @@ element around the text — `<li><h3>` in plain HTML. Dropping to
 from the accessibility tree, which is a silent regression a passing rule cannot
 show you.
 
+**Where it cannot be moved, keep the text as an accessible name.** The same
+subheader inside a `listbox` has nowhere to move the heading to (#259).
+`listitem` is not an allowed child there either, and — measured, and asserted as
+a control in `list/list-a11y.spec.ts` — **axe reads THROUGH a `group` when it
+collects what a listbox owns**, so wrapping the heading in the one container the
+listbox does allow reports the identical violation with the heading named
+instead. So the host becomes the `group` and takes the section's own text as its
+accessible name, via `aria-labelledby` to the unmarked span around it. The text
+is still in the accessibility tree and still announced; what it is announced as
+changes, from a heading to a named section.
+
+That the answer differs per container is the point of asking who owns you: there
+is no one substitute role, and `presentation` is never it.
+
+**A decorative element needs no substitute at all** — it carries no role and the
+stylesheet still draws it. `tn-divider` resolves to `presentation` because its
+host is shared with the standalone case; the two rules in
+`select.component.html`, written directly inside that component's own listbox,
+simply have no `role` attribute. Where an element sits is only a question worth
+asking with `ariaOwner()` when the same component renders in both places.
+
 ### Live Regions
 
 **Declare politeness exactly once.** A live-region role implies one — `alert` is

--- a/projects/truenas-ui/src/lib/list-subheader/list-subheader.component.html
+++ b/projects/truenas-ui/src/lib/list-subheader/list-subheader.component.html
@@ -1,7 +1,9 @@
 <!--
-  The heading role lives here when the host has had to become a `listitem` —
-  see the class docblock. Rendered either way rather than behind an `@if`, so
-  there is one DOM shape and one `<ng-content>`; outside a list it is an
-  unmarked span and the host is the heading.
+  The heading role lives here when a list has made the host the `listitem` it
+  requires — see the class docblock. Rendered either way rather than behind an
+  `@if`, so there is one DOM shape and one `<ng-content>`; where the host is the
+  heading, and inside a listbox where nothing may be one, this is an unmarked
+  span. The `id` is emitted only for the listbox, which is the one form that has
+  to point at this text to be named by it.
 -->
-<span [attr.role]="inList() ? 'heading' : null" [attr.aria-level]="inList() ? '3' : null"><ng-content /></span>
+<span [attr.id]="namesGroup() ? textId : null" [attr.role]="headingInside() ? 'heading' : null" [attr.aria-level]="headingInside() ? '3' : null"><ng-content /></span>

--- a/projects/truenas-ui/src/lib/list-subheader/list-subheader.component.ts
+++ b/projects/truenas-ui/src/lib/list-subheader/list-subheader.component.ts
@@ -3,21 +3,47 @@ import { Component, computed, input } from '@angular/core';
 import type { DoCheck } from '@angular/core';
 import { ariaOwner } from '../a11y/aria-owner';
 
+let nextId = 0;
+
 /**
  * A section heading inside a list.
  *
- * A `role="list"` owns only `listitem`, so a heading between two rows
- * invalidates the list (#237). The heading is not dropped for that — it is
- * moved: inside a list the host becomes the `listitem` the list requires, and
- * the `role="heading"` goes on the element around the text, one level in. That
- * is what `<li><h3>Pools</h3></li>` is in plain HTML, and it keeps the section
- * heading in the accessibility tree at the same level it always had. Where the
- * list is not what owns it — outside one, or nested inside a row of one — the
- * host carries the heading itself, as before, and the inner element is an
- * ordinary span. See `ariaOwnerRole` for what "owns" means here.
+ * A container role can forbid its children's roles, so a heading between two
+ * rows invalidates the container — axe's `aria-required-children`, and the
+ * defect fixed in #237 and #259. The heading is not dropped for that; it is
+ * moved, and where the HOST goes depends on what owns it. See `ariaOwnerRole`
+ * for what "owns" means here.
  *
- * The cost is that the list counts one more item per section, which is the same
- * count a browser reports for the HTML above.
+ * | Owner | Host | The element around the text |
+ * |---|---|---|
+ * | `role="list"` | `listitem` | `heading`, level 3 |
+ * | `role="listbox"` | `group`, named by the text below | an ordinary span |
+ * | anything else | `heading`, level 3 | an ordinary span |
+ *
+ * Inside a LIST the host becomes the `listitem` the list requires and the
+ * heading goes one level in — `<li><h3>Pools</h3></li>` in plain HTML, which
+ * keeps the section heading in the accessibility tree at the level it always
+ * had. The cost is that the list counts one more item per section, which is the
+ * same count a browser reports for that HTML.
+ *
+ * Inside a LISTBOX neither of those is available. `listitem` is not an allowed
+ * child of a listbox either, so it trades one `aria-required-children` violation
+ * for another; and the heading cannot move one level in the way it does for a
+ * list, because axe reads THROUGH a `group` when it collects what a listbox
+ * owns — measured, a `group` wrapping a `role="heading"` reports the same
+ * violation, now naming the heading. So the section survives as a `group` with
+ * the subheader's own text as its accessible name, via `aria-labelledby` to the
+ * unmarked span: the text is still in the accessibility tree and still
+ * announced, as a named section rather than as a heading.
+ *
+ * That group holds the text and NOT the rows that follow it: a subheader is
+ * projected content and is a sibling of the rows it introduces, so it can name
+ * a section without enclosing one. Genuinely nesting the options is markup for
+ * the consumer to write.
+ *
+ * Outside either — or nested inside a row of one, where a heading is already
+ * legal — the host carries the heading itself and the inner element is an
+ * ordinary span.
  */
 @Component({
   selector: 'tn-list-subheader',
@@ -28,8 +54,9 @@ import { ariaOwner } from '../a11y/aria-owner';
   host: {
     'class': 'tn-list-subheader',
     '[class.tn-list-subheader--inset]': 'inset()',
-    '[attr.role]': 'inList() ? "listitem" : "heading"',
-    '[attr.aria-level]': 'inList() ? null : "3"'
+    '[attr.role]': 'hostRole()',
+    '[attr.aria-level]': 'headingOnHost() ? "3" : null',
+    '[attr.aria-labelledby]': 'namesGroup() ? textId : null'
   }
 })
 export class TnListSubheaderComponent implements DoCheck {
@@ -38,12 +65,47 @@ export class TnListSubheaderComponent implements DoCheck {
   private readonly owner = ariaOwner();
 
   /**
-   * `list` and nothing else, unlike the divider's wider test: becoming a
-   * `listitem` is the LIST's answer to the ownership rule. A `listbox` owns
-   * `option` and `group`, so a section there is a `group` with an accessible
-   * name — different markup, and not this ticket's.
+   * Id of the inner span, so that the `group` form can be named by the text.
+   *
+   * Allocated per instance rather than per render, and emitted only when the
+   * group needs it — see the template.
    */
-  protected readonly inList = computed(() => this.owner.role() === 'list');
+  protected readonly textId = `tn-list-subheader-${nextId++}`;
+
+  /**
+   * Which of the three containers in the class docblock this is sitting in.
+   *
+   * Only the two that prescribe their children are named; every other owner,
+   * `null` included, leaves the heading on the host where it has always been.
+   */
+  private readonly ownerKind = computed<'list' | 'listbox' | 'other'>(() => {
+    const role = this.owner.role();
+    return role === 'list' || role === 'listbox' ? role : 'other';
+  });
+
+  /** The role the host carries. See the table in the class docblock. */
+  protected readonly hostRole = computed(() => {
+    switch (this.ownerKind()) {
+      case 'list': return 'listitem';
+      case 'listbox': return 'group';
+      default: return 'heading';
+    }
+  });
+
+  /** Whether the heading is on the HOST, which is where `aria-level` follows it. */
+  protected readonly headingOnHost = computed(() => this.ownerKind() === 'other');
+
+  /**
+   * Whether the heading has moved one level in, onto the span.
+   *
+   * `list` alone, and never both this and {@link headingOnHost}: one section is
+   * one heading, and a host that is both a `listitem` and a heading is what
+   * #237 removed.
+   */
+  protected readonly headingInside = computed(() => this.ownerKind() === 'list');
+
+  /** Whether the host is a `group` that the span below has to name. */
+  protected readonly namesGroup = computed(() => this.ownerKind() === 'listbox');
 
   ngDoCheck(): void {
     this.owner.check();

--- a/projects/truenas-ui/src/lib/list/list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/list/list-a11y.spec.ts
@@ -3,6 +3,7 @@ import type { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TnListComponent } from './list.component';
+import { accessibleName } from '../a11y/accessible-name-testing';
 import { axeResult, axeScan } from '../a11y/axe-testing';
 import { TnDividerComponent } from '../divider/divider.component';
 import { TnDividerDirective, TnListItemTitleDirective } from '../list-directives/list-directives';
@@ -177,6 +178,25 @@ class GatedHostComponent {}
   `,
 })
 class ListboxHostComponent {}
+
+/**
+ * A SUBHEADER in that same listbox, which #237 deliberately left alone and #259
+ * is (see the describe block below for what the answer is and why it differs
+ * from the list's).
+ */
+@Component({
+  selector: 'tn-listbox-subheader-a11y-host',
+  standalone: true,
+  imports: [TnSelectionListComponent, TnListOptionComponent, TnListSubheaderComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-selection-list aria-label="Mailboxes">
+      <tn-list-subheader>Personal</tn-list-subheader>
+      <tn-list-option [value]="'inbox'">Inbox</tn-list-option>
+    </tn-selection-list>
+  `,
+})
+class ListboxSubheaderHostComponent {}
 
 /** The same three components, with nothing around them. */
 @Component({
@@ -435,6 +455,117 @@ describe('tn-list section accessibility', () => {
       );
       expect(violated).toEqual([]);
       expect(evaluated).toContain('aria-required-children');
+    });
+  });
+
+  /**
+   * #259. `listitem` is the LIST's answer to `aria-required-children` and is not
+   * available here — a `listbox` owns `option` and `group` and no more — so the
+   * subheader becomes the `group` and takes the section's text as its accessible
+   * name.
+   *
+   * Moving the heading one level in, the way a list does, does NOT work here and
+   * the case below proves it: axe reads THROUGH a `group` when it collects what
+   * a listbox owns, so a group wrapping a `role="heading"` reports the same
+   * violation with the heading named instead. The section is therefore announced
+   * as a named group rather than as a heading, which is the route the ticket
+   * asks for — what it rules out is `role="presentation"`, which would take the
+   * text out of the tree altogether.
+   *
+   * The group holds the text and NOT the options that follow it. A subheader is
+   * a sibling of the rows it introduces — it is projected content and has
+   * nothing to wrap — so this names the section without enclosing it. A listbox
+   * that wants its options genuinely grouped has to nest them, which is markup
+   * for the consumer to write.
+   */
+  describe('a subheader inside a listbox', () => {
+    let listbox: ComponentFixture<ListboxSubheaderHostComponent>;
+
+    const find = <T extends HTMLElement>(selector: string): T => {
+      const found = listbox.nativeElement.querySelector(selector) as T | null;
+      if (!found) { throw new Error(`no element matched ${selector}`); }
+      return found;
+    };
+
+    beforeEach(async () => { listbox = await createHost(ListboxSubheaderHostComponent); });
+
+    it('reports no aria-required-children violation on the listbox', async () => {
+      const { violated, evaluated } = await axeResult(
+        listbox.nativeElement,
+        [find('tn-selection-list')],
+        ['aria-required-children'],
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('aria-required-children');
+    });
+
+    it('is the group a listbox may own, and is not a heading anywhere', () => {
+      const subheader = find('tn-list-subheader');
+
+      expect(subheader.getAttribute('role')).toBe('group');
+      // Neither on the host nor one level in. Both are the violation, in the
+      // two shapes this component can produce them — see the docblock above.
+      expect(subheader.getAttribute('aria-level')).toBeNull();
+      expect(subheader.querySelectorAll('[role="heading"]')).toHaveLength(0);
+    });
+
+    it('keeps the section text in the accessibility tree, as the group name', () => {
+      const subheader = find('tn-list-subheader');
+      const text = find('tn-list-subheader span');
+
+      // The assertion the ticket's criterion is about: dropping the role is
+      // only correct while the text is still announced, and a `role="group"`
+      // that resolved to no name would announce nothing at all.
+      expect(subheader.getAttribute('aria-labelledby')).toBe(text.id);
+      expect(text.id).not.toBe('');
+      expect(accessibleName(subheader)).toBe('Personal');
+    });
+
+    it('positive control: the pre-#259 roles still fail the same rule', async () => {
+      // The shape this ticket removed, rebuilt by hand — without it, the empty
+      // `violated` above is also what an axe upgrade that stopped matching this
+      // markup looks like.
+      const panel = document.createElement('div');
+      panel.setAttribute('role', 'listbox');
+      panel.setAttribute('aria-label', 'Mailboxes');
+      panel.innerHTML =
+        '<div role="heading" aria-level="3">Personal</div>'
+        + '<div role="option" aria-selected="false">Inbox</div>';
+      document.body.appendChild(panel);
+
+      try {
+        const { violated } = await axeResult(panel, [panel], ['aria-required-children']);
+
+        expect(violated).toEqual(['aria-required-children']);
+      } finally {
+        panel.remove();
+      }
+    });
+
+    it('control: a group around the heading does not rescue it either', async () => {
+      // The list's answer — move the heading one level in — applied to a
+      // listbox, which is the obvious fix and the wrong one. axe reads through
+      // a `group` when it collects what a listbox owns, so the heading is still
+      // reported as a child of the listbox. This is why the heading role is
+      // dropped inside a listbox rather than relocated, and it is asserted
+      // rather than described because the reason is entirely in axe's
+      // behaviour.
+      const panel = document.createElement('div');
+      panel.setAttribute('role', 'listbox');
+      panel.setAttribute('aria-label', 'Mailboxes');
+      panel.innerHTML =
+        '<div role="group"><span role="heading" aria-level="3">Personal</span></div>'
+        + '<div role="option" aria-selected="false">Inbox</div>';
+      document.body.appendChild(panel);
+
+      try {
+        const { violated } = await axeResult(panel, [panel], ['aria-required-children']);
+
+        expect(violated).toEqual(['aria-required-children']);
+      } finally {
+        panel.remove();
+      }
     });
   });
 

--- a/projects/truenas-ui/src/lib/select/select-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select-a11y.spec.ts
@@ -1,0 +1,132 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { TnSelectOption, TnSelectOptionGroup } from './select.component';
+import { TnSelectComponent } from './select.component';
+import { axeResult } from '../a11y/axe-testing';
+
+/**
+ * Guards the structure fixed for #259 on the `tn-select` dropdown: the panel
+ * declares `role="listbox"`, which owns only `option` and `group`, and the
+ * template put `<div class="tn-select-separator" role="separator">` directly
+ * inside it — once above the select-all row and once between option groups.
+ * Same axe rule and same message as #237's list: *"Element has children which
+ * are not allowed: [role=separator]"*.
+ *
+ * The separators are decorative, so this is the case
+ * `docs/component_conventions.md` calls a role that can simply be dropped —
+ * unlike the subheader in `list/list-a11y.spec.ts`, whose heading has to be
+ * re-exposed somewhere valid. Nothing here needs `ariaOwner()` either: these
+ * two elements are written inside the listbox in this component's own
+ * template, so where they sit is not a question.
+ *
+ * `aria-required-children` is pure DOM structure and axe evaluates it correctly
+ * under jsdom; the positive control below keeps that fact from rotting.
+ *
+ * The dropdown is portaled into a CDK overlay in `document.body` rather than
+ * rendered inside the host, so every query and every scan root here is the
+ * document rather than `fixture.nativeElement`.
+ */
+
+@Component({
+  selector: 'tn-select-a11y-host',
+  standalone: true,
+  imports: [TnSelectComponent],
+  // Both separator sites at once: the select-all row puts one above the
+  // options, and a group preceded by ungrouped options puts one above itself.
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-select
+      placeholder="Select fruits"
+      [multiple]="true"
+      [showSelectAll]="true"
+      [options]="options()"
+      [optionGroups]="optionGroups()" />
+  `,
+})
+class SelectA11yHostComponent {
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+  ]);
+
+  optionGroups = signal<TnSelectOptionGroup<string>[]>([
+    { label: 'Citrus', options: [{ value: 'lemon', label: 'Lemon' }] },
+  ]);
+}
+
+describe('tn-select dropdown accessibility (#259)', () => {
+  let fixture: ComponentFixture<SelectA11yHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectA11yHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectA11yHostComponent);
+    fixture.detectChanges();
+
+    (fixture.nativeElement.querySelector('.tn-select-trigger') as HTMLElement).click();
+    fixture.detectChanges();
+  });
+
+  const listbox = (): HTMLElement => {
+    const found = document.querySelector<HTMLElement>('.tn-select-dropdown');
+    if (!found) { throw new Error('the dropdown did not open'); }
+    return found;
+  };
+
+  const separators = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll<HTMLElement>('.tn-select-separator'));
+
+  it('reports no aria-required-children violation on the open dropdown', async () => {
+    const { violated, evaluated } = await axeResult(
+      document.body,
+      [listbox()],
+      ['aria-required-children'],
+    );
+
+    expect(violated).toEqual([]);
+    // Proof the rule looked at this listbox rather than passing vacuously: it
+    // is the rule that failed here, on this element, before the fix.
+    expect(evaluated).toContain('aria-required-children');
+  });
+
+  it('positive control: a separator inside a listbox still fails the same rule', async () => {
+    // The shape this ticket removed, rebuilt by hand. Without it, a `violated`
+    // of `[]` above would also be what an axe upgrade that stopped matching
+    // this markup looks like.
+    const panel = document.createElement('div');
+    panel.setAttribute('role', 'listbox');
+    panel.innerHTML =
+      '<div role="option" aria-selected="false">Apple</div>'
+      + '<div role="separator"></div>';
+    document.body.appendChild(panel);
+
+    try {
+      const { violated } = await axeResult(panel, [panel], ['aria-required-children']);
+
+      expect(violated).toEqual(['aria-required-children']);
+    } finally {
+      panel.remove();
+    }
+  });
+
+  it('renders both separators, and neither carries a role', () => {
+    // Decorative means unannounced, not absent. The rules are styled divs, so
+    // the class the stylesheet keys on is what "still drawn" means here — one
+    // under the select-all row, one above the option group.
+    expect(separators()).toHaveLength(2);
+    expect(separators().map((rule) => rule.getAttribute('role'))).toEqual([null, null]);
+  });
+
+  it('keeps every other child of the listbox a role the listbox may own', () => {
+    // The other half of the rule: dropping `separator` is only correct while
+    // what remains is `option` and `group`, which is what makes the wrapper
+    // divs between them transparent rather than a second defect.
+    const owned = Array.from(listbox().querySelectorAll<HTMLElement>('[role]'))
+      .map((el) => el.getAttribute('role'));
+
+    expect(new Set(owned)).toEqual(new Set(['option', 'group']));
+  });
+});

--- a/projects/truenas-ui/src/lib/select/select.component.html
+++ b/projects/truenas-ui/src/lib/select/select.component.html
@@ -75,7 +75,11 @@
             [hideLabel]="true" />
           {{ selectAllLabel() }}
         </div>
-        <div class="tn-select-separator" role="separator"></div>
+        <!-- Decorative only, and deliberately role-less: the panel above is a
+             `role="listbox"`, which owns `option` and `group` and nothing else,
+             so a `role="separator"` here invalidates the whole listbox
+             (aria-required-children, #259). The rule is drawn by its class. -->
+        <div class="tn-select-separator"></div>
       }
 
       <!-- Regular Options (preceded by the synthetic empty option when allowEmpty is set) -->
@@ -111,12 +115,11 @@
 
       <!-- Option Groups -->
       @for (group of optionGroups(); track $index; let isFirst = $first) {
-        <!-- Group Separator (not shown before first group if we have regular options) -->
+        <!-- Group Separator (not shown before first group if we have regular
+             options). Role-less for the same reason as the one above the
+             options — see there. -->
         @if (!isFirst || displayOptions().length > 0) {
-          <div
-            class="tn-select-separator"
-            role="separator">
-          </div>
+          <div class="tn-select-separator"></div>
         }
 
         <div role="group" [attr.aria-labelledby]="'tn-select-group-' + idNamespace() + '-' + $index">


### PR DESCRIPTION
Fixes #259.

`role="listbox"` owns `option` and `group` and no more. Two places in the library put something else directly inside one — the same axe rule and the same message as the `role="list"` defect fixed in #237, *"Element has children which are not allowed"*.

## Reproduced first

Both are guarded by specs that were written before the fix and failed on it:

- `select-a11y.spec.ts` — `aria-required-children` violated on the open dropdown, with both separators carrying `role="separator"`.
- `list-a11y.spec.ts` — `aria-required-children` violated on a `tn-selection-list` holding a `tn-list-subheader`.

Each has a positive control that rebuilds the pre-fix markup by hand and asserts it still fails, so a green result here cannot come from an axe upgrade that stopped matching this markup.

## `tn-select`: drop the role

`select.component.html` rendered `<div class="tn-select-separator" role="separator">` twice inside the `role="listbox"` panel — above the select-all row, and between option groups. Both are decorative, so the role is dropped rather than substituted. The class the stylesheet keys on is untouched and the spec asserts both rules are still rendered.

Nothing here needs `ariaOwner()`: these two elements are written inside the listbox in this component's own template, so where they sit is not a question. That is the distinction from `tn-divider`, whose host is shared with the standalone case.

## `tn-list-subheader`: name the section instead

#237's answer for a list — make the host the `listitem` and move the heading one level in — is not available inside a listbox, and both halves of that are asserted rather than asserted-by-assumption:

- `listitem` is not an allowed child of a listbox either, so it trades one violation for another.
- **axe reads THROUGH a `group` when it collects what a listbox owns.** A `group` wrapping a `role="heading"` reports the identical violation with the heading named instead. This was measured, and is now the `control: a group around the heading does not rescue it either` case in `list-a11y.spec.ts`, because the reason lives entirely in axe's behaviour and nothing else in the repo would show it.

So inside a listbox the host becomes the `group` and takes the section's own text as its accessible name, via `aria-labelledby` to the unmarked span around it — the first route the ticket's acceptance criterion names. The text stays in the accessibility tree and stays announced; what changes is that it is announced as a named section rather than as a heading. `role="presentation"`, which the ticket rules out, would have removed it altogether, and `accessibleName(subheader)` is asserted to be `'Personal'` so that a `group` resolving to no name cannot pass.

Behaviour in the other two containers is unchanged and still asserted: `listitem` plus an inner heading inside a `role="list"`, and `role="heading"` with `aria-level="3"` on the host anywhere else — including nested inside a row, where a heading is already legal.

The group holds the section's text and **not** the options that follow it. A subheader is projected content and is a sibling of the rows it introduces, so it can name a section without enclosing one; genuinely nesting options in a group is markup for a consumer to write. That limit is written into the component docblock and the spec.

## Acceptance criteria

- [x] A `tn-select` dropdown with a select-all row and with grouped options produces no `aria-required-children` violation, guarded by a spec using `axeResult`
- [x] The visual separators in the select dropdown are still drawn
- [x] A `tn-selection-list` containing a `tn-list-subheader` produces no `aria-required-children` violation
- [x] The section heading is still announced — as a `role="group"` carrying the subheader's text as its accessible name
- [x] `tn-list-subheader` outside a listbox is unchanged

## Checks run locally

- `yarn test` — 132 suites, 3364 tests, all passing
- `yarn test:scripts` — 42 passing
- `yarn build` — clean
- `yarn build-storybook` — clean
- `yarn lint` — **the only 4 errors are pre-existing `import/order` failures in `input.component.ts` and `menu-panel.component.ts`**, neither of which this branch touches. That is #251, which is already open with its own PR. No file in this diff produces a lint error.
- `Storybook Interaction Tests` was **not** run: it drives a real browser through Playwright and this machine has neither the browser nor the system libraries to supply one. No story composes a `tn-list-subheader` into a `tn-selection-list`, and no story or harness asserts on the select separators' role, so the change should be invisible to that suite — but that is reasoning about the diff rather than a run of it.

## Local review

`local-review.py` ran the project's own reviewer in a separate process and returned **clean at MEDIUM and above** (exit 0, same rubric and threshold as the required check). It raised three LOW findings, left unfixed deliberately — every fix is a new diff and a new review round, and these are all worth a reader's attention rather than a round:

1. **The `role="group"` owns no options, so a screen reader may not announce the section name while arrowing through the listbox.** This is the structural limit described above, not something this component can fix alone: a subheader has no rows to wrap. Worth its own ticket if the library wants genuinely grouped listbox sections, which would change the markup consumers write.
2. **`ownerKind` enumerates `list`/`listbox` itself rather than going through `prescribesItsChildren()`**, so widening that shared helper would not reach this component. Deliberate — the helper answers "may a decorative element keep its role here?", one bit, while this component needs to know *which* container it is in to pick between three different answers. Folding them would make the helper return something other than a boolean for one caller's benefit.
3. **No Storybook story covers a subheader inside a `tn-selection-list`.** True; the new variant is covered by jsdom specs only. Adding one is a reasonable follow-up and is not something this fix depends on.
