### PR TITLE
NAS-142526 / 27.0.0-BETA.1 / fix(stories): point the last ten phantom custom properties at declared tokens

### DIFF
--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -51,13 +51,16 @@ const THEMES_CSS = join(__dirname, '../../styles/themes.css');
  * fallback in all nine palettes.
  *
  * Empty, and meant to stay that way. #268 seeded it with the ten the scan
- * turned up outside that ticket's own `--border-color`, and #279 swept them:
- * `--fg1`/`--fg2`/`--lines` were `--tn-` prefixes dropped by hand,
- * `--tn-alt-bg` resolved to `--tn-alt-bg1`, `--success`/`--warning`/`--danger`
- * to the semantic status tokens, and `--warning-bg`/`--success-bg` to
- * `--tn-alt-bg1`, which is the surface `tn-banner` paints behind a status
- * heading and the one the status tokens are measured against — no palette
- * declares a status-tinted background of its own.
+ * turned up outside that ticket's own `--border-color`, and #279 swept all
+ * ten: `--fg1`, `--fg2` and `--lines` were `--tn-` prefixes dropped by hand;
+ * `--tn-alt-bg` resolved to `--tn-alt-bg1`; `--success`, `--warning` and
+ * `--danger` to the semantic status tokens; and the two status callouts'
+ * surfaces, `--warning-bg` and `--success-bg`, to `--tn-alt-bg1`, which is
+ * what `tn-banner` paints behind a status heading and one of the three
+ * surfaces the status tokens are measured on — no palette declares a
+ * status-tinted background of its own. `--warning-fg`, the text of the
+ * callout `--warning-bg` filled, became `--tn-warning` alongside it, matching
+ * what `--success` already did in the other one.
  *
  * An addition here is a new phantom token being recorded rather than fixed,
  * which is a decision to argue for in review, not a formality.

--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -20,13 +20,14 @@ import { join, relative } from 'path';
  * mechanism, and after the first fix nothing stopped the second — which is what
  * this spec is for.
  *
- * KNOWN_PHANTOM_TOKENS records the ones still outstanding. It is deliberately
- * not an ignore list: every entry is asserted to still be referenced, so an
- * entry cannot outlive the defect it excuses — fixing a token turns this spec
- * red until its entry goes too. It does not stop the list GROWING: a new
- * phantom token added with a matching entry in the same commit passes here.
- * What it removes is doing that silently, since the entry is an edit to this
- * file and reads as what it is. The sweep that empties it is proposed on #268.
+ * KNOWN_PHANTOM_TOKENS records the ones still outstanding, and is now empty:
+ * #279 swept the ten it was seeded with. It is deliberately not an ignore
+ * list: every entry is asserted to still be referenced, so an entry cannot
+ * outlive the defect it excuses — fixing a token turns this spec red until its
+ * entry goes too. It does not stop the list GROWING: a new phantom token added
+ * with a matching entry in the same commit passes here. What it removes is
+ * doing that silently, since the entry is an edit to this file and reads as
+ * what it is.
  *
  * SCOPE. This reads `src/stories/` only — the demo markup, where a token is
  * typed into an inline `style` attribute with no stylesheet to check it
@@ -49,26 +50,19 @@ const THEMES_CSS = join(__dirname, '../../styles/themes.css');
  * with the count of references behind each. Every one renders its hardcoded
  * fallback in all nine palettes.
  *
- * These are #268's scope boundary: that ticket covers `--border-color` in
- * `icon.stories.ts`, and these are what the same scan turned up elsewhere.
- * Each wants a token chosen per site rather than a global rename —
- * `--success`/`--warning`/`--danger` are semantic status colours with
- * `--tn-green`/`--tn-yellow`/`--tn-red` and the `--tn-*-bg` pairs as
- * candidates, and `--fg1`/`--fg2`/`--lines`/`--tn-alt-bg` look like `--tn-`
- * prefixes dropped by hand. Proposed as a sweep on #268.
+ * Empty, and meant to stay that way. #268 seeded it with the ten the scan
+ * turned up outside that ticket's own `--border-color`, and #279 swept them:
+ * `--fg1`/`--fg2`/`--lines` were `--tn-` prefixes dropped by hand,
+ * `--tn-alt-bg` resolved to `--tn-alt-bg1`, `--success`/`--warning`/`--danger`
+ * to the semantic status tokens, and `--warning-bg`/`--success-bg` to
+ * `--tn-alt-bg1`, which is the surface `tn-banner` paints behind a status
+ * heading and the one the status tokens are measured against — no palette
+ * declares a status-tinted background of its own.
+ *
+ * An addition here is a new phantom token being recorded rather than fixed,
+ * which is a decision to argue for in review, not a formality.
  */
-const KNOWN_PHANTOM_TOKENS: Record<string, number> = {
-  '--danger': 1,
-  '--fg1': 4,
-  '--fg2': 3,
-  '--lines': 1,
-  '--success': 4,
-  '--success-bg': 1,
-  '--tn-alt-bg': 1,
-  '--warning': 1,
-  '--warning-bg': 1,
-  '--warning-fg': 1,
-};
+const KNOWN_PHANTOM_TOKENS: Record<string, number> = {};
 
 interface Reference {
   property: string;

--- a/projects/truenas-ui/src/stories/button-toggle-demo.component.html
+++ b/projects/truenas-ui/src/stories/button-toggle-demo.component.html
@@ -1,6 +1,6 @@
 <div style="display: grid; gap: 32px; padding: 20px; max-width: 800px;">
   <div>
-    <h2 style="margin-bottom: 16px; color: var(--fg1);">Single Selection (Radio Mode)</h2>
+    <h2 style="margin-bottom: 16px; color: var(--tn-fg1);">Single Selection (Radio Mode)</h2>
     <tn-form-field label="Text Alignment">
       <tn-button-toggle-group name="alignment" aria-label="Text alignment" [(ngModel)]="alignment">
         <tn-button-toggle value="left">Left</tn-button-toggle>
@@ -9,11 +9,11 @@
         <tn-button-toggle value="justify">Justify</tn-button-toggle>
       </tn-button-toggle-group>
     </tn-form-field>
-    <p style="margin-top: 8px; color: var(--fg2); font-size: 14px;">Selected: {{ alignment || 'none' }}</p>
+    <p style="margin-top: 8px; color: var(--tn-fg2); font-size: 14px;">Selected: {{ alignment || 'none' }}</p>
   </div>
 
   <div>
-    <h2 style="margin-bottom: 16px; color: var(--fg1);">Multiple Selection (Checkbox Mode)</h2>
+    <h2 style="margin-bottom: 16px; color: var(--tn-fg1);">Multiple Selection (Checkbox Mode)</h2>
     <tn-form-field label="Font Style">
       <tn-button-toggle-group name="fontStyle" aria-label="Font style" [multiple]="true" [(ngModel)]="fontStyles">
         <tn-button-toggle value="bold">Bold</tn-button-toggle>
@@ -22,22 +22,22 @@
         <tn-button-toggle value="strikethrough">Strikethrough</tn-button-toggle>
       </tn-button-toggle-group>
     </tn-form-field>
-    <p style="margin-top: 8px; color: var(--fg2); font-size: 14px;">Selected: {{ fontStyles?.length ? fontStyles.join(', ') : 'none' }}</p>
+    <p style="margin-top: 8px; color: var(--tn-fg2); font-size: 14px;">Selected: {{ fontStyles?.length ? fontStyles.join(', ') : 'none' }}</p>
   </div>
 
 
   <div>
-    <h2 style="margin-bottom: 16px; color: var(--fg1);">Standalone Toggle</h2>
+    <h2 style="margin-bottom: 16px; color: var(--tn-fg1);">Standalone Toggle</h2>
     <tn-form-field label="Enable feature">
       <tn-button-toggle value="enabled" [(ngModel)]="featureEnabled">
         {{ featureEnabled ? 'Enabled' : 'Enable Feature' }}
       </tn-button-toggle>
     </tn-form-field>
-    <p style="margin-top: 8px; color: var(--fg2); font-size: 14px;">Status: {{ featureEnabled ? 'enabled' : 'disabled' }}</p>
+    <p style="margin-top: 8px; color: var(--tn-fg2); font-size: 14px;">Status: {{ featureEnabled ? 'enabled' : 'disabled' }}</p>
   </div>
 
   <div>
-    <h2 style="margin-bottom: 16px; color: var(--fg1);">Disabled State</h2>
+    <h2 style="margin-bottom: 16px; color: var(--tn-fg1);">Disabled State</h2>
     <tn-form-field label="Read-only options">
       <tn-button-toggle-group name="readonly" aria-label="Read-only options" [disabled]="true">
         <tn-button-toggle value="option1">Option 1</tn-button-toggle>

--- a/projects/truenas-ui/src/stories/icon.stories.ts
+++ b/projects/truenas-ui/src/stories/icon.stories.ts
@@ -390,9 +390,9 @@ export const SizesAndColors: Story = {
         <h4>Colors</h4>
         <div style="display: flex; align-items: center; gap: 16px;">
           <tn-icon name="server" library="mdi" size="lg" color="var(--tn-primary, #007acc)"></tn-icon>
-          <tn-icon name="server" library="mdi" size="lg" color="var(--success, #28a745)"></tn-icon>
-          <tn-icon name="server" library="mdi" size="lg" color="var(--warning, #ffc107)"></tn-icon>
-          <tn-icon name="server" library="mdi" size="lg" color="var(--danger, #dc3545)"></tn-icon>
+          <tn-icon name="server" library="mdi" size="lg" color="var(--tn-success, var(--tn-green, #416f26))"></tn-icon>
+          <tn-icon name="server" library="mdi" size="lg" color="var(--tn-warning, var(--tn-orange, #955313))"></tn-icon>
+          <tn-icon name="server" library="mdi" size="lg" color="var(--tn-error, var(--tn-red, #bd2626))"></tn-icon>
           <tn-icon name="server" library="mdi" size="lg" color="#9c27b0"></tn-icon>
         </div>
       </div>

--- a/projects/truenas-ui/src/stories/patterns/captive-wizard.stories.html
+++ b/projects/truenas-ui/src/stories/patterns/captive-wizard.stories.html
@@ -86,7 +86,7 @@
             <div>
                 <tn-checkbox label="Enable deduplication" [(ngModel)]="config.storage.enableDeduplication" />
                 @if (config.storage.enableDeduplication) {
-                <div style="margin-top: 8px; padding: 8px; background: var(--warning-bg); border-radius: 4px; font-size: 14px; color: var(--warning-fg);">
+                <div style="margin-top: 8px; padding: 8px; background: var(--tn-alt-bg1); border-radius: 4px; font-size: 14px; color: var(--tn-warning, var(--tn-orange, #955313));">
                 <strong>Warning:</strong> Deduplication requires significant RAM (5GB+ recommended per TB of storage).
                 </div>
                 }
@@ -299,9 +299,9 @@
             </div>
         </div>
         
-        <div style="padding: 16px; background: var(--success-bg); border-radius: 8px; border: 1px solid var(--success);">
-            <h4 style="margin: 0 0 8px 0; color: var(--success);">Ready to Complete Setup</h4>
-            <p style="margin: 0; font-size: 14px; color: var(--success);">
+        <div style="padding: 16px; background: var(--tn-alt-bg1); border-radius: 8px; border: 1px solid var(--tn-success, var(--tn-green, #416f26));">
+            <h4 style="margin: 0 0 8px 0; color: var(--tn-success, var(--tn-green, #416f26));">Ready to Complete Setup</h4>
+            <p style="margin: 0; font-size: 14px; color: var(--tn-success, var(--tn-green, #416f26));">
             Your TrueNAS system is configured and ready to be initialized. Click "Complete Setup" to apply all settings and start your system.
             </p>
         </div>

--- a/projects/truenas-ui/src/stories/slide-toggle.stories.ts
+++ b/projects/truenas-ui/src/stories/slide-toggle.stories.ts
@@ -193,7 +193,7 @@ export const FullWidth: Story = {
     props: args,
     template: `
       <div style="width: 360px; display: flex; flex-direction: column; gap: 16px;
-                  padding: 16px; border: 1px dashed var(--lines, #ccc);">
+                  padding: 16px; border: 1px dashed var(--tn-lines);">
         <tn-slide-toggle
           [label]="label"
           [labelPosition]="labelPosition"

--- a/projects/truenas-ui/src/stories/tree-virtual-scroll-view.stories.ts
+++ b/projects/truenas-ui/src/stories/tree-virtual-scroll-view.stories.ts
@@ -179,7 +179,7 @@ export const StickyHeader: Story = {
     },
     template: `
       <div style="height: 420px; border: 1px solid var(--tn-lines); border-radius: 6px; overflow: hidden; display: flex; flex-direction: column;">
-        <div style="overflow: hidden; border-bottom: 1px solid var(--tn-lines); background: var(--tn-alt-bg);">
+        <div style="overflow: hidden; border-bottom: 1px solid var(--tn-lines); background: var(--tn-alt-bg1);">
           <div
             style="display: flex; gap: 24px; padding: 8px 16px; width: 900px; font-weight: 600;"
             [style.transform]="'translateX(' + (-headerScrollLeft) + 'px)'"


### PR DESCRIPTION
Ten custom properties read by five story files were declared by no palette. Each rendered its hardcoded fallback in all nine themes — or, where the site had no fallback, nothing at all: `background: var(--warning-bg)` computed to transparent and `color: var(--warning-fg)` to the inherited colour, so the wizard's deduplication warning has been an untinted, unmarked block of body text.

`Fixes #279`.

## Chosen per site

| was | is | why |
|---|---|---|
| `--fg1` ×4, `--fg2` ×3 | `--tn-fg1`, `--tn-fg2` | `button-toggle-demo.component.html`'s section headings and "Selected:" lines. Dropped `--tn-` prefixes; both sit on the story canvas, which is inside the 4.5:1 text guarantee |
| `--lines` | `--tn-lines` | `slide-toggle.stories.ts`'s dashed demo frame. Same dropped prefix |
| `--tn-alt-bg` | `--tn-alt-bg1` | the column-header strip above the tree in `tree-virtual-scroll-view.stories.ts` |
| `--success`, `--warning`, `--danger` | `--tn-success`, `--tn-warning`, `--tn-error` | `icon.stories.ts`'s "Colors" row |
| `--warning-bg`, `--success-bg` | `--tn-alt-bg1` | the two `captive-wizard.stories.html` status callouts |
| `--warning-fg`, `--success` | `--tn-warning`, `--tn-success` | their text and borders |

**`--tn-alt-bg` was the only genuinely ambiguous one**, and the tree resolves it. `tree-node.component.scss` hovers a row to `--tn-alt-bg2` and paints `--tn-alt-bg1` on `:active`, so a header painted `--tn-alt-bg2` would read as a hovered row sitting above the list. `--tn-alt-bg1` is also what the other story panels already use — `stepper.stories.ts`, `expansion-panel.stories.ts`, `keyboard-shortcut.stories.html`, `progressive-disclosure.stories.html`.

**`--danger` maps to `--tn-error`**, not `--tn-red`. The library's semantic set is info/warning/error/success, and the swatch beside these three already reads `--tn-primary` rather than `--tn-blue`.

**The status reads are spelled as the full chain** — `var(--tn-success, var(--tn-green, #416f26))` and so on. `semantic-status-contrast.spec.ts` scans `stories/` as well as `lib/` and pins that exact shape; a bare `var(--tn-success)` fails it. The first draft here used bare reads and that spec caught them.

## The palette gap, stated rather than papered over

**No palette declares a status-tinted surface.** There is no `--tn-warning-bg`, no `--tn-success-bg`, nothing of that shape — the closest is `--tn-primary-txt`/`--tn-accent-txt`, which are text-on-fill pairs for the primary and accent colours only. So `--warning-bg` and `--success-bg` have no like-for-like replacement.

`--tn-alt-bg1` is what the library does instead. `tn-banner`'s four variants all fill `--tn-alt-bg1` and carry the status colour on the left border, heading and icon, and `progressive-disclosure.stories.html` already writes that pattern inline in story markup. It is also one of the three surfaces the status tokens are measured on: themes.css guarantees `--tn-info`/`--tn-warning`/`--tn-error`/`--tn-success` at ≥4.5:1 on `--tn-alt-bg1`, `--tn-bg1` and `--tn-bg2` in every palette, and `semantic-status-contrast.spec.ts` holds all nine to it. So both callouts' text is measured rather than assumed. This is noted on #279 as well.

## What pins it

`KNOWN_PHANTOM_TOKENS` in `story-token-declarations.spec.ts` is now `{}`. That is the record emptying, not the guard going away: `reads no undeclared custom property outside the recorded ones` still scans every `var()` in `src/stories/` against every declaration in `themes.css`, and with nothing recorded, any undeclared property fails it. #278 confirmed the spec survives an empty record before this ticket existed, and it does.

The record's comment now says what each of the ten became, so the next reader gets the decisions rather than just the absence.

## Checks

`yarn lint`, `yarn test` (3827 passing, 137 suites), `yarn test:scripts`, `yarn build` and `yarn build-storybook` all pass locally.

**`Storybook Interaction Tests` was not run locally.** It drives a browser this host cannot provide, so CI is the first place it runs against this change. It is the check most likely to have an opinion here, since these are story files — though every edit is a token swap inside an inline `style` attribute, with no markup, no story structure and no component source touched.

## Reviewed locally

One round, exit 0 — the project's own reviewer, same rubric and threshold as the required check, run in a separate process. It returned nothing at MEDIUM or above.

Three LOWs. One was fixed because it made the diff's own prose wrong: the record's comment enumerated nine of the ten swept tokens and left `--warning-fg` out, so a note about a completed sweep read as an incomplete one. That is the second commit here, and it changes a comment only.

The other two are recorded rather than acted on:

- **The new `var(--tn-success, var(--tn-green, #416f26))` fallback rungs are unreachable, and the middle rung is the raw hue `themes.css` rejected for contrast on `--tn-alt-bg1`.** Both true. Every palette in this repo declares all four semantic tokens, so the chain always stops at the first link, and `--tn-green` is indeed the untuned hue — that is why `--tn-success` exists. The chain is the repo-wide convention that `semantic-status-contrast.spec.ts` requires on every read, for consumer stylesheets that predate these four tokens and define the TrueNAS palette themselves; the spec's own comment explains it. Departing from it here would fail the spec. If the convention is wrong it is wrong in ~30 places and is its own ticket.
- **The status colour now applies to the whole panel body in the wizard's completion callout, where `tn-banner` tints only the heading and icon and lets the body inherit.** True, and it is what the markup already asked for — `color: var(--success)` was on the `<p>` as well as the `<h4>` before this change, and both are `--tn-success` after it. Retinting the body to `--tn-fg2` would be a design change to a demo, which is more than a phantom-token sweep should decide. It is measured either way: `--tn-success` clears 4.5:1 on `--tn-alt-bg1` in all nine palettes.

## One thing worth knowing

The tree's column-header strip now paints `--tn-alt-bg1` where it painted nothing, and its labels take their colour by inheritance from the story canvas. That surface is outside the text guarantee, and #282 records `--tn-fg1` measuring 3.91:1 on `.tn-midnight`'s `--tn-alt-bg1`. So this site inherits that open defect rather than introducing a new one — fixing `.tn-midnight` fixes it here too, and giving this one strip a colour of its own would not be the fix.
