### PR TITLE
NAS-142535 / 27.0.0-BETA.1 / fix(theme): lift .tn-midnight's --tn-fg1 so it clears AA on every fill it lands on

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -542,8 +542,26 @@
   --tn-bg1: #212a35;
   --tn-bg2: #303d48;
   --tn-bg3: #3d4a55;
-  --tn-fg1: #aaaaaa;
-  --tn-fg2: #cccccc;
+  /* Was #aaaaaa, the calmer half of a deliberate inversion: --tn-fg2 (#cccccc)
+     was this palette's emphasis colour and --tn-fg1 the quieter one, the only
+     palette of nine ordered that way. Both cleared 4.5:1 on --tn-bg1 and
+     --tn-bg2, which is all the text tokens claim — but on the three fills that
+     sit above --tn-bg2, #aaaaaa read 3.91:1 on --tn-bg3/--tn-alt-bg1 and
+     3.19:1 on --tn-alt-bg2, the worst of the nine palettes (#282). Those fills
+     are the hovered menu item and list item, the active table row, the banner
+     and the stepper indicator, so that was primary text on ordinary
+     interactive states.
+
+     THE FILLS COULD NOT MOVE INSTEAD. #aaaaaa clears 4.5:1 only on a surface of
+     luminance 0.0504 or below, and --tn-bg2 is already at 0.0443: all three
+     fills would have had to land in the band between the card surface and a
+     ceiling just above it, 12.9% of the elevation --tn-alt-bg2 has today. The
+     fills exist to read as raised, so keeping the inversion meant keeping the
+     failure. #cccccc holds its role unchanged. */
+  --tn-fg1: #e0e0e0; /* 10.99:1 on --tn-bg1, 8.43:1 on --tn-bg2, 6.89:1 on
+                        --tn-bg3/--tn-alt-bg1, 5.62:1 on --tn-alt-bg2 */
+  --tn-fg2: #cccccc; /* 9.04:1 on --tn-bg1, 6.93:1 on --tn-bg2, 5.66:1 on
+                        --tn-bg3/--tn-alt-bg1, 4.62:1 on --tn-alt-bg2 */
   /* Non-text, 3:1 on --tn-bg1/--tn-bg2 — see the note in :root (#240).
      #666666 read 1.94:1 on --tn-bg2 and #888888 3.14:1, so --tn-fg4 had to
      move a long way and --tn-fg3 had to move with it to stay a step ahead. */

--- a/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
@@ -76,9 +76,12 @@ const SURFACES: Readonly<Record<string, string>> = {
  * as well as one carrying body copy is the way this fix could go wrong.
  *
  * Their order relative to EACH OTHER is a per-theme choice and is deliberately
- * not pinned: `.tn-midnight` reads `--tn-fg2` at 9.04:1 over `--tn-fg1` at
- * 6.25:1 on `--tn-bg1`. The claim is only that neither muted token out-reads
- * either of these.
+ * not pinned. `.tn-midnight` used to be the example — it read `--tn-fg2` at
+ * 9.04:1 over `--tn-fg1` at 6.25:1 on `--tn-bg1` — until #282 lifted its
+ * `--tn-fg1` to clear AA on the fills above `--tn-bg2`, and no palette inverts
+ * the pair today. Not pinned all the same: which of the two leads is
+ * `text-fg-contrast.spec.ts`'s question, and it records rather than forbids.
+ * The claim here is only that neither muted token out-reads either of these.
  */
 const TEXT_TOKENS = ['--tn-fg1', '--tn-fg2'];
 

--- a/projects/truenas-ui/src/lib/theme/text-fg-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-fg-contrast.spec.ts
@@ -90,11 +90,22 @@ const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...Object.keys(TEXT_TOKENS)];
  * Asserted to STILL BE TRUE rather than merely skipped, the same way
  * `OUTREADS_TEXT` is, so a palette that stops inverting takes its entry out
  * instead of leaving a note here that has quietly stopped describing it.
+ *
+ * EMPTY, AND THAT IS THE CURRENT STATE RATHER THAN A DISABLED RECORD. Its one
+ * entry was `.tn-midnight`, whose `--tn-fg2` (#cccccc) was the emphasis colour
+ * and whose `--tn-fg1` (#aaaaaa) was the calmer one. #282 is what took it out:
+ * the two clear 4.5:1 on the two surfaces measured here, which is what this
+ * record said and it was true, but on the three fills above `--tn-bg2` the
+ * calmer of the two ran out first and `--tn-fg1` failed the primary text role on
+ * the hovered menu item, the hovered row and the active table row — the exact
+ * shape described above, arriving on surfaces this file does not measure.
+ * `--tn-fg1` is now #e0e0e0 and leads the ramp, so the entry describes nothing.
+ *
+ * The record stays because the inversion it covers is still a legitimate
+ * per-theme choice — what #282 showed is that it costs a palette its headroom on
+ * the untuned fills, not that it is forbidden.
  */
-const FG2_OUTREADS_FG1: Readonly<Record<string, string>> = {
-  '.tn-midnight': '--tn-fg2 (#cccccc) is the emphasis colour here and --tn-fg1 (#aaaaaa) '
-    + 'the calmer one; both clear 4.5:1 on both surfaces, so neither role is failing',
-};
+const FG2_OUTREADS_FG1: Readonly<Record<string, string>> = {};
 
 interface TokenCase {
   selector: string;

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -208,41 +208,6 @@ interface KnownGap {
  * them describing a defect that no longer existed.
  */
 const KNOWN_GAPS: readonly KnownGap[] = [
-  // .tn-midnight is the one palette of nine that inverts its text ramp on
-  // purpose: --tn-fg2 (#cccccc) is its emphasis colour and --tn-fg1 (#aaaaaa)
-  // the calmer one, which text-fg-contrast.spec.ts records in FG2_OUTREADS_FG1
-  // and holds to still being true. Both clear 4.5:1 on --tn-bg1 and --tn-bg2,
-  // which is the whole of what the tokens claim. On the three surfaces above
-  // --tn-bg2 the calmer of the two runs out first, and its own --tn-fg2 clears
-  // every one of them (5.66:1, 4.62:1, 5.66:1) — so this is the palette's
-  // deliberate ordering meeting a surface nothing tuned it against, not a token
-  // that is wrong everywhere.
-  //
-  // Not fixed here, and the two ways to fix it are both palette design: lifting
-  // --tn-fg1 above --tn-fg2 undoes the inversion this theme chose, and darkening
-  // three fills that sit deliberately above --tn-bg2 (#303d48) takes the
-  // elevation cue with them. #277 is the ticket that measured it; changing a
-  // theme's ramp is not a survey's call to make.
-  {
-    selector: '.tn-midnight',
-    token: '--tn-fg1',
-    surface: '--tn-alt-bg1',
-    why: '#aaaaaa on #3d4a55 — 3.91:1. Its --tn-fg2 (#cccccc) reads 5.66:1 on the same fill',
-  },
-  {
-    selector: '.tn-midnight',
-    token: '--tn-fg1',
-    surface: '--tn-alt-bg2',
-    why: '#aaaaaa on #4a5762 — 3.19:1, the worst of the nine. Its --tn-fg2 reads 4.62:1 there',
-  },
-  {
-    selector: '.tn-midnight',
-    token: '--tn-fg1',
-    surface: '--tn-bg3',
-    why: '#aaaaaa on #3d4a55 — 3.91:1. --tn-bg3 and --tn-alt-bg1 are the same colour in this '
-      + 'palette, so this is the entry above under the other name, and both are measured '
-      + 'because a palette is free to separate them',
-  },
   // The pairing #277 was filed for. --tn-alt-fg1 is Solarized's base1, picked by
   // #265 as the dimmest of that palette's own tones clearing 4.5:1 on --tn-bg1
   // (5.61:1) and --tn-bg2 (4.86:1) — the step below --tn-fg2 rather than a

--- a/projects/truenas-ui/src/stories/api/theming.mdx
+++ b/projects/truenas-ui/src/stories/api/theming.mdx
@@ -282,7 +282,7 @@ Dark theme with blues and grays for a professional look.
 - `--tn-accent`: #c17ecc
 - `--tn-bg1`: #212a35
 - `--tn-bg2`: #303d48
-- `--tn-fg1`: #aaaaaa
+- `--tn-fg1`: #e0e0e0
 - `--tn-fg2`: #cccccc
 - `--tn-lines`: #383838
 - `--tn-red`: #ff0013

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -542,8 +542,26 @@
   --tn-bg1: #212a35;
   --tn-bg2: #303d48;
   --tn-bg3: #3d4a55;
-  --tn-fg1: #aaaaaa;
-  --tn-fg2: #cccccc;
+  /* Was #aaaaaa, the calmer half of a deliberate inversion: --tn-fg2 (#cccccc)
+     was this palette's emphasis colour and --tn-fg1 the quieter one, the only
+     palette of nine ordered that way. Both cleared 4.5:1 on --tn-bg1 and
+     --tn-bg2, which is all the text tokens claim — but on the three fills that
+     sit above --tn-bg2, #aaaaaa read 3.91:1 on --tn-bg3/--tn-alt-bg1 and
+     3.19:1 on --tn-alt-bg2, the worst of the nine palettes (#282). Those fills
+     are the hovered menu item and list item, the active table row, the banner
+     and the stepper indicator, so that was primary text on ordinary
+     interactive states.
+
+     THE FILLS COULD NOT MOVE INSTEAD. #aaaaaa clears 4.5:1 only on a surface of
+     luminance 0.0504 or below, and --tn-bg2 is already at 0.0443: all three
+     fills would have had to land in the band between the card surface and a
+     ceiling just above it, 12.9% of the elevation --tn-alt-bg2 has today. The
+     fills exist to read as raised, so keeping the inversion meant keeping the
+     failure. #cccccc holds its role unchanged. */
+  --tn-fg1: #e0e0e0; /* 10.99:1 on --tn-bg1, 8.43:1 on --tn-bg2, 6.89:1 on
+                        --tn-bg3/--tn-alt-bg1, 5.62:1 on --tn-alt-bg2 */
+  --tn-fg2: #cccccc; /* 9.04:1 on --tn-bg1, 6.93:1 on --tn-bg2, 5.66:1 on
+                        --tn-bg3/--tn-alt-bg1, 4.62:1 on --tn-alt-bg2 */
   /* Non-text, 3:1 on --tn-bg1/--tn-bg2 — see the note in :root (#240).
      #666666 read 1.94:1 on --tn-bg2 and #888888 3.14:1, so --tn-fg4 had to
      move a long way and --tn-fg3 had to move with it to stay a step ahead. */


### PR DESCRIPTION
`.tn-midnight` drew `--tn-fg1` below AA on all three of the fills that sit above `--tn-bg2`:

| surface | value | ratio |
|---|---|---|
| `--tn-alt-bg1` (#3d4a55) | `--tn-fg1` #aaaaaa | 3.91:1 |
| `--tn-alt-bg2` (#4a5762) | `--tn-fg1` #aaaaaa | **3.19:1**, the worst of the nine palettes |
| `--tn-bg3` (#3d4a55) | `--tn-fg1` #aaaaaa | 3.91:1 |

Those fills are the hovered menu item, the hovered or selected list item and option, the hovered tree node, the active table row and card, the banner and the stepper indicator — primary text on ordinary interactive states, not an edge case.

`Fixes #282`.

## Reproduced first

#277 measured these and recorded them in `KNOWN_GAPS`, so the failing state is asserted rather than merely present. Taking the three `.tn-midnight` entries out and running the suite against the shipped values is what that assertion turns into:

```
● .tn-midnight: --tn-fg1 … is #aaaaaa on --tn-alt-bg2 (#4a5762, …) at 3.19:1
● .tn-midnight: --tn-fg1 … is #aaaaaa on --tn-alt-bg1 (#3d4a55, …) at 3.91:1
● .tn-midnight: --tn-fg1 … is #aaaaaa on --tn-bg3 (#3d4a55, …) at 3.91:1
```

Three failures, the three ratios the ticket reports, from `lib/a11y/contrast-testing.ts` rather than from any arithmetic written here.

## Only one of the ticket's two routes is available

The ticket names two, both palette design: lift `--tn-fg1` above `--tn-fg2`, or darken the three fills.

**Darkening the fills does not work, and that is measurable rather than a matter of taste.** #aaaaaa clears 4.5:1 only on a surface of luminance **0.0504 or below**. `--tn-bg2` — the card surface these three fills exist to sit *above* — is already at **0.0443**. So all three would have to land in the band `[0.0443, 0.0504]`, which is **12.9% of the elevation `--tn-alt-bg2` has today** (0.0915). That is the elevation cue removed, not reduced, in exchange for keeping one token still. Working checked in `state/scratch/282/probe.mjs`, whose arithmetic is pinned against six ratios the real suite printed in its own case titles before it is used for anything.

So `--tn-fg1` moves.

## The value

**#aaaaaa → #e0e0e0**, which is what `.tn-dark` already declares for the same role, so this is a value the design system ships rather than a new one.

| surface | ratio |
|---|---|
| `--tn-bg1` (#212a35) | 10.99:1 |
| `--tn-bg2` (#303d48) | 8.43:1 |
| `--tn-bg3` / `--tn-alt-bg1` (#3d4a55) | 6.89:1 |
| `--tn-alt-bg2` (#4a5762) | 5.62:1 |

`--tn-fg2` (#cccccc) is untouched and already cleared all four (9.04, 6.93, 5.66, 4.62). **No surface value moves**, so `--tn-fg3`/`--tn-fg4` and `--tn-alt-fg1`/`--tn-alt-fg2` measure exactly what they did before — the third and fourth acceptance criteria are satisfied by the change being confined to one foreground.

## The inversion ends, and it could not have survived in any useful form

`.tn-midnight` was the one palette of nine ordered deliberately the other way: `--tn-fg2` the emphasis colour, `--tn-fg1` the calmer one, recorded in `text-fg-contrast.spec.ts`'s `FG2_OUTREADS_FG1`.

That record was accurate about what it claimed — both tokens clear 4.5:1 on `--tn-bg1` and `--tn-bg2`, which is the whole of the text tokens' guarantee. The failure arrived on the three surfaces that file does not measure.

**Keeping the ordering was not an option with a real value in it.** `--tn-fg2` reads 4.62:1 on `--tn-alt-bg2`. For `--tn-fg1` to clear 4.5:1 there *and* still read dimmer than `--tn-fg2`, it would have to sit between #cacaca and #cccccc — one shade from the token it is supposed to be the quieter partner of. There is no calmer token in that gap, only a second name for `--tn-fg2`.

So the entry comes out, and the ramp now descends the way the other eight palettes' do: `--tn-fg1` 10.99:1, `--tn-fg2` 9.04:1, `--tn-alt-fg1` 8.06:1 on `--tn-bg1`. Worth noting what the old ordering had also produced: #aaaaaa was dimmer than this palette's own *muted* token, `--tn-alt-fg1` (#c1c1c1, 8.06:1) — primary text reading below placeholder text.

**`FG2_OUTREADS_FG1` is now empty and stays.** An inversion is still a legitimate per-theme choice; what this shows is what it costs a palette on the untuned fills. The doc comment says so, so an empty record does not read as a disabled one — the same shape #279 left `KNOWN_PHANTOM_TOKENS` in.

## The records that had to move with it

- The three `.tn-midnight` entries are out of `KNOWN_GAPS`, and are now measured as live pairings like any other. **The comment that explained why they were left went with them** — a paragraph about a gap that no longer exists is exactly what these asserted records exist to prevent, and removing the entries alone would have orphaned it above the `.tn-solarized-dark` entry it does not describe.
- `.tn-midnight` is out of `FG2_OUTREADS_FG1`, which asserts every recorded inversion is still there.
- Both tokens carry their measured ratios next to them in `themes.css`, as that file does elsewhere, along with why the fills could not move instead.
- `yarn copy-themes` has been run, so `.storybook/public/themes.css` matches.

## Checks

`yarn lint`, `yarn test` (3990 passing, 138 suites), `yarn test:scripts` (42), `yarn build` and `yarn build-storybook` all pass locally.

The test count is 2 lower than `main`'s 3992 and that is the expected arithmetic, not a suite that stopped running: removing `.tn-midnight` from `FG2_OUTREADS_FG1` drops its two "recorded inversion is still there" cases, one per surface. The three `KNOWN_GAPS` removals are net zero — each pairing leaves the "still a gap" table and joins the live one.

**`Storybook Interaction Tests` was not run locally.** It drives a browser this host cannot provide, so CI is the first place it runs against this change. What the diff changes there is one hex value in a palette and one line of Storybook prose; no story, markup or component source is touched.

## Reviewed locally

**Exit 0** — the project's own reviewer, same rubric, threshold and parser as the required check, run in a separate process. It returned nothing at MEDIUM or above.

It returned three LOWs. Two of them were prose this change had made false, which is a defect the reviewer happened to score low rather than polish, so both are fixed in the second commit:

- `theming.mdx`'s Midnight Key Colors block still listed `--tn-fg1: #aaaaaa`. Nothing checks that block against `themes.css`, so it would have gone on documenting the removed value indefinitely.
- `muted-fg-contrast.spec.ts`'s comment cited `.tn-midnight` reading `--tn-fg2` (9.04:1) above `--tn-fg1` (6.25:1) as its example of an order that file deliberately does not pin. That palette no longer does and no other one does either; the point stands, so the example is now marked historical and points at the file whose question it is.

**The third is left, deliberately.** `--tn-fg1` #e0e0e0 is one step from this palette's `--tn-alt-fg2` #e1e1e1, which the reviewer reads as collapsing that token's role. Fair to raise, and I disagree that this change causes it: `.tn-dark` ships exactly that pair — `--tn-fg1: #e0e0e0` beside `--tn-alt-fg2: #e1e1e1` — so it is the house arrangement for a dark palette rather than something introduced here, and `--tn-alt-fg2`'s role is which surfaces it is tuned against, not being a distinct shade. Moving it would be a change to a token this ticket has no measurement against, in a palette whose fills it does not touch. If it is worth pursuing it is worth its own ticket, across every palette that pairs them.
