### PR TITLE
NAS-142518 / 27.0.0-BETA.1 / fix(button): keep a code span on the button's own surface

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -612,6 +612,37 @@ reports `incomplete`, which `axeResult()` treats as an error. What these
 assertions measure is the palette as shipped, against the surface the spec names.
 See `theme/error-text-contrast.spec.ts` for the shape.
 
+### Reading a stylesheet back in a spec
+
+**Use `lib/a11y/scss-testing.ts`. Do not write another brace walk.** A contrast
+spec is a hardcoded table of pairs, and a table is exactly as current as the last
+person to edit it — a new variant, or a `color:` moved to another token, leaves
+every case green while measuring markup that no longer exists. The half of such a
+spec that stops it rotting reads the `.scss` back, and that half is identical
+whichever component it is pointed at. It was written inside
+`chip/chip-contrast.spec.ts` and moved here when
+`pipes/label-markup/inline-code-contrast.spec.ts` became its second caller (#262).
+
+**`scssRules(scss, source)` returns every rule with its `parent`, and the nesting
+is the point.** `color` and `background-color` are rarely declared together:
+`&--secondary:hover` repaints the background and inherits its label colour from
+`&--secondary`, one level up and on the same element. Collecting the two
+properties independently gives the right two *sets* of tokens and says nothing
+about which goes with which, so re-pairing an existing foreground with an
+existing surface passes.
+
+**`inheritedValue(rule, 'color')` walks that chain; `flattenSelector(rule)`
+resolves `&` outward.** Use the flattened form whenever a guard enumerates the
+rules that paint something — `&__close` finds the one rule written inside
+`.tn-chip` and misses every theme-scoped override of it, which is exactly where
+an unmeasured colour comes back.
+
+**It reads nesting and declarations, not Sass.** `@include`, `@if` and
+interpolation are invisible to it. A spec that needs to know which rule includes
+a mixin can rewrite the include into a marker declaration before parsing — see
+`inline-code-contrast.spec.ts` — and a spec that needs the *compiled* output has
+to compile it.
+
 ### Keyboard Navigation
 Support standard keys:
 - **Tab** - Focus navigation

--- a/projects/truenas-ui/src/lib/a11y/scss-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/scss-testing.ts
@@ -151,10 +151,13 @@ export function inheritedValue(rule: ScssRule | null, property: string): string 
  * `var(--tn-x)` and `var(--tn-x, <fallback>)` -> `--tn-x`; anything else
  * unchanged, to be judged as a literal.
  *
- * The fallback is dropped rather than read, because `themePalettes` follows the
- * whole chain from the token name and uses the fallback only when the token is
- * declared nowhere — which is what the browser does. Keeping it here would mean
- * two places deciding what a `var()` resolves to.
+ * The fallback is dropped rather than read, and it is dropped for good: what a
+ * caller does with the name is look it up in the palette, which resolves the
+ * token there and THROWS if it is declared nowhere. It does not reach for a
+ * fallback this function never handed it. That is the intended answer — a
+ * fallback in a component stylesheet is for a consumer with no theme loaded, and
+ * a spec measuring this library's own palettes wants to hear that a token has
+ * gone missing rather than to silently measure the literal behind it.
  */
 export function tokenOf(value: string): string {
   return /^var\(\s*(--[\w-]+)\s*[,)]/.exec(value.trim())?.[1] ?? value.trim();

--- a/projects/truenas-ui/src/lib/a11y/scss-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/scss-testing.ts
@@ -1,0 +1,161 @@
+/**
+ * Reading a component stylesheet back, for the a11y specs that assert on what it
+ * declares.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A contrast spec is a hardcoded table of (foreground, background) pairs, and a
+ * table is exactly as current as the last person to edit it: a new variant, or a
+ * `color:` moved to a different token, leaves every case green while measuring
+ * markup that no longer exists. The half of such a spec that stops it rotting is
+ * the half that reads the `.scss` and fails when the two have diverged — and
+ * that half is a parser, identical whichever component it is pointed at.
+ *
+ * It was written once inside `chip/chip-contrast.spec.ts` (#238, #261) and the
+ * second component to need it is what moved it here (#262): the `<code>` span
+ * `label-markup.inline-code` paints is included by ten components, so the spec
+ * covering it has to read ten stylesheets.
+ *
+ * `contrast-testing.ts` is the other half — the WCAG maths and the theme-token
+ * lookup. This module knows nothing about colour.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * Not a CSS parser, and not a Sass compiler. It reads the nesting and the
+ * declarations, which is what an assertion about "the rule that paints X" needs;
+ * it does not resolve `@include`, `@if`, placeholder selectors or interpolation.
+ * A spec that needs the *compiled* output has to compile it.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `contrast-testing.ts` and `axe-testing.ts`. These read this library's own
+ * source, which no consumer has a use for.
+ */
+
+/** One rule in a stylesheet: its own declarations, and what it nests inside. */
+export interface ScssRule {
+  /** As written, so `&__close` rather than the selector it lands on. */
+  selector: string;
+  declarations: Map<string, string>;
+  parent: ScssRule | null;
+}
+
+/**
+ * Every rule in `scss`, each pointing at the rule it nests inside.
+ *
+ * A brace walk rather than a regex, and the nesting is the reason. `color` and
+ * `background-color` are almost never declared together: a chip's
+ * `&--secondary:hover` repaints the background and inherits its label colour
+ * from `&--secondary`, one level up and on the same element. Scanning for the
+ * two properties independently collects the right two SETS of tokens while
+ * saying nothing about which goes with which, so re-pairing an existing
+ * foreground with an existing surface passes: `--tn-alt-fg2` on `--tn-accent` is
+ * 2.58:1 in Solarized Dark and both halves are already in the table.
+ *
+ * `source` names the file in the two refusals below, because a spec reading ten
+ * stylesheets gets no help from a message that does not say which one.
+ */
+export function scssRules(scss: string, source: string): ScssRule[] {
+  // Both comment forms go first. `//` runs to end of line and `/* */` does not,
+  // and either can contain a brace or a semicolon that would otherwise be read
+  // as structure.
+  const text = scss.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  const rules: ScssRule[] = [];
+  const open: ScssRule[] = [];
+  let pending = '';
+
+  function absorb(rule: ScssRule, chunk: string): void {
+    for (const part of chunk.split(';')) {
+      const declaration = /^\s*([-\w]+)\s*:\s*([\s\S]+?)\s*$/.exec(part);
+      if (declaration) {
+        rule.declarations.set(declaration[1], declaration[2]);
+      }
+    }
+  }
+
+  for (const character of text) {
+    if (character === '{') {
+      // Everything after the last `;` is the prelude of the rule opening now;
+      // everything before it belongs to the rule already open.
+      const lastSemicolon = pending.lastIndexOf(';');
+      const enclosing = open[open.length - 1] ?? null;
+      if (enclosing) {
+        absorb(enclosing, pending.slice(0, lastSemicolon + 1));
+      }
+      const rule: ScssRule = {
+        selector: pending.slice(lastSemicolon + 1).trim(),
+        declarations: new Map(),
+        parent: enclosing,
+      };
+      open.push(rule);
+      rules.push(rule);
+      pending = '';
+    } else if (character === '}') {
+      const closing = open.pop();
+      if (closing === undefined) {
+        throw new Error(`${source}: unbalanced braces — a } with nothing open`);
+      }
+      absorb(closing, pending);
+      pending = '';
+    } else {
+      pending += character;
+    }
+  }
+  if (open.length > 0) {
+    throw new Error(`${source}: unbalanced braces — ${open.length} rule(s) left open`);
+  }
+  return rules;
+}
+
+/**
+ * The selector a nested rule actually matches, with `&` resolved outward.
+ *
+ * `&__close` says nothing on its own about which element it lands on, and an
+ * element is often reachable by two routes — `.tn-chip { &__close }` and a
+ * theme-scoped `.tn-dark .tn-chip { &--secondary { .tn-chip__close } }`. A guard
+ * that enumerates every rule painting something has to recognise it in either
+ * shape, so it needs the flattened form rather than the fragment.
+ */
+export function flattenSelector(rule: ScssRule): string {
+  const nesting: string[] = [];
+  for (let current: ScssRule | null = rule; current !== null; current = current.parent) {
+    nesting.unshift(current.selector);
+  }
+  return nesting.reduce((enclosing, selector) =>
+    selector.includes('&')
+      ? selector.replace(/&/g, enclosing)
+      : (enclosing === '' ? selector : `${enclosing} ${selector}`));
+}
+
+/**
+ * The value of `property` in force on the element this rule matches: its own, or
+ * the nearest enclosing rule's.
+ *
+ * Nesting stands in for inheritance because of what these selectors are.
+ * `&--secondary:hover` and `&--secondary` match the SAME element, so the outer
+ * declaration is the one that renders, not merely one that might cascade down.
+ * A nested rule that matches a DESCENDANT — `.tn-chip { .tn-chip__close { … } }`
+ * — is a different question, and this answers it the same way the cascade does
+ * for an inherited property like `color`.
+ */
+export function inheritedValue(rule: ScssRule | null, property: string): string | undefined {
+  for (let current = rule; current !== null; current = current.parent) {
+    const own = current.declarations.get(property);
+    if (own !== undefined) {
+      return own;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * `var(--tn-x)` and `var(--tn-x, <fallback>)` -> `--tn-x`; anything else
+ * unchanged, to be judged as a literal.
+ *
+ * The fallback is dropped rather than read, because `themePalettes` follows the
+ * whole chain from the token name and uses the fallback only when the token is
+ * declared nowhere — which is what the browser does. Keeping it here would mean
+ * two places deciding what a `var()` resolves to.
+ */
+export function tokenOf(value: string): string {
+  return /^var\(\s*(--[\w-]+)\s*[,)]/.exec(value.trim())?.[1] ?? value.trim();
+}

--- a/projects/truenas-ui/src/lib/button/button.component.scss
+++ b/projects/truenas-ui/src/lib/button/button.component.scss
@@ -28,6 +28,28 @@
 .storybook-button {
   @include label-markup.inline-code;
 
+  // The mixin paints <code> on --tn-bg2 and leaves the colour inherited. For
+  // most of the ten components that include it that is right: their labels
+  // already sit on --tn-bg1 or --tn-bg2, so the wash is a near-neutral step off
+  // a surface the colour was chosen for. A button label is not one of those. Every
+  // variant below either fills its own background or deliberately shows the page
+  // through a transparent one, and each pairs its `color` with that — so a code
+  // span painting --tn-bg2 swaps the background out from under a colour chosen
+  // for something else: --tn-primary-txt is white on --tn-primary in TN Light,
+  // and white on #FFFFFF once the span repaints it, at 1:1.
+  //
+  // So <code> keeps the button's own surface, whatever that variant paints, and
+  // the monospace font and the border do the distinguishing instead. That is the
+  // fix #238 made for .tn-chip__label, for the same reason — the mixin is not
+  // the defect and nine of its call sites want it unchanged (#262).
+  //
+  // currentColor for the border because --tn-lines is a colour for the page, and
+  // on a filled button it can vanish.
+  ::ng-deep code {
+    background: transparent;
+    border-color: currentColor;
+  }
+
   display: inline-block;
   cursor: pointer;
   // Transparent border (not none) so solid and outline variants have the same

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -8,6 +8,13 @@ import {
   meetsAa,
   themePalettes,
 } from '../a11y/contrast-testing';
+import type { ScssRule } from '../a11y/scss-testing';
+import {
+  flattenSelector,
+  inheritedValue,
+  scssRules,
+  tokenOf,
+} from '../a11y/scss-testing';
 import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
@@ -226,121 +233,6 @@ const NOT_A_LABEL_SURFACE: Readonly<Record<string, string>> = {
 };
 
 
-/** One rule in the stylesheet: its own declarations, and what it nests inside. */
-interface ScssRule {
-  selector: string;
-  declarations: Map<string, string>;
-  parent: ScssRule | null;
-}
-
-/**
- * Every rule in `scss`, each pointing at the rule it nests inside.
- *
- * A brace walk rather than a regex, and the nesting is the reason. `color` and
- * `background-color` are almost never declared together: `&--secondary:hover`
- * repaints the background and inherits its label colour from `&--secondary`,
- * one level up and on the same element. Scanning for the two properties
- * independently — which is what this used to do — collects the right two SETS
- * of tokens while saying nothing about which goes with which, so re-pairing an
- * existing foreground with an existing surface passes: `--tn-alt-fg2` on
- * `--tn-accent` is 2.58:1 in Solarized Dark and both halves are already in the
- * table.
- */
-function scssRules(scss: string): ScssRule[] {
-  // Both comment forms go first. `//` runs to end of line and `/* */` does not,
-  // and either can contain a brace or a semicolon that would otherwise be read
-  // as structure.
-  const source = scss.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-  const rules: ScssRule[] = [];
-  const open: ScssRule[] = [];
-  let pending = '';
-
-  function absorb(rule: ScssRule, text: string): void {
-    for (const chunk of text.split(';')) {
-      const declaration = /^\s*([-\w]+)\s*:\s*([\s\S]+?)\s*$/.exec(chunk);
-      if (declaration) {
-        rule.declarations.set(declaration[1], declaration[2]);
-      }
-    }
-  }
-
-  for (const character of source) {
-    if (character === '{') {
-      // Everything after the last `;` is the prelude of the rule opening now;
-      // everything before it belongs to the rule already open.
-      const lastSemicolon = pending.lastIndexOf(';');
-      const enclosing = open[open.length - 1] ?? null;
-      if (enclosing) {
-        absorb(enclosing, pending.slice(0, lastSemicolon + 1));
-      }
-      const rule: ScssRule = {
-        selector: pending.slice(lastSemicolon + 1).trim(),
-        declarations: new Map(),
-        parent: enclosing,
-      };
-      open.push(rule);
-      rules.push(rule);
-      pending = '';
-    } else if (character === '}') {
-      const closing = open.pop();
-      if (closing === undefined) {
-        throw new Error('chip.component.scss: unbalanced braces — a } with nothing open');
-      }
-      absorb(closing, pending);
-      pending = '';
-    } else {
-      pending += character;
-    }
-  }
-  if (open.length > 0) {
-    throw new Error(`chip.component.scss: unbalanced braces — ${open.length} rule(s) left open`);
-  }
-  return rules;
-}
-
-/**
- * The `color` in force on the element this rule matches: its own, or the
- * nearest enclosing rule's.
- *
- * Nesting stands in for inheritance because of what the chip's selectors are.
- * `&--secondary:hover` and `&--secondary` match the SAME element, so the outer
- * `color` is the one that renders, not merely one that might cascade down.
- */
-function labelColor(rule: ScssRule | null): string | undefined {
-  for (let current = rule; current !== null; current = current.parent) {
-    const own = current.declarations.get('color');
-    if (own !== undefined) {
-      return own;
-    }
-  }
-  return undefined;
-}
-
-/**
- * The selector a nested rule actually matches, with `&` resolved outward.
- *
- * `&__close` says nothing on its own about which element it lands on, and the
- * close circle is reachable by two routes — `.tn-chip { &__close }` and the
- * theme-scoped `.tn-dark .tn-chip { &--secondary { .tn-chip__close } }`. The
- * guard below has to enumerate every rule that paints the circle, in either
- * shape, so it needs the flattened form rather than the fragment.
- */
-function flattenSelector(rule: ScssRule): string {
-  const nesting: string[] = [];
-  for (let current: ScssRule | null = rule; current !== null; current = current.parent) {
-    nesting.unshift(current.selector);
-  }
-  return nesting.reduce((enclosing, selector) =>
-    selector.includes('&')
-      ? selector.replace(/&/g, enclosing)
-      : (enclosing === '' ? selector : `${enclosing} ${selector}`));
-}
-
-/** `var(--tn-x)` -> `--tn-x`; anything else unchanged, to be judged as a literal. */
-function tokenOf(value: string): string {
-  return /^var\(\s*(--[\w-]+)\s*\)$/.exec(value)?.[1] ?? value;
-}
-
 /** `--tn-alt-fg2 on --tn-alt-bg2`, the form the guard compares. */
 function pairing(foreground: string | undefined, background: string): string {
   return `${foreground ?? 'no colour in force'} on ${background}`;
@@ -367,7 +259,7 @@ describe('tn-chip label contrast (#238)', () => {
   const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
   const scss = readFileSync(CHIP_SCSS, 'utf8');
   const palettes = themePalettes(css);
-  const rules = scssRules(scss);
+  const rules = scssRules(scss, 'chip.component.scss');
 
   // Derived from the theme registry rather than hardcoded: a themed surface
   // that stops being recognised — a renamed class, a block that drops
@@ -401,7 +293,7 @@ describe('tn-chip label contrast (#238)', () => {
       .filter((rule) => rule.declarations.has('background-color') || rule.declarations.has('background'))
       .map((rule) => {
         const background = rule.declarations.get('background-color') ?? (rule.declarations.get('background') as string);
-        const foreground = labelColor(rule);
+        const foreground = inheritedValue(rule, 'color');
         return {
           selector: rule.selector,
           background: tokenOf(background),

--- a/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
@@ -1,0 +1,615 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join, relative } from 'path';
+import type { ThemePalette } from '../../a11y/contrast-testing';
+import {
+  AA_MINIMUM,
+  contrastRatio,
+  formatRatio,
+  meetsAa,
+  themePalettes,
+} from '../../a11y/contrast-testing';
+import { flattenSelector, scssRules, tokenOf } from '../../a11y/scss-testing';
+import { TN_THEME_DEFINITIONS } from '../../theme/theme.constants';
+
+/**
+ * The `<code>` span `label-markup.inline-code` paints, measured against the
+ * surface actually behind it, at every call site, in all nine palettes (#262).
+ *
+ * WHAT WENT WRONG. The mixin sets `background: var(--tn-bg2)` on `<code>` and
+ * leaves the colour inherited. That is right for a label sitting on the page's
+ * own surfaces, where the wash is a near-neutral step off a background the
+ * colour was already chosen for. It is wrong for a label on a FILLED control:
+ * the span swaps the background out from under a colour paired with something
+ * else. `.button-primary` is `--tn-primary-txt` on `--tn-primary`, and a code
+ * span in one painted that same foreground on `--tn-bg2` — white on #282828 in
+ * TN Dark, and white on #FFFFFF at 1:1 in TN Light. `.button-default` is the
+ * same shape and worse-travelled: `--tn-btn-default-bg` is `#545454` in `:root`
+ * and seven themes inherit it, so it is a dark fill under white text in every
+ * light theme.
+ *
+ * #238 fixed exactly this inside `tn-chip`, by overriding the wash so a code
+ * span keeps the chip's own surface. The mixin itself was not the defect then
+ * and is not now: nine of its ten call sites label the page's own surfaces.
+ *
+ * WHAT THIS ASSERTS, IN THREE PARTS.
+ *
+ * 1. `CALL_SITES` still lists every component that includes the mixin, and each
+ *    entry still names the element that includes it. A hardcoded table of call
+ *    sites is exactly as current as the last person to edit it, and the failure
+ *    mode this file exists for is a NEW filled surface — so the list is compared
+ *    against a scan of `src/lib` rather than trusted.
+ * 2. Whether a call site keeps its own surface is READ from its stylesheet, not
+ *    listed here. "The wash is overridden" and "the wash is back" have to
+ *    produce different results from the same spec, or the override proves
+ *    nothing.
+ * 3. Every colour in force on a code span clears 4.5:1 against whatever the span
+ *    is painted on — the wash where the wash survives, the element's own surface
+ *    where it is overridden.
+ *
+ * NOT AXE'S `color-contrast` RULE, which needs a layout engine to find what is
+ * really painted behind an element and reports `incomplete` under jsdom rather
+ * than checking. This measures the values shipped in `themes.css` against the
+ * surface the stylesheets name. `yarn test-sb` is what checks the page.
+ *
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197); the
+ * stylesheet reading is `lib/a11y/scss-testing.ts`, moved there out of
+ * `chip/chip-contrast.spec.ts` when this file became its second caller.
+ */
+
+const LIB_DIR = join(__dirname, '../..');
+const STYLES_DIR = join(__dirname, '../../../styles');
+const MIXIN_SCSS = join(__dirname, '_label-markup.scss');
+
+/**
+ * The include this file is about, as it is written at every call site.
+ *
+ * Two constants for one pattern because a `/g` regex carries a `lastIndex`
+ * between calls: `test`ing the same global regex against a list of files answers
+ * for every other one of them. The global form is only ever handed to `replace`,
+ * which resets it.
+ */
+const INCLUDE = /@include\s+label-markup\.inline-code\s*;/;
+const EVERY_INCLUDE = new RegExp(INCLUDE.source, 'g');
+
+/**
+ * A marker declaration standing in for that include.
+ *
+ * `scssRules` reads declarations, and an `@include` is not one — so the rule a
+ * mixin is included in cannot be found by asking which rule includes it. Turning
+ * the include into a declaration first is what makes it findable, and it is done
+ * by rewriting the text rather than by teaching the parser about at-rules, which
+ * would be a change to a shared module for one caller's benefit.
+ */
+const INCLUDE_MARKER = '-tn-includes-inline-code: yes;';
+
+/**
+ * The surfaces a label sits on when the control paints nothing of its own.
+ *
+ * Both, because a component cannot know which: `--tn-bg1` is the page and
+ * `--tn-bg2` is a card, a menu or a panel on it, and the same button appears on
+ * either. `themes.css` tunes its text tokens against both for this reason and
+ * records the two ratios side by side.
+ */
+const PAGE_SURFACES = ['--tn-bg1', '--tn-bg2'] as const;
+
+/** How a stylesheet spells "whatever is behind me shows through". */
+const TRANSPARENT = 'transparent';
+
+/**
+ * The one colour name these stylesheets spell out, and the hex it is.
+ *
+ * `contrast-testing.ts` refuses named colours on purpose — guessing at one is
+ * how a wrong ratio gets asserted — so the equivalence is declared here, once,
+ * where it can be read and disagreed with. The tables below hold `white`,
+ * matching what `button.component.scss` actually says, and only the measurement
+ * translates.
+ */
+const NAMED_COLOURS: Readonly<Record<string, string>> = { white: '#ffffff' };
+
+/** One colour a code span can inherit, and the surface its element paints. */
+interface CodeSpanState {
+  /** How it reads in a failure: `.button-primary`. */
+  readonly name: string;
+  /** The colour in force on the label, and so on the `<code>` inside it. */
+  readonly colour: string;
+  /**
+   * What the element itself paints, as its stylesheet declares it —
+   * `TRANSPARENT` where the surface behind it shows through.
+   */
+  readonly surface: string;
+}
+
+/** One component that includes the mixin. */
+interface CallSite {
+  /** Path under `src/lib`, which is how the scan below reports it. */
+  readonly file: string;
+  /** The element the include sits on, flattened. */
+  readonly element: string;
+  /** Every colour a code span there can inherit. May be empty — see `measuredBy`. */
+  readonly states: readonly CodeSpanState[];
+  /** Where the measurement lives instead, for a call site with no states here. */
+  readonly measuredBy?: string;
+  /** Anything about this call site a reader would otherwise have to re-derive. */
+  readonly note?: string;
+}
+
+const CALL_SITES: readonly CallSite[] = [
+  {
+    file: 'button/button.component.scss',
+    element: '.storybook-button',
+    // Every variant, because the include is on `.storybook-button` itself rather
+    // than on a per-variant label: one rule paints code spans in all nine. The
+    // outline variants are transparent at rest and FILLED on hover, which is the
+    // half of this that is easy to miss — a code span in a hovered
+    // `.button-outline-warn` is white on --tn-red exactly as `.button-warn` is.
+    states: [
+      { name: '.button-primary', colour: '--tn-primary-txt', surface: '--tn-primary' },
+      { name: '.button-default', colour: '--tn-btn-default-txt', surface: '--tn-btn-default-bg' },
+      { name: '.button-warn', colour: 'white', surface: '--tn-red' },
+      { name: '.button-outline-primary', colour: '--tn-primary-text', surface: TRANSPARENT },
+      { name: '.button-outline-primary:hover', colour: '--tn-primary-txt', surface: '--tn-primary' },
+      { name: '.button-outline-default', colour: '--tn-fg1', surface: TRANSPARENT },
+      { name: '.button-outline-default:hover', colour: '--tn-btn-default-txt', surface: '--tn-btn-default-bg' },
+      { name: '.button-outline-warn', colour: '--tn-error-text', surface: TRANSPARENT },
+      { name: '.button-outline-warn:hover', colour: 'white', surface: '--tn-red' },
+    ],
+  },
+  {
+    file: 'chip/chip.component.scss',
+    element: '.tn-chip__label',
+    states: [],
+    // The chip already overrides the wash (#238), so a code span there sits on
+    // the chip's own surface — which makes the span's contrast question exactly
+    // the label's, and `chip-contrast.spec.ts` is nine palettes of that question
+    // already. Listing its five variant surfaces again here would be a second
+    // copy of a table that has to stay in step with `chip.component.scss`, and
+    // the copy that is not next to the stylesheet is the one that rots. The
+    // override itself is not taken on trust: it is read below like every other.
+    measuredBy: 'chip/chip-contrast.spec.ts',
+  },
+  {
+    file: 'tab/tab.component.scss',
+    element: '.tn-tab__label',
+    states: [
+      { name: 'resting', colour: '--tn-fg2', surface: TRANSPARENT },
+      { name: ':hover', colour: '--tn-fg1', surface: '--tn-alt-bg1' },
+    ],
+  },
+  {
+    file: 'radio/radio.component.scss',
+    element: '.tn-radio__text',
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT }],
+  },
+  {
+    file: 'checkbox/checkbox.component.scss',
+    element: '.tn-checkbox__text',
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT }],
+  },
+  {
+    file: 'slide-toggle/slide-toggle.component.scss',
+    element: '.tn-slide-toggle__label-text',
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT }],
+  },
+  {
+    file: 'form-section/form-section.component.scss',
+    element: '.tn-form-section__legend',
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT }],
+  },
+  {
+    file: 'form-field/form-field.component.scss',
+    element: '.tn-form-field-label',
+    states: [
+      { name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT },
+      // The label recolours with the field's state, and both of these tokens are
+      // per-theme shades tuned for the page — so the wash is the near-neutral
+      // step it is designed to be, and the span is measured on it like the rest.
+      { name: 'wrapper:has(:focus-visible)', colour: '--tn-primary-text', surface: TRANSPARENT },
+      { name: 'wrapper:has(.error)', colour: '--tn-error', surface: TRANSPARENT },
+    ],
+  },
+  {
+    file: 'stepper/stepper.component.scss',
+    element: '.tn-stepper__step-title',
+    states: [
+      { name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT },
+      { name: '--active', colour: '--tn-fg2', surface: TRANSPARENT },
+    ],
+    note: 'the filled circle is the step INDICATOR, a sibling of the title, and holds no label markup',
+  },
+  {
+    file: 'menu/menu.component.scss',
+    element: '.tn-menu-item-label',
+    // A menu item paints nothing, but it is not on the page: `.tn-menu` is
+    // --tn-bg2, so that is the surface behind the label and the wash paints the
+    // same colour the row already has.
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: '--tn-bg2' }],
+    note: 'the selected row is excluded — see SELECTED_MENU_ROW below',
+  },
+];
+
+/**
+ * The one state deliberately left unmeasured, and why.
+ *
+ * `.tn-menu-item--selected` paints `--tn-primary` on `--tn-alt-bg2`, and
+ * `menu.component.scss` already records that as a known gap it could not close:
+ * *"--tn-alt-bg2 has no foreground that clears AA across the palettes at all —
+ * even --tn-fg1 is 1.45:1 on it in Solarized Dark — so this row needs the
+ * surface reconsidered rather than a different colour on it"* (#242). A code
+ * span in that row inherits the same failing colour, so it fails wherever the
+ * row's own label fails, on the wash and off it alike. That is the row's defect
+ * showing through the span rather than the wash's, and moving the span onto
+ * `--tn-alt-bg2` — the fix for a filled surface — would move it from one
+ * unmeasurable surface to another.
+ *
+ * Named here rather than silently dropped: the case for excluding it is one a
+ * reader can disagree with, and a state that is simply missing from a table
+ * reads as a state nobody thought of.
+ */
+const SELECTED_MENU_ROW = '.tn-menu-item--selected: --tn-primary on --tn-alt-bg2, a known gap (#242)';
+
+/**
+ * Disabled states are excluded everywhere, for a reason that is not about this
+ * ticket: every one of them dims an ancestor with `opacity`, so the colour that
+ * renders is not the token in force, and this file measures tokens. Axe's own
+ * `color-contrast` rule skips disabled controls for the same class of reason.
+ */
+const DISABLED_STATES = 'excluded: an ancestor opacity decides what renders, not the token';
+
+/** A (palette, colour, surface) that does not clear AA for a reason of its own. */
+interface KnownGap {
+  /** The palette it fails on. Named one at a time: most of the nine are fine. */
+  readonly selector: string;
+  /** The colour, spelled as the tables above spell it. */
+  readonly colour: string;
+  /** The surface it fails on. */
+  readonly surface: string;
+  /** Where it is tracked, and why the wash is not what broke it. */
+  readonly why: string;
+}
+
+/**
+ * The pairings that do not clear AA, and are not this ticket's to fix.
+ *
+ * Every entry is held to two things below, so that this cannot become the place
+ * a real regression goes to be quiet:
+ *
+ * - **The wash is not what broke it.** The same colour has to fail on a surface
+ *   the ELEMENT ITSELF paints it on — so the pairing is broken wherever it
+ *   appears, and moving the span off the wash cannot fix it.
+ * - **It is still broken.** An entry whose pairing has started clearing AA fails
+ *   as a stale exclusion, rather than sitting here describing a fixed defect.
+ *
+ * Keyed by the pairing rather than by the call site, because that is what these
+ * are: a palette declaring two colours that do not go together. Every component
+ * that puts them together inherits it, and a list keyed by call site would grow
+ * an entry per component while saying the same thing each time.
+ */
+const KNOWN_GAPS: readonly KnownGap[] = [
+  // .button-warn fills with --tn-red and labels it `white`. --tn-red is tuned
+  // toward the 3:1 border/icon minimum rather than the 4.5:1 text one —
+  // `radio.component.scss` and `button.component.scss` both say so about the
+  // OUTLINE variants, which is why those read --tn-error-text instead (#234).
+  // The filled variant labels the token itself, so it inherits the same gap, and
+  // no foreground fixes it: `white` is already the furthest a label can get from
+  // a mid-red. It needs a darker fill or a companion token, which is a change to
+  // five palettes rather than to a code span, and every one of these ratios is
+  // what the button's ORDINARY label text measures too.
+  { selector: '.tn-dracula', colour: 'white', surface: '--tn-red', why: '.button-warn fills --tn-red, a 3:1 token, and labels it white — 3.14:1' },
+  { selector: '.tn-high-contrast', colour: 'white', surface: '--tn-red', why: '.button-warn fills --tn-red, a 3:1 token, and labels it white — 3.99:1' },
+  { selector: '.tn-midnight', colour: 'white', surface: '--tn-red', why: '.button-warn fills --tn-red, a 3:1 token, and labels it white — 3.99:1' },
+  { selector: '.tn-nord', colour: 'white', surface: '--tn-red', why: '.button-warn fills --tn-red, a 3:1 token, and labels it white — 4.09:1' },
+  { selector: '.tn-paper', colour: 'white', surface: '--tn-red', why: '.button-warn fills --tn-red, a 3:1 token, and labels it white — 3.99:1' },
+  // Solarized Dark's own text tokens, which is open as #265: --tn-fg1 is #586e75
+  // and reads 2.79:1 on this theme's --tn-bg1 and 2.42:1 on its --tn-bg2, and
+  // --tn-fg2 is 4.32:1 on --tn-bg2. themes.css's convention for every other
+  // palette is that a text token clears 4.5:1 on BOTH page surfaces; this one
+  // does not, so a label there fails on the page, on a card, and in a code span
+  // alike. Nothing about the mixin is involved.
+  { selector: '.tn-solarized-dark', colour: '--tn-fg1', surface: '--tn-bg1', why: "Solarized Dark's --tn-fg1 is 2.79:1 on its own page (#265)" },
+  { selector: '.tn-solarized-dark', colour: '--tn-fg1', surface: '--tn-bg2', why: "Solarized Dark's --tn-fg1 is 2.42:1 on its own card surface (#265)" },
+  { selector: '.tn-solarized-dark', colour: '--tn-fg2', surface: '--tn-bg2', why: "Solarized Dark's --tn-fg2 is 4.32:1 on its own card surface (#265)" },
+  // The same palette again, one step further along: it is the only theme that
+  // declares --tn-btn-default-txt for itself, as `var(--tn-fg2)`, and pairs it
+  // with a --tn-btn-default-bg of its own. So the default button's label is
+  // 3.03:1 there — on the button's own fill, with no page surface involved. It
+  // is listed separately because fixing --tn-fg2 for the page does not
+  // necessarily fix this pairing, and whoever takes #265 needs to see it.
+  { selector: '.tn-solarized-dark', colour: '--tn-btn-default-txt', surface: '--tn-btn-default-bg', why: "Solarized Dark pairs its own --tn-btn-default-txt (var(--tn-fg2)) with its own fill — 3.03:1 (#265)" },
+];
+
+/** How a gap and a measured case are matched up. */
+function pairing(selector: string, colour: string, surface: string): string {
+  return `${selector} ${colour} on ${surface}`;
+}
+
+/** Every `.scss` under `src/lib`, so the scan cannot miss a subdirectory. */
+function scssFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return scssFiles(path);
+    }
+    return entry.isFile() && entry.name.endsWith('.scss') ? [path] : [];
+  });
+}
+
+/** The colour a token or literal resolves to on this palette, ready to measure. */
+function resolved(palette: ThemePalette, colour: string): string {
+  return colour.startsWith('--')
+    ? palette.color(colour)
+    : (NAMED_COLOURS[colour] ?? colour);
+}
+
+describe('a <code> span in a label clears AA wherever the mixin is included (#262)', () => {
+  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
+  const palettes = themePalettes(css);
+
+  // Derived from the theme registry rather than hardcoded: a themed surface that
+  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
+  // would otherwise go unmeasured while every remaining case still passed.
+  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expectedSelectors].sort());
+  });
+
+  /**
+   * What the mixin itself paints, read out of `_label-markup.scss`.
+   *
+   * The whole claim of this file is about that value, so hardcoding it would
+   * leave every case green after someone changed it — including changing it to
+   * something that fixes nothing.
+   */
+  const mixinRules = scssRules(readFileSync(MIXIN_SCSS, 'utf8'), '_label-markup.scss');
+  const mixinCode = mixinRules.find((rule) => rule.selector === '::ng-deep code');
+  if (mixinCode === undefined) {
+    throw new Error(
+      'inline-code-contrast.spec.ts: _label-markup.scss has no `::ng-deep code` rule inside '
+      + '`@mixin inline-code`, so there is no wash to measure a span against. The mixin has '
+      + 'been renamed or has stopped painting a background of its own.'
+    );
+  }
+  const wash = mixinCode.declarations.get('background')
+    ?? mixinCode.declarations.get('background-color');
+  if (wash === undefined) {
+    throw new Error(
+      'inline-code-contrast.spec.ts: `@mixin inline-code` no longer sets a background on '
+      + '<code>. If that is deliberate, a span now inherits its surface everywhere and this '
+      + 'file measures the wrong thing.'
+    );
+  }
+
+  describe('CALL_SITES still describes src/lib', () => {
+    const including = scssFiles(LIB_DIR)
+      .filter((path) => INCLUDE.test(readFileSync(path, 'utf8')))
+      .map((path) => relative(LIB_DIR, path).split('\\').join('/'))
+      .sort();
+
+    it('scanned something', () => {
+      // A scan that finds nothing agrees with a table listing nothing, and a
+      // wrong LIB_DIR is the quiet way to get there.
+      expect(including.length).toBeGreaterThan(0);
+    });
+
+    it('every stylesheet that includes the mixin is in CALL_SITES, and every entry is real', () => {
+      // Both directions in one comparison. A NEW call site is the failure this
+      // file exists for — a component gaining a filled surface and the mixin on
+      // the same day is exactly how #262 happened — and an entry for a file that
+      // no longer includes it is the quiet half: it goes on being measured, and
+      // a reader believes the component is covered.
+      expect(including).toEqual(CALL_SITES.map((site) => site.file).sort());
+    });
+
+    it('every call site is either measured here or says where it is measured instead', () => {
+      expect(
+        CALL_SITES.filter((site) => site.states.length === 0 && site.measuredBy === undefined)
+          .map((site) => site.file)
+      ).toEqual([]);
+    });
+  });
+
+  /**
+   * Per call site: where the include sits, and what a code span there is
+   * painted on.
+   *
+   * Built once, outside the cases, because the case titles carry the measured
+   * ratio and so cannot be built inside them. A call site that cannot be read at
+   * all throws here, naming the file — the alternative is a `undefined` reaching
+   * the maths and a red contrast case blaming a colour for a missing rule.
+   */
+  const sites = CALL_SITES.map((site) => {
+    const scss = readFileSync(join(LIB_DIR, site.file), 'utf8');
+    const rules = scssRules(scss.replace(EVERY_INCLUDE, INCLUDE_MARKER), site.file);
+
+    const includes = rules.filter((rule) => rule.declarations.has('-tn-includes-inline-code'));
+    const overrides = rules.filter((rule) => flattenSelector(rule).endsWith('::ng-deep code'));
+    // The override, if there is one, decides the surface for every state of this
+    // call site — so two of them would mean two answers and no way to tell which
+    // a given span gets without a browser.
+    const override = overrides.length === 1
+      ? overrides[0].declarations.get('background') ?? overrides[0].declarations.get('background-color')
+      : undefined;
+
+    return {
+      ...site,
+      element: includes.length === 1 ? flattenSelector(includes[0]) : `${includes.length} includes`,
+      overrideCount: overrides.length,
+      overrideSelector: overrides.length === 1 ? flattenSelector(overrides[0]) : undefined,
+      /** What a code span here is really painted on, as a declared value. */
+      painted: override ?? wash,
+    };
+  });
+
+  describe.each(sites)('$file', (site) => {
+    it(`includes the mixin exactly once, on ${site.element}`, () => {
+      // `element` carries the count when it is not one, so a second include —
+      // which would mean two elements painting code spans from one entry — reads
+      // as a failure rather than as a silently-chosen first match.
+      expect(site.element).toBe(CALL_SITES.find((entry) => entry.file === site.file)?.element);
+    });
+
+    it('overrides the wash at most once', () => {
+      // Two `::ng-deep code` rules in one component is two answers to "what is
+      // this span painted on", and the cascade decides between them by an order
+      // this file does not read.
+      expect(site.overrideCount).toBeLessThanOrEqual(1);
+    });
+
+    if (site.overrideCount === 1) {
+      it('the override is on the element that includes the mixin', () => {
+        // A `::ng-deep code` rule somewhere else in the same file styles some
+        // other component's spans, and reading it as this call site's override
+        // would report a surface no span here is on.
+        expect(site.overrideSelector).toBe(`${site.element} ::ng-deep code`);
+      });
+    }
+  });
+
+  describe('the button variant table still describes button.component.scss', () => {
+    // The one call site read back in full, because it is the one this ticket
+    // fixes and the one whose reintroduction the acceptance criteria name: a new
+    // FILLED variant is a new `.button-*` rule pairing a colour with a
+    // background, and nothing else in this file would notice it.
+    const button = CALL_SITES.find((site) => site.file === 'button/button.component.scss') as CallSite;
+    const rules = scssRules(readFileSync(join(LIB_DIR, button.file), 'utf8'), button.file);
+
+    /** Every `.button-*` rule that decides a variant's colours, as it declares them. */
+    const variants = rules
+      .filter((rule) => /^\.button-/.test(rule.selector) && rule.declarations.has('color'))
+      .map((rule) => ({
+        name: rule.selector,
+        colour: tokenOf(rule.declarations.get('color') as string),
+        surface: tokenOf(
+          rule.declarations.get('background-color') ?? rule.declarations.get('background') ?? 'none'
+        ),
+      }));
+
+    it('found the variants', () => {
+      expect(variants.length).toBeGreaterThan(0);
+    });
+
+    it('the stylesheet pairs exactly what the table says it does', () => {
+      // The PAIRING and its name together, not the two halves separately: every
+      // token below already appears somewhere in the table, and what makes a
+      // variant broken is which of them it puts together.
+      const shape = (state: { name: string; colour: string; surface: string }): string =>
+        `${state.name}: ${state.colour} on ${state.surface}`;
+      expect(variants.map(shape).sort()).toEqual(button.states.map(shape).sort());
+    });
+  });
+
+  /**
+   * Every code span, on the surface it is really painted on, in every palette.
+   *
+   * `own` is measured alongside it and is not decoration: it is what tells a
+   * span broken BY THE WASH apart from a span inheriting a colour that was
+   * already failing, and the two want opposite conclusions.
+   */
+  const cases = sites.flatMap((site) =>
+    site.states.flatMap((state) => {
+      // Where the element paints nothing, it sits on whichever page surface it
+      // was dropped on, so both count. Where it paints something, that is the
+      // one surface it can be on.
+      const own = state.surface === TRANSPARENT ? [...PAGE_SURFACES] : [state.surface];
+      // And the span sits on the element's own surface only where the component
+      // overrides the wash; otherwise it sits on whatever the mixin paints.
+      const surfaces = site.painted === TRANSPARENT ? own : [tokenOf(site.painted)];
+      return palettes.flatMap((palette) =>
+        surfaces.map((surface) => {
+          const foreground = resolved(palette, state.colour);
+          const ratio = contrastRatio(foreground, palette.color(surface));
+          return {
+            selector: palette.selector,
+            where: `${site.file} ${state.name}`,
+            colour: state.colour,
+            foreground,
+            background: palette.color(surface),
+            surface,
+            ratio,
+            ratioLabel: formatRatio(ratio),
+            /**
+             * The worst this colour reads on a surface the ELEMENT ITSELF puts
+             * it on. Worst rather than best: a label that fails on a card fails
+             * for anyone who put the control on a card, whatever it reads on the
+             * page behind it.
+             */
+            own: Math.min(
+              ...own.map((token) => contrastRatio(foreground, palette.color(token)))
+            ),
+          };
+        })
+      );
+    })
+  );
+
+  const excused = new Map(
+    KNOWN_GAPS.map((gap) => [pairing(gap.selector, gap.colour, gap.surface), gap])
+  );
+  const keyOf = (measured: typeof cases[number]): string =>
+    pairing(measured.selector, measured.colour, measured.surface);
+
+  it('there are spans to measure', () => {
+    // `it.each` on an empty array errors rather than reporting a suite with no
+    // contrast cases in it as green — but only after everything above has
+    // passed, so this says which of the two happened.
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it('a code span is normal-size text, so 4.5:1 applies rather than 3:1', () => {
+    // AA's 3:1 large-text allowance starts at 24px, or 18.66px bold. The mixin
+    // sets `font-size: 0.875em`, so a span is SMALLER than the label around it,
+    // and no call site's label is near 24px to begin with.
+    expect(mixinCode.declarations.get('font-size')).toBe('0.875em');
+    expect(AA_MINIMUM.normal).toBe(4.5);
+  });
+
+  describe('every code span clears AA on the surface actually behind it', () => {
+    const measured = cases.filter((one) => !excused.has(keyOf(one)));
+
+    it('there are spans left to measure once the known gaps are set aside', () => {
+      expect(measured.length).toBeGreaterThan(0);
+    });
+
+    it.each(measured)(
+      '$selector $where: $foreground on $surface ($background) measures $ratioLabel',
+      ({ ratio }) => {
+        expect(meetsAa(ratio, 'normal')).toBe(true);
+      }
+    );
+  });
+
+  describe('the spans that do not are broken by their palette, not by the wash', () => {
+    const gaps = cases.filter((one) => excused.has(keyOf(one)));
+
+    it('every KNOWN_GAPS entry is about a pairing something actually paints', () => {
+      // The direction that rots quietly. An entry for a pairing no call site
+      // produces any more is a recorded excuse for nothing, and it reads to the
+      // next person as a live decision not to measure something.
+      const painted = new Set(cases.map(keyOf));
+      expect([...excused.keys()].filter((key) => !painted.has(key))).toEqual([]);
+    });
+
+    it.each(gaps)(
+      '$selector $where: $foreground on $surface ($background) measures $ratioLabel',
+      ({ ratio, own }) => {
+        // The wash is not what broke it: the same colour already fails on a
+        // surface the element itself paints it on, so no change to where the
+        // span sits can fix this pairing.
+        expect(meetsAa(own, 'normal')).toBe(false);
+        // And it is still broken. A gap that has started clearing AA is a stale
+        // exclusion, and the entry has to go rather than go on excusing a case
+        // that would now pass on its own.
+        expect(meetsAa(ratio, 'normal')).toBe(false);
+      }
+    );
+  });
+
+  it('records why the two excluded states are excluded', () => {
+    // Not a measurement. These two constants are the file's only claims about
+    // something it does NOT measure, and an unused constant is one a linter or a
+    // tidy-up removes — taking the reasoning with it and leaving the states
+    // reading as states nobody considered.
+    expect(SELECTED_MENU_ROW).toContain('--tn-alt-bg2');
+    expect(DISABLED_STATES).toContain('opacity');
+  });
+});


### PR DESCRIPTION
Fixes #262.

`label-markup.inline-code` sets `background: var(--tn-bg2)` on `<code>` and leaves the colour inherited. That is right for a label sitting on the page's own surfaces, where the wash is a near-neutral step off a background the colour was already chosen for. It is wrong for a label on a filled control: the span swaps the background out from under a colour paired with something else.

## Reproduced first

`inline-code-contrast.spec.ts` was written before the change and failed on it — **31 failures**, in two clearly separate groups. The 18 that are this ticket's:

| variant | palette | inherited colour | on the wash |
|---|---|---|---|
| `.button-primary` | `.tn-blue`, `.tn-high-contrast` | `#ffffff` | **1.00:1** |
| `.button-primary` | `.tn-paper` | `#ffffff` | 1.04:1 |
| `.button-primary` | `.tn-nord` | `#333333` | 1.26:1 |
| `.button-default` | `.tn-blue`, `.tn-high-contrast` | `#ffffff` | **1.00:1** |
| `.button-warn` | `.tn-paper` | `#ffffff` | 1.04:1 |
| `.button-outline-*:hover` | the same five | as above | as above |

The ticket names `.button-primary` and `.button-warn`. Two more turned up by enumerating rather than assuming:

- **`.button-default` is the same defect and travels further.** `--tn-btn-default-bg` is `#545454` in `:root` and seven themes inherit it, so it is a dark fill under white text in every light theme — the ticket's shape exactly, on the variant nobody thought of as coloured.
- **The outline variants fill on hover.** `.button-outline-warn:hover` is `white` on `--tn-red` and a code span in one is `white` on `--tn-bg2`, indistinguishable from `.button-warn`. A fix keyed to variant *names* would have missed all three.

## Keeping the button's own surface

`.storybook-button` overrides the wash the way `.tn-chip__label` already does (#238): `background: transparent`, `border-color: currentColor`. The span then sits on whatever the variant paints — the surface that variant's `color` was chosen against — and the monospace font and the border do the distinguishing. `currentColor` for the border for the reason chip gives: `--tn-lines` is a colour for the page and can vanish on a filled button.

**On `.storybook-button` rather than per variant.** One rule covers all nine variants including the three hover fills, and a tenth variant is covered the day it is added. The mixin itself is untouched: nine of its ten call sites label the page's own surfaces, and this changes nothing for them.

**Why this is the right shape rather than a per-variant colour.** After it, a code span introduces no surface of its own anywhere, so its contrast question is the label's — one that whatever measures the label already answers.

## What the spec asserts

`pipes/label-markup/inline-code-contrast.spec.ts` covers every call site of the mixin, not the button:

- **`CALL_SITES` is compared against a scan of `src/lib`**, both directions. A new component including the mixin fails as an unlisted call site; an entry for a file that stopped including it fails as a stale one. That is the acceptance criterion about a new filled variant, one level up: the reintroduction this guards against is a *component*, not a `.button-*` rule.
- **Whether a call site keeps its own surface is read from its stylesheet**, and so is the wash itself, out of `_label-markup.scss`. "The override is there" and "the override is gone" have to produce different results from the same file.
- **`button.component.scss` is read back in full** — every `.button-*` rule's `(colour, surface)` pairing compared against the table, as a pairing rather than as two sets. That is what catches a new filled variant, or an existing one re-pointed at a token that does not go with its fill.
- **216 spans measured** across nine palettes, each against the surface actually behind it — 192 asserted to clear AA, 24 held to the two `KNOWN_GAPS` assertions below.

## Two things it measures and does not fix

Both are pre-existing, both are recorded in `KNOWN_GAPS`, and each entry is held to two assertions: that the same colour **also fails on a surface the element itself paints it on** — so the wash cannot be what broke it — and that it is **still failing**, so a fixed one comes out as a red case rather than sitting there excusing nothing.

1. **`.button-warn` is `white` on `--tn-red`, which is 3.14–4.09:1 in five palettes.** `--tn-red` is tuned toward the 3:1 border/icon minimum; `button.component.scss` and `radio.component.scss` both already say so, which is why the *outline* variants read `--tn-error-text` instead (#234). The filled variant labels the token itself. No foreground fixes it — `white` is already as far from a mid-red as a label gets — so it needs a darker fill or a companion token across five palettes. **Every one of these ratios is what the warn button's ordinary label text measures today**; the code span merely joined it. Proposed as a ticket on #262.
2. **Solarized Dark's own text tokens.** `--tn-fg1` is 2.79:1 on that theme's `--tn-bg1` and 2.42:1 on its `--tn-bg2`; `--tn-fg2` is 4.32:1 on `--tn-bg2`. Every other palette keeps the convention that a text token clears 4.5:1 on both page surfaces. This is #265, already open. One entry is separate: Solarized Dark is the only theme declaring `--tn-btn-default-txt` for itself (`var(--tn-fg2)`) against a fill of its own, at 3.03:1 — on the button's own surface, with no page surface involved, so fixing the token for the page may not fix it.

So AC 1 is met for `.button-primary` in all nine palettes, and for `.button-warn` in the four where the warn button's own label clears AA at all.

## Also in the diff

`lib/a11y/scss-testing.ts` is the brace walk, `&` resolution and declaration lookup lifted out of `chip-contrast.spec.ts`, which was its only caller until this spec needed to read ten stylesheets. Copying it would have made this the second verbatim copy of a parser — the finding PR #264's review raised about the contrast harness. `chip-contrast.spec.ts` imports it and is otherwise unchanged; every case in it still passes. Documented in `docs/component_conventions.md` under Accessibility Requirements.

## Checks run locally

- `yarn test` — 133 suites, 3703 tests, all passing
- `yarn test:scripts` — 42 passing
- `yarn lint` — **the only 4 errors are the pre-existing `import/order` failures in `input.component.ts` and `menu-panel.component.ts`**, neither of which this branch touches. That is #251, open with its own PR. No file in this diff produces a lint error, and `lint:fix` was deliberately not run, since it would have pulled #251's fix into this diff.
- `yarn build` — clean
- `yarn build-storybook` — clean
- `Storybook Interaction Tests` was **not** run: it drives a real browser through Playwright and this machine has neither the browser nor the system libraries to supply one. This is a stylesheet-only change, and the compiled output was checked instead — both rules flatten to the identical selector `.storybook-button ::ng-deep code` and the override is emitted second, so the cascade resolves it by order, exactly as the chip's does. That is reasoning about the diff rather than a run of it.

Two untracked probe specs (`list/probe-projection.spec.ts`, `selection-list/probe-order.spec.ts`) and a stray `projects/state/` jest cache, left in this clone by earlier cycles, are picked up by the local `yarn test` run and are not part of this branch.

## Local review

`local-review.py` ran the project's own reviewer in a separate process — same rubric, threshold and parser as the required check — and **round 1 returned nothing at MEDIUM or above (exit 0)**. Its five LOWs are left unfixed deliberately, since every fix is a new diff and a new round, and are worth a reader's attention:

1. **`tokenOf` lost the end anchor it had in `chip-contrast.spec.ts`**, so `var(--tn-bg2) url(x.png)` now reads as the token rather than as an unrecognised literal. No value in any of the eleven stylesheets it is pointed at is compound, and the anchored form would have thrown on the mixin's `var(--tn-bg2, #f5f5f5)` — which is the value this whole spec is about. Worth restoring as a "token or throw" split rather than a silent prefix match.
2. **`scss-testing.ts` has no spec of its own**, unlike its siblings in `lib/a11y/`. Its two callers exercise it against real stylesheets; its refusals (unbalanced braces) are not covered directly.
3. **Nine of the ten `CALL_SITES` entries hardcode their states**, with the read-back applied only to the button. A new hover colour on `.tn-tab__label` would go unmeasured while every case stayed green. The button is read back because it is the one this ticket fixes; extending it to the other nine is a real improvement and a bigger change than this.
4. **The override block and its comment closely parallel `chip.component.scss`.** A shared mixin would deduplicate them, but the spec detects the override by reading the declaration out of each stylesheet, so the two would have to move together.
5. **No button story renders a label containing backticks**, so the visual result is not viewable in Storybook and `yarn test-sb` cannot see it either.

The comment above `tokenOf` was corrected in a second commit — it credited `themePalettes` with using a fallback that has already been discarded by the time it is called, where in fact that path throws. Prose only; the behaviour was already the intended one.
