### PR TITLE
NAS-142520 / 27.0.0-BETA.1 / fix(stories): point the icon demo borders at --tn-lines and guard the phantom-token class

### DIFF
--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -1,0 +1,147 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Every custom property a story file reads with `var()` must be one
+ * `src/styles/themes.css` declares.
+ *
+ * A `var(--not-a-real-token, #ccc)` does not fail, blank the element or warn —
+ * it silently renders the fallback, in every palette, forever. So a phantom
+ * token pins a demo to one hardcoded colour while reading like part of the
+ * design system, and the showcase stops showing what the library does. Nothing
+ * catches it: not the compiler, not `lint`, not axe (as long as the fallback
+ * happens to clear its contrast minimum), and not review, unless a reader
+ * checks each token by hand against the stylesheet.
+ *
+ * This has now been found twice by accident. #247 fixed seven
+ * `var(--text-secondary, #666)` in `icon.stories.ts`, all rendering `#666` at
+ * 2.90:1. #268 fixed ten `var(--border-color, #ccc)` in the same file, found by
+ * PR #267's review while it was reading that fix. Neither was caught by a
+ * mechanism, and after the first fix nothing stopped the second — which is what
+ * this spec is for.
+ *
+ * KNOWN_PHANTOM_TOKENS records the ones still outstanding. It is deliberately
+ * not an ignore list: every entry is asserted to still be referenced, so
+ * fixing one turns this spec red until its entry goes too, and the list can
+ * only ever shrink. See #278 for the sweep that empties it.
+ *
+ * SCOPE. This reads `src/stories/` only — the demo markup, where a token is
+ * typed into an inline `style` attribute with no stylesheet to check it
+ * against. Component source is not scanned: its custom properties are
+ * component-scoped by design, declared in each component's own `.scss` rather
+ * than in `themes.css`, and holding them to this rule would be wrong.
+ *
+ * LIMITATION. A story file that declares a custom property itself and then
+ * reads it back would be reported here as undeclared. No story does that
+ * today — the only local declarations in `src/stories/` are in a design-system
+ * proposal document that never reads them — so this stays a flat scan rather
+ * than carrying parsing it does not need.
+ */
+
+const STORIES_DIR = join(__dirname, '../../stories');
+const THEMES_CSS = join(__dirname, '../../styles/themes.css');
+
+/**
+ * Custom properties `src/stories/` reads that `themes.css` does not declare,
+ * with the count of references behind each. Every one renders its hardcoded
+ * fallback in all nine palettes.
+ *
+ * These are #268's scope boundary: that ticket covers `--border-color` in
+ * `icon.stories.ts`, and these are what the same scan turned up elsewhere.
+ * Each wants a token chosen per site rather than a global rename —
+ * `--success`/`--warning`/`--danger` are semantic status colours with
+ * `--tn-green`/`--tn-yellow`/`--tn-red` and the `--tn-*-bg` pairs as
+ * candidates, and `--fg1`/`--fg2`/`--lines`/`--tn-alt-bg` look like `--tn-`
+ * prefixes dropped by hand. Proposed as #278.
+ */
+const KNOWN_PHANTOM_TOKENS: Record<string, number> = {
+  '--danger': 1,
+  '--fg1': 4,
+  '--fg2': 3,
+  '--lines': 1,
+  '--success': 4,
+  '--success-bg': 1,
+  '--tn-alt-bg': 1,
+  '--warning': 1,
+  '--warning-bg': 1,
+  '--warning-fg': 1,
+};
+
+interface Reference {
+  property: string;
+  file: string;
+  line: number;
+}
+
+function storyFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    return statSync(path).isDirectory() ? storyFiles(path) : [path];
+  });
+}
+
+/** Every `--custom-property` on the left of a `:` in the stylesheet. */
+function declaredProperties(): Set<string> {
+  const css = readFileSync(THEMES_CSS, 'utf8');
+  return new Set([...css.matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)].map((match) => match[1]));
+}
+
+/**
+ * Every `var(--x)` read in the story tree, one entry per site. Matching on
+ * `var(` rather than on whole declarations keeps the nested
+ * `var(--a, var(--b))` form honest — both properties are read, so both count.
+ */
+function storyReferences(): Reference[] {
+  return storyFiles(STORIES_DIR).flatMap((path) =>
+    readFileSync(path, 'utf8')
+      .split('\n')
+      .flatMap((text, index) =>
+        [...text.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)/g)].map((match) => ({
+          property: match[1],
+          file: relative(STORIES_DIR, path),
+          line: index + 1,
+        })),
+      ),
+  );
+}
+
+describe('custom properties read by the story files (#268)', () => {
+  const declared = declaredProperties();
+  const references = storyReferences();
+
+  // Guards the two below: both are vacuously true against an empty scan, so a
+  // walk that silently stops finding files would leave them passing.
+  it('finds the story tree and the stylesheet', () => {
+    expect(references.length).toBeGreaterThan(100);
+    expect(declared.size).toBeGreaterThan(20);
+    expect(declared.has('--tn-lines')).toBe(true);
+  });
+
+  it('reads no undeclared custom property outside the recorded ones', () => {
+    const undeclared = references.filter(
+      (reference) => !declared.has(reference.property) && !(reference.property in KNOWN_PHANTOM_TOKENS),
+    );
+
+    expect(
+      undeclared.map((reference) => `${reference.property} at ${reference.file}:${reference.line}`),
+    ).toEqual([]);
+  });
+
+  // Not an ignore list: an entry that stops matching reality fails here, so a
+  // fixed token cannot be left recorded as broken and a worsening count cannot
+  // pass unnoticed.
+  it.each(Object.entries(KNOWN_PHANTOM_TOKENS))(
+    'still reads the recorded phantom token %s at %i site(s) — fix it and delete its entry (#278)',
+    (property, count) => {
+      expect(declared.has(property)).toBe(false);
+      expect(references.filter((reference) => reference.property === property)).toHaveLength(count);
+    },
+  );
+
+  // #268's own defect, named so its regression reads as itself rather than as a
+  // line in the general case above.
+  it('no longer reads --border-color, which no palette ever declared', () => {
+    expect(references.filter((reference) => reference.property === '--border-color')).toEqual([]);
+    expect('--border-color' in KNOWN_PHANTOM_TOKENS).toBe(false);
+  });
+});

--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -26,7 +26,7 @@ import { join, relative } from 'path';
  * red until its entry goes too. It does not stop the list GROWING: a new
  * phantom token added with a matching entry in the same commit passes here.
  * What it removes is doing that silently, since the entry is an edit to this
- * file and reads as what it is. See #278 for the sweep that empties it.
+ * file and reads as what it is. The sweep that empties it is proposed on #268.
  *
  * SCOPE. This reads `src/stories/` only — the demo markup, where a token is
  * typed into an inline `style` attribute with no stylesheet to check it
@@ -55,7 +55,7 @@ const THEMES_CSS = join(__dirname, '../../styles/themes.css');
  * `--success`/`--warning`/`--danger` are semantic status colours with
  * `--tn-green`/`--tn-yellow`/`--tn-red` and the `--tn-*-bg` pairs as
  * candidates, and `--fg1`/`--fg2`/`--lines`/`--tn-alt-bg` look like `--tn-`
- * prefixes dropped by hand. Proposed as #278.
+ * prefixes dropped by hand. Proposed as a sweep on #268.
  */
 const KNOWN_PHANTOM_TOKENS: Record<string, number> = {
   '--danger': 1,
@@ -136,9 +136,9 @@ describe('custom properties read by the story files (#268)', () => {
   //
   // One case over the whole record rather than `it.each` over its entries,
   // because `it.each` on an empty table is a jest error — and emptying this
-  // record is exactly what #278 finishing looks like. The sweep that retires
+  // record is exactly what the sweep finishing looks like. The sweep that retires
   // this list must not have to repair the spec that asked for it.
-  it('reads every recorded phantom token, still undeclared and at the recorded count (#278)', () => {
+  it('reads every recorded phantom token, still undeclared and at the recorded count', () => {
     const recorded = Object.entries(KNOWN_PHANTOM_TOKENS).map(([property, count]) => `${property} ×${count}`);
 
     const actual = Object.keys(KNOWN_PHANTOM_TOKENS).map((property) => {

--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -130,13 +130,24 @@ describe('custom properties read by the story files (#268)', () => {
   // Not an ignore list: an entry that stops matching reality fails here, so a
   // fixed token cannot be left recorded as broken and a worsening count cannot
   // pass unnoticed.
-  it.each(Object.entries(KNOWN_PHANTOM_TOKENS))(
-    'still reads the recorded phantom token %s at %i site(s) — fix it and delete its entry (#278)',
-    (property, count) => {
-      expect(declared.has(property)).toBe(false);
-      expect(references.filter((reference) => reference.property === property)).toHaveLength(count);
-    },
-  );
+  //
+  // One case over the whole record rather than `it.each` over its entries,
+  // because `it.each` on an empty table is a jest error — and emptying this
+  // record is exactly what #278 finishing looks like. The sweep that retires
+  // this list must not have to repair the spec that asked for it.
+  it('reads every recorded phantom token, still undeclared and at the recorded count (#278)', () => {
+    const recorded = Object.entries(KNOWN_PHANTOM_TOKENS).map(([property, count]) => `${property} ×${count}`);
+
+    const actual = Object.keys(KNOWN_PHANTOM_TOKENS).map((property) => {
+      const sites = references.filter((reference) => reference.property === property);
+      // A recorded token that themes.css now declares is fixed by the other
+      // route — it stopped being phantom without its references moving — and
+      // says so here rather than passing on the count alone.
+      return `${property} ×${sites.length}${declared.has(property) ? ' (now declared in themes.css)' : ''}`;
+    });
+
+    expect(actual).toEqual(recorded);
+  });
 
   // #268's own defect, named so its regression reads as itself rather than as a
   // line in the general case above.

--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -21,9 +21,12 @@ import { join, relative } from 'path';
  * this spec is for.
  *
  * KNOWN_PHANTOM_TOKENS records the ones still outstanding. It is deliberately
- * not an ignore list: every entry is asserted to still be referenced, so
- * fixing one turns this spec red until its entry goes too, and the list can
- * only ever shrink. See #278 for the sweep that empties it.
+ * not an ignore list: every entry is asserted to still be referenced, so an
+ * entry cannot outlive the defect it excuses — fixing a token turns this spec
+ * red until its entry goes too. It does not stop the list GROWING: a new
+ * phantom token added with a matching entry in the same commit passes here.
+ * What it removes is doing that silently, since the entry is an edit to this
+ * file and reads as what it is. See #278 for the sweep that empties it.
  *
  * SCOPE. This reads `src/stories/` only — the demo markup, where a token is
  * typed into an inline `style` attribute with no stylesheet to check it

--- a/projects/truenas-ui/src/stories/icon.stories.ts
+++ b/projects/truenas-ui/src/stories/icon.stories.ts
@@ -332,19 +332,19 @@ export const LibraryComparison: Story = {
   render: () => ({
     template: `
       <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; padding: 20px;">
-        <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+        <div style="text-align: center; border: 1px solid var(--tn-lines); padding: 16px; border-radius: 8px;">
           <h4 style="margin-top: 0;">Material (Default)</h4>
           <tn-icon name="home" size="lg" tooltip="Material Home"></tn-icon>
           <div style="margin-top: 8px;">name="home"</div>
           <div style="font-size: 12px; color: var(--tn-alt-fg1);">Unicode fallback</div>
         </div>
-        <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+        <div style="text-align: center; border: 1px solid var(--tn-lines); padding: 16px; border-radius: 8px;">
           <h4 style="margin-top: 0;">Lucide</h4>
           <tn-icon name="home" library="lucide" size="lg" tooltip="Lucide Home"></tn-icon>
           <div style="margin-top: 8px;">library="lucide"</div>
           <div style="font-size: 12px; color: var(--tn-alt-fg1);">Library parameter</div>
         </div>
-        <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+        <div style="text-align: center; border: 1px solid var(--tn-lines); padding: 16px; border-radius: 8px;">
           <h4 style="margin-top: 0;">MDI</h4>
           <tn-icon name="folder" library="mdi" size="lg" tooltip="MDI Folder"></tn-icon>
           <div style="margin-top: 8px;">library="mdi"</div>
@@ -419,19 +419,19 @@ export const FullSize: Story = {
 
         <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 24px;">
           <div style="text-align: center;">
-            <div style="width: 48px; height: 48px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+            <div style="width: 48px; height: 48px; border: 2px dashed var(--tn-lines); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
               <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
             </div>
             <div style="margin-top: 8px; font-size: 12px;">48×48 container</div>
           </div>
           <div style="text-align: center;">
-            <div style="width: 80px; height: 80px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+            <div style="width: 80px; height: 80px; border: 2px dashed var(--tn-lines); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
               <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
             </div>
             <div style="margin-top: 8px; font-size: 12px;">80×80 container</div>
           </div>
           <div style="text-align: center;">
-            <div style="width: 120px; height: 120px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+            <div style="width: 120px; height: 120px; border: 2px dashed var(--tn-lines); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
               <tn-icon name="harddisk" library="mdi" [fullSize]="true"></tn-icon>
             </div>
             <div style="margin-top: 8px; font-size: 12px;">120×120 container</div>
@@ -440,17 +440,17 @@ export const FullSize: Story = {
 
         <h4>Comparison: Fixed Size vs Full Size</h4>
         <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px;">
-          <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+          <div style="text-align: center; border: 1px solid var(--tn-lines); padding: 16px; border-radius: 8px;">
             <h5 style="margin-top: 0;">Fixed Size (default)</h5>
-            <div style="width: 100px; height: 100px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+            <div style="width: 100px; height: 100px; border: 2px dashed var(--tn-lines); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
               <tn-icon name="server" library="mdi" size="lg"></tn-icon>
             </div>
             <code style="display: block; margin-top: 8px; font-size: 11px;">size="lg"</code>
             <div style="font-size: 12px; color: var(--tn-alt-fg1);">Icon stays at fixed lg size</div>
           </div>
-          <div style="text-align: center; border: 1px solid var(--border-color, #ccc); padding: 16px; border-radius: 8px;">
+          <div style="text-align: center; border: 1px solid var(--tn-lines); padding: 16px; border-radius: 8px;">
             <h5 style="margin-top: 0;">Full Size</h5>
-            <div style="width: 100px; height: 100px; border: 2px dashed var(--border-color, #ccc); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+            <div style="width: 100px; height: 100px; border: 2px dashed var(--tn-lines); display: flex; align-items: center; justify-content: center; margin: 0 auto;">
               <tn-icon name="server" library="mdi" [fullSize]="true"></tn-icon>
             </div>
             <code style="display: block; margin-top: 8px; font-size: 11px;">[fullSize]="true"</code>


### PR DESCRIPTION
Fixes #268

`icon.stories.ts` read `var(--border-color, #ccc)` on ten elements, and `--border-color` is declared by none of the nine palettes — so all ten rendered the hardcoded `#ccc` in every theme. They now read `var(--tn-lines)`, which every palette declares.

## Reproduced first

Before anything changed, a scan of `src/stories/` against `themes.css` confirmed the report exactly — `--border-color`, ten references, declared nowhere:

```
icon.stories.ts:335, 341, 347, 422, 428, 434, 443, 445, 451, 453
```

The new spec was written at that point and **failed on the unmodified tree**, listing those same ten sites. That failure is what the fix turned green.

## Why this one hid

A `var(--not-a-real-token, #ccc)` does not throw, blank the element or warn. It silently renders the fallback, forever, in every palette. Nothing in the toolchain catches it: not the compiler, not lint, and not axe — borders are non-text and held to 3:1 rather than 4.5:1, and `#ccc` clears that comfortably on the dark palettes. That is why #247 did not turn this up while fixing `var(--text-secondary, #666)` in **this same file**.

So the new values carry **no fallback**. `--tn-lines` is declared in all nine palettes, which makes a fallback dead code — and the fallback is precisely the thing that renders when a token is missing, so writing one is what let this defect look correct for as long as it did. Bare `var(--tn-lines)` is also the prevailing form in these files (the majority of its ~60 uses across `src/stories/`), and the form #247's fix used here.

## The guard

That is twice now that a phantom token has been found in this file by accident, and after the first fix nothing stopped the second. `lib/theme/story-token-declarations.spec.ts` closes that: **every custom property `src/stories/` reads with `var()` must be one `themes.css` declares.**

It reads the source tree the way `themes-css-copy.spec.ts` does, and would have caught #247 and #268 both.

## Ten other phantom tokens — recorded, not fixed

The same scan found ten more across five other story files, so `--border-color` was not an isolated slip:

| token | refs | where |
|---|---|---|
| `--fg1`, `--fg2` | 4, 3 | `button-toggle-demo.component.html` |
| `--success` | 4 | `icon.stories.ts:393`, `patterns/captive-wizard.stories.html` ×3 |
| `--warning`, `--danger` | 1, 1 | `icon.stories.ts:394-395` |
| `--warning-bg`, `--warning-fg`, `--success-bg` | 1, 1, 1 | `patterns/captive-wizard.stories.html` |
| `--lines` | 1 | `slide-toggle.stories.ts:196` |
| `--tn-alt-bg` | 1 | `tree-virtual-scroll-view.stories.ts:182` |

**They are recorded in `KNOWN_PHANTOM_TOKENS`, not fixed here.** This ticket's AC is `--border-color` in `icon.stories.ts`, and each of these wants a token chosen per site rather than a global rename — the semantic three have `--tn-green`/`--tn-yellow`/`--tn-red` and the `--tn-*-bg` pairs as candidates, while `--fg1`/`--lines`/`--tn-alt-bg` look like prefixes dropped by hand. Judging ten of those is a second change, and it would land unreviewed alongside a fix that is already testable on its own.

**The record is not an ignore list.** Every entry is asserted to still be referenced at its recorded count, so fixing a token turns this spec red until its entry goes too. It cannot silently outlive the defect it excuses. It does *not* prevent the list growing — a new phantom token added with a matching entry in the same commit passes — and the docstring says so rather than overclaiming.

A sweep ticket is proposed as a comment on #268 for the ten. The spec points there rather than at a ticket number: an earlier commit on this branch cited the sweep as "#278", a number guessed before the ticket existed — which the forge then assigned to *this pull request*. A worker here cannot open an issue, so there was never a number to cite.

## Acceptance criteria

- [x] Every `var(--border-color, ...)` in `icon.stories.ts` replaced with a token declared in `themes.css` — all ten, with `--tn-lines`
- [x] `grep -rn 'border-color' projects/truenas-ui/src/stories/` returns no reference to an undefined custom property — it now returns **nothing at all**
- [x] Other story files checked for the same token — `--border-color` appears in no other file anywhere in the repository. The scan that established that also found the ten unrelated phantom tokens above
- [x] No component source changed — the diff is one story file and one new spec
- [x] `yarn lint`, `yarn test`, `yarn build-storybook` pass (see below)

## Checks run locally

- `yarn test` — 135 suites, 3800 tests, all passing
- `yarn test:scripts` — 42 passing
- `yarn build` — clean
- `yarn build-storybook` — clean
- `yarn lint` — **the only 4 errors are the pre-existing `import/order` failures in `input.component.ts` and `menu-panel.component.ts`**, neither touched by this branch. That is #251, which has its own open PR. No file in this diff produces a lint error, and `lint:fix` was deliberately not run, since it would pull #251's fix into this diff.
- `Storybook Interaction Tests` was **not** run: it drives a real browser through Playwright and this machine has neither the browser nor the system libraries for one. This diff changes no template logic and no component — ten inline `style` attributes and one spec that reads files off disk. The colour claim is verified by the spec rather than by rendering: `--tn-lines` is asserted present in the stylesheet the page is served from.

## Local review

`local-review.py` ran the project's own reviewer in a separate process — same rubric, threshold and parser as the required check.

**Round 1 returned a HIGH, and it was a real defect in the guard's own retirement path.** The recorded tokens were asserted with `it.each(Object.entries(KNOWN_PHANTOM_TOKENS))`, and `it.each` on an empty table is a jest error rather than zero cases — so the moment the sweep deleted the last entry, this spec would have gone red with an opaque empty-table failure. The sweep this file asks for would have had to repair the spec that asked for it. It is now one case over the whole record, which is a pass when the record is empty; **confirmed by emptying the record and running it**, not just by reading the docs.

**Round 2 returned nothing at MEDIUM or above (exit 0).** Three LOWs, of which one was fixed and two are left:

1. **Fixed** — the docstring claimed the record "can only ever shrink", which is false: a new phantom token added with its entry in one commit passes. Fixed because it made this diff's own prose wrong, not because LOWs are being swept up; comment text only, no assertion changed.
2. **Left: `--success`/`--warning`/`--danger` are still phantom in this same file** (lines 393-395), and are plausibly one-token swaps to `--tn-green`/`--tn-yellow`/`--tn-red`. Deliberate — see the scope argument above. They are recorded, so they cannot rot further, and they are in the proposed sweep.
3. **Left: `declaredProperties()` accepts a token declared in any single selector.** A token declared in only *some* palettes — the reviewer names `--tn-topbar-txt`, 6 of 9 — would pass here while still falling back in the rest. A genuine gap in the guard's strength, and a real one to fix: it wants per-palette declaration checking, which is the shape `text-fg-contrast.spec.ts` already uses for its own tokens. It is a strictly stronger version of this spec rather than a correction to it, and changing it touches executable code, so it belongs in its own change. Worth a ticket.

Also noted by round 2 and worth a reader's attention: `declaredProperties()` does not strip CSS comments, so a commented-out declaration in `themes.css` would count as declared. No such declaration exists today.
