### PR TITLE
NAS-142516 / 27.0.0-BETA.1 / fix(chip): give the close button a ring instead of a wash

### DIFF
--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.spec.ts
@@ -1,4 +1,11 @@
-import { AA_MINIMUM, contrastRatio, formatRatio, meetsAa, themePalettes } from './contrast-testing';
+import {
+  AA_MINIMUM,
+  compositeColor,
+  contrastRatio,
+  formatRatio,
+  meetsAa,
+  themePalettes,
+} from './contrast-testing';
 import * as contrastTesting from './contrast-testing';
 import * as publicApi from '../../public-api';
 
@@ -131,6 +138,65 @@ describe('contrastRatio', () => {
       expect(() => contrastRatio('#ffffff', 'rgba(0, 0, 0, 0.5)')).toThrow('is not opaque');
       expect(() => contrastRatio('#ffffff', '#00000080')).toThrow('is not opaque');
     });
+  });
+});
+
+/**
+ * The way out of the refusal above: `contrastRatio` tells a caller to composite
+ * a translucent background against what is behind it and pass the result, and
+ * this is what does that.
+ */
+describe('compositeColor', () => {
+  it('mixes each channel by the front colour\'s alpha, source-over', () => {
+    // 20% white over #007db3 — the wash #261 removed from the chip's close
+    // circle. Worked by hand: 0.2 x 255 + 0.8 x 0 = 51 on red, and
+    // 0.2 x 255 + 0.8 x 179 = 194.2 on blue.
+    expect(compositeColor('rgba(255, 255, 255, 0.2)', '#007db3')).toBe('rgb(51, 151, 194.20000000000002)');
+  });
+
+  it('does not round the channels, because the gamma curve is applied after this', () => {
+    // A fractional channel is not a defect to be tidied up: rounding here moves
+    // the ratio in whichever direction the rounding went, and the whole reason
+    // the close circle needed measuring was a pair sitting at 3.31:1 against a
+    // 4.5 threshold. The two-decimal difference this makes is the difference
+    // between #261's own table (3.24:1 for Dracula, channels rounded) and what
+    // this file reports (3.23:1).
+    expect(compositeColor('rgba(255, 255, 255, 0.2)', '#007db3')).not.toBe('rgb(51, 151, 194)');
+  });
+
+  it('returns the backdrop unchanged for a fully transparent front', () => {
+    // `background-color: transparent` is what the fixed close circle declares,
+    // and reading it back out of the stylesheet has to mean "no wash" rather
+    // than throw — otherwise the spec that composites a declared background
+    // cannot express the state the fix puts it in.
+    expect(compositeColor('transparent', '#007db3')).toBe('rgb(0, 125, 179)');
+  });
+
+  it('returns the front unchanged when it is fully opaque', () => {
+    expect(compositeColor('#ffffff', '#007db3')).toBe('rgb(255, 255, 255)');
+  });
+
+  it('composites to a colour contrastRatio then accepts as a background', () => {
+    // The two halves fitting together is the point of the export: the result is
+    // opaque, so it does not hit the refusal that sent the caller here. The
+    // number is #261's own headline — white on --tn-primary is 4.58:1 on the
+    // chip, the ratio themes.css records next to the token, and 3.31:1 once the
+    // close circle's wash is between them. Both are asserted, because a wash
+    // that made no difference would satisfy the first line on its own.
+    const behind = compositeColor('rgba(255, 255, 255, 0.2)', '#007db3');
+    expect(formatRatio(contrastRatio('#ffffff', behind))).toBe('3.31:1');
+    expect(formatRatio(contrastRatio('#ffffff', '#007db3'))).toBe('4.58:1');
+  });
+
+  it('refuses a translucent backdrop, for the same reason contrastRatio does', () => {
+    expect(() => compositeColor('rgba(255, 255, 255, 0.2)', 'rgba(0, 0, 0, 0.5)'))
+      .toThrow('is not opaque');
+  });
+
+  it('refuses a colour it cannot read rather than guessing at one', () => {
+    // `transparent` is the one keyword read, and it is not a hue. A real colour
+    // name still has to be converted by the caller.
+    expect(() => compositeColor('red', '#007db3')).toThrow('is not a colour this can read');
   });
 });
 

--- a/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/contrast-testing.ts
@@ -149,6 +149,39 @@ export function contrastRatio(foreground: string, background: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+/**
+ * The opaque colour a translucent `front` renders as when it is painted over
+ * `back` — source-over compositing, as `rgb(r, g, b)`.
+ *
+ * This is the answer `contrastRatio` refuses to guess at. A translucent
+ * BACKGROUND has no ratio of its own, so that function throws and tells the
+ * caller to "composite it against that surface and pass the result" — and until
+ * this was exported there was no way to do so, which is how a wash painted over
+ * a themed surface came to be excused from measurement rather than measured
+ * (#261: `.tn-chip__close` washing `rgba(255,255,255,0.2)` over the chip, with
+ * the `×` inheriting a colour chosen for the unwashed surface, at 3.31:1).
+ *
+ * `back` must be opaque, for the same reason `contrastRatio`'s background must
+ * be: what is behind it decides the answer. Stacking two washes is therefore
+ * two calls, innermost first, which is also the order a browser paints them.
+ *
+ * Channels are not rounded. The result feeds `contrastRatio`, which linearises
+ * each channel through a gamma curve, and rounding first moves the ratio in
+ * whichever direction the rounding went — the same class of mistake as
+ * comparing a `formatRatio` string against a threshold.
+ */
+export function compositeColor(front: string, back: string): string {
+  const behind = parseColor(back, 'back');
+  if (behind.a !== 1) {
+    throw new Error(
+      `compositeColor: the backdrop ${back} is not opaque, so the colour it renders `
+      + 'as depends on what is behind it. Composite that pair first and pass the result.'
+    );
+  }
+  const { r, g, b } = compositeOver(parseColor(front, 'front'), behind);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
 /** One themed surface from `themes.css`: `:root`, `.tn-dark`, `.tn-nord`, … */
 export interface ThemePalette {
   /** The selector the block was declared under. */
@@ -416,6 +449,15 @@ function customProperties(body: string): Map<string, string> {
 
 function parseColor(value: string, context: string): Rgba {
   const text = value.trim();
+  // The one colour keyword read here, and it is not a hue: `transparent` is
+  // `rgba(0, 0, 0, 0)`, which is how a stylesheet says "paint nothing". Refusing
+  // it would mean a spec compositing a declared background could not read the
+  // value that means there is no wash — the very state #261's fix puts the
+  // close circle in. Every actual colour name stays refused: `red` has to be
+  // converted, and guessing at one is how a wrong ratio gets asserted.
+  if (text.toLowerCase() === 'transparent') {
+    return { r: 0, g: 0, b: 0, a: 0 };
+  }
   const hex = /^#([0-9a-f]+)$/i.exec(text);
   if (hex) {
     return parseHex(hex[1], text, context);

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -135,28 +135,66 @@ const CLOSE_SURFACES: readonly CloseSurface[] = [
  * measurement below rests on: the glyph colour in `CLOSE_SURFACES` is the
  * variant's label colour, and that is only true while the circle inherits it.
  */
-const CLOSE_RULES: Readonly<Record<string, { background: string; color: string; why: string }>> = {
+const CLOSE_RULES: Readonly<Record<string, { paints: Readonly<Record<string, string>>; why: string }>> = {
   '.tn-chip__close': {
-    background: 'transparent',
-    color: 'inherit',
+    paints: {
+      'background-color': 'transparent',
+      color: 'inherit',
+      border: '1px solid currentColor',
+      outline: 'none',
+    },
     why: 'the resting circle, composited over every variant by "the × clears AA" below',
   },
+  '.tn-chip__close:focus-visible': {
+    paints: { outline: '1px solid currentColor' },
+    why: 'the focus ring, drawn outside the circle and so on the chip, in the label colour',
+  },
   '.tn-chip--primary .tn-chip__close:hover:not(:disabled)': {
-    background: 'var(--tn-primary-txt)',
-    color: 'var(--tn-primary)',
+    paints: {
+      'background-color': 'var(--tn-primary-txt)',
+      color: 'var(--tn-primary)',
+      'outline-color': 'var(--tn-primary-txt)',
+    },
     why: 'the hover invert, whose pair is in CHIP_SURFACES and measured with the labels',
   },
   '.tn-chip--secondary .tn-chip__close:hover:not(:disabled)': {
-    background: 'var(--tn-alt-fg2)',
-    color: 'var(--tn-alt-bg2)',
+    paints: {
+      'background-color': 'var(--tn-alt-fg2)',
+      color: 'var(--tn-alt-bg2)',
+      'outline-color': 'var(--tn-alt-fg2)',
+    },
     why: 'the same invert on the hovered secondary chip, which is on --tn-alt-bg2 by then',
   },
   '.tn-chip--accent .tn-chip__close:hover:not(:disabled)': {
-    background: 'var(--tn-alt-fg2)',
-    color: 'var(--tn-alt-bg2)',
+    paints: {
+      'background-color': 'var(--tn-alt-fg2)',
+      color: 'var(--tn-alt-bg2)',
+      'outline-color': 'var(--tn-alt-fg2)',
+    },
     why: 'the same invert on the hovered accent chip, which lands on the same surface',
   },
 };
+
+/**
+ * Every property that decides what colour some part of the close circle comes
+ * out, longhand and shorthand alike.
+ *
+ * Wider than the two the measurement itself reads, because the guard is about
+ * what a rule is ALLOWED to do rather than about what this file happens to
+ * measure. A theme-scoped `border-color` repaints the ring that is the whole of
+ * the circle's visibility, and an `outline-color` repaints the focus indicator;
+ * neither touches `background-color` or `color`, so a guard keyed to those two
+ * would admit the rule to the stylesheet without admitting it to this table.
+ */
+const COLOUR_PROPERTIES = [
+  'background',
+  'background-color',
+  'color',
+  'border',
+  'border-color',
+  'outline',
+  'outline-color',
+];
 
 /**
  * Both halves of every pair above, which is what each palette has to declare
@@ -523,10 +561,17 @@ describe('tn-chip label contrast (#238)', () => {
     // theme-scoped override — `.tn-dark .tn-chip--secondary .tn-chip__close`
     // was one until #261 — which is exactly where a colour nobody measured
     // would come back.
+    /** What `rule` sets that decides a colour, and nothing else. */
+    function paints(rule: ScssRule): Record<string, string> {
+      return Object.fromEntries(
+        COLOUR_PROPERTIES
+          .filter((property) => rule.declarations.has(property))
+          .map((property) => [property, rule.declarations.get(property) as string])
+      );
+    }
+
     const closeRules = rules.filter(
-      (rule) =>
-        flattenSelector(rule).includes('__close')
-        && ['background-color', 'background', 'color'].some((property) => rule.declarations.has(property))
+      (rule) => flattenSelector(rule).includes('__close') && Object.keys(paints(rule)).length > 0
     );
 
     it('only the rules named in CLOSE_RULES colour the close circle', () => {
@@ -534,14 +579,14 @@ describe('tn-chip label contrast (#238)', () => {
     });
 
     it.each(Object.entries(CLOSE_RULES))('%s paints what CLOSE_RULES says it does', (selector, expected) => {
-      // Not just WHICH rules colour the circle but WHAT they set, because the
-      // cases below take both from the table: the glyph colour comes from
-      // `CLOSE_SURFACES`, which is only right while `.tn-chip__close` is still
-      // `color: inherit` and no other rule has repainted it.
+      // The WHOLE set, not the properties this file goes on to measure. The
+      // cases below take the glyph colour from `CLOSE_SURFACES`, which is only
+      // right while `.tn-chip__close` is still `color: inherit` and nothing has
+      // repainted it — and the ring and the focus indicator are not measured
+      // here at all, so an exact comparison is what stops them changing
+      // unremarked under a spec that would still be green.
       const rule = closeRules.find((candidate) => flattenSelector(candidate) === selector);
-      expect(rule?.declarations.get('background-color') ?? rule?.declarations.get('background'))
-        .toBe(expected.background);
-      expect(rule?.declarations.get('color')).toBe(expected.color);
+      expect(rule && paints(rule)).toEqual(expected.paints);
     });
 
     it('a rule that inverts the circle restates the focus ring as the label colour', () => {
@@ -556,18 +601,23 @@ describe('tn-chip label contrast (#238)', () => {
       // The fill is the label colour, so restating `outline-color` as the fill
       // is what puts it back. Asserted as EQUAL TO the fill rather than as a
       // named token, so that changing the invert moves both or fails.
-      const inverting = Object.entries(CLOSE_RULES).filter(([, rule]) => rule.color !== 'inherit');
+      //
+      // Derived from the table rather than listed: an invert is any rule that
+      // fills the circle and repaints the glyph, so a fourth variant gaining
+      // one is covered the moment it is described, without a second list to
+      // remember to add it to.
+      const inverting = Object.entries(CLOSE_RULES).filter(
+        ([, rule]) => rule.paints.color !== undefined && rule.paints.color !== 'inherit'
+      );
       expect(inverting.length).toBeGreaterThan(0);
       expect(
         inverting
           .map(([selector, expected]) => ({
             selector,
-            outline: closeRules
-              .find((rule) => flattenSelector(rule) === selector)
-              ?.declarations.get('outline-color'),
-            fill: expected.background,
+            outline: expected.paints['outline-color'],
+            fill: expected.paints['background-color'],
           }))
-          .filter(({ outline, fill }) => outline !== fill)
+          .filter(({ outline, fill }) => outline === undefined || outline !== fill)
       ).toEqual([]);
     });
 

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -121,22 +121,41 @@ const CLOSE_SURFACES: readonly CloseSurface[] = [
 ];
 
 /**
- * Every rule allowed to paint a background on the close circle, flattened, with
- * what it is for.
+ * Every rule allowed to colour the close circle, by the selector it really
+ * matches, with what it may set and why.
  *
  * An allowlist rather than a measurement of whatever it finds, because the
- * defect this file now guards is a rule that paints the circle a colour NOBODY
+ * defect this file guards is a rule colouring the circle in a way NOBODY
  * measured — and a spec that measures every rule it finds can only ever report
  * on rules it knows how to interpret. A new theme-scoped override lands here as
  * a failure naming the selector, which is the point at which someone has to say
  * what it is and where it is measured.
+ *
+ * `color` as well as `background`, because the two together are what the
+ * measurement below rests on: the glyph colour in `CLOSE_SURFACES` is the
+ * variant's label colour, and that is only true while the circle inherits it.
  */
-const CLOSE_BACKGROUND_RULES: Readonly<Record<string, string>> = {
-  '.tn-chip__close': 'the resting circle, measured against every variant by "the × clears AA" below',
-  '.tn-chip--primary .tn-chip__close:hover:not(:disabled)':
-    'the hover invert, whose pair is in CHIP_SURFACES and measured with the labels',
-  '.tn-chip--secondary .tn-chip__close:hover:not(:disabled)': 'the same invert on the hovered secondary chip',
-  '.tn-chip--accent .tn-chip__close:hover:not(:disabled)': 'the same invert on the hovered accent chip',
+const CLOSE_RULES: Readonly<Record<string, { background: string; color: string; why: string }>> = {
+  '.tn-chip__close': {
+    background: 'transparent',
+    color: 'inherit',
+    why: 'the resting circle, composited over every variant by "the × clears AA" below',
+  },
+  '.tn-chip--primary .tn-chip__close:hover:not(:disabled)': {
+    background: 'var(--tn-primary-txt)',
+    color: 'var(--tn-primary)',
+    why: 'the hover invert, whose pair is in CHIP_SURFACES and measured with the labels',
+  },
+  '.tn-chip--secondary .tn-chip__close:hover:not(:disabled)': {
+    background: 'var(--tn-alt-fg2)',
+    color: 'var(--tn-alt-bg2)',
+    why: 'the same invert on the hovered secondary chip, which is on --tn-alt-bg2 by then',
+  },
+  '.tn-chip--accent .tn-chip__close:hover:not(:disabled)': {
+    background: 'var(--tn-alt-fg2)',
+    color: 'var(--tn-alt-bg2)',
+    why: 'the same invert on the hovered accent chip, which lands on the same surface',
+  },
 };
 
 /**
@@ -498,50 +517,77 @@ describe('tn-chip label contrast (#238)', () => {
     // Read out of the stylesheet, not listed: the whole claim is about what the
     // circle paints over the chip, so a spec that hardcoded the value would go
     // on passing after someone changed it.
+    // Every rule that touches the circle's own colours, by the selector it
+    // really matches. `flattenSelector` rather than the fragment: `&__close`
+    // finds the one rule written inside `.tn-chip` and misses every
+    // theme-scoped override — `.tn-dark .tn-chip--secondary .tn-chip__close`
+    // was one until #261 — which is exactly where a colour nobody measured
+    // would come back.
     const closeRules = rules.filter(
       (rule) =>
         flattenSelector(rule).includes('__close')
-        && (rule.declarations.has('background-color') || rule.declarations.has('background'))
+        && ['background-color', 'background', 'color'].some((property) => rule.declarations.has(property))
     );
-    const resting = closeRules.find((rule) => flattenSelector(rule) === '.tn-chip__close');
 
-    it('only the rules named in CLOSE_BACKGROUND_RULES paint the close circle', () => {
-      // Catches the reintroduction this file cannot otherwise see: a
-      // theme-scoped override — `.tn-dark .tn-chip--secondary .tn-chip__close`
-      // was one until #261 — paints a surface the cases below never reach,
-      // because they composite the RESTING rule over each variant. A wash that
-      // exists only under one theme class would be invisible to them.
-      expect(closeRules.map(flattenSelector).sort()).toEqual(Object.keys(CLOSE_BACKGROUND_RULES).sort());
+    it('only the rules named in CLOSE_RULES colour the close circle', () => {
+      expect(closeRules.map(flattenSelector).sort()).toEqual(Object.keys(CLOSE_RULES).sort());
     });
 
-    it('the resting circle declares a background', () => {
-      // `resting` is read with `?.` below, and a `.tn-chip__close` that stops
-      // declaring one at all would leave every case measuring `undefined` —
-      // which throws in `compositeColor` rather than passing, but says nothing
-      // useful about why. This says it.
-      expect(resting).toBeDefined();
+    it.each(Object.entries(CLOSE_RULES))('%s paints what CLOSE_RULES says it does', (selector, expected) => {
+      // Not just WHICH rules colour the circle but WHAT they set, because the
+      // cases below take both from the table: the glyph colour comes from
+      // `CLOSE_SURFACES`, which is only right while `.tn-chip__close` is still
+      // `color: inherit` and no other rule has repainted it.
+      const rule = closeRules.find((candidate) => flattenSelector(candidate) === selector);
+      expect(rule?.declarations.get('background-color') ?? rule?.declarations.get('background'))
+        .toBe(expected.background);
+      expect(rule?.declarations.get('color')).toBe(expected.color);
     });
 
-    const wash = resting?.declarations.get('background-color')
-      ?? (resting?.declarations.get('background') as string);
-
-    it('the glyph takes the chip\'s label colour and nothing of its own', () => {
-      // The premise of `CLOSE_SURFACES.glyph`. `.tn-chip__close` says
-      // `color: inherit` and `.tn-chip__close-icon` says nothing, so the `×`
-      // renders in the variant's label colour — which is why washing the
-      // circle moves the surface out from under a colour chosen for the chip.
-      // A `color:` appearing on either would make every case below measure a
-      // colour the glyph no longer has.
-      const glyphRules = rules.filter(
-        (rule) => rule.selector === '&__close' || rule.selector === '&__close-icon'
-      );
-      expect(glyphRules.map((rule) => rule.selector).sort()).toEqual(['&__close', '&__close-icon']);
+    it('a rule that inverts the circle restates the focus ring as the label colour', () => {
+      // `.tn-chip__close:focus-visible` draws `outline: 1px solid currentColor`,
+      // and the outline is OUTSIDE the circle — it lands on the chip's own
+      // background. At rest that is fine: `currentColor` is the label colour
+      // there. Under the invert `currentColor` becomes the chip's BACKGROUND,
+      // so a keyboard user who happens to be hovering the button they are
+      // focused on gets a ring painted in the background colour on the
+      // background: 1:1, no indicator at all.
+      //
+      // The fill is the label colour, so restating `outline-color` as the fill
+      // is what puts it back. Asserted as EQUAL TO the fill rather than as a
+      // named token, so that changing the invert moves both or fails.
+      const inverting = Object.entries(CLOSE_RULES).filter(([, rule]) => rule.color !== 'inherit');
+      expect(inverting.length).toBeGreaterThan(0);
       expect(
-        glyphRules
-          .filter((rule) => (rule.declarations.get('color') ?? 'inherit') !== 'inherit')
-          .map((rule) => rule.selector)
+        inverting
+          .map(([selector, expected]) => ({
+            selector,
+            outline: closeRules
+              .find((rule) => flattenSelector(rule) === selector)
+              ?.declarations.get('outline-color'),
+            fill: expected.background,
+          }))
+          .filter(({ outline, fill }) => outline !== fill)
       ).toEqual([]);
     });
+
+    // Thrown rather than asserted in an `it`. Everything below is built here in
+    // the describe body — the case titles carry the measured ratio, so they
+    // cannot be — and a guard that runs after the thing it guards is not a
+    // guard: an absent rule would already have thrown inside `compositeColor`
+    // during collection, with a message about `undefined` rather than about the
+    // stylesheet. This is the same failure, said usefully, at the point it
+    // happens.
+    const resting = closeRules.find((rule) => flattenSelector(rule) === '.tn-chip__close');
+    if (resting === undefined) {
+      throw new Error(
+        'chip-contrast.spec.ts: no rule in chip.component.scss flattens to .tn-chip__close, so '
+        + 'there is nothing to composite over the variants. The close circle has been renamed or '
+        + 'has stopped declaring a background of its own.'
+      );
+    }
+    const wash = resting.declarations.get('background-color')
+      ?? (resting.declarations.get('background') as string);
 
     it('the × is normal-size text, so 4.5:1 applies rather than 3:1', () => {
       // AA's large-text allowance starts at 24px, or 18.66px bold. The glyph is

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -1,6 +1,13 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { AA_MINIMUM, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import {
+  AA_MINIMUM,
+  compositeColor,
+  contrastRatio,
+  formatRatio,
+  meetsAa,
+  themePalettes,
+} from '../a11y/contrast-testing';
 import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
@@ -68,7 +75,69 @@ const CHIP_SURFACES: readonly ChipSurface[] = [
   // surface's companion rather than carrying --tn-accent-txt, which is tuned
   // for the accent fill and measures 1.93:1 on the grey in Solarized Dark.
   { name: '--accent:hover', foreground: '--tn-alt-fg2', background: '--tn-alt-bg2' },
+  // The close circle's hover, which fills with the chip's label colour and
+  // paints the × in the chip's background — each of the three below is one of
+  // the pairs above with its two halves swapped (#261). They are listed rather
+  // than derived because a contrast ratio being symmetric is a fact about the
+  // maths, not a promise that the stylesheet swapped the right pair: writing
+  // --tn-accent-txt as the fill on a hovered accent chip would be an invert of
+  // something, just not of the surface it lands on.
+  { name: '--primary close:hover', foreground: '--tn-primary', background: '--tn-primary-txt' },
+  { name: '--secondary close:hover', foreground: '--tn-alt-bg2', background: '--tn-alt-fg2' },
+  { name: '--accent close:hover', foreground: '--tn-alt-bg2', background: '--tn-alt-fg2' },
 ];
+
+/**
+ * The `×` in the close button, and the surface it is really painted on (#261).
+ *
+ * The glyph is `color: inherit` all the way up to the variant, so its colour is
+ * the chip's LABEL colour — chosen, in the table above, for the chip's own
+ * background. The circle then paints something of its own over that background,
+ * and the glyph sits on the result. Those are two different surfaces, and the
+ * table above measures the wrong one of them.
+ *
+ * `chipBackground` is what the circle is painted over, so it is the variant's
+ * background in the state that variant is in — `--secondary:hover` moves the
+ * chip to `--tn-alt-bg2` and the circle's backdrop moves with it. What the
+ * circle paints ON that is read out of the stylesheet rather than listed here,
+ * because "the wash is gone" and "the wash is still there" have to produce
+ * different results from the same spec, or removing it proves nothing.
+ */
+interface CloseSurface {
+  /** How it reads in a failure: `--accent:hover`. */
+  readonly name: string;
+  /** The token in force on the `×`, which is the variant's label colour. */
+  readonly glyph: string;
+  /** The chip's own background, which the close circle is painted over. */
+  readonly chipBackground: string;
+}
+
+const CLOSE_SURFACES: readonly CloseSurface[] = [
+  { name: '--primary', glyph: '--tn-primary-txt', chipBackground: '--tn-primary' },
+  { name: '--secondary', glyph: '--tn-alt-fg2', chipBackground: '--tn-alt-bg1' },
+  { name: '--secondary:hover', glyph: '--tn-alt-fg2', chipBackground: '--tn-alt-bg2' },
+  { name: '--accent', glyph: '--tn-accent-txt', chipBackground: '--tn-accent' },
+  { name: '--accent:hover', glyph: '--tn-alt-fg2', chipBackground: '--tn-alt-bg2' },
+];
+
+/**
+ * Every rule allowed to paint a background on the close circle, flattened, with
+ * what it is for.
+ *
+ * An allowlist rather than a measurement of whatever it finds, because the
+ * defect this file now guards is a rule that paints the circle a colour NOBODY
+ * measured — and a spec that measures every rule it finds can only ever report
+ * on rules it knows how to interpret. A new theme-scoped override lands here as
+ * a failure naming the selector, which is the point at which someone has to say
+ * what it is and where it is measured.
+ */
+const CLOSE_BACKGROUND_RULES: Readonly<Record<string, string>> = {
+  '.tn-chip__close': 'the resting circle, measured against every variant by "the × clears AA" below',
+  '.tn-chip--primary .tn-chip__close:hover:not(:disabled)':
+    'the hover invert, whose pair is in CHIP_SURFACES and measured with the labels',
+  '.tn-chip--secondary .tn-chip__close:hover:not(:disabled)': 'the same invert on the hovered secondary chip',
+  '.tn-chip--accent .tn-chip__close:hover:not(:disabled)': 'the same invert on the hovered accent chip',
+};
 
 /**
  * Both halves of every pair above, which is what each palette has to declare
@@ -89,12 +158,16 @@ const REQUIRED_TOKENS = [
  */
 const NOT_A_LABEL_SURFACE: Readonly<Record<string, string>> = {
   none: 'the body button, which is transparent over the wrapper the pairs above measure',
-  transparent: 'the <code> override, which puts a code span back on the chip\'s own surface after the label-markup mixin painted it --tn-bg2',
-  'rgba(255, 255, 255, 0.2)': 'the close circle, a wash over whatever the chip already paints — the × is a glyph on that wash, not the label, and is not measured here',
-  'rgba(255, 255, 255, 0.3)': 'the same wash, on hover',
-  'rgba(0, 0, 0, 0.2)': 'the same circle in TN Dark on --secondary, where a light wash would disappear',
-  'rgba(0, 0, 0, 0.3)': 'the same dark wash, on hover',
+  // Two rules paint this and neither introduces a surface: the <code> override,
+  // which puts a code span back on the chip's own surface after the
+  // label-markup mixin painted it --tn-bg2, and the resting close circle, which
+  // paints nothing so that the × sits on the chip's own surface too (#261). The
+  // second is not merely excused — "the × clears AA" below composites whatever
+  // that rule declares over every variant, so a wash returning there is caught
+  // as a contrast failure rather than as an unexplained literal.
+  transparent: 'the <code> override and the resting close circle, both of which leave the chip\'s own surface showing',
 };
+
 
 /** One rule in the stylesheet: its own declarations, and what it nests inside. */
 interface ScssRule {
@@ -186,6 +259,26 @@ function labelColor(rule: ScssRule | null): string | undefined {
   return undefined;
 }
 
+/**
+ * The selector a nested rule actually matches, with `&` resolved outward.
+ *
+ * `&__close` says nothing on its own about which element it lands on, and the
+ * close circle is reachable by two routes — `.tn-chip { &__close }` and the
+ * theme-scoped `.tn-dark .tn-chip { &--secondary { .tn-chip__close } }`. The
+ * guard below has to enumerate every rule that paints the circle, in either
+ * shape, so it needs the flattened form rather than the fragment.
+ */
+function flattenSelector(rule: ScssRule): string {
+  const nesting: string[] = [];
+  for (let current: ScssRule | null = rule; current !== null; current = current.parent) {
+    nesting.unshift(current.selector);
+  }
+  return nesting.reduce((enclosing, selector) =>
+    selector.includes('&')
+      ? selector.replace(/&/g, enclosing)
+      : (enclosing === '' ? selector : `${enclosing} ${selector}`));
+}
+
 /** `var(--tn-x)` -> `--tn-x`; anything else unchanged, to be judged as a literal. */
 function tokenOf(value: string): string {
   return /^var\(\s*(--[\w-]+)\s*\)$/.exec(value)?.[1] ?? value;
@@ -217,6 +310,7 @@ describe('tn-chip label contrast (#238)', () => {
   const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
   const scss = readFileSync(CHIP_SCSS, 'utf8');
   const palettes = themePalettes(css);
+  const rules = scssRules(scss);
 
   // Derived from the theme registry rather than hardcoded: a themed surface
   // that stops being recognised — a renamed class, a block that drops
@@ -229,7 +323,6 @@ describe('tn-chip label contrast (#238)', () => {
   });
 
   describe('the table above still describes chip.component.scss', () => {
-    const rules = scssRules(scss);
     const chipRule = rules.find((rule) => rule.selector === '.tn-chip');
 
     it('reads the stylesheet', () => {
@@ -291,6 +384,18 @@ describe('tn-chip label contrast (#238)', () => {
           (value) => !(value in NOT_A_LABEL_SURFACE)
         )
       ).toEqual([]);
+    });
+
+    it('every explanation is about a literal the stylesheet still paints', () => {
+      // The other direction, and the one that rots quietly. This map is the
+      // only place in the file that says "no need to measure that", so an entry
+      // for a value nothing paints is that sentence about nothing: #261 deleted
+      // four `rgba()` washes and their four excuses would have sat here
+      // indefinitely, reading to the next person as a live decision not to
+      // measure the close circle. The tally above catches a themed pairing that
+      // disappears; this catches a literal one.
+      const paintedLiterals = new Set(onALiteral.map((surface) => surface.background));
+      expect(Object.keys(NOT_A_LABEL_SURFACE).filter((value) => !paintedLiterals.has(value))).toEqual([]);
     });
 
     it('no rule reintroduces --tn-fg1 as the chip label', () => {
@@ -384,6 +489,106 @@ describe('tn-chip label contrast (#238)', () => {
     it.each(cases)(
       '$selector $name: $foreground on $background measures $ratioLabel',
       ({ ratio }) => {
+        expect(meetsAa(ratio, 'normal')).toBe(true);
+      }
+    );
+  });
+
+  describe('the × clears AA on the surface actually painted behind it (#261)', () => {
+    // Read out of the stylesheet, not listed: the whole claim is about what the
+    // circle paints over the chip, so a spec that hardcoded the value would go
+    // on passing after someone changed it.
+    const closeRules = rules.filter(
+      (rule) =>
+        flattenSelector(rule).includes('__close')
+        && (rule.declarations.has('background-color') || rule.declarations.has('background'))
+    );
+    const resting = closeRules.find((rule) => flattenSelector(rule) === '.tn-chip__close');
+
+    it('only the rules named in CLOSE_BACKGROUND_RULES paint the close circle', () => {
+      // Catches the reintroduction this file cannot otherwise see: a
+      // theme-scoped override — `.tn-dark .tn-chip--secondary .tn-chip__close`
+      // was one until #261 — paints a surface the cases below never reach,
+      // because they composite the RESTING rule over each variant. A wash that
+      // exists only under one theme class would be invisible to them.
+      expect(closeRules.map(flattenSelector).sort()).toEqual(Object.keys(CLOSE_BACKGROUND_RULES).sort());
+    });
+
+    it('the resting circle declares a background', () => {
+      // `resting` is read with `?.` below, and a `.tn-chip__close` that stops
+      // declaring one at all would leave every case measuring `undefined` —
+      // which throws in `compositeColor` rather than passing, but says nothing
+      // useful about why. This says it.
+      expect(resting).toBeDefined();
+    });
+
+    const wash = resting?.declarations.get('background-color')
+      ?? (resting?.declarations.get('background') as string);
+
+    it('the glyph takes the chip\'s label colour and nothing of its own', () => {
+      // The premise of `CLOSE_SURFACES.glyph`. `.tn-chip__close` says
+      // `color: inherit` and `.tn-chip__close-icon` says nothing, so the `×`
+      // renders in the variant's label colour — which is why washing the
+      // circle moves the surface out from under a colour chosen for the chip.
+      // A `color:` appearing on either would make every case below measure a
+      // colour the glyph no longer has.
+      const glyphRules = rules.filter(
+        (rule) => rule.selector === '&__close' || rule.selector === '&__close-icon'
+      );
+      expect(glyphRules.map((rule) => rule.selector).sort()).toEqual(['&__close', '&__close-icon']);
+      expect(
+        glyphRules
+          .filter((rule) => (rule.declarations.get('color') ?? 'inherit') !== 'inherit')
+          .map((rule) => rule.selector)
+      ).toEqual([]);
+    });
+
+    it('the × is normal-size text, so 4.5:1 applies rather than 3:1', () => {
+      // AA's large-text allowance starts at 24px, or 18.66px bold. The glyph is
+      // bold, so the second threshold is the one in play and 14px is under it.
+      // Read off `&__close-icon` itself: `.tn-chip` also declares
+      // `font-size: 14px`, so a file-wide search passes while the glyph grows.
+      const glyph = rules.find((rule) => rule.selector === '&__close-icon');
+      expect(glyph?.declarations.get('font-size')).toBe('14px');
+      expect(glyph?.declarations.get('font-weight')).toBe('bold');
+      expect(AA_MINIMUM.normal).toBe(4.5);
+    });
+
+    const cases = palettes
+      .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+      .flatMap((palette) =>
+        CLOSE_SURFACES.map((surface) => {
+          // Two steps, in the order a browser paints them: the circle's own
+          // background over the chip's, then the glyph on the result. Going
+          // straight to `contrastRatio` with the wash as the background throws,
+          // by design — a translucent surface has no ratio of its own.
+          const behind = compositeColor(wash, palette.color(surface.chipBackground));
+          const ratio = contrastRatio(palette.color(surface.glyph), behind);
+          return {
+            selector: palette.selector,
+            name: surface.name,
+            glyph: palette.color(surface.glyph),
+            chip: palette.color(surface.chipBackground),
+            behind,
+            ratio,
+            ratioLabel: formatRatio(ratio),
+          };
+        })
+      );
+
+    it('there are circles to measure', () => {
+      expect(cases).toHaveLength(expectedSelectors.length * CLOSE_SURFACES.length);
+    });
+
+    it.each(cases)(
+      '$selector $name: the × in $glyph on $chip, washed to $behind, measures $ratioLabel',
+      ({ ratio }) => {
+        // 4.5:1, not 3:1. The `×` is a visible text node inside a button that
+        // carries its own `aria-label`, so axe's `color-contrast` rule evaluates
+        // it as text — and hiding it from the accessibility tree would satisfy
+        // the rule while changing nothing a sighted user sees, which is not a
+        // fix. `.tn-chip__close-icon` is 14px, below the 18.66px bold that would
+        // make 3:1 apply.
         expect(meetsAa(ratio, 'normal')).toBe(true);
       }
     );

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -54,6 +54,15 @@
     // 3.14:1, and Solarized Dark, at 3.68:1. .button-primary, the filled
     // button, likewise changes no colour on hover; the lift and shadow on
     // .tn-chip:hover above are the affordance every variant shares.
+
+    // The close circle's own hover, which the chip's lack of one does not
+    // cover: it is a second control and needs to say when it is the target.
+    // This variant repaints nothing on hover, so the circle inverts against
+    // --tn-primary in both states.
+    .tn-chip__close:hover:not(:disabled) {
+      background-color: var(--tn-primary-txt);
+      color: var(--tn-primary);
+    }
   }
 
   &--secondary {
@@ -64,6 +73,15 @@
     &:hover:not(.tn-chip--disabled) {
       background-color: var(--tn-alt-bg2);
       border-color: var(--tn-accent);
+    }
+
+    // Not nested inside the rule above, and it does not need to be: the close
+    // button cannot be hovered without the chip being hovered, so the surface
+    // this inverts against is always --tn-alt-bg2 and its companion is always
+    // --tn-alt-fg2. Nesting it would only lengthen the selector.
+    .tn-chip__close:hover:not(:disabled) {
+      background-color: var(--tn-alt-fg2);
+      color: var(--tn-alt-bg2);
     }
   }
 
@@ -80,6 +98,13 @@
       // fill onto a grey one, which is 1.93:1 in Solarized Dark.
       color: var(--tn-alt-fg2);
       border-color: var(--tn-alt-bg2);
+    }
+
+    // Hover moves this variant onto the same surface --secondary:hover uses, so
+    // the circle inverts against the same pair. See the note there.
+    .tn-chip__close:hover:not(:disabled) {
+      background-color: var(--tn-alt-fg2);
+      color: var(--tn-alt-bg2);
     }
   }
 
@@ -171,25 +196,49 @@
     max-width: 200px;
   }
 
+  // A RING, NOT A WASH (#261). This used to paint rgba(255, 255, 255, 0.2) over
+  // whatever the chip already paints, while the × inside took `color: inherit`
+  // — the chip's label colour, which every variant above chooses for its own
+  // UNWASHED surface. The wash lightens the circle by a fixed 20% towards white
+  // in every theme, so a light label loses contrast against it: white on
+  // --tn-primary is 4.58:1 on the chip and 3.31:1 on the circle, and eight of
+  // the 27 variant/palette combinations landed between 3:1 and 4.5:1. The × is
+  // a visible text node in a button carrying its own aria-label, so axe reads it
+  // as text and 4.5:1 is the threshold; hiding it from the accessibility tree
+  // would clear the rule without changing anything a sighted user sees, and is
+  // not a fix.
+  //
+  // Painting nothing puts the glyph back on the chip's own surface — the one
+  // pair chip-contrast.spec.ts already asserts clears 4.5:1 in all nine
+  // palettes — so the circle stops having a contrast question of its own, and
+  // the border does the distinguishing instead. currentColor for the ring
+  // because it is the label colour, already measured against this surface;
+  // --tn-lines is a colour for the page and can vanish on a filled chip, the
+  // same reason __label's <code> border uses currentColor.
   &__close {
     display: flex;
     align-items: center;
     justify-content: center;
+    box-sizing: border-box;
     width: 20px;
     height: 20px;
     padding: 0;
     margin: 0;
-    border: none;
+    border: 1px solid currentColor;
     border-radius: 50%;
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: transparent;
     color: inherit;
     cursor: pointer;
-    transition: background-color 0.2s ease-in-out;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
     outline: none;
 
-    &:hover:not(:disabled) {
-      background-color: rgba(255, 255, 255, 0.3);
-    }
+    // Hover is per variant, not here: it fills the circle with the chip's own
+    // label colour and paints the × in the chip's background, which is the
+    // label pair reversed. Contrast is symmetric, so every one of those is a
+    // ratio chip-contrast.spec.ts already measures — a hover state that cannot
+    // fail AA without the resting label failing first. It cannot be written
+    // once at this level, because `currentColor` would give the fill but there
+    // is no keyword for "the background behind me" to give the glyph.
 
     &:focus-visible {
       outline: 1px solid currentColor;
@@ -209,18 +258,13 @@
   }
 }
 
-// Dark theme adjustments
-.tn-dark .tn-chip {
-  &--secondary {
-    .tn-chip__close {
-      background-color: rgba(0, 0, 0, 0.2);
-      
-      &:hover:not(:disabled) {
-        background-color: rgba(0, 0, 0, 0.3);
-      }
-    }
-  }
-}
+// No dark theme adjustment for the close circle any more (#261). It used to
+// wash rgba(0, 0, 0, 0.2) instead of the white one, for TN Dark's --secondary
+// only — a light wash on that variant's grey would have disappeared. It was a
+// per-theme patch on a per-theme problem, and it covered exactly one of the
+// eight palettes the white wash actually broke: Nord's --secondary measured
+// 3.70:1 and Midnight's 3.97:1 with no override of their own. Painting nothing
+// removes the question in all nine at once, so there is nothing left to patch.
 
 // High contrast theme adjustments
 .high-contrast .tn-chip {

--- a/projects/truenas-ui/src/lib/chip/chip.component.scss
+++ b/projects/truenas-ui/src/lib/chip/chip.component.scss
@@ -62,6 +62,9 @@
     .tn-chip__close:hover:not(:disabled) {
       background-color: var(--tn-primary-txt);
       color: var(--tn-primary);
+      // The focus ring is drawn outside the circle, on the chip, so it stays
+      // the label colour while `color` goes to the background. See __close.
+      outline-color: var(--tn-primary-txt);
     }
   }
 
@@ -82,6 +85,9 @@
     .tn-chip__close:hover:not(:disabled) {
       background-color: var(--tn-alt-fg2);
       color: var(--tn-alt-bg2);
+      // See __close: the ring is outside the circle, so it keeps the label
+      // colour while `color` goes to the background.
+      outline-color: var(--tn-alt-fg2);
     }
   }
 
@@ -105,6 +111,7 @@
     .tn-chip__close:hover:not(:disabled) {
       background-color: var(--tn-alt-fg2);
       color: var(--tn-alt-bg2);
+      outline-color: var(--tn-alt-fg2);
     }
   }
 
@@ -240,6 +247,15 @@
     // once at this level, because `currentColor` would give the fill but there
     // is no keyword for "the background behind me" to give the glyph.
 
+    // `currentColor` is right here and ONLY here. The outline is drawn outside
+    // the circle, on the chip's own background, so it has to be the chip's
+    // label colour — which is what `color` holds while the circle is at rest.
+    // It is not what `color` holds once the circle is hovered: the invert puts
+    // the chip's BACKGROUND there, and an outline in the background colour
+    // drawn on the background is 1:1 and gone. Each variant's hover rule
+    // therefore restates `outline-color` as its label token, and
+    // chip-contrast.spec.ts asserts that it equals the fill so the two cannot
+    // drift apart.
     &:focus-visible {
       outline: 1px solid currentColor;
       outline-offset: 1px;

--- a/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
@@ -65,6 +65,14 @@ const FALLBACK_LITERAL = '#0074a7';
  * `--tn-primary-text`.
  */
 const KEEPS_PRIMARY: Readonly<Record<string, { count: number; why: string }>> = {
+  'chip/chip.component.scss': {
+    count: 1,
+    why: 'the × on a hovered close button, which is text but paints on --tn-primary-txt — '
+      + 'the primary chip\'s own label colour, filling the circle — and not on --tn-bg1/--tn-bg2. '
+      + '--tn-primary-text is tuned for the page background and would be the wrong colour on a '
+      + 'fill; this pair is the primary chip\'s label pair reversed, and chip-contrast.spec.ts '
+      + 'measures it at 4.5:1 in all nine palettes (#261)',
+  },
   'expansion-panel/expansion-panel.component.scss': { count: 1, why: 'the <svg> chevron' },
   'file-picker/file-picker-popup.component.scss': {
     count: 3,


### PR DESCRIPTION
Fixes #261.

`.tn-chip__close` washed `rgba(255, 255, 255, 0.2)` over whatever the chip already paints, while the `×` inside took `color: inherit` — the chip's label colour, which each variant chooses for its own *unwashed* surface. The wash lightens the circle by a fixed 20% towards white in every theme, so a light label loses contrast against it: white on `--tn-primary` is 4.58:1 on the chip and **3.31:1** on the circle.

The `×` is a visible text node in a button that carries its own `aria-label`, so axe's `color-contrast` rule evaluates it as text. Every one of the eight failures cleared the 3:1 non-text minimum and missed the 4.5:1 text one — the band where hiding the glyph from the accessibility tree would satisfy the rule while changing nothing a sighted user sees. That is not the fix and was not done.

## Reproduced first

The measurement was written before the change and failed on it. `chip-contrast.spec.ts` composites the close circle's declared background over each variant's chip background and measures the inherited glyph colour on the result; on the unfixed stylesheet that produced 18 failures, of which the 9 resting ones are exactly the ticket's eight plus `.tn-nord --secondary`:

| | ticket | measured here |
|---|---|---|
| `:root` / `.tn-dark` / `.tn-blue` `--primary` | 3.31 | 3.31 |
| `.tn-dracula --primary` | 3.24 | 3.23 |
| `.tn-solarized-dark --primary` | 3.55 | 3.55 |
| `.tn-midnight --primary` | 3.49 | 3.50 |
| `.tn-midnight --secondary` | 3.98 | 3.97 |
| `.tn-nord --secondary` | 3.68 | 3.70 |

The differences of 0.01–0.02 are one deliberate decision: `compositeColor` does **not** round the composited channels, because the gamma curve is applied after it and rounding first moves the ratio in whichever direction the rounding went. `contrast-testing.ts` already warns about the same class of mistake for `formatRatio`. The verdict is identical in every row either way.

The other nine failures were the `:hover` states, which the ticket's 27-cell table does not cover and which are the same defect (the hover wash was `0.3`, so worse).

## A ring, not a wash

The circle paints nothing now and is drawn with a `1px solid currentColor` border. That puts the glyph back on the chip's own surface — the pair `chip-contrast.spec.ts` already asserts clears 4.5:1 in all nine palettes — so the close circle stops having a contrast question of its own rather than getting a per-theme answer to one. The lowest of the 45 cases is now 4.75:1.

`currentColor` for the ring, not `--tn-lines`, for the reason `__label`'s `<code>` border already gives: `--tn-lines` is a colour for the page and can vanish on a filled chip.

**Hover inverts**: the circle fills with the chip's label colour and paints the `×` in the chip's background. That is the label pair with its halves swapped, and contrast is symmetric, so it is a hover state that cannot fail AA without the resting label failing first. It is written per variant because `currentColor` gives the fill but there is no keyword for "the background behind me" to give the glyph.

**The TN Dark `--secondary` override is deleted.** It swapped in `rgba(0, 0, 0, 0.2)` where a light wash would have disappeared — a per-theme patch on a per-theme problem, and it covered exactly one of the eight palettes the white wash actually broke. Nord's `--secondary` (3.70:1) and Midnight's (3.97:1) had no override of their own.

## What the spec now guards

- It reads the circle's background **out of the stylesheet** rather than listing it, so "the wash is gone" and "the wash is back" produce different results from the same file.
- `CLOSE_RULES` allowlists every rule permitted to colour the circle, by flattened selector, pinning the whole set of colour declarations — `background`, `color`, `border`, `outline` and their longhands. A theme-scoped override is invisible to a spec that composites only the resting rule, and a `border-color` or `outline-color` override touches neither of the two properties this measures.
- `NOT_A_LABEL_SURFACE` is now checked in both directions. The four `rgba()` excuses this change deletes would otherwise have sat there reading as a live decision not to measure the close circle.

## `compositeColor`

`contrastRatio` refuses a translucent background and tells the caller to "composite it against that surface and pass the result" — and exported no way to do that, which is how a wash over a themed surface came to be *excused* from measurement rather than measured. `contrast-testing.ts` now exports the operation, with its own cases in `contrast-testing.spec.ts`.

`parseColor` also reads `transparent`, the one colour keyword that is not a hue and what a stylesheet says to mean "paint nothing". Every actual colour name stays refused.

## `primary-text-contrast.spec.ts`

The `#242` guard caught the new `color: var(--tn-primary)` and was right to. It is recorded in `KEEPS_PRIMARY` rather than migrated: the `×` is text, but it paints on `--tn-primary-txt` — the primary chip's own label colour, filling the circle — and not on `--tn-bg1`/`--tn-bg2`, which is what `--tn-primary-text` is tuned for. Same shape as the existing `menu.component.scss` entry.

## Acceptance criteria

- [x] The close glyph measures at least 4.5:1 against the surface actually painted behind it, for all three variants in all nine palettes — 45 cases including the hover states, lowest 4.75:1
- [x] A spec asserts that per variant per palette, compositing the wash rather than measuring the chip background
- [x] The `×` is not removed from the accessibility tree, and the close button keeps its accessible name — no template change in this diff at all
- [x] The close circle remains visually distinguishable from the chip body — by a `1px currentColor` ring, which fills on hover

## Checks run locally

- `yarn test` — 132 suites, 3454 tests, all passing
- `yarn test:scripts` — 42 passing
- `yarn build` — clean
- `yarn build-storybook` — clean
- `yarn lint` — **the only 4 errors are the pre-existing `import/order` failures in `input.component.ts` and `menu-panel.component.ts`**, neither of which this branch touches. That is #251, open with its own PR. No file in this diff produces a lint error.
- `Storybook Interaction Tests` was **not** run: it drives a real browser through Playwright and this machine has neither the browser nor the system libraries to supply one. This change is a stylesheet-only change to a component whose stories exist, so it is the suite most likely to have something to say about it — if the Chip stories run with `a11y: { test: 'error' }`, this is one of the reasons #261 predicted they would still fail after #238. That is reasoning about the diff rather than a run of it.

Two untracked probe specs (`list/probe-projection.spec.ts`, `selection-list/probe-order.spec.ts`) and a stray `projects/state/` jest cache, left in this clone by earlier cycles, are picked up by the local `yarn test` run and are not part of this branch. They are untracked, so nothing here commits them; they inflate the local suite count relative to CI's.

## Local review

`local-review.py` ran the project's own reviewer in a separate process — same rubric, threshold and parser as the required check — over three rounds. Rounds 1 and 2 returned findings and are fixed; **round 3 returned nothing at MEDIUM or above (exit 0)**.

Round 1, one HIGH and two MEDIUM, all correct and all fixed:

- **HIGH: the focus ring went invisible while the button was hovered.** `:focus-visible` draws its outline *outside* the circle, on the chip's background, in `currentColor` — fine at rest, where that is the label colour, and 1:1 under the invert, where `currentColor` has become the chip's background. A keyboard user hovering the button they are focused on had no indicator. Each hover rule now restates `outline-color` as its label token, and the spec asserts it **equals the fill** rather than naming it separately, so changing the invert moves both or fails. This was introduced by the fix, not found in it.
- **MEDIUM:** a `toBeDefined()` guard that could never fail, because the value it guarded was consumed during collection. It is a thrown error at that point now, naming what about the stylesheet is wrong.
- **MEDIUM:** the glyph-colour guard filtered on the raw `&__close` fragment, so a theme-scoped `color` override would have gone undetected while all 45 cases measured a colour the glyph no longer had.

Round 2, one MEDIUM, fixed: the allowlist admitted a rule only if it set `background`/`background-color`/`color`, so it read wider than it was — `border-color` and `outline-color` overrides slipped past it. It goes through a `COLOUR_PROPERTIES` list now and compares the whole declaration set.

Round 3's two LOWs are left unfixed deliberately — every fix is a new diff and a new round — and are worth a reader's attention:

1. **The resting ring and the focus outline are both 1px `currentColor`, so focus reads as a second concentric hairline.** True, and it predates this change in half: the outline was always 1px `currentColor`, but it used to sit against a filled circle rather than a ringed one. Worth its own ticket; a thicker or offset focus ring is a visual-design decision rather than a contrast one, and the indicator is present and clears 3:1 either way.
2. **The `resting` throw checks the rule exists but not that it declares a background**, so removing `background-color` from `.tn-chip__close` would crash collection with a `TypeError` rather than the written message. The failure is still loud and still in the right file; only the wording degrades.

The same review also noted, and this is worth recording separately because it is **pre-existing and not touched here**: `chip.component.scss` ends with a `.high-contrast .tn-chip` block, but the registered theme class is `tn-high-contrast` (`theme.constants.ts`), so that block — the 2px border and the 3px focus outline — matches nothing and has never applied. Fixing it would start changing High Contrast's rendering, which is not this ticket and is not something to slip into an a11y contrast fix. Proposed as its own ticket on #261.
