### PR TITLE
NAS-142525 / 27.0.0-BETA.1 / feat(components): form errors and list editor

### DIFF
--- a/projects/truenas-ui/src/lib/dialog/dialog-shell-mocked-ref.spec.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell-mocked-ref.spec.ts
@@ -1,0 +1,80 @@
+import { DialogRef } from '@angular/cdk/dialog';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TN_DIALOG_SHELL_DEFAULT_LABEL, TnDialogShellComponent } from './dialog-shell.component';
+
+/**
+ * Guards `tn-dialog-shell` against being rendered OUTSIDE an open dialog.
+ *
+ * Consumers test a dialog component by creating it directly and satisfying its
+ * `DialogRef` with a mock provider — the shape spectator's `mockProvider` and
+ * Angular's own `useValue` stubs produce: the methods are there, `config` is
+ * not. That violates `DialogRef`'s type, which is why nothing warns at compile
+ * time, and it is also what most of the dialog specs downstream of this library
+ * do. Reading `ref.config` unguarded threw for every one of them, before the
+ * component had rendered anything.
+ *
+ * The naming routes themselves are covered against real, opened dialogs in
+ * `dialog-shell-a11y.spec.ts`; this file only pins the config-less case.
+ */
+
+@Component({
+  selector: 'tn-mocked-ref-host',
+  imports: [TnDialogShellComponent],
+  template: `
+    <tn-dialog-shell [title]="title()" [ariaLabel]="ariaLabel()">
+      <p>Content</p>
+    </tn-dialog-shell>
+  `,
+})
+class MockedRefHostComponent {
+  readonly title = signal('');
+  readonly ariaLabel = signal<string | null>(null);
+}
+
+describe('tn-dialog-shell with a mocked DialogRef', () => {
+  let warn: jest.SpyInstance;
+
+  /** Applies `setup` BEFORE the first render, so the naming runs once, with it. */
+  function render(setup: (host: MockedRefHostComponent) => void = () => undefined): void {
+    const fixture = TestBed.createComponent(MockedRefHostComponent);
+    setup(fixture.componentInstance);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [MockedRefHostComponent],
+      // No `config`, exactly as a mock provider leaves it.
+      providers: [{ provide: DialogRef, useValue: { close: jest.fn() } }],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('renders instead of throwing when the ref carries no config', () => {
+    expect(() => render()).not.toThrow();
+  });
+
+  it('still names an untitled shell from the fallback', () => {
+    render();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(TN_DIALOG_SHELL_DEFAULT_LABEL));
+  });
+
+  it('still takes the name from its own ariaLabel input', () => {
+    render((host) => host.ariaLabel.set('Restart SMB service'));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('still takes the name from its own title', () => {
+    render((host) => host.title.set('Restart SMB service'));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
+++ b/projects/truenas-ui/src/lib/dialog/dialog-shell.component.ts
@@ -153,14 +153,19 @@ export class TnDialogShellComponent implements OnInit {
    * `ref.config` rather than leaving CDK's binding to render it, because this
    * component writes both attributes onto that element and would otherwise
    * clear one it did not set.
+   *
+   * Guarded, even though `DialogRef.config` is non-optional: a shell rendered
+   * directly in a consumer's test gets its `DialogRef` from a mock provider,
+   * which supplies the methods but no config. Naming then falls back to the
+   * component's own inputs, which is what such a test is exercising anyway.
    */
   private resolvedAriaLabelledby = computed(() => (
-    this.hasTitle() ? this.titleId : firstNonBlank(this.ariaLabelledby(), this.ref.config.ariaLabelledBy)
+    this.hasTitle() ? this.titleId : firstNonBlank(this.ariaLabelledby(), this.ref.config?.ariaLabelledBy)
   ));
 
   /** An explicit label, from this component's input or from the `DialogConfig`. */
   private explicitAriaLabel = computed(
-    () => firstNonBlank(this.ariaLabel(), this.ref.config.ariaLabel)
+    () => firstNonBlank(this.ariaLabel(), this.ref.config?.ariaLabel)
   );
 
   /**

--- a/projects/truenas-ui/src/lib/form-errors/form-errors-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors-a11y.spec.ts
@@ -1,0 +1,130 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { TnFormErrorsComponent } from './form-errors.component';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+
+/**
+ * The accessibility guard for `tn-form-errors`.
+ *
+ * The component's whole job is ARIA: it renders a group's validation message
+ * where no field can own it, as a `role="alert"` so assistive technology reads
+ * it when it appears, with an id a control can point `aria-describedby` at. Two
+ * things it does are easy to undo without noticing, so they are pinned here.
+ *
+ * THE BUTTON STAYS OUTSIDE THE ALERT
+ * ----------------------------------
+ * `role="alert"` is implicitly `aria-live="assertive" aria-atomic="true"`: the
+ * region is re-announced whole whenever it changes, so anything inside it
+ * becomes part of the error the user hears. Moving the close button in — the
+ * obvious simplification, one element instead of a row of two — would append
+ * "Dismiss this error, button" to the message every time it changed. The DOM
+ * assertion below is what catches that; axe has no rule for it.
+ *
+ * THE BUTTON HAS A NAME
+ * ---------------------
+ * It is icon-only, so `aria-label` is the only thing naming it, and
+ * `button-name` is the rule that reports its absence.
+ */
+
+@Component({
+  selector: 'tn-form-errors-a11y-host',
+  standalone: true,
+  imports: [TnFormErrorsComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-errors
+      [control]="group"
+      [showWhenUntouched]="true"
+      [dismissibleErrors]="dismissibleErrors()"
+    />
+  `,
+})
+class FormErrorsA11yHostComponent {
+  readonly group = new FormGroup({ day: new FormControl('', Validators.required) });
+  readonly dismissibleErrors = signal<readonly string[]>([]);
+
+  constructor() {
+    this.group.setErrors({ scheduleConflict: 'Pick at least one day' });
+  }
+}
+
+describe('tn-form-errors accessibility', () => {
+  let host: FormErrorsA11yHostComponent;
+  let fixture: ComponentFixture<FormErrorsA11yHostComponent>;
+
+  const message = (): HTMLElement | null =>
+    fixture.nativeElement.querySelector('.tn-form-errors');
+  const dismiss = (): HTMLElement | null =>
+    fixture.nativeElement.querySelector('.tn-form-errors-dismiss button');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormErrorsA11yHostComponent],
+    }).compileComponents();
+
+    // Attached to the document, because axe exempts every node of a detached
+    // tree and would report a clean scan whatever the markup says.
+    fixture = TestBed.createComponent(FormErrorsA11yHostComponent);
+    document.body.appendChild(fixture.nativeElement);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.nativeElement.remove();
+  });
+
+  it('raises no violation on the message itself', async () => {
+    const { violated, evaluated } = await axeResult(
+      fixture.nativeElement, message(), ['aria-roles', 'aria-allowed-role', 'aria-required-attr']
+    );
+
+    expect(violated).toEqual([]);
+    // Non-vacuous: `role="alert"` is what all three rules match on here, and it
+    // is the thing that must not quietly go away — without it the message
+    // renders and is simply never announced.
+    expect(evaluated).toContain('aria-roles');
+  });
+
+  it('names the dismiss button, which has nothing but its icon otherwise', async () => {
+    host.dismissibleErrors.set(['scheduleConflict']);
+    fixture.detectChanges();
+
+    const { violated, evaluated } = await axeResult(
+      fixture.nativeElement, dismiss(), ['button-name']
+    );
+
+    expect(violated).toEqual([]);
+    expect(evaluated).toContain('button-name');
+  });
+
+  it('keeps the dismiss button out of the alert, so its name is not read as part of the error', () => {
+    host.dismissibleErrors.set(['scheduleConflict']);
+    fixture.detectChanges();
+
+    const alert: HTMLElement = fixture.nativeElement.querySelector('[role="alert"]');
+
+    expect(alert).toBe(message());
+    expect(alert.contains(dismiss())).toBe(false);
+  });
+
+  describe('the whole message, with no rule named in advance', () => {
+    it.each([
+      ['plain', () => { /* the default fixture */ }],
+      ['dismissible', () => host.dismissibleErrors.set(['scheduleConflict'])],
+    ])('has nothing for axe to report when %s', async (_name, arrange) => {
+      arrange();
+      fixture.detectChanges();
+
+      const { violations, incomplete, passed } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      // Stops the two assertions above going vacuous: a scan that matched no
+      // rule at all returns empty too, and only `passed` tells the two apart.
+      expect(passed).toContain('aria-roles');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
@@ -1,11 +1,26 @@
 @if (show()) {
-  <!-- role="alert" is implicitly assertive and atomic, so no aria-live beside
-       it — the same markup tn-form-field uses for its own subscript. -->
-  <div
-    class="tn-form-errors"
-    role="alert"
-    tnTestIdType="error"
-    [attr.id]="errorId"
-    [tnTestId]="testId()"
-  >{{ errorMessage() }}</div>
+  <div class="tn-form-errors-row">
+    <!-- role="alert" is implicitly assertive and atomic, so no aria-live beside
+         it — the same markup tn-form-field uses for its own subscript. The
+         dismiss button stays OUTSIDE it: a live region announces everything it
+         contains, and the button's name is not part of the error. -->
+    <div
+      class="tn-form-errors"
+      role="alert"
+      tnTestIdType="error"
+      [attr.id]="errorId"
+      [tnTestId]="testId()"
+    >{{ errorMessage() }}</div>
+    @if (showDismiss()) {
+      <tn-icon-button
+        class="tn-form-errors-dismiss"
+        name="close"
+        library="mdi"
+        size="sm"
+        [ariaLabel]="resolvedDismissAriaLabel()"
+        [tooltip]="resolvedDismissTooltip()"
+        (onClick)="dismissError()"
+      />
+    }
+  </div>
 }

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
@@ -1,0 +1,11 @@
+@if (show()) {
+  <!-- role="alert" is implicitly assertive and atomic, so no aria-live beside
+       it — the same markup tn-form-field uses for its own subscript. -->
+  <div
+    class="tn-form-errors"
+    role="alert"
+    tnTestIdType="error"
+    [attr.id]="errorId"
+    [tnTestId]="testId()"
+  >{{ errorMessage() }}</div>
+}

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.html
@@ -11,14 +11,14 @@
       [attr.id]="errorId"
       [tnTestId]="testId()"
     >{{ errorMessage() }}</div>
-    @if (showDismiss()) {
+    @if (dismissible.showDismiss()) {
       <tn-icon-button
         class="tn-form-errors-dismiss"
         name="close"
         library="mdi"
         size="sm"
-        [ariaLabel]="resolvedDismissAriaLabel()"
-        [tooltip]="resolvedDismissTooltip()"
+        [ariaLabel]="dismissible.resolvedDismissAriaLabel()"
+        [tooltip]="dismissible.resolvedDismissTooltip()"
         (onClick)="dismissError()"
       />
     }

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
@@ -1,28 +1,21 @@
+@use '../form-field/error-row';
+
+// A plain row so a dismissible error can carry its button beside the message.
+.tn-form-errors-row {
+  @include error-row.row;
+}
+
 // Matches `.tn-form-field-error`, so a group message and the field messages
 // around it are the same text at the same weight.
 .tn-form-errors {
+  @include error-row.message;
+
   color: var(--tn-error, var(--tn-red, #bd2626));
   font-size: 0.75rem;
   line-height: 1.4;
   margin: 0;
 }
 
-// A plain row so a dismissible error can carry its button beside the message.
-// With no button this lays out exactly as the message alone did.
-.tn-form-errors-row {
-  display: flex;
-  // Centred, not top-aligned: the button's 32px box (the WCAG 2.5.8 minimum
-  // target, which a smaller icon button would miss) is twice the height of the
-  // message, and top-aligning would drop its icon well below the text.
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.tn-form-errors {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
 .tn-form-errors-dismiss {
-  flex: none;
+  @include error-row.dismiss;
 }

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
@@ -1,0 +1,8 @@
+// Matches `.tn-form-field-error`, so a group message and the field messages
+// around it are the same text at the same weight.
+.tn-form-errors {
+  color: var(--tn-error, var(--tn-red, #bd2626));
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin: 0;
+}

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.scss
@@ -6,3 +6,23 @@
   line-height: 1.4;
   margin: 0;
 }
+
+// A plain row so a dismissible error can carry its button beside the message.
+// With no button this lays out exactly as the message alone did.
+.tn-form-errors-row {
+  display: flex;
+  // Centred, not top-aligned: the button's 32px box (the WCAG 2.5.8 minimum
+  // target, which a smaller icon button would miss) is twice the height of the
+  // message, and top-aligning would drop its icon well below the text.
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.tn-form-errors {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tn-form-errors-dismiss {
+  flex: none;
+}

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.spec.ts
@@ -7,8 +7,9 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import type { AbstractControl, ValidationErrors } from '@angular/forms';
 import { TnFormErrorsComponent } from './form-errors.component';
 import { TnFormErrorsHarness } from './form-errors.harness';
-import { TN_FORM_FIELD_ERRORS } from '../form-field/form-field.errors';
+import { TN_FORM_FIELD_DISMISSIBLE_ERRORS, TN_FORM_FIELD_ERRORS } from '../form-field/form-field.errors';
 import type { TnFormFieldErrorMessages, TnFormFieldErrorResolver } from '../form-field/form-field.errors';
+import { TnIconTesting } from '../icon/icon-testing';
 
 /** Fails the GROUP, the way a cross-field validator does. */
 function bothOrNeither(group: AbstractControl): ValidationErrors | null {
@@ -20,8 +21,11 @@ function bothOrNeither(group: AbstractControl): ValidationErrors | null {
 @Component({
   selector: 'tn-form-errors-host',
   imports: [ReactiveFormsModule, TnFormErrorsComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `<tn-form-errors
     [control]="control()" [errorMessages]="errorMessages()" [showWhenUntouched]="showWhenUntouched()"
+    [dismissibleErrors]="dismissibleErrors()" [dismissAriaLabel]="dismissAriaLabel()"
+    (dismiss)="dismissed.push($event)"
   />`,
 })
 class HostComponent {
@@ -41,6 +45,9 @@ class HostComponent {
   readonly control = signal<AbstractControl>(this.group);
   readonly errorMessages = signal<TnFormFieldErrorMessages>({});
   readonly showWhenUntouched = signal(false);
+  readonly dismissibleErrors = signal<readonly string[] | undefined>([]);
+  readonly dismissAriaLabel = signal<string | undefined>(undefined);
+  readonly dismissed: string[] = [];
 }
 
 describe('TnFormErrorsComponent', () => {
@@ -49,10 +56,19 @@ describe('TnFormErrorsComponent', () => {
   let loader: HarnessLoader;
   let errors: TnFormErrorsHarness;
 
-  async function setUp(resolver?: TnFormFieldErrorResolver): Promise<void> {
+  async function setUp(
+    resolver?: TnFormFieldErrorResolver,
+    appWideDismissible?: readonly string[]
+  ): Promise<void> {
     await TestBed.configureTestingModule({
       imports: [HostComponent],
-      providers: resolver ? [{ provide: TN_FORM_FIELD_ERRORS, useValue: resolver }] : [],
+      providers: [
+        TnIconTesting.jest.providers(),
+        ...(resolver ? [{ provide: TN_FORM_FIELD_ERRORS, useValue: resolver }] : []),
+        ...(appWideDismissible
+          ? [{ provide: TN_FORM_FIELD_DISMISSIBLE_ERRORS, useValue: appWideDismissible }]
+          : []),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HostComponent);
@@ -205,6 +221,122 @@ describe('TnFormErrorsComponent', () => {
       const id = fixture.nativeElement.querySelector('.tn-form-errors')?.getAttribute('id');
 
       expect(id).toMatch(/^tn-form-errors-\d+$/);
+    });
+  });
+
+  describe('dismissing an error', () => {
+    /**
+     * Attaches a server-side style failure the user cannot edit their way out of.
+     * The value is the message itself, which the resolution ladder renders as-is.
+     */
+    function attachServerError(): void {
+      host.group.setErrors({ manualValidateError: 'The pool is offline' });
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+    }
+
+    beforeEach(async () => {
+      await setUp();
+    });
+
+    it('leaves an ordinary error undismissable', async () => {
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.isDismissible()).toBe(false);
+    });
+
+    it('offers a dismiss button for a listed error key', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      attachServerError();
+
+      expect(await errors.isDismissible()).toBe(true);
+    });
+
+    it('emits the key of the message that was on screen', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      attachServerError();
+
+      await errors.dismiss();
+
+      expect(host.dismissed).toEqual(['manualValidateError']);
+    });
+
+    it('drops the dismissed key, so the message goes with it', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      attachServerError();
+
+      await errors.dismiss();
+      fixture.detectChanges();
+
+      expect(host.group.errors).toBeNull();
+      expect(await errors.hasMessage()).toBe(false);
+    });
+
+    it('leaves the group\'s other errors alone', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      host.group.setErrors({ manualValidateError: 'The pool is offline', bothOrNeither: true });
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      await errors.dismiss();
+      fixture.detectChanges();
+
+      expect(host.group.errors).toEqual({ bothOrNeither: true });
+      expect(await errors.getMessage()).toBe('bothOrNeither');
+    });
+
+    it('honours an app-wide default when the instance names no keys', async () => {
+      TestBed.resetTestingModule();
+      await setUp(undefined, ['manualValidateError']);
+      host.dismissibleErrors.set(undefined);
+      attachServerError();
+
+      expect(await errors.isDismissible()).toBe(true);
+    });
+
+    it('withholds the button when a listed key is not the error being shown', async () => {
+      // `required` outranks the custom key, so the message on screen is the
+      // required one — and the button would then belong to a message nobody sees.
+      host.dismissibleErrors.set(['manualValidateError']);
+      host.group.setErrors({ required: true, manualValidateError: 'Nope' });
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(true);
+      expect(await errors.isDismissible()).toBe(false);
+    });
+
+    it('names the button in English by default', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      attachServerError();
+
+      const button = fixture.nativeElement.querySelector('.tn-form-errors-dismiss button');
+
+      expect(button?.getAttribute('aria-label')).toBe('Dismiss this error');
+    });
+
+    it('lets a consumer supply a translated name for the button', async () => {
+      // The library ships no localized strings, so an app with an i18n layer has
+      // to be able to name the button itself.
+      host.dismissibleErrors.set(['manualValidateError']);
+      host.dismissAriaLabel.set('Diese Fehlermeldung entfernen');
+      attachServerError();
+
+      const button = fixture.nativeElement.querySelector('.tn-form-errors-dismiss button');
+
+      expect(button?.getAttribute('aria-label')).toBe('Diese Fehlermeldung entfernen');
+    });
+
+    it('keeps the button out of the alert, so its name is not announced as part of the error', async () => {
+      host.dismissibleErrors.set(['manualValidateError']);
+      attachServerError();
+
+      const alert = fixture.nativeElement.querySelector('.tn-form-errors');
+
+      expect(alert.querySelector('button')).toBeNull();
+      expect(await errors.getMessage()).toBe('The pool is offline');
     });
   });
 });

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.spec.ts
@@ -1,0 +1,210 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import type { AbstractControl, ValidationErrors } from '@angular/forms';
+import { TnFormErrorsComponent } from './form-errors.component';
+import { TnFormErrorsHarness } from './form-errors.harness';
+import { TN_FORM_FIELD_ERRORS } from '../form-field/form-field.errors';
+import type { TnFormFieldErrorMessages, TnFormFieldErrorResolver } from '../form-field/form-field.errors';
+
+/** Fails the GROUP, the way a cross-field validator does. */
+function bothOrNeither(group: AbstractControl): ValidationErrors | null {
+  const first = !!(group.get('first') as FormControl<string>).value;
+  const second = !!(group.get('second') as FormControl<string>).value;
+  return first === second ? null : { bothOrNeither: true };
+}
+
+@Component({
+  selector: 'tn-form-errors-host',
+  imports: [ReactiveFormsModule, TnFormErrorsComponent],
+  template: `<tn-form-errors
+    [control]="control()" [errorMessages]="errorMessages()" [showWhenUntouched]="showWhenUntouched()"
+  />`,
+})
+class HostComponent {
+  readonly group = new FormGroup(
+    { first: new FormControl(''), second: new FormControl('') },
+    bothOrNeither
+  );
+  /** A second group, failing on a DIFFERENT key, to switch the input to. */
+  readonly other = new FormGroup(
+    { only: new FormControl('') },
+    (group) => ((group.get('only') as FormControl<string>).value ? null : { required: true })
+  );
+
+  /** Invalid only in its CHILD — the group itself reports no error. */
+  readonly childOnly = new FormGroup({ only: new FormControl('', Validators.required) });
+
+  readonly control = signal<AbstractControl>(this.group);
+  readonly errorMessages = signal<TnFormFieldErrorMessages>({});
+  readonly showWhenUntouched = signal(false);
+}
+
+describe('TnFormErrorsComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+  let loader: HarnessLoader;
+  let errors: TnFormErrorsHarness;
+
+  async function setUp(resolver?: TnFormFieldErrorResolver): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: resolver ? [{ provide: TN_FORM_FIELD_ERRORS, useValue: resolver }] : [],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    errors = await loader.getHarness(TnFormErrorsHarness);
+  }
+
+  /** Puts the group in the failing state without touching it. */
+  function invalidate(): void {
+    host.group.controls.first.setValue('a');
+  }
+
+  describe('when to show', () => {
+    beforeEach(async () => {
+      await setUp();
+    });
+
+    it('shows nothing while the group is valid', async () => {
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(false);
+    });
+
+    it('shows nothing for an invalid group the user has not reached yet', async () => {
+      invalidate();
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(false);
+    });
+
+    it('shows once the group is touched, which is what submitting does', async () => {
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.getMessage()).toBe('bothOrNeither');
+    });
+
+    it('shows once the group is dirty', async () => {
+      invalidate();
+      host.group.markAsDirty();
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(true);
+    });
+
+    it('shows an untouched group when asked to, for a form filled in from an API', async () => {
+      host.showWhenUntouched.set(true);
+      invalidate();
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(true);
+    });
+
+    it('stops showing when the group becomes valid again', async () => {
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+      expect(await errors.hasMessage()).toBe(true);
+
+      host.group.controls.second.setValue('b');
+      fixture.detectChanges();
+
+      expect(await errors.hasMessage()).toBe(false);
+    });
+
+    it('ignores an error that belongs to a child rather than to the group', async () => {
+      host.childOnly.markAllAsTouched();
+      host.control.set(host.childOnly);
+      fixture.detectChanges();
+
+      // The group is invalid, but `errors` is null — the failure is the
+      // child's, and `tn-form-field` is already showing it under that field.
+      expect(host.childOnly.invalid).toBe(true);
+      expect(await errors.hasMessage()).toBe(false);
+    });
+
+    it('follows the control it is pointed at when that changes', async () => {
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+      expect(await errors.getMessage()).toBe('bothOrNeither');
+
+      host.other.markAllAsTouched();
+      host.control.set(host.other);
+      fixture.detectChanges();
+
+      expect(await errors.getMessage()).toBe('This field is required');
+    });
+  });
+
+  describe('which message', () => {
+    it('takes a per-instance override first', async () => {
+      await setUp(() => 'from the resolver');
+      host.errorMessages.set({ bothOrNeither: 'Fill in both, or neither' });
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.getMessage()).toBe('Fill in both, or neither');
+    });
+
+    it('falls through to the app-wide resolver', async () => {
+      await setUp((key) => `resolved:${key}`);
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(await errors.getMessage()).toBe('resolved:bothOrNeither');
+    });
+
+    it('falls through to the built-in defaults, so it reads like a field message', async () => {
+      await setUp();
+      host.other.markAllAsTouched();
+      host.control.set(host.other);
+      fixture.detectChanges();
+
+      expect(await errors.getMessage()).toBe('This field is required');
+    });
+
+    it('renders nothing when every layer declines to name the error', async () => {
+      await setUp(() => '   ');
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+
+      // The raw key is the last resort, so there is always something — the
+      // point of the case is that a blank resolver answer does not win.
+      expect(await errors.getMessage()).toBe('bothOrNeither');
+    });
+  });
+
+  describe('the message element', () => {
+    beforeEach(async () => {
+      await setUp();
+      invalidate();
+      host.group.markAllAsTouched();
+      fixture.detectChanges();
+    });
+
+    it('is an alert, so assistive technology announces it when it appears', () => {
+      expect(fixture.nativeElement.querySelector('.tn-form-errors')?.getAttribute('role'))
+        .toBe('alert');
+    });
+
+    it('carries an id a control can be described by', () => {
+      const id = fixture.nativeElement.querySelector('.tn-form-errors')?.getAttribute('id');
+
+      expect(id).toMatch(/^tn-form-errors-\d+$/);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
@@ -155,6 +155,13 @@ export class TnFormErrorsComponent {
   });
 
   /**
+   * The id when there is a message to point at, and null when there is not — so
+   * a caller can bind this straight to `aria-describedby` without ever naming
+   * an element that is not on screen.
+   */
+  readonly describedBy = computed(() => (this.show() ? this.errorId : null));
+
+  /**
    * The error key the shown message came from. Same pick `resolveErrorMessage`
    * makes, so the dismiss button can never belong to an error other than the one
    * being read.

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
@@ -1,11 +1,15 @@
-import { Component, DestroyRef, computed, effect, inject, input, signal } from '@angular/core';
+import { Component, DestroyRef, computed, effect, inject, input, output, signal } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import type { AbstractControl, ValidationErrors } from '@angular/forms';
 import {
+  TN_FORM_FIELD_DISMISSIBLE_ERRORS,
   TN_FORM_FIELD_ERRORS,
+  activeErrorKey,
+  clearDismissibleErrors,
   resolveErrorMessage,
 } from '../form-field/form-field.errors';
 import type { TnFormFieldErrorMessages } from '../form-field/form-field.errors';
+import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective } from '../test-id';
 import type { TnTestIdValue } from '../test-id';
 
@@ -46,7 +50,7 @@ const EMPTY_STATE: FormErrorsState = { invalid: false, interacted: false, errors
   selector: 'tn-form-errors',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TnTestIdDirective],
+  imports: [TnTestIdDirective, TnIconButtonComponent],
   templateUrl: './form-errors.component.html',
   styleUrls: ['./form-errors.component.scss'],
 })
@@ -78,6 +82,45 @@ export class TnFormErrorsComponent {
   testId = input<TnTestIdValue>(undefined);
 
   /**
+   * Error keys whose message renders with a dismiss button beside it — in
+   * practice a failure the user cannot fix by editing a field, so the message
+   * would otherwise stick: a server-side rejection an error handler attached to
+   * the group.
+   *
+   * Only the error actually being shown gets the button, since that is the
+   * message the button belongs to.
+   *
+   * Dismissing deletes these keys from the group's errors — listing them here is
+   * what grants that. Every listed key the group carries goes at once, not just
+   * the one behind the message, so a failure spread across sibling keys cannot
+   * reappear from a sibling. Unlike `tn-form-field` there is no control to hand
+   * focus back to once the button goes away, so a consumer who cares where focus
+   * lands should move it in the {@link dismiss} handler.
+   *
+   * Left unset, the app-wide {@link TN_FORM_FIELD_DISMISSIBLE_ERRORS} default
+   * applies; pass `[]` to opt this message out of it.
+   */
+  dismissibleErrors = input<readonly string[] | undefined>(undefined);
+
+  /**
+   * Accessible name for the dismiss button, which is icon-only and so has
+   * nothing else to be named by. The library cannot translate its own
+   * `'Dismiss this error'` default, so a consumer with an i18n layer passes an
+   * already-translated string here.
+   */
+  dismissAriaLabel = input<string | undefined>(undefined);
+
+  /**
+   * Hover tooltip for the dismiss button. Defaults to the resolved
+   * `dismissAriaLabel`, so one translated string covers both the accessible name
+   * and the visible hint.
+   */
+  dismissTooltip = input<string | undefined>(undefined);
+
+  /** Emits the error key whose message the user dismissed, after it is removed. */
+  dismiss = output<string>();
+
+  /**
    * Id of the message element, so a caller can point a control's
    * `aria-describedby` at a group message it is covered by.
    */
@@ -85,6 +128,9 @@ export class TnFormErrorsComponent {
 
   private destroyRef = inject(DestroyRef);
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
+
+  /** App-wide dismissible keys, used when the instance names none of its own. */
+  private defaultDismissibleErrors = inject(TN_FORM_FIELD_DISMISSIBLE_ERRORS, { optional: true });
 
   private state = signal<FormErrorsState>(EMPTY_STATE);
 
@@ -111,6 +157,45 @@ export class TnFormErrorsComponent {
     const { invalid, interacted } = this.state();
     return invalid && (interacted || this.showWhenUntouched()) && !!this.errorMessage();
   });
+
+  /**
+   * The error key the shown message came from. Same pick `resolveErrorMessage`
+   * makes, so the dismiss button can never belong to an error other than the one
+   * being read.
+   */
+  protected activeError = computed(() => {
+    const { errors } = this.state();
+    return errors ? activeErrorKey(errors) : null;
+  });
+
+  /** The instance's own list when it has one, otherwise the app-wide default. */
+  protected resolvedDismissibleErrors = computed(
+    () => this.dismissibleErrors() ?? this.defaultDismissibleErrors ?? [],
+  );
+
+  protected showDismiss = computed(() => {
+    const key = this.activeError();
+    return this.show() && !!key && this.resolvedDismissibleErrors().includes(key);
+  });
+
+  protected readonly resolvedDismissAriaLabel = computed(
+    () => this.dismissAriaLabel() ?? 'Dismiss this error',
+  );
+
+  protected readonly resolvedDismissTooltip = computed(
+    () => this.dismissTooltip() ?? this.resolvedDismissAriaLabel(),
+  );
+
+  protected dismissError(): void {
+    const key = this.activeError();
+    if (!key) {
+      return;
+    }
+    const control = this.control();
+    clearDismissibleErrors(control, this.resolvedDismissibleErrors());
+    this.sync(control);
+    this.dismiss.emit(key);
+  }
 
   constructor() {
     // `events` (not `statusChanges`) because a group also has to react to

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
@@ -1,0 +1,136 @@
+import { Component, DestroyRef, computed, effect, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy } from '@angular/core';
+import type { AbstractControl, ValidationErrors } from '@angular/forms';
+import {
+  TN_FORM_FIELD_ERRORS,
+  resolveErrorMessage,
+} from '../form-field/form-field.errors';
+import type { TnFormFieldErrorMessages } from '../form-field/form-field.errors';
+import { TnTestIdDirective } from '../test-id';
+import type { TnTestIdValue } from '../test-id';
+
+let nextId = 0;
+
+/** Snapshot of the bound control's validation state. */
+interface FormErrorsState {
+  invalid: boolean;
+  interacted: boolean;
+  errors: ValidationErrors | null;
+}
+
+const EMPTY_STATE: FormErrorsState = { invalid: false, interacted: false, errors: null };
+
+/**
+ * Renders the validation message for a control that is NOT projected into a
+ * `tn-form-field` — in practice a `FormGroup` or `FormArray`, whose errors
+ * belong to the group as a whole and so have no single field to sit under.
+ *
+ * `tn-form-field` covers the ordinary case and should still be preferred: it
+ * owns the label, the `aria-describedby` wiring and the subscript slot. Reach
+ * for this component only where there is no field to own the message —
+ * a cross-field validator on a group, a `minArrayLength` on a form array, a
+ * server-side error attached to a group by an error handler.
+ *
+ * The message comes from the same ladder `tn-form-field` uses (per-instance
+ * `errorMessages`, then the app-wide {@link TN_FORM_FIELD_ERRORS} resolver,
+ * then the built-in defaults), so a group message reads exactly like the field
+ * messages around it. Like `tn-form-field`, it shows ONE message — the active
+ * error, chosen by the same priority — rather than every error at once.
+ *
+ * @example
+ * ```html
+ * <tn-form-errors [control]="form.controls.schedule" />
+ * ```
+ */
+@Component({
+  selector: 'tn-form-errors',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TnTestIdDirective],
+  templateUrl: './form-errors.component.html',
+  styleUrls: ['./form-errors.component.scss'],
+})
+export class TnFormErrorsComponent {
+  /** The control whose errors are rendered. Usually a group or an array. */
+  control = input.required<AbstractControl>();
+
+  /**
+   * Per-instance overrides, keyed by error key. Take precedence over the
+   * app-wide resolver, exactly as on `tn-form-field`.
+   */
+  errorMessages = input<TnFormFieldErrorMessages>({});
+
+  /**
+   * Show the message before the user has touched or dirtied the control.
+   *
+   * Off by default, so a freshly opened form does not greet the user with
+   * errors. Turn it on where the invalid value did not come from the user —
+   * an edit form populated from an API, or a group an error handler has just
+   * attached a server-side failure to.
+   */
+  showWhenUntouched = input<boolean>(false);
+
+  /**
+   * Test-id base for the message element (`error-` prefixed). There is no
+   * fallback: an `AbstractControl` does not know its own name, so a message
+   * that needs to be addressable in a test has to be named here.
+   */
+  testId = input<TnTestIdValue>(undefined);
+
+  /**
+   * Id of the message element, so a caller can point a control's
+   * `aria-describedby` at a group message it is covered by.
+   */
+  readonly errorId = `tn-form-errors-${nextId++}`;
+
+  private destroyRef = inject(DestroyRef);
+  private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
+
+  private state = signal<FormErrorsState>(EMPTY_STATE);
+
+  protected errorMessage = computed(() => {
+    const { errors } = this.state();
+    if (!errors) {
+      return '';
+    }
+    return resolveErrorMessage({
+      errors,
+      errorMessages: this.errorMessages(),
+      resolver: this.errorResolver,
+      control: this.control(),
+      selector: 'tn-form-errors',
+    });
+  });
+
+  /**
+   * Whether to render. A control can be invalid with no message to show — a
+   * group whose only error resolves to blank — so the message is part of the
+   * condition rather than something the template renders empty.
+   */
+  protected show = computed(() => {
+    const { invalid, interacted } = this.state();
+    return invalid && (interacted || this.showWhenUntouched()) && !!this.errorMessage();
+  });
+
+  constructor() {
+    // `events` (not `statusChanges`) because a group also has to react to
+    // touched-only transitions: `markAllAsTouched()` on submit is what reveals
+    // a cross-field error the user never focused into.
+    effect((onCleanup) => {
+      const control = this.control();
+      const subscription = control.events.subscribe(() => this.sync(control));
+      onCleanup(() => subscription.unsubscribe());
+      this.sync(control);
+    });
+
+    this.destroyRef.onDestroy(() => this.state.set(EMPTY_STATE));
+  }
+
+  private sync(control: AbstractControl): void {
+    this.state.set({
+      invalid: control.invalid,
+      interacted: control.dirty || control.touched,
+      errors: control.errors,
+    });
+  }
+}

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.component.ts
@@ -1,8 +1,8 @@
-import { Component, DestroyRef, computed, effect, inject, input, output, signal } from '@angular/core';
+import { Component, computed, effect, inject, input, output, signal } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import type { AbstractControl, ValidationErrors } from '@angular/forms';
+import { dismissibleErrorState } from '../form-field/dismissible-error';
 import {
-  TN_FORM_FIELD_DISMISSIBLE_ERRORS,
   TN_FORM_FIELD_ERRORS,
   activeErrorKey,
   clearDismissibleErrors,
@@ -126,11 +126,7 @@ export class TnFormErrorsComponent {
    */
   readonly errorId = `tn-form-errors-${nextId++}`;
 
-  private destroyRef = inject(DestroyRef);
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
-
-  /** App-wide dismissible keys, used when the instance names none of its own. */
-  private defaultDismissibleErrors = inject(TN_FORM_FIELD_DISMISSIBLE_ERRORS, { optional: true });
 
   private state = signal<FormErrorsState>(EMPTY_STATE);
 
@@ -168,23 +164,18 @@ export class TnFormErrorsComponent {
     return errors ? activeErrorKey(errors) : null;
   });
 
-  /** The instance's own list when it has one, otherwise the app-wide default. */
-  protected resolvedDismissibleErrors = computed(
-    () => this.dismissibleErrors() ?? this.defaultDismissibleErrors ?? [],
-  );
-
-  protected showDismiss = computed(() => {
-    const key = this.activeError();
-    return this.show() && !!key && this.resolvedDismissibleErrors().includes(key);
+  /**
+   * Which list applies, whether the button shows, and what it is called — shared
+   * with `tn-form-field` so a group message and the field messages beside it can
+   * never decide dismissibility by different rules.
+   */
+  protected dismissible = dismissibleErrorState({
+    showError: () => this.show(),
+    activeError: () => this.activeError(),
+    dismissibleErrors: () => this.dismissibleErrors(),
+    dismissAriaLabel: () => this.dismissAriaLabel(),
+    dismissTooltip: () => this.dismissTooltip(),
   });
-
-  protected readonly resolvedDismissAriaLabel = computed(
-    () => this.dismissAriaLabel() ?? 'Dismiss this error',
-  );
-
-  protected readonly resolvedDismissTooltip = computed(
-    () => this.dismissTooltip() ?? this.resolvedDismissAriaLabel(),
-  );
 
   protected dismissError(): void {
     const key = this.activeError();
@@ -192,7 +183,7 @@ export class TnFormErrorsComponent {
       return;
     }
     const control = this.control();
-    clearDismissibleErrors(control, this.resolvedDismissibleErrors());
+    clearDismissibleErrors(control, this.dismissible.resolvedDismissibleErrors());
     this.sync(control);
     this.dismiss.emit(key);
   }
@@ -207,8 +198,6 @@ export class TnFormErrorsComponent {
       onCleanup(() => subscription.unsubscribe());
       this.sync(control);
     });
-
-    this.destroyRef.onDestroy(() => this.state.set(EMPTY_STATE));
   }
 
   private sync(control: AbstractControl): void {

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
@@ -1,0 +1,63 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * A set of criteria that can be used to filter a list of
+ * `TnFormErrorsHarness` instances.
+ */
+export interface TnFormErrorsHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the rendered message. Supports string or regex matching. */
+  textContains?: string | RegExp;
+}
+
+/**
+ * Harness for `tn-form-errors`.
+ *
+ * The host renders nothing while the control is valid, untouched, or has no
+ * message to show, so `hasMessage()` — not the presence of the harness — is
+ * what tells you whether an error is visible.
+ *
+ * @example
+ * ```typescript
+ * const errors = await loader.getHarness(TnFormErrorsHarness);
+ * expect(await errors.getMessage()).toBe('Select at least one day');
+ * ```
+ */
+export class TnFormErrorsHarness extends ComponentHarness {
+  static hostSelector = 'tn-form-errors';
+
+  /**
+   * Gets a `HarnessPredicate` for finding a `tn-form-errors` by its message.
+   *
+   * @param options Options for filtering which instances are considered a match.
+   */
+  static with(options: TnFormErrorsHarnessFilters = {}) {
+    return new HarnessPredicate(TnFormErrorsHarness, options)
+      .addOption('textContains', options.textContains, (harness, text) =>
+        HarnessPredicate.stringMatches(
+          harness.getMessage(),
+          typeof text === 'string' ? new RegExp(escapeRegex(text)) : text
+        )
+      );
+  }
+
+  private message = this.locatorForOptional('.tn-form-errors');
+
+  /** Whether a message is currently rendered. */
+  async hasMessage(): Promise<boolean> {
+    return (await this.message()) !== null;
+  }
+
+  /** The rendered message, or `''` when none is shown. */
+  async getMessage(): Promise<string> {
+    const message = await this.message();
+    return message ? (await message.text()).trim() : '';
+  }
+}
+
+/**
+ * Stands in for `RegExp.escape`, which the ES2023 deployment target predates.
+ */
+function escapeRegex(text: string): string {
+  return text.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+}

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
@@ -42,6 +42,7 @@ export class TnFormErrorsHarness extends ComponentHarness {
   }
 
   private message = this.locatorForOptional('.tn-form-errors');
+  private dismissButton = this.locatorForOptional('.tn-form-errors-dismiss button');
 
   /** Whether a message is currently rendered. */
   async hasMessage(): Promise<boolean> {
@@ -52,6 +53,30 @@ export class TnFormErrorsHarness extends ComponentHarness {
   async getMessage(): Promise<string> {
     const message = await this.message();
     return message ? (await message.text()).trim() : '';
+  }
+
+  /**
+   * Whether the shown message carries a dismiss button — true only when the
+   * active error key is one of the host's `dismissibleErrors`.
+   */
+  async isDismissible(): Promise<boolean> {
+    return (await this.dismissButton()) !== null;
+  }
+
+  /**
+   * Clicks the dismiss button, as a user clearing a server-side error would.
+   *
+   * The component only emits `dismiss` — clearing the error is the consumer's
+   * job — so what the message does next depends on the handler under test.
+   *
+   * @throws If the shown message is not dismissible.
+   */
+  async dismiss(): Promise<void> {
+    const button = await this.dismissButton();
+    if (!button) {
+      throw new Error('Cannot dismiss: tn-form-errors shows no dismissible error.');
+    }
+    await button.click();
   }
 }
 

--- a/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
+++ b/projects/truenas-ui/src/lib/form-errors/form-errors.harness.ts
@@ -66,8 +66,10 @@ export class TnFormErrorsHarness extends ComponentHarness {
   /**
    * Clicks the dismiss button, as a user clearing a server-side error would.
    *
-   * The component only emits `dismiss` — clearing the error is the consumer's
-   * job — so what the message does next depends on the handler under test.
+   * The component clears the error itself — every key in its `dismissibleErrors`
+   * that the control carries — and then emits `dismiss` with the key that was on
+   * screen, so the message is gone by the time this resolves. The handler is for
+   * what the app does next, such as moving focus.
    *
    * @throws If the shown message is not dismissible.
    */

--- a/projects/truenas-ui/src/lib/form-field/_error-row.scss
+++ b/projects/truenas-ui/src/lib/form-field/_error-row.scss
@@ -1,0 +1,29 @@
+// The layout a validation message and its optional close button share between
+// `tn-form-field`'s subscript and the standalone `tn-form-errors`.
+//
+// One copy rather than two: the two hosts render the same row — a message that
+// fills the line, a button beside it — and the reasoning below is what a second
+// copy would have to restate to stay correct.
+
+// The row. With no button this lays out exactly as the message alone did: one
+// flex child taking the full width.
+@mixin row {
+  display: flex;
+  // Centred, not top-aligned: the button's 32px box — comfortably past the 24px
+  // WCAG 2.5.8 minimum, which a smaller icon button would miss — is taller than
+  // the message, and top-aligning would drop its icon below the text.
+  align-items: center;
+  gap: 0.25rem;
+}
+
+// The message. `min-width: 0` so a long unbroken message shrinks instead of
+// pushing the button off the row.
+@mixin message {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+// The close button.
+@mixin dismiss {
+  flex: none;
+}

--- a/projects/truenas-ui/src/lib/form-field/dismissible-error.ts
+++ b/projects/truenas-ui/src/lib/form-field/dismissible-error.ts
@@ -1,0 +1,81 @@
+import { computed, inject } from '@angular/core';
+import type { Signal } from '@angular/core';
+import { TN_FORM_FIELD_DISMISSIBLE_ERRORS } from './form-field.errors';
+
+/**
+ * The inputs a host reads to decide whether the message it is showing carries a
+ * close button, as plain accessors so a caller can pass `() => this.someInput()`
+ * without depending on the order its own class fields initialize in.
+ *
+ * @internal
+ */
+export interface DismissibleErrorSources {
+  /** Whether a message is on screen at all — there is nothing to dismiss otherwise. */
+  showError: () => boolean;
+  /** The error key the shown message came from, or `null`. */
+  activeError: () => string | null;
+  /** The host's own `dismissibleErrors` input; `undefined` defers to the app-wide token. */
+  dismissibleErrors: () => readonly string[] | undefined;
+  /** The host's own `dismissAriaLabel` input. */
+  dismissAriaLabel: () => string | undefined;
+  /** The host's own `dismissTooltip` input. */
+  dismissTooltip: () => string | undefined;
+}
+
+/** What a host binds its template and its dismiss handler to. @internal */
+export interface DismissibleErrorState {
+  /** The host's own list when it has one, otherwise the app-wide default. */
+  resolvedDismissibleErrors: Signal<readonly string[]>;
+  /** Whether the shown message renders a close button beside it. */
+  showDismiss: Signal<boolean>;
+  /** Accessible name for that button. */
+  resolvedDismissAriaLabel: Signal<string>;
+  /** Hover hint for that button. */
+  resolvedDismissTooltip: Signal<string>;
+}
+
+/**
+ * The dismiss-button derivations `tn-form-field` and `tn-form-errors` share.
+ *
+ * Both render the same control against the same opt-in list, and both fall back
+ * to {@link TN_FORM_FIELD_DISMISSIBLE_ERRORS} and to the same English default
+ * name. Kept in one place so the two cannot answer differently — a field message
+ * and the group message above it deciding dismissibility by different rules is a
+ * bug a reader would have to diff two components to see.
+ *
+ * Only the derivation is shared: what dismissing *does* differs (the field hands
+ * focus back to its control, the group has no control to hand it to), so each
+ * host writes its own handler over `clearDismissibleErrors`.
+ *
+ * Must be called from an injection context — in practice a component field
+ * initializer.
+ *
+ * @internal
+ */
+export function dismissibleErrorState(sources: DismissibleErrorSources): DismissibleErrorState {
+  const appWide = inject(TN_FORM_FIELD_DISMISSIBLE_ERRORS, { optional: true });
+
+  const resolvedDismissibleErrors = computed(
+    () => sources.dismissibleErrors() ?? appWide ?? [],
+  );
+
+  // Only the error actually being shown gets a button, since that is the message
+  // the button belongs to.
+  const showDismiss = computed(() => {
+    const key = sources.activeError();
+    return sources.showError() && !!key && resolvedDismissibleErrors().includes(key);
+  });
+
+  const resolvedDismissAriaLabel = computed(
+    () => sources.dismissAriaLabel() ?? 'Dismiss this error',
+  );
+
+  return {
+    resolvedDismissibleErrors,
+    showDismiss,
+    resolvedDismissAriaLabel,
+    resolvedDismissTooltip: computed(
+      () => sources.dismissTooltip() ?? resolvedDismissAriaLabel(),
+    ),
+  };
+}

--- a/projects/truenas-ui/src/lib/form-field/form-field-dismiss.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field-dismiss.spec.ts
@@ -1,0 +1,251 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TnFormFieldComponent } from './form-field.component';
+import { TN_FORM_FIELD_DISMISSIBLE_ERRORS } from './form-field.errors';
+import { TnFormFieldHarness } from './form-field.harness';
+import { TnIconTesting } from '../icon/icon-testing';
+import { TnInputComponent } from '../input/input.component';
+
+/**
+ * Stands in for a server-side rejection: an error handler attaches it to a
+ * control the user has already filled in correctly as far as any validator can
+ * tell, so nothing they type will clear it.
+ */
+const SERVER_ERROR = 'manualValidateError';
+
+@Component({
+  selector: 'tn-test-host',
+  standalone: true,
+  imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-field
+      label="Image"
+      [dismissibleErrors]="dismissibleErrors()"
+      [dismissAriaLabel]="dismissAriaLabel()"
+      (dismiss)="dismissed.push($event)"
+    >
+      <tn-input [formControl]="control" />
+    </tn-form-field>
+  `,
+})
+class TestHostComponent {
+  readonly control = new FormControl('logo.png', Validators.required);
+  readonly dismissibleErrors = signal<readonly string[] | undefined>([SERVER_ERROR]);
+  readonly dismissAriaLabel = signal<string | undefined>(undefined);
+  readonly dismissed: string[] = [];
+}
+
+describe('TnFormFieldComponent dismissible errors', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let loader: HarnessLoader;
+  let field: TnFormFieldHarness;
+
+  async function setUp(appWideDismissible?: readonly string[]): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        TnIconTesting.jest.providers(),
+        ...(appWideDismissible
+          ? [{ provide: TN_FORM_FIELD_DISMISSIBLE_ERRORS, useValue: appWideDismissible }]
+          : []),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    field = await loader.getHarness(TnFormFieldHarness);
+  }
+
+  beforeEach(async () => {
+    await setUp();
+  });
+
+  /** Puts the control in the state an error handler leaves it in. */
+  function attachServerError(message = 'The pool is offline'): void {
+    host.control.setErrors({ [SERVER_ERROR]: message });
+    host.control.markAsTouched();
+    fixture.detectChanges();
+  }
+
+  function dismissButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector('.tn-form-field-error-dismiss button');
+  }
+
+  it('leaves an ordinary validation error undismissable', async () => {
+    host.control.setValue('');
+    host.control.markAsTouched();
+    fixture.detectChanges();
+
+    expect(await field.getErrorMessage()).toBe('This field is required');
+    expect(await field.isErrorDismissible()).toBe(false);
+  });
+
+  it('offers a dismiss button for a listed error key', async () => {
+    attachServerError();
+
+    expect(await field.getErrorMessage()).toBe('The pool is offline');
+    expect(await field.isErrorDismissible()).toBe(true);
+  });
+
+  it('emits the key of the message that was on screen', async () => {
+    attachServerError();
+
+    await field.dismissError();
+
+    expect(host.dismissed).toEqual([SERVER_ERROR]);
+  });
+
+  it('drops the dismissed key, so the message goes with it', async () => {
+    attachServerError();
+
+    await field.dismissError();
+    fixture.detectChanges();
+
+    expect(host.control.errors).toBeNull();
+    expect(await field.hasError()).toBe(false);
+  });
+
+  it('takes sibling dismissible keys with it, so the message cannot come back', async () => {
+    // An error handler that spreads one failure across a flag, its message and a
+    // legacy alias: leave any of them and the same text renders again.
+    host.dismissibleErrors.set([SERVER_ERROR, 'manualValidateErrorMsg', 'ixManualValidateError']);
+    host.control.setErrors({
+      [SERVER_ERROR]: true,
+      manualValidateErrorMsg: 'The pool is offline',
+      ixManualValidateError: 'The pool is offline',
+    });
+    host.control.markAsTouched();
+    fixture.detectChanges();
+
+    await field.dismissError();
+    fixture.detectChanges();
+
+    expect(host.control.errors).toBeNull();
+    expect(await field.hasError()).toBe(false);
+  });
+
+  it('leaves the control\'s other errors alone', async () => {
+    // Only the key behind the message on screen is the user's to close; a second
+    // failure alongside it still has to be dealt with. Both keys are custom, so
+    // insertion order decides which is active — the dismissible one.
+    host.control.setErrors({ [SERVER_ERROR]: 'The pool is offline', quotaExceeded: 'Out of space' });
+    host.control.markAsTouched();
+    fixture.detectChanges();
+
+    expect(await field.getErrorMessage()).toBe('The pool is offline');
+
+    await field.dismissError();
+    fixture.detectChanges();
+
+    expect(host.control.errors).toEqual({ quotaExceeded: 'Out of space' });
+    expect(await field.getErrorMessage()).toBe('Out of space');
+  });
+
+  it('withholds the button when a listed key is not the error being shown', async () => {
+    // `required` outranks the custom key, so the required message is what is on
+    // screen — and the button would then belong to a message nobody can see.
+    host.control.setErrors({ required: true, [SERVER_ERROR]: 'Nope' });
+    host.control.markAsTouched();
+    fixture.detectChanges();
+
+    expect(await field.getErrorMessage()).toBe('This field is required');
+    expect(await field.isErrorDismissible()).toBe(false);
+  });
+
+  it('shows no button at all until a key is listed', async () => {
+    host.dismissibleErrors.set([]);
+    attachServerError();
+
+    expect(await field.hasError()).toBe(true);
+    expect(await field.isErrorDismissible()).toBe(false);
+  });
+
+  describe('the app-wide default', () => {
+    it('applies to a field that names no keys of its own', async () => {
+      // An app whose server failures always land under the same key wires it
+      // once, rather than on each of hundreds of fields.
+      TestBed.resetTestingModule();
+      await setUp([SERVER_ERROR]);
+      host.dismissibleErrors.set(undefined);
+      attachServerError();
+
+      expect(await field.isErrorDismissible()).toBe(true);
+    });
+
+    it('gives way to a field that names its own', async () => {
+      TestBed.resetTestingModule();
+      await setUp([SERVER_ERROR]);
+      host.dismissibleErrors.set(['somethingElse']);
+      attachServerError();
+
+      expect(await field.isErrorDismissible()).toBe(false);
+    });
+
+    it('is opted out of with an empty list, which is not the same as unset', async () => {
+      TestBed.resetTestingModule();
+      await setUp([SERVER_ERROR]);
+      host.dismissibleErrors.set([]);
+      attachServerError();
+
+      expect(await field.isErrorDismissible()).toBe(false);
+    });
+  });
+
+  it('names the button in English by default', () => {
+    attachServerError();
+
+    expect(dismissButton()?.getAttribute('aria-label')).toBe('Dismiss this error');
+  });
+
+  it('lets a consumer supply a translated name for the button', () => {
+    // The library ships no localized strings, so an app with an i18n layer has
+    // to be able to name the button itself.
+    host.dismissAriaLabel.set('Diese Fehlermeldung entfernen');
+    attachServerError();
+
+    expect(dismissButton()?.getAttribute('aria-label')).toBe('Diese Fehlermeldung entfernen');
+  });
+
+  it('keeps the button out of the alert, so its name is not announced as part of the error', () => {
+    attachServerError();
+
+    const alert = fixture.nativeElement.querySelector('.tn-form-field-error');
+
+    expect(alert.getAttribute('role')).toBe('alert');
+    expect(alert.querySelector('button')).toBeNull();
+  });
+
+  it('hands focus back to the control, rather than losing it with the button', async () => {
+    attachServerError();
+    const button = dismissButton();
+    button?.focus();
+
+    await field.dismissError();
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('input'));
+  });
+
+  it('does not steal focus from elsewhere when the click never focused the button', async () => {
+    // Safari leaves a clicked button unfocused; there is no focus to rescue then,
+    // and moving it would yank the user out of wherever they actually are.
+    attachServerError();
+    const elsewhere: HTMLInputElement = document.createElement('input');
+    document.body.appendChild(elsewhere);
+    elsewhere.focus();
+
+    await field.dismissError();
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(elsewhere);
+    elsewhere.remove();
+  });
+});

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -43,15 +43,15 @@
             [attr.id]="errorId">
             {{ errorMessage() }}
           </div>
-          @if (showDismiss()) {
+          @if (dismissible.showDismiss()) {
             <tn-icon-button
               #dismissButton
               class="tn-form-field-error-dismiss"
               name="close"
               library="mdi"
               size="sm"
-              [ariaLabel]="resolvedDismissAriaLabel()"
-              [tooltip]="resolvedDismissTooltip()"
+              [ariaLabel]="dismissible.resolvedDismissAriaLabel()"
+              [tooltip]="dismissible.resolvedDismissTooltip()"
               (onClick)="dismissError()"
             />
           }

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.html
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.html
@@ -31,14 +31,30 @@
   @if (showSubscript()) {
     <div class="tn-form-field-subscript" [class.tn-form-field-subscript-dynamic]="subscriptSizing() === 'dynamic'">
       @if (showError()) {
-        <!-- role="alert" is implicitly assertive+atomic, so no aria-live here.
-             The id feeds the projected control's aria-describedby (see
-             TnFormFieldContext). -->
-        <div
-          class="tn-form-field-error"
-          role="alert"
-          [attr.id]="errorId">
-          {{ errorMessage() }}
+        <div class="tn-form-field-error-row">
+          <!-- role="alert" is implicitly assertive+atomic, so no aria-live here.
+               The id feeds the projected control's aria-describedby (see
+               TnFormFieldContext). The dismiss button stays OUTSIDE it: a live
+               region announces everything it contains, and the button's name is
+               not part of the error. -->
+          <div
+            class="tn-form-field-error"
+            role="alert"
+            [attr.id]="errorId">
+            {{ errorMessage() }}
+          </div>
+          @if (showDismiss()) {
+            <tn-icon-button
+              #dismissButton
+              class="tn-form-field-error-dismiss"
+              name="close"
+              library="mdi"
+              size="sm"
+              [ariaLabel]="resolvedDismissAriaLabel()"
+              [tooltip]="resolvedDismissTooltip()"
+              (onClick)="dismissError()"
+            />
+          }
         </div>
       }
       @if (showHint()) {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -1,4 +1,5 @@
 @use '../pipes/label-markup/label-markup' as label-markup;
+@use 'error-row';
 
 .tn-form-field {
   display: block;
@@ -115,26 +116,28 @@
 }
 
 // A plain row so a dismissible error can carry its button beside the message.
-// With no button this lays out exactly as the message alone did: one flex child
-// that takes the full width.
 .tn-form-field-error-row {
-  display: flex;
-  // Centred, not top-aligned: the button's 32px box (the WCAG 2.5.8 minimum
-  // target, which a smaller icon button would miss) is twice the height of the
-  // message, and top-aligning would drop its icon well below the text.
-  align-items: center;
-  gap: 0.25rem;
+  @include error-row.row;
 }
 
 .tn-form-field-error {
+  @include error-row.message;
+
   color: var(--tn-error, var(--tn-red, #bd2626));
   margin: 0;
-  flex: 1 1 auto;
-  min-width: 0;
 }
 
 .tn-form-field-error-dismiss {
-  flex: none;
+  @include error-row.dismiss;
+
+  // Give the button a layout box the height of the line the subscript reserves,
+  // and let the 32px target it renders overflow that box rather than open the
+  // row to 32px. `subscriptSizing="fixed"` exists so that revealing an error
+  // does not shift the fields below it, and an error that happens to be
+  // dismissible must not be the one case that shifts them anyway.
+  display: flex;
+  align-items: center;
+  height: 1.25rem;
 }
 
 .tn-form-field-hint {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.scss
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.scss
@@ -114,9 +114,27 @@
   }
 }
 
+// A plain row so a dismissible error can carry its button beside the message.
+// With no button this lays out exactly as the message alone did: one flex child
+// that takes the full width.
+.tn-form-field-error-row {
+  display: flex;
+  // Centred, not top-aligned: the button's 32px box (the WCAG 2.5.8 minimum
+  // target, which a smaller icon button would miss) is twice the height of the
+  // message, and top-aligning would drop its icon well below the text.
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .tn-form-field-error {
   color: var(--tn-error, var(--tn-red, #bd2626));
   margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tn-form-field-error-dismiss {
+  flex: none;
 }
 
 .tn-form-field-hint {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,7 +1,7 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import type { AfterContentInit } from '@angular/core';
-import { Component, input, computed, signal, contentChild, forwardRef, inject, isDevMode, DestroyRef } from '@angular/core';
+import { Component, input, computed, signal, contentChild, forwardRef, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl, Validators } from '@angular/forms';
 import type { ValidationErrors } from '@angular/forms';
@@ -9,8 +9,7 @@ import { TN_FORM_FIELD_CONTEXT } from './form-field-context';
 import type { TnFormFieldContext } from './form-field-context';
 import {
   TN_FORM_FIELD_ERRORS,
-  activeErrorKey,
-  defaultErrorMessage,
+  resolveErrorMessage,
 } from './form-field.errors';
 import type { TnFormFieldErrorMessages } from './form-field.errors';
 import { TnIconComponent } from '../icon/icon.component';
@@ -213,60 +212,19 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
    * `errorMessages` input (and the injected resolver), so it is reactive: the
    * displayed message updates when either the control errors or the overrides
    * change — e.g. a runtime locale switch.
+   *
+   * The ladder itself lives in `./form-field.errors`, shared with
+   * `tn-form-errors` so a group-level message reads exactly like the
+   * field-level one it sits beside.
    */
   private resolveErrorMessage(errors: ValidationErrors): string {
-    const key = activeErrorKey(errors);
-    if (!key) {return 'Invalid input';}
-
-    const value = errors[key];
-
-    // 1. Per-field override (string or factory). A throwing factory must not
-    //    break change detection, so fall through to the next layer instead.
-    const override = this.errorMessages()[key];
-    if (override != null) {
-      const message = this.runGuarded(
-        () => (typeof override === 'function' ? override(value) : override),
-        `errorMessages["${key}"]`
-      );
-      if (message != null) {return message;}
-    }
-
-    // 2. App-wide resolver (e.g. wired to a translation service).
-    const resolved = this.runGuarded(
-      () => this.errorResolver?.(key, value, this.control()?.control ?? null),
-      'TN_FORM_FIELD_ERRORS resolver'
-    );
-    if (resolved != null) {return resolved;}
-
-    // 3. Built-in default messages for standard validators.
-    const builtIn = defaultErrorMessage(key, value);
-    if (builtIn != null) {return builtIn;}
-
-    // 4. A custom validator that returned its own message string.
-    if (typeof value === 'string') {return value;}
-
-    // 5. Last resort: the raw error key.
-    return key;
-  }
-
-  /**
-   * Runs a caller-supplied message provider, swallowing any throw so a buggy
-   * override or resolver cannot break change detection. Logs in dev mode and
-   * returns null so resolution falls through to the next layer.
-   */
-  private runGuarded(provider: () => string | null | undefined, context: string): string | null {
-    try {
-      // Treat a blank message as "no answer" so it falls through to the next
-      // layer instead of hiding the error — e.g. a translation service that
-      // returns '' for a missing key.
-      const message = provider();
-      return message != null && message.trim() !== '' ? message : null;
-    } catch (error) {
-      if (isDevMode()) {
-        console.error(`[tn-form-field] ${context} threw while resolving a validation message`, error);
-      }
-      return null;
-    }
+    return resolveErrorMessage({
+      errors,
+      errorMessages: this.errorMessages(),
+      resolver: this.errorResolver,
+      control: this.control()?.control ?? null,
+      selector: 'tn-form-field',
+    });
   }
 
   showError = computed(() => {

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -8,10 +8,10 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl, Validators } from '@angular/forms';
 import type { ValidationErrors } from '@angular/forms';
+import { dismissibleErrorState } from './dismissible-error';
 import { TN_FORM_FIELD_CONTEXT } from './form-field-context';
 import type { TnFormFieldContext } from './form-field-context';
 import {
-  TN_FORM_FIELD_DISMISSIBLE_ERRORS,
   TN_FORM_FIELD_ERRORS,
   activeErrorKey,
   clearDismissibleErrors,
@@ -206,9 +206,6 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
    */
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
 
-  /** App-wide dismissible keys, used when the field names none of its own. */
-  private defaultDismissibleErrors = inject(TN_FORM_FIELD_DISMISSIBLE_ERRORS, { optional: true });
-
   /**
    * Snapshot of the relevant control state. Updated from the control's status
    * stream because `NgControl` itself is not signal-based; downstream `computed`s
@@ -266,23 +263,18 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
     return errors ? activeErrorKey(errors) : null;
   });
 
-  /** The field's own list when it has one, otherwise the app-wide default. */
-  protected resolvedDismissibleErrors = computed(
-    () => this.dismissibleErrors() ?? this.defaultDismissibleErrors ?? [],
-  );
-
-  protected showDismiss = computed(() => {
-    const key = this.activeError();
-    return this.showError() && !!key && this.resolvedDismissibleErrors().includes(key);
+  /**
+   * Which list applies, whether the button shows, and what it is called — shared
+   * with `tn-form-errors` so a field message and a group message beside it can
+   * never decide dismissibility by different rules.
+   */
+  protected dismissible = dismissibleErrorState({
+    showError: () => this.showError(),
+    activeError: () => this.activeError(),
+    dismissibleErrors: () => this.dismissibleErrors(),
+    dismissAriaLabel: () => this.dismissAriaLabel(),
+    dismissTooltip: () => this.dismissTooltip(),
   });
-
-  protected readonly resolvedDismissAriaLabel = computed(
-    () => this.dismissAriaLabel() ?? 'Dismiss this error',
-  );
-
-  protected readonly resolvedDismissTooltip = computed(
-    () => this.dismissTooltip() ?? this.resolvedDismissAriaLabel(),
-  );
 
   /**
    * Drops the dismissed error, then puts focus back on the control rather than
@@ -304,7 +296,7 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
     const button = this.dismissButton()?.nativeElement;
     const hadFocus = !!button && button.contains(button.ownerDocument.activeElement);
 
-    clearDismissibleErrors(control, this.resolvedDismissibleErrors());
+    clearDismissibleErrors(control, this.dismissible.resolvedDismissibleErrors());
     this.syncControlState();
     this.dismiss.emit(key);
 

--- a/projects/truenas-ui/src/lib/form-field/form-field.component.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.component.ts
@@ -1,18 +1,25 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import type { AfterContentInit } from '@angular/core';
-import { Component, input, computed, signal, contentChild, forwardRef, inject, DestroyRef } from '@angular/core';
+import {
+  Component, ElementRef, input, output, computed, signal, contentChild, forwardRef, inject,
+  viewChild, DestroyRef,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl, Validators } from '@angular/forms';
 import type { ValidationErrors } from '@angular/forms';
 import { TN_FORM_FIELD_CONTEXT } from './form-field-context';
 import type { TnFormFieldContext } from './form-field-context';
 import {
+  TN_FORM_FIELD_DISMISSIBLE_ERRORS,
   TN_FORM_FIELD_ERRORS,
+  activeErrorKey,
+  clearDismissibleErrors,
   resolveErrorMessage,
 } from './form-field.errors';
 import type { TnFormFieldErrorMessages } from './form-field.errors';
 import { TnIconComponent } from '../icon/icon.component';
+import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 import { plainTextMessage } from '../tooltip/interactive-content';
@@ -22,6 +29,21 @@ import type { TooltipPosition } from '../tooltip/tooltip.directive';
 export type SubscriptSizing = 'fixed' | 'dynamic';
 
 let nextId = 0;
+
+/**
+ * What counts as the control to hand focus back to once the dismiss button the
+ * user just activated has been removed from the DOM. First match inside the
+ * field's wrapper wins — for every control the library projects that is the
+ * control itself.
+ */
+const FOCUSABLE_SELECTOR = [
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 /** Snapshot of the projected control's validation state. */
 interface ControlStateSnapshot {
@@ -34,7 +56,10 @@ interface ControlStateSnapshot {
 @Component({
   selector: 'tn-form-field',
   standalone: true,
-  imports: [NgTemplateOutlet, TnTestIdDirective, TnIconComponent, TnTooltipDirective, LabelMarkupPipe],
+  imports: [
+    NgTemplateOutlet, TnTestIdDirective, TnIconComponent, TnIconButtonComponent, TnTooltipDirective,
+    LabelMarkupPipe,
+  ],
   providers: [
     // Published to projected controls (their element injector chains through
     // this host), which bind aria-labelledby/-describedby/-invalid/-required
@@ -115,7 +140,62 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
    */
   errorMessages = input<TnFormFieldErrorMessages>({});
 
+  /**
+   * Error keys whose message renders with a dismiss button beside it — in
+   * practice a failure the user cannot fix by editing the value, so the message
+   * would otherwise stick until the control changes: a server-side rejection an
+   * error handler attached to the control, or an async validator that judged the
+   * value the user already picked.
+   *
+   * Only the error actually being shown gets the button. A control carrying both
+   * a dismissible key and `required` shows the `required` message, undismissable,
+   * because that is the message on screen.
+   *
+   * Dismissing deletes these keys from the control's errors — listing them here
+   * is what grants that, since a message the user can close but that does not go
+   * away would be worse than no button. Every listed key the control carries goes
+   * at once, not just the one behind the message: an app that spreads one failure
+   * across sibling keys (a flag, its message, a legacy alias) would otherwise see
+   * the message reappear from a sibling. Unlisted errors are left alone, and
+   * {@link dismiss} reports which message went.
+   *
+   * Left unset, the app-wide {@link TN_FORM_FIELD_DISMISSIBLE_ERRORS} default
+   * applies; pass `[]` to opt this field out of it.
+   */
+  dismissibleErrors = input<readonly string[] | undefined>(undefined);
+
+  /**
+   * Accessible name for the dismiss button, which is icon-only and so has
+   * nothing else to be named by. The library cannot translate its own
+   * `'Dismiss this error'` default, so a consumer with an i18n layer passes an
+   * already-translated string here.
+   */
+  dismissAriaLabel = input<string | undefined>(undefined);
+
+  /**
+   * Hover tooltip for the dismiss button. Defaults to the resolved
+   * `dismissAriaLabel`, so one translated string covers both the accessible name
+   * and the visible hint.
+   */
+  dismissTooltip = input<string | undefined>(undefined);
+
+  /**
+   * Emits the error key the user dismissed, after it has been removed — the key
+   * of the message that was on screen, so a consumer listing several dismissible
+   * keys knows which one went.
+   */
+  dismiss = output<string>();
+
   control = contentChild(NgControl);
+
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /**
+   * `read: ElementRef` because the ref sits on `tn-icon-button`, and a component
+   * ref resolves to the instance by default — the element is what the focus
+   * check needs.
+   */
+  private dismissButton = viewChild('dismissButton', { read: ElementRef<HTMLElement> });
 
   private destroyRef = inject(DestroyRef);
 
@@ -125,6 +205,9 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
    * runtime will not be picked up by an already-created field.
    */
   private errorResolver = inject(TN_FORM_FIELD_ERRORS, { optional: true });
+
+  /** App-wide dismissible keys, used when the field names none of its own. */
+  private defaultDismissibleErrors = inject(TN_FORM_FIELD_DISMISSIBLE_ERRORS, { optional: true });
 
   /**
    * Snapshot of the relevant control state. Updated from the control's status
@@ -172,6 +255,66 @@ export class TnFormFieldComponent implements AfterContentInit, TnFormFieldContex
     const { errors } = this.controlState();
     return errors ? this.resolveErrorMessage(errors) : '';
   });
+
+  /**
+   * The error key the shown message came from. Same pick `resolveErrorMessage`
+   * makes, so the dismiss button can never belong to an error other than the one
+   * being read.
+   */
+  protected activeError = computed(() => {
+    const { errors } = this.controlState();
+    return errors ? activeErrorKey(errors) : null;
+  });
+
+  /** The field's own list when it has one, otherwise the app-wide default. */
+  protected resolvedDismissibleErrors = computed(
+    () => this.dismissibleErrors() ?? this.defaultDismissibleErrors ?? [],
+  );
+
+  protected showDismiss = computed(() => {
+    const key = this.activeError();
+    return this.showError() && !!key && this.resolvedDismissibleErrors().includes(key);
+  });
+
+  protected readonly resolvedDismissAriaLabel = computed(
+    () => this.dismissAriaLabel() ?? 'Dismiss this error',
+  );
+
+  protected readonly resolvedDismissTooltip = computed(
+    () => this.dismissTooltip() ?? this.resolvedDismissAriaLabel(),
+  );
+
+  /**
+   * Drops the dismissed error, then puts focus back on the control rather than
+   * letting it fall to `<body>` with the button — dismissing a server-side error
+   * means "let me try again", and the control is where trying again happens.
+   *
+   * Focus only moves if it was on the button to begin with: a dismiss triggered
+   * from anywhere else (a Safari mouse click, which leaves the button unfocused)
+   * has no focus to lose and should not steal any.
+   */
+  protected dismissError(): void {
+    const key = this.activeError();
+    const control = this.control()?.control;
+    if (!key || !control) {
+      return;
+    }
+    // `contains`, not identity: tn-icon-button delegates focus to the native
+    // button it renders, so the active element is that child, not the host.
+    const button = this.dismissButton()?.nativeElement;
+    const hadFocus = !!button && button.contains(button.ownerDocument.activeElement);
+
+    clearDismissibleErrors(control, this.resolvedDismissibleErrors());
+    this.syncControlState();
+    this.dismiss.emit(key);
+
+    if (hadFocus) {
+      this.host.nativeElement
+        .querySelector('.tn-form-field-wrapper')
+        ?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+        ?.focus();
+    }
+  }
 
   ngAfterContentInit(): void {
     const control = this.control();

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.spec.ts
@@ -1,4 +1,5 @@
-import { activeErrorKey, defaultErrorMessage } from './form-field.errors';
+import { FormArray, FormControl, Validators } from '@angular/forms';
+import { activeErrorKey, clearDismissibleErrors, defaultErrorMessage } from './form-field.errors';
 
 describe('activeErrorKey', () => {
   it('returns null when there are no errors', () => {
@@ -55,5 +56,50 @@ describe('defaultErrorMessage', () => {
     expect(defaultErrorMessage('maxlength', true)).toBe('Value is too long');
     expect(defaultErrorMessage('min', null)).toBe('Value is too small');
     expect(defaultErrorMessage('max', undefined)).toBe('Value is too large');
+  });
+});
+
+describe('clearDismissibleErrors', () => {
+  it('drops every listed key', () => {
+    const control = new FormControl('');
+    control.setErrors({ manualValidateError: true, manualValidateErrorMsg: 'Nope' });
+
+    clearDismissibleErrors(control, ['manualValidateError', 'manualValidateErrorMsg']);
+
+    expect(control.errors).toBeNull();
+  });
+
+  it('leaves the keys nobody dismissed, without re-running the validators', () => {
+    // The surviving key is the point: a manual error is one nothing validates,
+    // so recomputing the map here would delete it.
+    const control = new FormControl('');
+    control.setErrors({ manualValidateError: true, bothOrNeither: true });
+
+    clearDismissibleErrors(control, ['manualValidateError']);
+
+    expect(control.errors).toEqual({ bothOrNeither: true });
+  });
+
+  it('re-runs the validators once nothing is left, so a still-failing one comes back', () => {
+    // A manual error REPLACES the map, so `minlength` is gone from it while the
+    // message is on screen. Clearing back to null has to ask the validators
+    // again rather than leave a one-entry array reporting VALID.
+    const entries = new FormArray([new FormControl('10.0.0.1')], Validators.minLength(2));
+    entries.setErrors({ manualValidateError: 'Pool "tank" is offline' });
+
+    clearDismissibleErrors(entries, ['manualValidateError']);
+
+    expect(entries.errors).toEqual({ minlength: { requiredLength: 2, actualLength: 1 } });
+    expect(entries.status).toBe('INVALID');
+  });
+
+  it('reports VALID once nothing fails any more', () => {
+    const control = new FormControl('logo.png', Validators.required);
+    control.setErrors({ manualValidateError: 'Upload failed' });
+
+    clearDismissibleErrors(control, ['manualValidateError']);
+
+    expect(control.errors).toBeNull();
+    expect(control.status).toBe('VALID');
   });
 });

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -99,9 +99,15 @@ export const TN_FORM_FIELD_DISMISSIBLE_ERRORS = new InjectionToken<readonly stri
  * sibling left behind would simply render the same message again with its own
  * close button. The opt-in list is what bounds this.
  *
- * `setErrors`, not a delete plus `updateValueAndValidity()`: re-running the
- * validators would recompute the whole map, and a manual error nothing validates
- * is exactly the kind that gets dismissed.
+ * `setErrors`, not a delete plus `updateValueAndValidity()`, while anything is
+ * left behind: re-running the validators would recompute the whole map, and a
+ * manual error nothing validates is exactly the kind that gets dismissed.
+ *
+ * When nothing is left there is no sibling to protect, and `setErrors(null)`
+ * alone would assert VALID on the validators' behalf — a manual error typically
+ * REPLACED the map an invalid control had, so a `minlength` the array still
+ * fails would stay gone until the next value change, and a submit in between
+ * would pass. Re-running them there is what restores the truth.
  *
  * @internal
  */
@@ -113,7 +119,12 @@ export function clearDismissibleErrors(
   for (const key of dismissible) {
     delete remaining[key];
   }
-  control.setErrors(Object.keys(remaining).length ? remaining : null);
+  if (Object.keys(remaining).length) {
+    control.setErrors(remaining);
+  } else {
+    control.setErrors(null);
+    control.updateValueAndValidity();
+  }
 }
 
 /**

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -225,8 +225,13 @@ export interface ResolveErrorMessageOptions {
   resolver?: TnFormFieldErrorResolver | null;
   /** The failing control, passed through to the resolver. */
   control?: AbstractControl | null;
-  /** Component selector, used only to attribute dev-mode error logs. */
-  selector: string;
+  /**
+   * Who is asking, used only to attribute the dev-mode `console.error` this
+   * logs when a caller-supplied message provider throws. Optional: the library's
+   * own components pass their selector so the log names the element on screen,
+   * and an outside caller has nothing useful to put here.
+   */
+  selector?: string;
 }
 
 /**
@@ -243,7 +248,7 @@ export interface ResolveErrorMessageOptions {
  * field-level one it sits beside.
  */
 export function resolveErrorMessage(options: ResolveErrorMessageOptions): string {
-  const { errors, errorMessages, resolver, control, selector } = options;
+  const { errors, errorMessages, resolver, control, selector = 'resolveErrorMessage' } = options;
 
   const key = activeErrorKey(errors);
   if (!key) {return 'Invalid input';}

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -68,6 +68,55 @@ export const TN_FORM_FIELD_ERRORS = new InjectionToken<TnFormFieldErrorResolver>
 );
 
 /**
+ * App-wide default for which error keys carry a dismiss button, for apps whose
+ * server-side failures always land under the same keys. A field's
+ * `dismissibleErrors` input overrides it — including with `[]`, to opt one field
+ * out of the default.
+ *
+ * Listing a key here grants permission to delete it: dismissing removes it from
+ * the control's errors, since a message the user can close but that will not go
+ * away is worse than no button at all.
+ *
+ * @example
+ * ```ts
+ * providers: [
+ *   {
+ *     provide: TN_FORM_FIELD_DISMISSIBLE_ERRORS,
+ *     useValue: ['manualValidateError', 'manualValidateErrorMsg'],
+ *   },
+ * ];
+ * ```
+ */
+export const TN_FORM_FIELD_DISMISSIBLE_ERRORS = new InjectionToken<readonly string[]>(
+  'TN_FORM_FIELD_DISMISSIBLE_ERRORS'
+);
+
+/**
+ * Removes every dismissible key a control currently carries, leaving the rest.
+ *
+ * All of them, not just the one behind the message: an app may spread a single
+ * failure across sibling keys — a flag, its message, a legacy alias — and a
+ * sibling left behind would simply render the same message again with its own
+ * close button. The opt-in list is what bounds this.
+ *
+ * `setErrors`, not a delete plus `updateValueAndValidity()`: re-running the
+ * validators would recompute the whole map, and a manual error nothing validates
+ * is exactly the kind that gets dismissed.
+ *
+ * @internal
+ */
+export function clearDismissibleErrors(
+  control: AbstractControl,
+  dismissible: readonly string[]
+): void {
+  const remaining = { ...control.errors };
+  for (const key of dismissible) {
+    delete remaining[key];
+  }
+  control.setErrors(Object.keys(remaining).length ? remaining : null);
+}
+
+/**
  * Built-in fallback messages for Angular's standard validators. Used only when
  * neither a per-field `errorMessages` entry nor a {@link TN_FORM_FIELD_ERRORS}
  * resolver supplies a message. English-only by design — override the others for

--- a/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.errors.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, isDevMode } from '@angular/core';
 import type { AbstractControl, ValidationErrors } from '@angular/forms';
 
 /**
@@ -134,4 +134,94 @@ export function activeErrorKey(errors: ValidationErrors): string | null {
     }
   }
   return Object.keys(errors)[0] ?? null;
+}
+
+/**
+ * Runs a caller-supplied message provider, swallowing any throw so a buggy
+ * override or resolver cannot break change detection. Logs in dev mode and
+ * returns null so resolution falls through to the next layer.
+ *
+ * A blank message counts as "no answer" and falls through too, so a
+ * translation service that returns `''` for a missing key does not hide the
+ * error behind an empty subscript.
+ *
+ * @internal
+ */
+function runGuarded(
+  provider: () => string | null | undefined,
+  selector: string,
+  context: string
+): string | null {
+  try {
+    const message = provider();
+    return message != null && message.trim() !== '' ? message : null;
+  } catch (error) {
+    if (isDevMode()) {
+      console.error(
+        `[${selector}] ${context} threw while resolving a validation message`,
+        error
+      );
+    }
+    return null;
+  }
+}
+
+/** What {@link resolveErrorMessage} needs to answer for one control. */
+export interface ResolveErrorMessageOptions {
+  /** The control's current errors — the caller has already checked it has some. */
+  errors: ValidationErrors;
+  /** Per-instance overrides, keyed by error key. Consulted first. */
+  errorMessages?: TnFormFieldErrorMessages;
+  /** The app-wide resolver from {@link TN_FORM_FIELD_ERRORS}, if one is provided. */
+  resolver?: TnFormFieldErrorResolver | null;
+  /** The failing control, passed through to the resolver. */
+  control?: AbstractControl | null;
+  /** Component selector, used only to attribute dev-mode error logs. */
+  selector: string;
+}
+
+/**
+ * Resolves a user-facing message for a control's active error, in the order
+ * `tn-form-field` has always used:
+ *
+ * 1. a per-instance `errorMessages` override (string or factory),
+ * 2. the app-wide {@link TN_FORM_FIELD_ERRORS} resolver,
+ * 3. {@link defaultErrorMessage} for Angular's standard validators,
+ * 4. the error value itself, when a custom validator returned its own string,
+ * 5. the raw error key.
+ *
+ * Shared with `tn-form-errors` so a group-level message reads exactly like the
+ * field-level one it sits beside.
+ */
+export function resolveErrorMessage(options: ResolveErrorMessageOptions): string {
+  const { errors, errorMessages, resolver, control, selector } = options;
+
+  const key = activeErrorKey(errors);
+  if (!key) {return 'Invalid input';}
+
+  const value = errors[key];
+
+  const override = errorMessages?.[key];
+  if (override != null) {
+    const message = runGuarded(
+      () => (typeof override === 'function' ? override(value) : override),
+      selector,
+      `errorMessages["${key}"]`
+    );
+    if (message != null) {return message;}
+  }
+
+  const resolved = runGuarded(
+    () => resolver?.(key, value, control ?? null),
+    selector,
+    'TN_FORM_FIELD_ERRORS resolver'
+  );
+  if (resolved != null) {return resolved;}
+
+  const builtIn = defaultErrorMessage(key, value);
+  if (builtIn != null) {return builtIn;}
+
+  if (typeof value === 'string') {return value;}
+
+  return key;
 }

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -34,6 +34,7 @@ export class TnFormFieldHarness extends ComponentHarness {
   private _error = this.locatorForOptional('.tn-form-field-error');
   private _hint = this.locatorForOptional('.tn-form-field-hint');
   private _tooltip = this.locatorForOptional('.tn-form-field-tooltip');
+  private _dismiss = this.locatorForOptional('.tn-form-field-error-dismiss button');
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a form field
@@ -113,6 +114,45 @@ export class TnFormFieldHarness extends ComponentHarness {
   async hasError(): Promise<boolean> {
     const error = await this._error();
     return error !== null;
+  }
+
+  /**
+   * Checks whether the shown error carries a dismiss button — true only when the
+   * active error key is one of the field's `dismissibleErrors`.
+   *
+   * @returns Promise resolving to true if the dismiss button is present.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Image' }));
+   * expect(await field.isErrorDismissible()).toBe(true);
+   * ```
+   */
+  async isErrorDismissible(): Promise<boolean> {
+    return (await this._dismiss()) !== null;
+  }
+
+  /**
+   * Clicks the dismiss button, as a user clearing a server-side error would.
+   *
+   * The field only emits `dismiss` — clearing the error is the consumer's job —
+   * so what the message does next depends on the handler under test.
+   *
+   * @throws If the shown error is not dismissible.
+   *
+   * @example
+   * ```typescript
+   * const field = await loader.getHarness(TnFormFieldHarness.with({ label: 'Image' }));
+   * await field.dismissError();
+   * expect(await field.hasError()).toBe(false);
+   * ```
+   */
+  async dismissError(): Promise<void> {
+    const button = await this._dismiss();
+    if (!button) {
+      throw new Error('Cannot dismiss: the form field shows no dismissible error.');
+    }
+    await button.click();
   }
 
   /**

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.ts
@@ -135,8 +135,10 @@ export class TnFormFieldHarness extends ComponentHarness {
   /**
    * Clicks the dismiss button, as a user clearing a server-side error would.
    *
-   * The field only emits `dismiss` — clearing the error is the consumer's job —
-   * so what the message does next depends on the handler under test.
+   * The field clears the error itself — every key in its `dismissibleErrors`
+   * that the control carries — puts focus back on the control, and then emits
+   * `dismiss` with the key that was on screen, so the message is gone by the
+   * time this resolves.
    *
    * @throws If the shown error is not dismissible.
    *

--- a/projects/truenas-ui/src/lib/form-list/form-list-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list-a11y.spec.ts
@@ -1,0 +1,146 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormArray, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TnFormListItemComponent } from './form-list-item.component';
+import { TnFormListComponent } from './form-list.component';
+import { axeResult, axeScan } from '../a11y/axe-testing';
+import { TnInputComponent } from '../input/input.component';
+
+/**
+ * The accessibility guard for `tn-form-list` and its entries.
+ *
+ * WHY A DISABLED LIST IS `aria-disabled` AND NOT `inert`
+ * -----------------------------------------------------
+ * The first fix for a locked list put `inert` on the entries. It closed a real
+ * keyboard hole — the fields and remove buttons are projected content, so
+ * `pointer-events: none` stopped the mouse and left the keyboard reaching every
+ * one of them — but it closed it by removing a subtree that is still ON SCREEN
+ * from the accessibility tree. A sighted user reads the dimmed addresses; a
+ * screen-reader user got nothing at all where they are. That is strictly less
+ * than a native disabled control, which stays in the tree and announces as
+ * unavailable.
+ *
+ * So the lock is now three narrower pieces, guarded below:
+ *
+ *   - `aria-disabled="true"` on the `role="group"` element, which is the role
+ *     that supports the attribute — a `div` with no role would fail
+ *     `aria-allowed-attr`, and that is asserted rather than assumed;
+ *   - `disabled` on Add and on every entry's remove button, reached over
+ *     `TN_FORM_LIST_CONTEXT` (see `form-list.component.spec.ts`);
+ *   - the fields themselves, which stay the consumer's `entries.disable()`.
+ *
+ * THE GROUP IS NAMED BY ITS LABEL TEXT ALONE
+ * ------------------------------------------
+ * `aria-labelledby` points at the label span and not at the header, so the name
+ * does not absorb the tooltip trigger and the Add button and repeat both on
+ * every field inside the list.
+ */
+
+@Component({
+  selector: 'tn-form-list-a11y-host',
+  standalone: true,
+  imports: [ReactiveFormsModule, TnFormListComponent, TnFormListItemComponent, TnInputComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-form-list
+      label="Allowed addresses"
+      tooltip="One address per entry"
+      [control]="entries"
+      [disabled]="disabled()"
+    >
+      @for (entry of entries.controls; track entry) {
+        <tn-form-list-item label="address">
+          <tn-input ariaLabel="Address" [formControl]="entry" />
+        </tn-form-list-item>
+      }
+    </tn-form-list>
+  `,
+})
+class FormListA11yHostComponent {
+  readonly entries = new FormArray([new FormControl('10.0.0.1')]);
+  readonly disabled = signal(false);
+}
+
+describe('tn-form-list accessibility', () => {
+  let host: FormListA11yHostComponent;
+  let fixture: ComponentFixture<FormListA11yHostComponent>;
+
+  const group = (): HTMLElement => fixture.nativeElement.querySelector('.tn-form-list');
+  const items = (): HTMLElement => fixture.nativeElement.querySelector('.tn-form-list__items');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormListA11yHostComponent],
+    }).compileComponents();
+
+    // Attached to the document, because axe exempts every node of a detached
+    // tree and would report a clean scan whatever the markup says.
+    fixture = TestBed.createComponent(FormListA11yHostComponent);
+    document.body.appendChild(fixture.nativeElement);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.nativeElement.remove();
+  });
+
+  it('puts aria-disabled on the element that carries a role supporting it', async () => {
+    host.disabled.set(true);
+    fixture.detectChanges();
+
+    const { violated, evaluated } = await axeResult(
+      fixture.nativeElement, group(), ['aria-allowed-attr', 'aria-valid-attr-value']
+    );
+
+    expect(violated).toEqual([]);
+    // Non-vacuous: this is the element carrying `aria-disabled` and
+    // `aria-labelledby`, so both rules have something here to look at. It is
+    // also the assertion that fails if the attribute moves back down onto the
+    // role-less `.tn-form-list__items` div.
+    expect(evaluated).toContain('aria-allowed-attr');
+    expect(group().getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('leaves the entries readable to assistive technology while the list is locked', () => {
+    host.disabled.set(true);
+    fixture.detectChanges();
+
+    // The values are dimmed, not hidden — so nothing may take them out of the
+    // accessibility tree. All three of these do.
+    expect(items().hasAttribute('inert')).toBe(false);
+    expect(items().hasAttribute('aria-hidden')).toBe(false);
+    expect(items().hidden).toBe(false);
+    expect(fixture.nativeElement.querySelector('input')).not.toBeNull();
+  });
+
+  it('names the group by its label text alone, not by the whole header', () => {
+    const labelledby = group().getAttribute('aria-labelledby');
+    const named: HTMLElement = fixture.nativeElement.querySelector(`#${labelledby}`);
+
+    expect(named.textContent?.trim()).toBe('Allowed addresses');
+    // The tooltip trigger and Add sit in the header beside the label span; if
+    // the id moved up to the header they would be read on every field inside.
+    expect(named.querySelector('button')).toBeNull();
+    expect(named.querySelector('tn-button')).toBeNull();
+  });
+
+  describe('the whole list, with no rule named in advance', () => {
+    it.each([
+      ['editable', () => { /* the default fixture */ }],
+      ['disabled', () => host.disabled.set(true)],
+    ])('has nothing for axe to report when %s', async (_name, arrange) => {
+      arrange();
+      fixture.detectChanges();
+
+      const { violations, incomplete, passed } = await axeScan(fixture);
+
+      expect(violations).toEqual([]);
+      expect(incomplete).toEqual([]);
+      // Stops the two assertions above going vacuous: a scan that matched no
+      // rule at all returns empty too, and only `passed` tells the two apart.
+      expect(passed).toContain('button-name');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/form-list/form-list-context.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list-context.ts
@@ -1,0 +1,25 @@
+import { InjectionToken } from '@angular/core';
+import type { Signal } from '@angular/core';
+
+/**
+ * What a `tn-form-list-item` needs to know about the list it was projected
+ * into. Published over DI rather than passed as an input, so that locking a
+ * list is one binding on the list and not one on every entry the consumer
+ * writes inside its `@for`.
+ *
+ * A projected entry's element injector chains through the `tn-form-list` it is
+ * declared inside, the same way a control projected into `tn-form-field` reaches
+ * {@link TN_FORM_FIELD_CONTEXT}. An entry used on its own injects nothing and
+ * falls back to its own defaults.
+ *
+ * Its own file, and not `form-list.component.ts`, because the list already
+ * imports the item to count its entries — a token declared beside either
+ * component would make that import cycle.
+ */
+export interface TnFormListContext {
+  /** Whether the enclosing list is locked, so an entry can disable its remove button. */
+  disabled: Signal<boolean>;
+}
+
+/** DI token under which `tn-form-list` exposes its {@link TnFormListContext}. */
+export const TN_FORM_LIST_CONTEXT = new InjectionToken<TnFormListContext>('TN_FORM_LIST_CONTEXT');

--- a/projects/truenas-ui/src/lib/form-list/form-list-item.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list-item.component.html
@@ -6,6 +6,7 @@
       library="mdi"
       size="sm"
       [ariaLabel]="resolvedRemoveAriaLabel()"
+      [disabled]="resolvedDisabled()"
       [testId]="resolvedTestId()"
       (onClick)="delete.emit()"
     />

--- a/projects/truenas-ui/src/lib/form-list/form-list-item.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list-item.component.html
@@ -1,0 +1,17 @@
+<div class="tn-form-list-item">
+  @if (canDelete()) {
+    <tn-icon-button
+      class="tn-form-list-item__remove"
+      name="close"
+      library="mdi"
+      size="sm"
+      [ariaLabel]="resolvedRemoveAriaLabel()"
+      [testId]="resolvedTestId()"
+      (onClick)="delete.emit()"
+    />
+  }
+
+  <div class="tn-form-list-item__content">
+    <ng-content />
+  </div>
+</div>

--- a/projects/truenas-ui/src/lib/form-list/form-list-item.component.scss
+++ b/projects/truenas-ui/src/lib/form-list/form-list-item.component.scss
@@ -1,0 +1,34 @@
+:host {
+  display: block;
+}
+
+.tn-form-list-item {
+  position: relative;
+  border: 1px solid var(--tn-lines, var(--tn-fg4, #d0d5dd));
+  border-radius: var(--tn-radius, 4px);
+  background: var(--tn-alt-bg1, transparent);
+  padding: 0.75rem;
+}
+
+// Sits in the item's top-right corner rather than in the flow, so a one-field
+// entry does not get a row of its own for the button and the fields keep the
+// full width.
+.tn-form-list-item__remove {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  z-index: 1;
+}
+
+// Stacked controls need their own rhythm: tn-form-field carries no outer
+// margin, so without this the fields inside one entry sit flush together.
+.tn-form-list-item__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+
+  // Leave room for the absolutely-positioned remove button, so a full-width
+  // first control does not run underneath it.
+  padding-right: 1.5rem;
+}

--- a/projects/truenas-ui/src/lib/form-list/form-list-item.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list-item.component.ts
@@ -1,0 +1,60 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { TnIconButtonComponent } from '../icon-button/icon-button.component';
+import { TnTestIdDirective } from '../test-id';
+import type { TnTestIdValue } from '../test-id';
+
+/**
+ * One entry of a {@link TnFormListComponent} — a bordered card holding the
+ * controls for a single element of the form array, with the control that
+ * removes it.
+ *
+ * The item owns only the frame and the remove button; the controls inside are
+ * the consumer's, bound to that element's `FormGroup`.
+ */
+@Component({
+  selector: 'tn-form-list-item',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TnIconButtonComponent, TnTestIdDirective],
+  templateUrl: './form-list-item.component.html',
+  styleUrls: ['./form-list-item.component.scss'],
+})
+export class TnFormListItemComponent {
+  /**
+   * Whether this entry can be removed. Turn it off for an entry the form
+   * requires — the button disappears rather than being disabled, since a
+   * permanently disabled control tells the user nothing about why.
+   */
+  canDelete = input<boolean>(true);
+
+  /**
+   * What one entry is called, in the singular ('ACL entry', 'Portal'). Used to
+   * name the remove button, which is icon-only and has nothing else to be
+   * named by. Pass it already translated.
+   */
+  label = input<string>('');
+
+  /**
+   * Accessible name for the remove button. Defaults to `Remove <label>`, or
+   * plain `Remove` when there is no label. Set it to translate the wording —
+   * the library ships English only.
+   */
+  removeAriaLabel = input<string>('');
+
+  /** Test-id base for the remove button (`icon-button-` prefixed). */
+  testId = input<TnTestIdValue>(undefined);
+
+  /** Emitted when the remove button is pressed. Removing is the consumer's. */
+  delete = output<void>();
+
+  protected resolvedRemoveAriaLabel = computed(() => {
+    const explicit = this.removeAriaLabel().trim();
+    if (explicit) {
+      return explicit;
+    }
+    const label = this.label().trim();
+    return label ? `Remove ${label}` : 'Remove';
+  });
+
+  protected resolvedTestId = computed(() => this.testId() ?? ['remove-from-list', this.label()]);
+}

--- a/projects/truenas-ui/src/lib/form-list/form-list-item.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list-item.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { TN_FORM_LIST_CONTEXT } from './form-list-context';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective } from '../test-id';
 import type { TnTestIdValue } from '../test-id';
@@ -41,11 +42,28 @@ export class TnFormListItemComponent {
    */
   removeAriaLabel = input<string>('');
 
+  /**
+   * Disables the remove button — the entry stays readable, the control just
+   * stops working, the way a native disabled control does.
+   *
+   * Left unset it follows the enclosing `tn-form-list`'s own `disabled`, so
+   * locking a list is one binding on the list rather than one per entry. Set it
+   * explicitly to lock a single entry inside an otherwise editable list.
+   */
+  disabled = input<boolean | undefined>(undefined);
+
   /** Test-id base for the remove button (`icon-button-` prefixed). */
   testId = input<TnTestIdValue>(undefined);
 
   /** Emitted when the remove button is pressed. Removing is the consumer's. */
   delete = output<void>();
+
+  /** Absent when the entry is used outside a `tn-form-list`. */
+  private list = inject(TN_FORM_LIST_CONTEXT, { optional: true });
+
+  protected resolvedDisabled = computed(
+    () => this.disabled() ?? this.list?.disabled() ?? false,
+  );
 
   protected resolvedRemoveAriaLabel = computed(() => {
     const explicit = this.removeAriaLabel().trim();

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.html
@@ -1,0 +1,57 @@
+<div
+  class="tn-form-list"
+  role="group"
+  tnTestIdType="form-list"
+  [tnTestId]="testId()"
+  [attr.aria-labelledby]="label() ? labelId : null"
+>
+  @if (label() || canAdd()) {
+    <div class="tn-form-list__header">
+      @if (label()) {
+        <span class="tn-form-list__label" [class.required]="required()">
+          <span [id]="labelId" [innerHTML]="label() | tnLabelMarkup"></span>
+          @if (required()) {
+            <span class="required-asterisk" aria-label="required">*</span>
+          }
+        </span>
+
+        @if (tooltip()) {
+          <button
+            type="button"
+            class="tn-form-list__tooltip"
+            [attr.aria-label]="tooltipAriaLabel()"
+            [tnTooltip]="tooltip()"
+            [tnTooltipPosition]="tooltipPosition()"
+          >
+            <tn-icon name="help-circle" library="mdi" size="sm" />
+          </button>
+        }
+      }
+
+      @if (canAdd()) {
+        <tn-button
+          class="tn-form-list__add"
+          variant="filled"
+          color="default"
+          [label]="addLabel()"
+          [ariaLabel]="addAriaLabel()"
+          [disabled]="disabled()"
+          [testId]="['add-item', label()]"
+          (onClick)="add.emit()"
+        />
+      }
+    </div>
+  }
+
+  @if (control(); as control) {
+    <tn-form-errors [control]="control" [errorMessages]="errorMessages()" />
+  }
+
+  <div class="tn-form-list__items" [class.tn-form-list__items--disabled]="disabled()">
+    <ng-content />
+
+    @if (isEmpty()) {
+      <p class="tn-form-list__empty">{{ emptyMessage() }}</p>
+    }
+  </div>
+</div>

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.html
@@ -1,9 +1,16 @@
+<!-- aria-disabled rather than `inert` on the entries: they stay VISIBLE while
+     the list is locked, and `inert` would take the addresses a sighted user can
+     still read straight out of the accessibility tree. A native disabled control
+     stays in the tree and announces as unavailable, and this says the same about
+     the group. `aria-disabled` lives here, on the element that carries the role
+     that supports it. -->
 <div
   class="tn-form-list"
   role="group"
   tnTestIdType="form-list"
   [tnTestId]="testId()"
   [attr.aria-labelledby]="label() ? labelId : null"
+  [attr.aria-disabled]="disabled() ? 'true' : null"
 >
   @if (label() || canAdd()) {
     <div class="tn-form-list__header">
@@ -44,14 +51,19 @@
   }
 
   @if (control(); as control) {
-    <tn-form-errors [control]="control" [errorMessages]="errorMessages()" />
+    <tn-form-errors
+      [control]="control"
+      [errorMessages]="errorMessages()"
+      [showWhenUntouched]="showErrorWhenUntouched()"
+      [dismissibleErrors]="dismissibleErrors()"
+      [dismissAriaLabel]="dismissAriaLabel()"
+      [dismissTooltip]="dismissTooltip()"
+      [testId]="testId()"
+      (dismiss)="dismiss.emit($event)"
+    />
   }
 
-  <div
-    class="tn-form-list__items"
-    [class.tn-form-list__items--disabled]="disabled()"
-    [attr.inert]="disabled() ? '' : null"
-  >
+  <div class="tn-form-list__items" [class.tn-form-list__items--disabled]="disabled()">
     <ng-content />
 
     @if (isEmpty()) {

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.html
@@ -10,9 +10,10 @@
   tnTestIdType="form-list"
   [tnTestId]="testId()"
   [attr.aria-labelledby]="label() ? labelId : null"
+  [attr.aria-describedby]="describedBy()"
   [attr.aria-disabled]="disabled() ? 'true' : null"
 >
-  @if (label() || canAdd()) {
+  @if (label() || tooltip() || canAdd()) {
     <div class="tn-form-list__header">
       @if (label()) {
         <span class="tn-form-list__label" [class.required]="required()">
@@ -21,18 +22,21 @@
             <span class="required-asterisk" aria-label="required">*</span>
           }
         </span>
+      }
 
-        @if (tooltip()) {
-          <button
-            type="button"
-            class="tn-form-list__tooltip"
-            [attr.aria-label]="tooltipAriaLabel()"
-            [tnTooltip]="tooltip()"
-            [tnTooltipPosition]="tooltipPosition()"
-          >
-            <tn-icon name="help-circle" library="mdi" size="sm" />
-          </button>
-        }
+      <!-- Outside the label's @if: a tooltip is bound to be shown, and one on a
+           label-less list rendering nothing at all is the one outcome with no
+           way for the consumer to notice. -->
+      @if (tooltip()) {
+        <button
+          type="button"
+          class="tn-form-list__tooltip"
+          [attr.aria-label]="tooltipAriaLabel()"
+          [tnTooltip]="tooltip()"
+          [tnTooltipPosition]="tooltipPosition()"
+        >
+          <tn-icon name="help-circle" library="mdi" size="sm" />
+        </button>
       }
 
       @if (canAdd()) {

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.html
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.html
@@ -47,7 +47,11 @@
     <tn-form-errors [control]="control" [errorMessages]="errorMessages()" />
   }
 
-  <div class="tn-form-list__items" [class.tn-form-list__items--disabled]="disabled()">
+  <div
+    class="tn-form-list__items"
+    [class.tn-form-list__items--disabled]="disabled()"
+    [attr.inert]="disabled() ? '' : null"
+  >
     <ng-content />
 
     @if (isEmpty()) {

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.scss
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.scss
@@ -61,6 +61,11 @@
   gap: 0.75rem;
   min-width: 0;
 
+  // The visual half of a disabled list. The interactive half is `inert` on the same element in
+  // the template, and it is the half that matters: entries are projected content, so
+  // `pointer-events: none` alone dimmed them for the mouse while leaving every consumer control
+  // — the entry inputs and each `tn-form-list-item` remove button — in the tab order, where
+  // Enter still emitted `delete` against a list the consumer had marked read-only.
   &--disabled {
     opacity: var(--tn-disabled-opacity, 0.5);
     pointer-events: none;

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.scss
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.scss
@@ -61,11 +61,12 @@
   gap: 0.75rem;
   min-width: 0;
 
-  // The visual half of a disabled list. The interactive half is `inert` on the same element in
-  // the template, and it is the half that matters: entries are projected content, so
-  // `pointer-events: none` alone dimmed them for the mouse while leaving every consumer control
-  // — the entry inputs and each `tn-form-list-item` remove button — in the tab order, where
-  // Enter still emitted `delete` against a list the consumer had marked read-only.
+  // The visual half of a disabled list, and the mouse half. It is deliberately
+  // not the whole lock: the remove buttons are disabled through
+  // `TN_FORM_LIST_CONTEXT`, and the fields are projected content, so a consumer
+  // who needs them locked for the keyboard too calls `disable()` on the
+  // `FormArray`. `inert` here would have covered all of it in one line, at the
+  // cost of deleting a still-visible list from the accessibility tree.
   &--disabled {
     opacity: var(--tn-disabled-opacity, 0.5);
     pointer-events: none;

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.scss
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.scss
@@ -1,0 +1,77 @@
+@use '../pipes/label-markup/label-markup' as label-markup;
+
+:host {
+  display: block;
+}
+
+.tn-form-list__header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+}
+
+.tn-form-list__label {
+  color: var(--tn-fg1, #333);
+  font-family: var(--tn-font-family-body, 'Inter'), sans-serif;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.4;
+
+  @include label-markup.inline-code;
+
+  &.required .required-asterisk {
+    color: var(--tn-error, var(--tn-red, #bd2626));
+    margin-left: 0.25rem;
+  }
+}
+
+// Pushes Add to the trailing edge whether or not there is a label beside it.
+.tn-form-list__add {
+  margin-left: auto;
+}
+
+.tn-form-list__tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--tn-fg2, #6c757d);
+  cursor: help;
+  line-height: 0;
+
+  &:hover,
+  &:focus-visible {
+    // Icon-only, so 3:1 applies.
+    color: var(--tn-primary, #007bff);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--tn-primary, #007bff);
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
+}
+
+.tn-form-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+
+  &--disabled {
+    opacity: var(--tn-disabled-opacity, 0.5);
+    pointer-events: none;
+  }
+}
+
+.tn-form-list__empty {
+  color: var(--tn-fg2, #6c757d);
+  font-size: 0.875rem;
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px dashed var(--tn-lines, var(--tn-fg4, #d0d5dd));
+  border-radius: var(--tn-radius, 4px);
+}

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
@@ -27,6 +27,7 @@ class HostComponent {
   readonly entries = new FormArray<FormControl<string | null>>([], Validators.minLength(2));
 
   readonly label = signal('Allowed addresses');
+  readonly tooltip = signal('');
   readonly required = signal(false);
   readonly canAdd = signal(true);
   readonly canDelete = signal(true);
@@ -309,6 +310,59 @@ describe('TnFormListComponent', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('.tn-form-errors')).toBeNull();
+    });
+
+    it('describes the group by the message, so tabbing in later still finds it', () => {
+      // role="alert" only covers the moment it appears.
+      host.entries.push(new FormControl(''));
+      host.entries.markAllAsTouched();
+      fixture.detectChanges();
+
+      const group: HTMLElement = fixture.nativeElement.querySelector('[role="group"]');
+      const message: HTMLElement = fixture.nativeElement.querySelector('.tn-form-errors');
+
+      expect(group.getAttribute('aria-describedby')).toBe(message.id);
+      expect(message.id).toBeTruthy();
+    });
+
+    it('describes the group by nothing while no message is on screen', () => {
+      const group: HTMLElement = fixture.nativeElement.querySelector('[role="group"]');
+
+      expect(group.getAttribute('aria-describedby')).toBeNull();
+    });
+
+    it('stops describing the group once the message goes', () => {
+      host.entries.push(new FormControl(''));
+      host.entries.markAllAsTouched();
+      fixture.detectChanges();
+      host.entries.push(new FormControl(''));
+      fixture.detectChanges();
+
+      const group: HTMLElement = fixture.nativeElement.querySelector('[role="group"]');
+
+      expect(group.getAttribute('aria-describedby')).toBeNull();
+    });
+  });
+
+  describe('the help tooltip', () => {
+    it('renders on a list with no label, rather than going with it', () => {
+      host.label.set('');
+      host.tooltip.set('One address per entry');
+      fixture.detectChanges();
+
+      const trigger: HTMLElement = fixture.nativeElement.querySelector('.tn-form-list__tooltip');
+
+      expect(trigger).not.toBeNull();
+      expect(trigger.getAttribute('aria-label')).toBe('One address per entry');
+    });
+
+    it('renders on a list with no label and no Add, which has no header otherwise', () => {
+      host.label.set('');
+      host.canAdd.set(false);
+      host.tooltip.set('One address per entry');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.tn-form-list__tooltip')).not.toBeNull();
     });
   });
 });

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
@@ -31,6 +31,7 @@ class HostComponent {
   readonly canAdd = signal(true);
   readonly canDelete = signal(true);
   readonly disabled = signal(false);
+  readonly lockFirstEntry = signal(false);
   readonly empty = signal<boolean | undefined>(undefined);
   /** Entry-level controls the consumer projects alongside the fields. */
   readonly entryActions = signal(false);
@@ -144,22 +145,56 @@ describe('TnFormListComponent', () => {
       expect(host.entries.length).toBe(0);
     });
 
-    it('takes the entries out of the tab order too, not just out of reach of the mouse', () => {
+    it('says the group is disabled, rather than hiding it', () => {
       host.entries.push(new FormControl('first'));
       host.disabled.set(true);
       fixture.detectChanges();
 
-      // The entries are projected, so a guard inside this component cannot reach them: without
-      // `inert` a keyboard user still tabs into the field and onto the remove button, and Enter
-      // there deletes from a list the consumer said may not be edited.
-      const items: HTMLElement = fixture.nativeElement.querySelector('.tn-form-list__items');
+      // `aria-disabled` and not `inert`: the entries are still on screen, and a
+      // screen-reader user has to be able to read the values a sighted user is
+      // being shown but not allowed to edit. It sits on the `role="group"`
+      // element, which is the role that supports the attribute.
+      const group: HTMLElement = fixture.nativeElement.querySelector('.tn-form-list');
 
-      expect(items.hasAttribute('inert')).toBe(true);
+      expect(group.getAttribute('role')).toBe('group');
+      expect(group.getAttribute('aria-disabled')).toBe('true');
+      expect(fixture.nativeElement.querySelector('[inert]')).toBeNull();
 
       host.disabled.set(false);
       fixture.detectChanges();
 
-      expect(items.hasAttribute('inert')).toBe(false);
+      expect(group.hasAttribute('aria-disabled')).toBe(false);
+    });
+
+    it('disables each entry remove button, so the keyboard cannot delete from a locked list', async () => {
+      host.entries.push(new FormControl('first'));
+      fixture.detectChanges();
+
+      const [entry] = await list.getItems();
+
+      expect(await entry.isRemoveDisabled()).toBe(false);
+
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      // Reached over TN_FORM_LIST_CONTEXT, so the consumer binds `disabled` on
+      // the list alone and not again inside its own @for.
+      expect(await entry.isRemoveDisabled()).toBe(true);
+
+      await entry.remove();
+      fixture.detectChanges();
+
+      expect(host.entries.length).toBe(1);
+    });
+
+    it('lets one entry be locked inside an editable list', async () => {
+      host.entries.push(new FormControl('first'));
+      host.lockFirstEntry.set(true);
+      fixture.detectChanges();
+
+      const [entry] = await list.getItems();
+
+      expect(await entry.isRemoveDisabled()).toBe(true);
     });
   });
 

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
@@ -1,0 +1,195 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormArray, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TnFormListItemComponent } from './form-list-item.component';
+import { TnFormListComponent } from './form-list.component';
+import { TnFormListHarness } from './form-list.harness';
+import { TnInputComponent } from '../input/input.component';
+
+@Component({
+  selector: 'tn-form-list-host',
+  imports: [ReactiveFormsModule, TnFormListComponent, TnFormListItemComponent, TnInputComponent],
+  templateUrl: './test-hosts/form-list-host.component.html',
+})
+class HostComponent {
+  readonly entries = new FormArray<FormControl<string | null>>([], Validators.minLength(2));
+
+  readonly label = signal('Allowed addresses');
+  readonly required = signal(false);
+  readonly canAdd = signal(true);
+  readonly canDelete = signal(true);
+  readonly disabled = signal(false);
+  readonly empty = signal<boolean | undefined>(undefined);
+
+  addEntry(): void {
+    this.entries.push(new FormControl(''));
+  }
+
+  removeEntry(index: number): void {
+    this.entries.removeAt(index);
+  }
+}
+
+describe('TnFormListComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+  let loader: HarnessLoader;
+  let list: TnFormListHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [HostComponent] }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    list = await loader.getHarness(TnFormListHarness);
+  });
+
+  describe('growing and shrinking the array', () => {
+    it('starts empty, and says so', async () => {
+      expect(await list.getItemCount()).toBe(0);
+      expect(await list.isEmpty()).toBe(true);
+      expect(await list.getEmptyMessage()).toBe('No items have been added yet.');
+    });
+
+    it('asks the consumer to append — it does not touch the array itself', async () => {
+      await list.add();
+      fixture.detectChanges();
+
+      expect(host.entries.length).toBe(1);
+      expect(await list.getItemCount()).toBe(1);
+      expect(await list.isEmpty()).toBe(false);
+    });
+
+    it('asks the consumer to remove the entry that was pressed', async () => {
+      host.entries.push(new FormControl('first'));
+      host.entries.push(new FormControl('second'));
+      fixture.detectChanges();
+
+      const [first] = await list.getItems();
+      await first.remove();
+      fixture.detectChanges();
+
+      expect(host.entries.value).toEqual(['second']);
+    });
+
+    it('stays quiet while the entries are still loading, if told to', async () => {
+      host.empty.set(false);
+      fixture.detectChanges();
+
+      expect(await list.getItemCount()).toBe(0);
+      expect(await list.isEmpty()).toBe(false);
+    });
+
+    it('goes back to the empty message when the last entry is removed', async () => {
+      host.entries.push(new FormControl('only'));
+      fixture.detectChanges();
+
+      const [only] = await list.getItems();
+      await only.remove();
+      fixture.detectChanges();
+
+      expect(await list.isEmpty()).toBe(true);
+    });
+  });
+
+  describe('what the consumer can turn off', () => {
+    it('hides Add at a maximum length', async () => {
+      host.canAdd.set(false);
+      fixture.detectChanges();
+
+      expect(await list.canAdd()).toBe(false);
+    });
+
+    it('hides the remove button on an entry the form requires', async () => {
+      host.entries.push(new FormControl('fixed'));
+      host.canDelete.set(false);
+      fixture.detectChanges();
+
+      const [only] = await list.getItems();
+
+      expect(await only.canRemove()).toBe(false);
+    });
+
+    it('disables Add for a list the user may not edit', async () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      expect(await list.isAddDisabled()).toBe(true);
+
+      await list.add();
+      fixture.detectChanges();
+
+      expect(host.entries.length).toBe(0);
+    });
+  });
+
+  describe('naming the group', () => {
+    it('names the group by its label, and nothing else in the header', () => {
+      const group: HTMLElement = fixture.nativeElement.querySelector('[role="group"]');
+      const labelId = group.getAttribute('aria-labelledby');
+
+      expect(labelId).toBeTruthy();
+      expect(fixture.nativeElement.querySelector(`#${labelId}`)?.textContent?.trim())
+        .toBe('Allowed addresses');
+    });
+
+    it('names Add after the list it adds to, not a bare "Add"', () => {
+      const add: HTMLElement = fixture.nativeElement.querySelector('.tn-form-list__add button');
+
+      expect(add.getAttribute('aria-label')).toBe('Add Allowed addresses');
+    });
+
+    it('names each remove button after one entry, in the singular', async () => {
+      host.entries.push(new FormControl(''));
+      fixture.detectChanges();
+
+      const remove: HTMLElement = fixture.nativeElement
+        .querySelector('.tn-form-list-item__remove button');
+
+      expect(remove.getAttribute('aria-label')).toBe('Remove address');
+    });
+
+    it('marks a required list, without putting the asterisk in the name', async () => {
+      host.required.set(true);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.required-asterisk')).not.toBeNull();
+      expect(await list.getLabel()).toBe('Allowed addresses');
+    });
+
+    it('leaves the group unnamed rather than naming it something wrong', () => {
+      host.label.set('');
+      fixture.detectChanges();
+
+      const group: HTMLElement = fixture.nativeElement.querySelector('[role="group"]');
+
+      expect(group.getAttribute('aria-labelledby')).toBeNull();
+    });
+  });
+
+  describe('the array-level error', () => {
+    it('shows an error that belongs to the array, once it is touched', () => {
+      host.entries.push(new FormControl(''));
+      host.entries.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(host.entries.errors).toEqual({ minlength: expect.anything() });
+      expect(fixture.nativeElement.querySelector('.tn-form-errors')?.textContent?.trim())
+        .toBe('Minimum length is 2');
+    });
+
+    it('shows nothing while the array satisfies it', () => {
+      host.entries.push(new FormControl(''));
+      host.entries.push(new FormControl(''));
+      host.entries.markAllAsTouched();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.tn-form-errors')).toBeNull();
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.spec.ts
@@ -7,11 +7,20 @@ import { FormArray, FormControl, ReactiveFormsModule, Validators } from '@angula
 import { TnFormListItemComponent } from './form-list-item.component';
 import { TnFormListComponent } from './form-list.component';
 import { TnFormListHarness } from './form-list.harness';
+import { TnButtonComponent } from '../button/button.component';
+import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnInputComponent } from '../input/input.component';
 
 @Component({
   selector: 'tn-form-list-host',
-  imports: [ReactiveFormsModule, TnFormListComponent, TnFormListItemComponent, TnInputComponent],
+  imports: [
+    ReactiveFormsModule,
+    TnButtonComponent,
+    TnFormListComponent,
+    TnFormListItemComponent,
+    TnIconButtonComponent,
+    TnInputComponent,
+  ],
   templateUrl: './test-hosts/form-list-host.component.html',
 })
 class HostComponent {
@@ -23,6 +32,14 @@ class HostComponent {
   readonly canDelete = signal(true);
   readonly disabled = signal(false);
   readonly empty = signal<boolean | undefined>(undefined);
+  /** Entry-level controls the consumer projects alongside the fields. */
+  readonly entryActions = signal(false);
+
+  readonly tested: number[] = [];
+
+  testEntry(index: number): void {
+    this.tested.push(index);
+  }
 
   addEntry(): void {
     this.entries.push(new FormControl(''));
@@ -125,6 +142,73 @@ describe('TnFormListComponent', () => {
       fixture.detectChanges();
 
       expect(host.entries.length).toBe(0);
+    });
+
+    it('takes the entries out of the tab order too, not just out of reach of the mouse', () => {
+      host.entries.push(new FormControl('first'));
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      // The entries are projected, so a guard inside this component cannot reach them: without
+      // `inert` a keyboard user still tabs into the field and onto the remove button, and Enter
+      // there deletes from a list the consumer said may not be edited.
+      const items: HTMLElement = fixture.nativeElement.querySelector('.tn-form-list__items');
+
+      expect(items.hasAttribute('inert')).toBe(true);
+
+      host.disabled.set(false);
+      fixture.detectChanges();
+
+      expect(items.hasAttribute('inert')).toBe(false);
+    });
+  });
+
+  describe('telling its own controls apart from the ones the consumer projects', () => {
+    beforeEach(() => {
+      host.entries.push(new FormControl('first'));
+      host.entryActions.set(true);
+    });
+
+    it('reports no remove button when the entry only projects other icon buttons', async () => {
+      host.canDelete.set(false);
+      fixture.detectChanges();
+
+      const [only] = await list.getItems();
+
+      expect(await only.canRemove()).toBe(false);
+      await expect(only.remove()).rejects.toThrow(/no remove button/);
+      expect(host.tested).toEqual([]);
+    });
+
+    it('removes through its own button, not the projected one', async () => {
+      fixture.detectChanges();
+
+      const [only] = await list.getItems();
+      await only.remove();
+      fixture.detectChanges();
+
+      expect(host.entries.length).toBe(0);
+      expect(host.tested).toEqual([]);
+    });
+
+    it('reports no Add when the header has none, whatever the entries project', async () => {
+      host.canAdd.set(false);
+      fixture.detectChanges();
+
+      expect(await list.canAdd()).toBe(false);
+      expect(await list.isAddDisabled()).toBe(false);
+      await expect(list.add()).rejects.toThrow(/no add button/);
+      expect(host.tested).toEqual([]);
+    });
+
+    it('adds through the header button, not an entry\'s', async () => {
+      fixture.detectChanges();
+
+      await list.add();
+      fixture.detectChanges();
+
+      expect(host.entries.length).toBe(2);
+      expect(host.tested).toEqual([]);
     });
   });
 

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.ts
@@ -1,5 +1,9 @@
-import { ChangeDetectionStrategy, Component, computed, contentChildren, input, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, computed, contentChildren, forwardRef, input, output,
+} from '@angular/core';
 import type { AbstractControl } from '@angular/forms';
+import { TN_FORM_LIST_CONTEXT } from './form-list-context';
+import type { TnFormListContext } from './form-list-context';
 import { TnFormListItemComponent } from './form-list-item.component';
 import { TnButtonComponent } from '../button/button.component';
 import { TnFormErrorsComponent } from '../form-errors/form-errors.component';
@@ -48,10 +52,19 @@ let nextUniqueId = 0;
     TnTestIdDirective,
     LabelMarkupPipe,
   ],
+  providers: [
+    // Published to the projected entries (their element injectors chain through
+    // this host), so `disabled` reaches each remove button without the consumer
+    // re-binding it inside its own @for. See TnFormListContext.
+    {
+      provide: TN_FORM_LIST_CONTEXT,
+      useExisting: forwardRef(() => TnFormListComponent),
+    },
+  ],
   templateUrl: './form-list.component.html',
   styleUrls: ['./form-list.component.scss'],
 })
-export class TnFormListComponent {
+export class TnFormListComponent implements TnFormListContext {
   /**
    * The `FormArray` being edited. Optional, and used only to render an error
    * that belongs to the array as a whole — a minimum or maximum length. The
@@ -79,9 +92,16 @@ export class TnFormListComponent {
   canAdd = input<boolean>(true);
 
   /**
-   * Locks the list, for one the user may not edit yet: Add is disabled and the entries are
-   * dimmed and made `inert`, so neither the mouse nor the keyboard reaches the projected
-   * fields or their remove buttons.
+   * Locks the list, for one the user may not edit yet: the group reports itself
+   * `aria-disabled`, the entries are dimmed and stop taking pointer events, and
+   * Add and every remove button are disabled.
+   *
+   * It does NOT disable the fields inside the entries — those are projected
+   * content the consumer owns, so locking them is `entries.disable()` on the
+   * `FormArray`, which is also what keeps their values out of `form.value`. This
+   * input deliberately does not reach them by going `inert` instead: the entries
+   * stay on screen, and `inert` would drop what a sighted user can still read out
+   * of the accessibility tree entirely.
    */
   disabled = input<boolean>(false);
 
@@ -101,11 +121,42 @@ export class TnFormListComponent {
   /** Per-error overrides for the array-level message, as on `tn-form-field`. */
   errorMessages = input<TnFormFieldErrorMessages>({});
 
-  /** Test-id base for the group (`form-list-` prefixed). */
+  /**
+   * Show the array-level message before the user has touched the array — for a
+   * list populated from an API, or one an error handler has just attached a
+   * server-side failure to. Passed straight to `tn-form-errors`.
+   */
+  showErrorWhenUntouched = input<boolean>(false);
+
+  /**
+   * Error keys whose array-level message renders with a close button, and which
+   * dismissing deletes. Unset takes the app-wide
+   * `TN_FORM_FIELD_DISMISSIBLE_ERRORS` default; `[]` opts this list out. Passed
+   * straight to `tn-form-errors`, which is where the reasoning lives.
+   */
+  dismissibleErrors = input<readonly string[] | undefined>(undefined);
+
+  /** Accessible name for that close button. Pass it already translated. */
+  dismissAriaLabel = input<string | undefined>(undefined);
+
+  /** Hover hint for that close button. Defaults to `dismissAriaLabel`. */
+  dismissTooltip = input<string | undefined>(undefined);
+
+  /**
+   * Test-id base for the group (`form-list-` prefixed). Also names the
+   * array-level message, which gets it `error-` prefixed.
+   */
   testId = input<TnTestIdValue>(undefined);
 
   /** Emitted when Add is pressed. Appending the element is the consumer's. */
   add = output<void>();
+
+  /**
+   * Emitted with the error key when the user closes the array-level message,
+   * after it has been removed. `tn-form-errors` has no control to hand focus
+   * back to, so a consumer who cares where focus lands moves it here.
+   */
+  dismiss = output<string>();
 
   /**
    * The projected entries. Counted rather than derived from the `FormArray`,

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy, Component, computed, contentChildren, forwardRef, input, output,
+  viewChild,
 } from '@angular/core';
 import type { AbstractControl } from '@angular/forms';
 import { TN_FORM_LIST_CONTEXT } from './form-list-context';
@@ -79,7 +80,10 @@ export class TnFormListComponent implements TnFormListContext {
    */
   label = input<string>('');
 
-  /** Optional help tooltip shown via an icon next to the label. */
+  /**
+   * Optional help tooltip, shown via an icon in the header — next to the label
+   * where there is one, and on its own where there is not.
+   */
   tooltip = input<string>('');
 
   /** Placement of the tooltip relative to its help icon. */
@@ -166,6 +170,22 @@ export class TnFormListComponent implements TnFormListContext {
   private items = contentChildren(TnFormListItemComponent);
 
   protected isEmpty = computed(() => this.empty() ?? this.items().length === 0);
+
+  /**
+   * The array-level message, queried rather than reached through a template
+   * reference: it renders inside an `@if`, and a reference declared in a block
+   * is scoped to that block.
+   */
+  private errors = viewChild(TnFormErrorsComponent);
+
+  /**
+   * Points the group at its own message. `role="alert"` covers the moment the
+   * error appears; it says nothing to a screen reader that tabs into the list
+   * afterwards, which would otherwise hear the label and never learn the array
+   * is in error. Null while there is no message, so this never names an element
+   * that is not on screen.
+   */
+  protected describedBy = computed(() => this.errors()?.describedBy() ?? null);
 
   /**
    * Accessible name for the Add control, which reads as a bare 'Add' beside

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.ts
@@ -1,0 +1,132 @@
+import { ChangeDetectionStrategy, Component, computed, contentChildren, input, output } from '@angular/core';
+import type { AbstractControl } from '@angular/forms';
+import { TnFormListItemComponent } from './form-list-item.component';
+import { TnButtonComponent } from '../button/button.component';
+import { TnFormErrorsComponent } from '../form-errors/form-errors.component';
+import type { TnFormFieldErrorMessages } from '../form-field/form-field.errors';
+import { TnIconComponent } from '../icon/icon.component';
+import { LabelMarkupPipe } from '../pipes/label-markup/label-markup.pipe';
+import { TnTestIdDirective } from '../test-id';
+import type { TnTestIdValue } from '../test-id';
+import { plainTextMessage } from '../tooltip/interactive-content';
+import { TnTooltipDirective } from '../tooltip/tooltip.directive';
+import type { TooltipPosition } from '../tooltip/tooltip.directive';
+
+let nextUniqueId = 0;
+
+/**
+ * The editor for a repeating group of fields — a `FormArray` the user grows
+ * and shrinks, rendered as a labelled group of {@link TnFormListItemComponent}
+ * cards with an Add control in the header.
+ *
+ * Not to be confused with `tn-list`, which DISPLAYS a list of items. This one
+ * edits one, and owns none of the array: the consumer holds the `FormArray`,
+ * renders an item per element, and does the pushing and splicing in response
+ * to `(add)` and each item's `(delete)`. That keeps the item's shape — which
+ * only the consumer knows — out of the library.
+ *
+ * @example
+ * ```html
+ * <tn-form-list label="ACL entries" [control]="form.controls.entries" (add)="addEntry()">
+ *   @for (entry of form.controls.entries.controls; track entry; let i = $index) {
+ *     <tn-form-list-item label="ACL entry" (delete)="removeEntry(i)">
+ *       <!-- the entry's own fields -->
+ *     </tn-form-list-item>
+ *   }
+ * </tn-form-list>
+ * ```
+ */
+@Component({
+  selector: 'tn-form-list',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    TnButtonComponent,
+    TnFormErrorsComponent,
+    TnIconComponent,
+    TnTooltipDirective,
+    TnTestIdDirective,
+    LabelMarkupPipe,
+  ],
+  templateUrl: './form-list.component.html',
+  styleUrls: ['./form-list.component.scss'],
+})
+export class TnFormListComponent {
+  /**
+   * The `FormArray` being edited. Optional, and used only to render an error
+   * that belongs to the array as a whole — a minimum or maximum length. The
+   * component neither reads the elements nor writes to it.
+   */
+  control = input<AbstractControl | undefined>(undefined);
+
+  /**
+   * What the list is called, in the plural ('ACL entries'). Names the group,
+   * so a screen reader announces which list a field is inside. Supports the
+   * same lightweight markup as `tn-form-field` labels.
+   */
+  label = input<string>('');
+
+  /** Optional help tooltip shown via an icon next to the label. */
+  tooltip = input<string>('');
+
+  /** Placement of the tooltip relative to its help icon. */
+  tooltipPosition = input<TooltipPosition>('above');
+
+  /** Marks the list as required — at least one entry. Renders the asterisk. */
+  required = input<boolean>(false);
+
+  /** Whether the Add control renders. Turn it off at a maximum length. */
+  canAdd = input<boolean>(true);
+
+  /** Dims the entries and disables Add, for a list the user may not edit yet. */
+  disabled = input<boolean>(false);
+
+  /** Text of the Add control. English by default — pass a translated string. */
+  addLabel = input<string>('Add');
+
+  /** Shown in place of the entries while there are none. */
+  emptyMessage = input<string>('No items have been added yet.');
+
+  /**
+   * Overrides the derived empty state. Set it to `false` while the entries are
+   * still being fetched, so a list that is merely not loaded yet does not
+   * announce itself as empty and then fill in.
+   */
+  empty = input<boolean | undefined>(undefined);
+
+  /** Per-error overrides for the array-level message, as on `tn-form-field`. */
+  errorMessages = input<TnFormFieldErrorMessages>({});
+
+  /** Test-id base for the group (`form-list-` prefixed). */
+  testId = input<TnTestIdValue>(undefined);
+
+  /** Emitted when Add is pressed. Appending the element is the consumer's. */
+  add = output<void>();
+
+  /**
+   * The projected entries. Counted rather than derived from the `FormArray`,
+   * so the empty state follows what is actually on screen — a consumer may
+   * filter or page the elements it renders, and `control` is optional anyway.
+   */
+  private items = contentChildren(TnFormListItemComponent);
+
+  protected isEmpty = computed(() => this.empty() ?? this.items().length === 0);
+
+  /**
+   * Accessible name for the Add control, which reads as a bare 'Add' beside
+   * every other list on a long form. Names the list it adds to.
+   */
+  protected addAriaLabel = computed(() => {
+    const label = plainTextMessage(this.label()).trim();
+    return label ? `${this.addLabel()} ${label}` : this.addLabel();
+  });
+
+  protected tooltipAriaLabel = computed(() => plainTextMessage(this.tooltip()));
+
+  /**
+   * Stable id naming the group from the label text alone. Without it the
+   * group's accessible name would also absorb the tooltip button and the Add
+   * control, announcing both on every field inside the list.
+   */
+  protected readonly labelId = `tn-form-list-${nextUniqueId++}`;
+}

--- a/projects/truenas-ui/src/lib/form-list/form-list.component.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.component.ts
@@ -78,7 +78,11 @@ export class TnFormListComponent {
   /** Whether the Add control renders. Turn it off at a maximum length. */
   canAdd = input<boolean>(true);
 
-  /** Dims the entries and disables Add, for a list the user may not edit yet. */
+  /**
+   * Locks the list, for one the user may not edit yet: Add is disabled and the entries are
+   * dimmed and made `inert`, so neither the mouse nor the keyboard reaches the projected
+   * fields or their remove buttons.
+   */
   disabled = input<boolean>(false);
 
   /** Text of the Add control. English by default — pass a translated string. */

--- a/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
@@ -40,6 +40,16 @@ export class TnFormListItemHarness extends ComponentHarness {
     return (await this.removeButton()) !== null;
   }
 
+  /**
+   * Whether the remove control is disabled — true for an entry inside a
+   * `disabled` list, or one given its own `disabled`. `false` when the entry
+   * offers no remove control at all; ask `canRemove()` to tell the two apart.
+   */
+  async isRemoveDisabled(): Promise<boolean> {
+    const button = await this.removeButton();
+    return button ? button.isDisabled() : false;
+  }
+
   /** Presses the remove control. Throws when the entry has none. */
   async remove(): Promise<void> {
     const button = await this.removeButton();

--- a/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
@@ -1,0 +1,122 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { TnButtonHarness } from '../button/button.harness';
+import { TnIconButtonHarness } from '../icon-button/icon-button.harness';
+
+/** Criteria for filtering `TnFormListHarness` instances. */
+export interface TnFormListHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the list's label. Supports string or regex matching. */
+  label?: string | RegExp;
+}
+
+/** Criteria for filtering `TnFormListItemHarness` instances. */
+export type TnFormListItemHarnessFilters = BaseHarnessFilters;
+
+/**
+ * Harness for one entry of a `tn-form-list`.
+ *
+ * @example
+ * ```typescript
+ * const [first] = await list.getItems();
+ * await first.remove();
+ * ```
+ */
+export class TnFormListItemHarness extends ComponentHarness {
+  static hostSelector = 'tn-form-list-item';
+
+  static with(options: TnFormListItemHarnessFilters = {}) {
+    return new HarnessPredicate(TnFormListItemHarness, options);
+  }
+
+  private removeButton = this.locatorForOptional(TnIconButtonHarness);
+
+  /** Whether this entry offers a remove control. */
+  async canRemove(): Promise<boolean> {
+    return (await this.removeButton()) !== null;
+  }
+
+  /** Presses the remove control. Throws when the entry has none. */
+  async remove(): Promise<void> {
+    const button = await this.removeButton();
+    if (!button) {
+      throw new Error('This tn-form-list-item has no remove button (canDelete is false).');
+    }
+    await button.click();
+  }
+}
+
+/**
+ * Harness for `tn-form-list`, the editor for a repeating group of fields.
+ *
+ * @example
+ * ```typescript
+ * const list = await loader.getHarness(TnFormListHarness.with({ label: 'ACL entries' }));
+ * expect(await list.getItemCount()).toBe(0);
+ * expect(await list.isEmpty()).toBe(true);
+ *
+ * await list.add();
+ * expect(await list.getItemCount()).toBe(1);
+ * ```
+ */
+export class TnFormListHarness extends ComponentHarness {
+  static hostSelector = 'tn-form-list';
+
+  static with(options: TnFormListHarnessFilters = {}) {
+    return new HarnessPredicate(TnFormListHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabel(), label)
+      );
+  }
+
+  private labelEl = this.locatorForOptional('.tn-form-list__label');
+  private addButton = this.locatorForOptional(TnButtonHarness);
+  private emptyEl = this.locatorForOptional('.tn-form-list__empty');
+
+  /** The list's label, or `''` when it has none. */
+  async getLabel(): Promise<string> {
+    const label = await this.labelEl();
+    // The asterisk is decoration, not part of the name.
+    return label ? (await label.text()).replace(/\*$/, '').trim() : '';
+  }
+
+  /** Whether the Add control renders. */
+  async canAdd(): Promise<boolean> {
+    return (await this.addButton()) !== null;
+  }
+
+  /** Whether the Add control is disabled. */
+  async isAddDisabled(): Promise<boolean> {
+    const button = await this.addButton();
+    return button ? button.isDisabled() : false;
+  }
+
+  /** Presses Add. Throws when the list offers no Add control. */
+  async add(): Promise<void> {
+    const button = await this.addButton();
+    if (!button) {
+      throw new Error('This tn-form-list has no add button (canAdd is false).');
+    }
+    await button.click();
+  }
+
+  /** The entries currently rendered. */
+  async getItems(): Promise<TnFormListItemHarness[]> {
+    return this.locatorForAll(TnFormListItemHarness)();
+  }
+
+  /** How many entries are rendered. */
+  async getItemCount(): Promise<number> {
+    return (await this.getItems()).length;
+  }
+
+  /** Whether the empty message is showing. */
+  async isEmpty(): Promise<boolean> {
+    return (await this.emptyEl()) !== null;
+  }
+
+  /** The empty message, or `''` when the list has entries. */
+  async getEmptyMessage(): Promise<string> {
+    const empty = await this.emptyEl();
+    return empty ? (await empty.text()).trim() : '';
+  }
+}

--- a/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
+++ b/projects/truenas-ui/src/lib/form-list/form-list.harness.ts
@@ -28,7 +28,12 @@ export class TnFormListItemHarness extends ComponentHarness {
     return new HarnessPredicate(TnFormListItemHarness, options);
   }
 
-  private removeButton = this.locatorForOptional(TnIconButtonHarness);
+  // Scoped to the component's own control: an unscoped `TnIconButtonHarness` matches whatever the
+  // consumer projected into the entry too, so with `canDelete="false"` the first projected icon
+  // button would stand in for a remove button that is not there.
+  private removeButton = this.locatorForOptional(
+    TnIconButtonHarness.with({ selector: '.tn-form-list-item__remove' })
+  );
 
   /** Whether this entry offers a remove control. */
   async canRemove(): Promise<boolean> {
@@ -69,7 +74,11 @@ export class TnFormListHarness extends ComponentHarness {
   }
 
   private labelEl = this.locatorForOptional('.tn-form-list__label');
-  private addButton = this.locatorForOptional(TnButtonHarness);
+  // Scoped for the same reason as `removeButton` above — a `tn-button` projected into an entry
+  // must not answer for the header's Add.
+  private addButton = this.locatorForOptional(
+    TnButtonHarness.with({ selector: '.tn-form-list__add' })
+  );
   private emptyEl = this.locatorForOptional('.tn-form-list__empty');
 
   /** The list's label, or `''` when it has none. */

--- a/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
+++ b/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
@@ -1,6 +1,7 @@
 <tn-form-list
   [control]="entries"
   [label]="label()"
+  [tooltip]="tooltip()"
   [required]="required()"
   [canAdd]="canAdd()"
   [disabled]="disabled()"

--- a/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
+++ b/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
@@ -1,0 +1,15 @@
+<tn-form-list
+  [control]="entries"
+  [label]="label()"
+  [required]="required()"
+  [canAdd]="canAdd()"
+  [disabled]="disabled()"
+  [empty]="empty()"
+  (add)="addEntry()"
+>
+  @for (entry of entries.controls; track entry; let i = $index) {
+    <tn-form-list-item label="address" [canDelete]="canDelete()" (delete)="removeEntry(i)">
+      <tn-input [formControl]="entry" />
+    </tn-form-list-item>
+  }
+</tn-form-list>

--- a/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
+++ b/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
@@ -10,6 +10,11 @@
   @for (entry of entries.controls; track entry; let i = $index) {
     <tn-form-list-item label="address" [canDelete]="canDelete()" (delete)="removeEntry(i)">
       <tn-input [formControl]="entry" />
+
+      @if (entryActions()) {
+        <tn-button label="Test connection" (onClick)="testEntry(i)" />
+        <tn-icon-button name="cog" library="mdi" ariaLabel="Configure" (onClick)="testEntry(i)" />
+      }
     </tn-form-list-item>
   }
 </tn-form-list>

--- a/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
+++ b/projects/truenas-ui/src/lib/form-list/test-hosts/form-list-host.component.html
@@ -8,7 +8,12 @@
   (add)="addEntry()"
 >
   @for (entry of entries.controls; track entry; let i = $index) {
-    <tn-form-list-item label="address" [canDelete]="canDelete()" (delete)="removeEntry(i)">
+    <tn-form-list-item
+      label="address"
+      [canDelete]="canDelete()"
+      [disabled]="lockFirstEntry() && i === 0 ? true : undefined"
+      (delete)="removeEntry(i)"
+    >
       <tn-input [formControl]="entry" />
 
       @if (entryActions()) {

--- a/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
@@ -206,6 +206,15 @@ const CALL_SITES: readonly CallSite[] = [
     ],
   },
   {
+    file: 'form-list/form-list.component.scss',
+    element: '.tn-form-list__label',
+    // The plain-text twin of `.tn-form-field-label`, and painted from the same
+    // token on the same page surface. It has no error or focus state of its own:
+    // the list's label names a group, and the array-level message is a sibling
+    // `tn-form-errors` rather than a recolouring of the label.
+    states: [{ name: 'resting', colour: '--tn-fg1', surface: TRANSPARENT }],
+  },
+  {
     file: 'stepper/stepper.component.scss',
     element: '.tn-stepper__step-title',
     states: [

--- a/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
@@ -72,6 +72,7 @@ const KEEPS_PRIMARY: Readonly<Record<string, { count: number; why: string }>> = 
   },
   'form-field/form-field.component.scss': { count: 1, why: 'the icon-only help button' },
   'form-section/form-section.component.scss': { count: 1, why: 'the icon-only help button' },
+  'form-list/form-list.component.scss': { count: 1, why: 'the icon-only help button' },
   'menu/menu.component.scss': {
     count: 1,
     why: 'the selected row, which is text but paints on --tn-alt-bg2, not --tn-bg1/--tn-bg2',

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -149,7 +149,7 @@ const PAIRINGS: readonly Pairing[] = [
     where: 'the table cell on a hovered, expanded or detail row; the hovered list item, tab and '
       + 'vertical tab; the selected select option; the highlighted autocomplete option; the '
       + 'expanded tree node; the hovered expansion-panel header; the marked calendar cell; the '
-      + 'list avatar',
+      + 'list avatar; the label of a field inside a tn-form-list entry card',
   },
   {
     token: '--tn-fg1',
@@ -173,7 +173,8 @@ const PAIRINGS: readonly Pairing[] = [
     token: '--tn-fg2',
     surface: '--tn-alt-bg1',
     where: 'the banner message; the secondary line of a hovered list item; the hovered '
-      + 'button-toggle label; the hovered table card sort direction',
+      + 'button-toggle label; the hovered table card sort direction; the hint of a field inside '
+      + 'a tn-form-list entry card',
   },
   {
     token: '--tn-fg2',
@@ -374,6 +375,13 @@ const PAINTS_UNTUNED: Readonly<Record<string, { fills: number; text: number; why
     fills: 1,
     text: 4,
     why: 'only the disabled input, which is under an opacity',
+  },
+  'form-list/form-list-item.component.scss': {
+    fills: 1,
+    text: 0,
+    why: 'the entry card fills --tn-alt-bg1 and declares no colour of its own — what sits on it '
+      + 'is the consumer\'s projected fields, so the pairings that matter are the --tn-fg1 label '
+      + 'and --tn-fg2 hint tn-form-field paints, both measured above',
   },
   'icon-button/icon-button.component.scss': {
     fills: 2,

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -57,6 +57,9 @@ export type {
 export * from './lib/form-field/form-field.harness';
 export * from './lib/form-errors/form-errors.component';
 export * from './lib/form-errors/form-errors.harness';
+export * from './lib/form-list/form-list.component';
+export * from './lib/form-list/form-list-item.component';
+export * from './lib/form-list/form-list.harness';
 export * from './lib/form-section/form-section.component';
 export * from './lib/form-section/form-section.harness';
 export * from './lib/select/select.component';

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -48,13 +48,15 @@ export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
 export { TN_FORM_FIELD_CONTEXT, injectTnFormFieldAria } from './lib/form-field/form-field-context';
 export type { TnFormFieldContext, TnFormFieldAriaBindings } from './lib/form-field/form-field-context';
-export { TN_FORM_FIELD_ERRORS } from './lib/form-field/form-field.errors';
+export { TN_FORM_FIELD_ERRORS, resolveErrorMessage } from './lib/form-field/form-field.errors';
 export type {
   TnFormFieldErrorMessage,
   TnFormFieldErrorMessages,
   TnFormFieldErrorResolver,
 } from './lib/form-field/form-field.errors';
 export * from './lib/form-field/form-field.harness';
+export * from './lib/form-errors/form-errors.component';
+export * from './lib/form-errors/form-errors.harness';
 export * from './lib/form-section/form-section.component';
 export * from './lib/form-section/form-section.harness';
 export * from './lib/select/select.component';

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -53,6 +53,7 @@ export {
   TN_FORM_FIELD_DISMISSIBLE_ERRORS, TN_FORM_FIELD_ERRORS, resolveErrorMessage,
 } from './lib/form-field/form-field.errors';
 export type {
+  ResolveErrorMessageOptions,
   TnFormFieldErrorMessage,
   TnFormFieldErrorMessages,
   TnFormFieldErrorResolver,
@@ -62,6 +63,8 @@ export * from './lib/form-errors/form-errors.component';
 export * from './lib/form-errors/form-errors.harness';
 export * from './lib/form-list/form-list.component';
 export * from './lib/form-list/form-list-item.component';
+export { TN_FORM_LIST_CONTEXT } from './lib/form-list/form-list-context';
+export type { TnFormListContext } from './lib/form-list/form-list-context';
 export * from './lib/form-list/form-list.harness';
 export * from './lib/form-section/form-section.component';
 export * from './lib/form-section/form-section.harness';

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -48,7 +48,9 @@ export * from './lib/keyboard-shortcut/keyboard-shortcut.component';
 export * from './lib/form-field/form-field.component';
 export { TN_FORM_FIELD_CONTEXT, injectTnFormFieldAria } from './lib/form-field/form-field-context';
 export type { TnFormFieldContext, TnFormFieldAriaBindings } from './lib/form-field/form-field-context';
-export { TN_FORM_FIELD_ERRORS, resolveErrorMessage } from './lib/form-field/form-field.errors';
+export {
+  TN_FORM_FIELD_DISMISSIBLE_ERRORS, TN_FORM_FIELD_ERRORS, resolveErrorMessage,
+} from './lib/form-field/form-field.errors';
 export type {
   TnFormFieldErrorMessage,
   TnFormFieldErrorMessages,

--- a/projects/truenas-ui/src/stories/form-errors.stories.ts
+++ b/projects/truenas-ui/src/stories/form-errors.stories.ts
@@ -1,0 +1,202 @@
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import type { AbstractControl, ValidationErrors } from '@angular/forms';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
+import { TnFormErrorsComponent } from '../lib/form-errors/form-errors.component';
+import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+import { TnInputComponent } from '../lib/input/input.component';
+
+const harnessDoc = loadHarnessDoc('form-errors');
+
+/** Fails the GROUP rather than either field, the way a cross-field rule does. */
+function bothOrNeither(group: AbstractControl): ValidationErrors | null {
+  const start = !!group.get('start')?.value;
+  const end = !!group.get('end')?.value;
+  return start === end ? null : { bothOrNeither: true };
+}
+
+function windowGroup(): FormGroup {
+  const group = new FormGroup(
+    {
+      start: new FormControl('02:00', Validators.required),
+      end: new FormControl(''),
+    },
+    bothOrNeither
+  );
+  group.markAllAsTouched();
+  return group;
+}
+
+const meta: Meta<TnFormErrorsComponent> = {
+  title: 'Components/Form Errors',
+  component: TnFormErrorsComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [ReactiveFormsModule, TnFormFieldComponent, TnInputComponent],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+Renders the validation message for a control that is **not** projected into a \`tn-form-field\` —
+in practice a \`FormGroup\` or \`FormArray\`, whose error belongs to the group as a whole and so has
+no single field to sit under.
+
+## When to reach for it
+
+\`tn-form-field\` covers the ordinary case and should still be preferred: it owns the label, the
+\`aria-describedby\` wiring and the subscript slot. Use \`tn-form-errors\` only where there is no
+field to own the message:
+
+- a cross-field validator on a group (\"end is required when start is set\")
+- a \`minLength\`-style rule on a \`FormArray\`
+- a server-side failure an error handler attached to a group
+
+## Wording
+
+The message comes from the same ladder \`tn-form-field\` uses — the per-instance \`errorMessages\`
+override, then the app-wide \`TN_FORM_FIELD_ERRORS\` resolver, then the built-in defaults — so a
+group message reads exactly like the field messages around it. Like \`tn-form-field\`, it shows
+**one** message: the active error, chosen by the same priority.
+
+## When it shows
+
+Only once the control is touched or dirty, so a freshly opened form does not greet the user with
+errors. Set \`showWhenUntouched\` where the invalid value did not come from the user — an edit form
+populated from an API.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    control: {
+      control: false,
+      description: 'The control whose errors are rendered. Usually a group or an array.',
+    },
+    errorMessages: {
+      control: 'object',
+      description:
+        'Per-instance overrides keyed by error key. Take precedence over the app-wide resolver.',
+    },
+    showWhenUntouched: {
+      control: 'boolean',
+      description:
+        'Show before the user has touched or dirtied the control — for values that came from an API rather than from the user.',
+    },
+    testId: {
+      control: 'text',
+      description:
+        'Test-id base for the message element (`error-` prefixed). No fallback: a control does not know its own name.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<TnFormErrorsComponent>;
+
+export const GroupLevelError: Story = {
+  render: () => {
+    const group = windowGroup();
+    return {
+      props: { group },
+      template: `
+        <div [formGroup]="group" style="max-width: 24rem">
+          <tn-form-field label="Start">
+            <tn-input formControlName="start"></tn-input>
+          </tn-form-field>
+
+          <tn-form-field label="End">
+            <tn-input formControlName="end"></tn-input>
+          </tn-form-field>
+
+          <tn-form-errors
+            [control]="group"
+            [errorMessages]="{ bothOrNeither: 'Set both ends of the window, or neither' }"
+          ></tn-form-errors>
+        </div>
+      `,
+    };
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Neither field is individually wrong, so neither `tn-form-field` has anything to say. The message belongs to the pair.',
+      },
+    },
+  },
+};
+
+export const UntouchedGroup: Story = {
+  render: () => {
+    const group = new FormGroup(
+      { start: new FormControl('02:00'), end: new FormControl('') },
+      bothOrNeither
+    );
+    return {
+      props: { group },
+      template: `
+        <div [formGroup]="group" style="max-width: 24rem">
+          <tn-form-errors [control]="group" [showWhenUntouched]="true"></tn-form-errors>
+        </div>
+      `,
+    };
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The user has touched nothing — the invalid value arrived with the form. Without `showWhenUntouched` this renders nothing at all.',
+      },
+    },
+  },
+};
+
+export const ChildErrorsStayWithTheirField: Story = {
+  render: () => {
+    const group = new FormGroup({ name: new FormControl('', Validators.required) });
+    group.markAllAsTouched();
+    return {
+      props: { group },
+      template: `
+        <div [formGroup]="group" style="max-width: 24rem">
+          <tn-form-field label="Name">
+            <tn-input formControlName="name"></tn-input>
+          </tn-form-field>
+
+          <tn-form-errors [control]="group"></tn-form-errors>
+        </div>
+      `,
+    };
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The group is invalid, but its own `errors` are null — the failure is the field\'s. `tn-form-errors` stays silent rather than repeating what the field already says.',
+      },
+    },
+  },
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none',
+      },
+      description: {
+        story: harnessDoc || '',
+      },
+    },
+    controls: { disable: true },
+    layout: 'fullscreen',
+  },
+  render: () => ({ template: '' }),
+};

--- a/projects/truenas-ui/src/stories/form-errors.stories.ts
+++ b/projects/truenas-ui/src/stories/form-errors.stories.ts
@@ -5,9 +5,12 @@ import { moduleMetadata } from '@storybook/angular';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnFormErrorsComponent } from '../lib/form-errors/form-errors.component';
 import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
 import { TnInputComponent } from '../lib/input/input.component';
 
 const harnessDoc = loadHarnessDoc('form-errors');
+
+tnIconMarker('close', 'mdi');
 
 /** Fails the GROUP rather than either field, the way a cross-field rule does. */
 function bothOrNeither(group: AbstractControl): ValidationErrors | null {
@@ -68,6 +71,19 @@ group message reads exactly like the field messages around it. Like \`tn-form-fi
 Only once the control is touched or dirty, so a freshly opened form does not greet the user with
 errors. Set \`showWhenUntouched\` where the invalid value did not come from the user — an edit form
 populated from an API.
+
+## Dismissible errors
+
+Some failures the user cannot edit their way out of — a server-side rejection an error handler
+attached to the group. List those keys in \`dismissibleErrors\` and the message gets a close button
+beside it.
+
+Dismissing deletes the key from the group's errors — listing it is what grants that — and
+\`dismiss\` reports what went, for a handler that wants to react. Unlike \`tn-form-field\` there is
+no control to hand focus back to afterwards, so move focus yourself if it matters.
+
+Leave the input unset to take the app-wide \`TN_FORM_FIELD_DISMISSIBLE_ERRORS\` default, which an
+app whose server failures always land under the same keys wires once; pass \`[]\` to opt out.
         `,
       },
     },
@@ -91,6 +107,24 @@ populated from an API.
       control: 'text',
       description:
         'Test-id base for the message element (`error-` prefixed). No fallback: a control does not know its own name.',
+    },
+    dismissibleErrors: {
+      control: 'object',
+      description:
+        'Error keys whose message renders with a close button, and which dismissing deletes. Only the error actually shown gets one. Unset falls back to the app-wide TN_FORM_FIELD_DISMISSIBLE_ERRORS default.',
+    },
+    dismissAriaLabel: {
+      control: 'text',
+      description:
+        'Accessible name for the close button. The library ships no localized strings, so pass an already-translated one.',
+    },
+    dismissTooltip: {
+      control: 'text',
+      description: 'Hover hint for the close button. Defaults to `dismissAriaLabel`.',
+    },
+    dismiss: {
+      action: 'dismiss',
+      description: 'Emits the error key the user dismissed.',
     },
   },
 };
@@ -178,6 +212,46 @@ export const ChildErrorsStayWithTheirField: Story = {
       description: {
         story:
           'The group is invalid, but its own `errors` are null — the failure is the field\'s. `tn-form-errors` stays silent rather than repeating what the field already says.',
+      },
+    },
+  },
+};
+
+export const DismissibleServerError: Story = {
+  render: () => {
+    const group = new FormGroup({ pool: new FormControl('tank') });
+    // What an error handler leaves behind after the API rejects the request.
+    const reject = (): void => {
+      group.setErrors({ manualValidateError: 'Pool "tank" is offline — bring it up and retry' });
+      group.markAllAsTouched();
+    };
+    reject();
+
+    return {
+      props: { group, reject },
+      template: `
+        <div [formGroup]="group" style="max-width: 24rem">
+          <tn-form-field label="Pool">
+            <tn-input formControlName="pool"></tn-input>
+          </tn-form-field>
+
+          <tn-form-errors
+            [control]="group"
+            [dismissibleErrors]="['manualValidateError']"
+          ></tn-form-errors>
+
+          <button type="button" style="width: fit-content; margin-top: 0.5rem" (click)="reject()">
+            Reject again
+          </button>
+        </div>
+      `,
+    };
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No edit to the form will clear this one, so the message would sit there forever. The close button drops the key the message came from — which listing it in `dismissibleErrors` is what permits.',
       },
     },
   },

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -12,6 +12,7 @@ import type { TnSelectOption } from '../lib/select/select.component';
 import { TnSelectComponent } from '../lib/select/select.component';
 
 tnIconMarker('help-circle', 'mdi');
+tnIconMarker('close', 'mdi');
 
 const harnessDoc = loadHarnessDoc('form-field');
 
@@ -90,6 +91,22 @@ When used with Angular reactive forms, the form field automatically:
     errorMessages: {
       control: 'object',
       description: 'Per-field overrides for validation messages, keyed by error key. Values are a string or a function receiving the error detail. Takes precedence over the app-wide TN_FORM_FIELD_ERRORS resolver and the built-in defaults.',
+    },
+    dismissibleErrors: {
+      control: 'object',
+      description: 'Error keys whose message renders with a close button, and which dismissing deletes — failures the user cannot edit their way out of, such as a server-side rejection. Only the error actually being shown gets the button. Unset falls back to the app-wide TN_FORM_FIELD_DISMISSIBLE_ERRORS default; [] opts out.',
+    },
+    dismissAriaLabel: {
+      control: 'text',
+      description: 'Accessible name for the close button. The library ships no localized strings, so an app with an i18n layer passes an already-translated one.',
+    },
+    dismissTooltip: {
+      control: 'text',
+      description: 'Hover hint for the close button. Defaults to dismissAriaLabel, so one string covers both.',
+    },
+    dismiss: {
+      action: 'dismiss',
+      description: 'Emits the error key the user dismissed. The field does not clear it — the consumer does.',
     },
   },
 };
@@ -305,6 +322,68 @@ export const CustomErrorMessages: Story = {
     `,
     moduleMetadata: {
       imports: [TnInputComponent, ReactiveFormsModule, CommonModule],
+    },
+  }),
+};
+
+export const DismissibleServerError: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A server-side rejection is not something the user can retype their way out ' +
+          'of, so without a way to clear it the message sits under the field forever. ' +
+          'List the key in `dismissibleErrors` and the message gets a close button.\n\n' +
+          'Dismissing drops that key from the control — listing it is what grants that — ' +
+          'and leaves any other errors in place. `dismiss` reports what went. Focus ' +
+          'returns to the control afterwards, since dismissing a server error means ' +
+          '"let me try again".\n\n' +
+          'Leave the input unset to take the app-wide `TN_FORM_FIELD_DISMISSIBLE_ERRORS` ' +
+          'default instead of naming keys on every field; pass `[]` to opt one out.',
+      },
+    },
+  },
+  args: {
+    label: 'Pool',
+    testId: 'pool-field',
+    dismissibleErrors: ['manualValidateError'],
+  },
+  render: (args) => ({
+    props: {
+      ...args,
+      poolControl: (() => {
+        const control = new FormControl('tank');
+        // What an error handler leaves behind after the API rejects the request.
+        control.setErrors({ manualValidateError: 'Pool "tank" is offline — bring it up and retry' });
+        control.markAsTouched();
+        return control;
+      })(),
+      reject(this: { poolControl: FormControl }) {
+        this.poolControl.setErrors({
+          manualValidateError: 'Pool "tank" is offline — bring it up and retry',
+        });
+        this.poolControl.markAsTouched();
+      },
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 400px;">
+        <tn-form-field
+          [label]="label"
+          [testId]="testId"
+          [dismissibleErrors]="dismissibleErrors">
+          <tn-input [formControl]="poolControl" />
+        </tn-form-field>
+
+        <button
+          type="button"
+          (click)="reject()"
+          style="width: fit-content; padding: 0.5rem 1rem; background: var(--tn-primary); color: white; border: none; border-radius: 0.25rem; cursor: pointer;">
+          Reject again
+        </button>
+      </div>
+    `,
+    moduleMetadata: {
+      imports: [TnInputComponent, ReactiveFormsModule],
     },
   }),
 };

--- a/projects/truenas-ui/src/stories/form-field.stories.ts
+++ b/projects/truenas-ui/src/stories/form-field.stories.ts
@@ -106,7 +106,7 @@ When used with Angular reactive forms, the form field automatically:
     },
     dismiss: {
       action: 'dismiss',
-      description: 'Emits the error key the user dismissed. The field does not clear it — the consumer does.',
+      description: 'Emits the error key the user dismissed, after the field has already removed every key it lists in dismissibleErrors from the control. Handle it for what happens next — retrying the request, telling the server.',
     },
   },
 };

--- a/projects/truenas-ui/src/stories/form-list.stories.ts
+++ b/projects/truenas-ui/src/stories/form-list.stories.ts
@@ -78,7 +78,10 @@ Labels and messages are English by default (\`addLabel\`, \`emptyMessage\`, an i
     tooltip: { control: 'text', description: 'Help text shown from an icon beside the label.' },
     required: { control: 'boolean', description: 'Marks the list as needing at least one entry.' },
     canAdd: { control: 'boolean', description: 'Whether Add renders. Turn off at a maximum length.' },
-    disabled: { control: 'boolean', description: 'Dims the entries and disables Add.' },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables Add and makes the entries inert — dimmed, and out of the tab order.',
+    },
     addLabel: { control: 'text', description: 'Text of the Add control.' },
     emptyMessage: { control: 'text', description: 'Shown while there are no entries.' },
     empty: {

--- a/projects/truenas-ui/src/stories/form-list.stories.ts
+++ b/projects/truenas-ui/src/stories/form-list.stories.ts
@@ -80,7 +80,11 @@ Labels and messages are English by default (\`addLabel\`, \`emptyMessage\`, an i
     canAdd: { control: 'boolean', description: 'Whether Add renders. Turn off at a maximum length.' },
     disabled: {
       control: 'boolean',
-      description: 'Disables Add and makes the entries inert — dimmed, and out of the tab order.',
+      description:
+        'Locks the list: the group reports itself aria-disabled, the entries dim and stop taking '
+        + 'pointer events, and Add and every remove button are disabled. It does NOT disable the '
+        + 'fields inside the entries — those are projected content, so call entries.disable() on '
+        + 'the FormArray for those. See the Disabled story.',
     },
     addLabel: { control: 'text', description: 'Text of the Add control.' },
     emptyMessage: { control: 'text', description: 'Shown while there are no entries.' },
@@ -90,7 +94,32 @@ Labels and messages are English by default (\`addLabel\`, \`emptyMessage\`, an i
         'Overrides the derived empty state — set false while the entries are still being fetched.',
     },
     errorMessages: { control: 'object', description: 'Per-error overrides for the array message.' },
-    testId: { control: 'text', description: 'Test-id base for the group (`form-list-` prefixed).' },
+    showErrorWhenUntouched: {
+      control: 'boolean',
+      description:
+        'Show the array-level message before the user has touched the array — for a list filled '
+        + 'in from an API, or one an error handler has just attached a failure to.',
+    },
+    dismissibleErrors: {
+      control: 'object',
+      description:
+        'Error keys whose array-level message renders with a close button, and which dismissing '
+        + 'deletes. Unset takes the app-wide TN_FORM_FIELD_DISMISSIBLE_ERRORS default; [] opts out.',
+    },
+    dismissAriaLabel: { control: 'text', description: 'Accessible name for that close button.' },
+    dismissTooltip: { control: 'text', description: 'Hover hint for that close button.' },
+    dismiss: {
+      action: 'dismiss',
+      description:
+        'Emits the error key the user closed, after it has been removed. tn-form-errors has no '
+        + 'control to hand focus back to, so move it here if it matters.',
+    },
+    testId: {
+      control: 'text',
+      description:
+        'Test-id base for the group (`form-list-` prefixed). Also names the array-level message, '
+        + 'which gets it `error-` prefixed.',
+    },
   },
 };
 
@@ -200,9 +229,38 @@ export const AtMaximumLength: Story = {
 
 export const Disabled: Story = {
   render: () => ({
-    props: props(new FormArray([entry('10.0.0.1')]), { disabled: true }),
+    props: props(
+      (() => {
+        const entries = new FormArray([entry('10.0.0.1')]);
+        // The other half of the lock, and the consumer's half: `disabled` on the
+        // list dims the entries and disables its own controls, but the fields
+        // inside are projected content it cannot reach.
+        entries.disable();
+        return entries;
+      })(),
+      { disabled: true },
+    ),
     template,
   }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Locking a list takes two things, and they are deliberately separate.\n\n' +
+          '`[disabled]` is the chrome: the group reports itself `aria-disabled`, the entries dim '
+          + 'and stop taking pointer events, and Add and every remove button are disabled. The '
+          + 'remove buttons get there over `TN_FORM_LIST_CONTEXT`, so you bind `disabled` on the '
+          + 'list and not again on every `tn-form-list-item` inside your `@for`.\n\n' +
+          '`entries.disable()` is the data: the fields inside an entry are **your** content '
+          + 'projected into the list, so only you can disable them — and disabling the `FormArray` '
+          + 'is also what keeps its values out of `form.value`.\n\n' +
+          'The list does not reach the fields for you by going `inert`, which would be one line '
+          + 'and would also delete a still-visible list from the accessibility tree: a sighted user '
+          + 'reads the dimmed addresses, and a screen-reader user would get nothing at all where '
+          + 'they are.',
+      },
+    },
+  },
 };
 
 export const ComponentHarness: Story = {

--- a/projects/truenas-ui/src/stories/form-list.stories.ts
+++ b/projects/truenas-ui/src/stories/form-list.stories.ts
@@ -1,0 +1,216 @@
+import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
+import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+import { TnFormListItemComponent } from '../lib/form-list/form-list-item.component';
+import { TnFormListComponent } from '../lib/form-list/form-list.component';
+import { tnIconMarker } from '../lib/icon/icon-marker';
+import { TnInputComponent } from '../lib/input/input.component';
+import { TnSelectComponent } from '../lib/select/select.component';
+
+tnIconMarker('help-circle', 'mdi');
+tnIconMarker('close', 'mdi');
+
+const harnessDoc = loadHarnessDoc('form-list');
+
+function entry(address = '', permission = 'read'): FormGroup {
+  return new FormGroup({
+    address: new FormControl(address, Validators.required),
+    permission: new FormControl(permission),
+  });
+}
+
+const meta: Meta<TnFormListComponent> = {
+  title: 'Components/Form List',
+  component: TnFormListComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [
+        ReactiveFormsModule,
+        TnFormListItemComponent,
+        TnFormFieldComponent,
+        TnInputComponent,
+        TnSelectComponent,
+      ],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+The editor for a repeating group of fields — a \`FormArray\` the user grows and shrinks.
+
+**Not \`tn-list\`.** That one *displays* a list of items; this one *edits* one.
+
+## What it owns, and what it doesn't
+
+It owns the label, the Add control, the empty state, the entry frames and the remove controls. It
+owns **none of the array**: the consumer holds the \`FormArray\`, renders one
+\`tn-form-list-item\` per element, and does the pushing and splicing in response to \`(add)\` and
+each item's \`(delete)\`. The shape of an entry is something only the consumer knows, so it stays
+out of the library.
+
+\`[control]\` is optional and used for one thing: rendering an error that belongs to the array as
+a whole — a minimum or maximum length — through \`tn-form-errors\`. The component never reads the
+elements or writes to the array.
+
+## Empty state
+
+Derived from the entries actually projected, not from the array's length, so a consumer that
+filters or pages what it renders still gets the right empty message. Override it with \`empty\`
+while the entries are still being fetched, so a list that is merely not loaded yet does not
+announce itself as empty and then fill in.
+
+## Wording
+
+Labels and messages are English by default (\`addLabel\`, \`emptyMessage\`, an item's
+\`removeAriaLabel\`). Pass translated strings — the library ships no localized text.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    control: { control: false, description: 'The FormArray, for the array-level error only.' },
+    label: { control: 'text', description: 'What the list is called, in the plural.' },
+    tooltip: { control: 'text', description: 'Help text shown from an icon beside the label.' },
+    required: { control: 'boolean', description: 'Marks the list as needing at least one entry.' },
+    canAdd: { control: 'boolean', description: 'Whether Add renders. Turn off at a maximum length.' },
+    disabled: { control: 'boolean', description: 'Dims the entries and disables Add.' },
+    addLabel: { control: 'text', description: 'Text of the Add control.' },
+    emptyMessage: { control: 'text', description: 'Shown while there are no entries.' },
+    empty: {
+      control: 'boolean',
+      description:
+        'Overrides the derived empty state — set false while the entries are still being fetched.',
+    },
+    errorMessages: { control: 'object', description: 'Per-error overrides for the array message.' },
+    testId: { control: 'text', description: 'Test-id base for the group (`form-list-` prefixed).' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<TnFormListComponent>;
+
+const template = `
+  <tn-form-list
+    [control]="entries"
+    [label]="label"
+    [tooltip]="tooltip"
+    [required]="required"
+    [canAdd]="canAdd"
+    [disabled]="disabled"
+    (add)="entries.push(makeEntry())"
+  >
+    @for (group of entries.controls; track group; let i = $index) {
+      <tn-form-list-item label="allowed address" (delete)="entries.removeAt(i)">
+        <div [formGroup]="group">
+          <tn-form-field label="Address" [required]="true">
+            <tn-input formControlName="address"></tn-input>
+          </tn-form-field>
+
+          <tn-form-field label="Permission">
+            <tn-select formControlName="permission" [options]="permissions"></tn-select>
+          </tn-form-field>
+        </div>
+      </tn-form-list-item>
+    }
+  </tn-form-list>
+`;
+
+const permissions = [
+  { label: 'Read only', value: 'read' },
+  { label: 'Read/Write', value: 'write' },
+];
+
+function props(entries: FormArray, overrides: Record<string, unknown> = {}) {
+  return {
+    entries,
+    permissions,
+    makeEntry: () => entry(),
+    label: 'Allowed addresses',
+    tooltip: '',
+    required: false,
+    canAdd: true,
+    disabled: false,
+    ...overrides,
+  };
+}
+
+export const WithEntries: Story = {
+  render: () => ({
+    props: props(new FormArray([entry('10.0.0.1'), entry('10.0.0.2', 'write')])),
+    template,
+  }),
+};
+
+export const Empty: Story = {
+  render: () => ({
+    props: props(new FormArray<FormGroup>([])),
+    template,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With nothing projected, the list says so rather than collapsing to a bare Add button.',
+      },
+    },
+  },
+};
+
+export const ArrayLevelError: Story = {
+  render: () => {
+    const entries = new FormArray([entry('10.0.0.1')], Validators.minLength(2));
+    entries.markAllAsTouched();
+    return {
+      props: props(entries, { required: true }),
+      template,
+    };
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The error belongs to the array, not to any one entry, so it renders under the header via `tn-form-errors`.',
+      },
+    },
+  },
+};
+
+export const AtMaximumLength: Story = {
+  render: () => ({
+    props: props(new FormArray([entry('10.0.0.1'), entry('10.0.0.2')]), { canAdd: false }),
+    template,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Add is removed rather than disabled — a permanently disabled control tells the user nothing about why.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  render: () => ({
+    props: props(new FormArray([entry('10.0.0.1')]), { disabled: true }),
+    template,
+  }),
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: { hidden: true, sourceState: 'none' },
+      description: { story: harnessDoc || '' },
+    },
+    controls: { disable: true },
+    layout: 'fullscreen',
+  },
+  render: () => ({ template: '' }),
+};


### PR DESCRIPTION
## What

Three form pieces webui was keeping its own copies of, plus a dialog fix.

- **`tn-form-errors`** — renders the message for an error that belongs to a `FormGroup`/`FormArray` (cross-field rule, min array length, server-side failure on a group), which has no field to sit under. Shares the resolution ladder with `tn-form-field`, so a group message reads exactly like the field messages beside it. Stays silent when the error is a child's — the field already shows that one.
- **`tn-form-list` + `tn-form-list-item`** — the chrome for editing a repeating group of fields: label, Add, empty state, entry frames, remove buttons. The consumer keeps the `FormArray` and does the pushing and splicing; the shape of an entry is only theirs to know.
- **Dismissible errors** — a server-side rejection is not something the user can retype their way out of, so it sat under the field forever. The legacy `ix-errors` gave every such message a close icon; nothing here replaced it. `dismissibleErrors` (per field, or app-wide via `TN_FORM_FIELD_DISMISSIBLE_ERRORS`) brings it back.
- **`fix(dialog)`** — `tn-dialog-shell` threw on a `DialogRef` with no `config`, which is what a mock provider supplies. 100+ specs in webui alone.

## Notes for review

- Only the error **actually on screen** gets a close button — the same `activeErrorKey` pick the message came from. A control with both a dismissible key and `required` shows the required message, undismissable.
- Dismissing clears **every listed key** the control carries, not just the active one: webui spreads one failure across `manualValidateError` / `manualValidateErrorMsg` / `ixManualValidateError`, and a sibling left behind re-renders the identical text under its own close button.
- The close button sits **outside** `role="alert"` — a live region announces everything it contains, and "Dismiss this error" is not part of the error.
- `tn-form-field` returns focus to the projected control after a dismiss, but only when focus was on the button (a Safari click never focuses it).