### PR TITLE
NAS-142540 / 27.0.0-BETA.1 / refactor(a11y): extract the scrollable-region measurement and apply it

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -503,6 +503,53 @@ passes just as happily on markup that reintroduces the other. Use `liveSources()
 and `politeness()` from `lib/a11y/live-region-testing.ts`; see
 `banner-a11y.spec.ts` for the shape.
 
+### Scrolling Regions
+
+**An element that scrolls has to be reachable from a keyboard.** axe's
+`scrollable-region-focusable` reports any element that scrolls, is not in the
+tab order, and contains nothing that is — because content below its fold is
+content a keyboard cannot get to. Five elements in this library are scroll
+containers and every one of them can be handed content with no control in it.
+
+**Take the measurement from `lib/a11y/scrollable-region.ts`. Do not write it
+again.** `tnScrollableRegion(() => element)` returns the signal a component
+binds its `tabindex` (and, where the element is not already named, its `role`
+and `aria-label`) to. What it is not is one comparison:
+
+- **axe's own 13px buffer**, `getScroll(node, 13)`. Measuring with a bare `>`
+  marks regions the rule considers fine, because `scrollHeight` and
+  `clientHeight` are integers rounded from fractional layout.
+- **The computed `overflow` on the overflowing axis.** Content wider than a
+  `overflow-x: visible` box does not scroll; it spills out and is on screen, and
+  axe does not report it.
+- **A `ResizeObserver` on the region AND on its direct children**, plus a
+  `MutationObserver`. The children are the half that catches growth no DOM
+  mutation announces — an image loading, a webfont swapping.
+- **A focus latch.** Removing `tabindex` from an element that HAS focus blurs it
+  to `<body>`, so a region that stops overflowing while someone is reading it
+  keeps its tab stop until focus leaves. Focus *retains* a stop; it does not
+  grant one — `tn-drawer` focuses its own panel on open, and the earlier
+  `overflowing || focused` reading made every modal drawer a tab stop.
+
+**The component still decides what to put on the element**, because that is what
+legitimately differs: `tn-drawer`'s panel is already a named `role="dialog"` and
+takes only the tab stop, while `tn-side-panel`'s bare `<section>` takes
+`role="group"` and a name as well. A directive owning those attributes through
+host bindings would clobber the template bindings the drawer already has.
+
+**A scrolling region that takes a tab stop is named.** A focusable element with
+no accessible name is announced as a bare "group". Prefer a name the component
+already has — `tn-tab-panel` uses its own `label`, which is what its tab says —
+and expose an input for it where there is none.
+
+**Test it with `lib/a11y/scrollable-region-testing.ts`.** jsdom has no layout
+engine, so nothing in this library can overflow under jest by itself:
+`scrollingTo(el, scrollSize, clientSize, axis)` stubs the two readings and sets
+the matching `overflow` inline, which is what both axe and the helper read.
+Stubbing only the sizes gives a rule that never matches and a spec that is green
+for nothing. `staticScroller()` is the positive control every such spec needs
+beside it.
+
 ### Running axe in a spec
 
 **Use `lib/a11y/axe-testing.ts`. Do not write another axe wrapper.** Three specs

--- a/projects/truenas-ui/src/lib/a11y/scrollable-region-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/scrollable-region-testing.ts
@@ -1,0 +1,165 @@
+/**
+ * The two stand-ins every `scrollable-region-focusable` spec needs, so that no
+ * copy of either can drift into being the lenient one.
+ *
+ * WHY A SPEC CANNOT SIMPLY MAKE SOMETHING OVERFLOW
+ * -----------------------------------------------
+ * jsdom has no layout engine, so `scrollHeight`, `clientHeight`, `scrollWidth`
+ * and `clientWidth` are `0` on every element and no component in this library
+ * can overflow under jest by itself. `scrollingTo` stubs the readings on a real
+ * element and sets the matching `overflow` inline — which is what both axe's
+ * `getScroll` and `tnScrollableRegion` read, and neither of them can tell the
+ * stub from a browser.
+ *
+ * That makes these specs a reproduction of the RULE, not of the rendering: they
+ * prove axe reports the defect on the unfixed markup and stops reporting it on
+ * the fixed markup. Whether a given story's content actually overflows at its
+ * rendered size is a question only `yarn test-sb` can answer.
+ *
+ * WHY THE INLINE `overflow` IS NOT OPTIONAL
+ * -----------------------------------------
+ * Both readers check it. `getScroll` returns nothing for an element whose
+ * computed `overflow-x`/`overflow-y` on the overflowing axis is not `auto` or
+ * `scroll`, because content that spills out of a `visible` box is on screen
+ * rather than hidden below a fold. A spec that stubbed only the heights would
+ * therefore assert against a rule that never matched — the vacuous green
+ * `axe-testing.ts` exists to prevent, arriving through the fixture instead of
+ * through the assertion. jest does not compile a component's SCSS, so the
+ * inline declaration stands in for the stylesheet's.
+ *
+ * `side-panel-scrollable-content.spec.ts` keeps private copies of both of
+ * these. That is deliberate: it is the guard #270 had to leave passing
+ * unchanged while the measurement moved out from under it, and a spec that was
+ * edited in the same commit as the thing it guards proves less.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `axe-testing.ts`.
+ */
+
+/** Which axis a region is being made to scroll on. */
+export type TnScrollAxis = 'vertical' | 'horizontal';
+
+/**
+ * Make `el` read as a scrolling element whose content is `scrollSize` long on
+ * `axis`, in a box of `clientSize`.
+ *
+ * The sizes are given rather than derived from a boolean because the threshold
+ * is what several of these specs are about: axe matches through
+ * `getScroll(node, 13)` and `tnScrollableRegion` measures against the same 13px,
+ * so two sizes 14 apart and two sizes 13 apart are on opposite sides of a line a
+ * true/false argument would hide.
+ */
+export function scrollingTo(
+  el: HTMLElement,
+  scrollSize: number,
+  clientSize: number,
+  axis: TnScrollAxis = 'vertical',
+): void {
+  const [scrollProp, clientProp] = axis === 'vertical'
+    ? ['scrollHeight', 'clientHeight']
+    : ['scrollWidth', 'clientWidth'];
+
+  if (axis === 'vertical') {
+    el.style.overflowY = 'auto';
+  } else {
+    el.style.overflowX = 'auto';
+  }
+
+  Object.defineProperty(el, scrollProp, { value: scrollSize, configurable: true });
+  Object.defineProperty(el, clientProp, { value: clientSize, configurable: true });
+}
+
+/**
+ * Stand-in for `ResizeObserver`, which jsdom does not implement — so the half
+ * of the measurement that reacts to a BOX change has no callback path without
+ * one.
+ *
+ * Declared here rather than reached for from `TnTableTesting`: that one is
+ * public API shaped around `tn-table`'s container width
+ * (`emitContainerWidth`), and none of these regions read either the entries or
+ * a width.
+ */
+export class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+
+  /**
+   * What this observer is currently watching, which is the half of the fix a
+   * callback cannot show: firing the callback proves the component re-measures,
+   * not that a resize of a CHILD would ever have reached it.
+   */
+  observed: Element[] = [];
+
+  constructor(private cb: ResizeObserverCallback) {
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed.push(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed = this.observed.filter((element) => element !== target);
+  }
+
+  disconnect(): void {
+    this.observed = [];
+  }
+
+  /** Everything every registered observer is watching. */
+  static targets(): Element[] {
+    return MockResizeObserver.instances.flatMap((observer) => observer.observed);
+  }
+
+  /**
+   * Fire every registered observer, as a resize of something it watches.
+   *
+   * The entries are empty because nothing reads them: the helper re-measures
+   * the region itself whatever resized, which is the only answer that is right
+   * when what resized was a child.
+   */
+  static emit(): void {
+    MockResizeObserver.instances.forEach(
+      (observer) => observer.cb([], observer as unknown as ResizeObserver)
+    );
+  }
+
+  /**
+   * Install the mock and hand back the teardown, so a spec's `beforeEach` and
+   * `afterEach` cannot disagree about which one they are restoring.
+   *
+   * Must run BEFORE the fixture is created: `tnScrollableRegion`
+   * feature-detects `ResizeObserver` once, when it binds to the region.
+   */
+  static install(): () => void {
+    const original = globalThis.ResizeObserver;
+    MockResizeObserver.instances = [];
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    return () => {
+      globalThis.ResizeObserver = original;
+      MockResizeObserver.instances = [];
+    };
+  }
+}
+
+/**
+ * A detached-then-attached scroll container with content and no tab stop —
+ * the shape axe reports, built from static markup.
+ *
+ * Every spec that asserts `violated).toEqual([])` on a fixed component needs
+ * one of these beside it, or the assertion would also pass if the rule stopped
+ * matching altogether. Returns the root to remove and the element to name as
+ * the target.
+ */
+export function staticScroller(
+  scrollSize: number,
+  clientSize: number,
+  axis: TnScrollAxis = 'vertical',
+): { root: HTMLElement; region: HTMLElement } {
+  const root = document.createElement('div');
+  root.innerHTML = '<section class="scroller"><p>Region body</p></section>';
+  document.body.appendChild(root);
+
+  const region = root.querySelector('.scroller') as HTMLElement;
+  scrollingTo(region, scrollSize, clientSize, axis);
+  return { root, region };
+}

--- a/projects/truenas-ui/src/lib/a11y/scrollable-region.ts
+++ b/projects/truenas-ui/src/lib/a11y/scrollable-region.ts
@@ -1,0 +1,362 @@
+import { DestroyRef, NgZone, effect, inject, signal, untracked } from '@angular/core';
+import type { Signal } from '@angular/core';
+
+/**
+ * The one place that decides whether a scrolling region needs a tab stop, and
+ * when it may give one back.
+ *
+ * WHY THIS EXISTS AT ALL
+ * ----------------------
+ * axe's `scrollable-region-focusable` fires on any element that scrolls, is not
+ * itself in the tab order, and contains nothing that is — because content below
+ * the fold of such a region is content a keyboard cannot reach. #248 fixed one
+ * instance of it, `.tn-side-panel__content`, and the fix was not one line: a
+ * measurement against axe's own 13px buffer, kept current by a `ResizeObserver`
+ * on the region AND on its direct children, plus a `MutationObserver`, plus a
+ * focus rule that decides when the tab stop may be REMOVED again.
+ *
+ * The same shape exists on four more elements in this library (#270). Copying
+ * that into each of them is how the lenient copy gets made — the argument
+ * `axe-testing.ts` sets out for its own existence, and the one
+ * `initial-focus.ts` makes with evidence: `tn-drawer` was written from
+ * `tn-side-panel` and the two have reached identical bugs three times (#214,
+ * #218, #227).
+ *
+ * WHY A FUNCTION AND NOT A DIRECTIVE
+ * ----------------------------------
+ * The ticket allows either. A directive would have to own `tabindex`, `role`
+ * and `aria-label` through host bindings, and two of the five callers already
+ * bind those attributes in their own templates for reasons that have nothing to
+ * do with scrolling — `tn-drawer`'s panel is a `role="dialog"` or a
+ * `role="navigation"` with a name of its own, and a directive host binding on
+ * the same attribute wins over the template binding and would clobber it with
+ * `null`.
+ *
+ * So what is shared is the MEASUREMENT and the focus rule, which is the subtle
+ * part; each component keeps its own attribute policy, which is the part that
+ * legitimately differs. That is also the shape of every other helper in this
+ * folder — `tnAccessibleName`, `tnFocusOnOpen` — and callers read as they do.
+ *
+ * WHAT EACH CALLER STILL DECIDES
+ * ------------------------------
+ * - **What the resting `tabindex` is.** `tn-side-panel`'s region has none;
+ *   `tn-drawer`'s panel is `-1`, because it is also the element `tnFocusOnOpen`
+ *   moves focus to.
+ * - **Whether a role and a name are needed.** A region that is already a named
+ *   `role="dialog"` needs neither; a bare `<section>` or a host element needs
+ *   `role="group"` and a name, or it is announced as nothing at all.
+ *
+ * Not exported from `public-api.ts`, and must not be: it is how this library's
+ * own components agree with each other, not API.
+ */
+
+/**
+ * How far the content has to exceed the region before the region counts as
+ * scrolling.
+ *
+ * This is axe's own number: `scrollable-region-focusable` matches through
+ * `getScroll(node, 13)`, so it ignores an overflow smaller than this and would
+ * not report a region that has one. Measuring with a bare `>` instead would put
+ * a tab stop on regions the rule considers fine — and `scrollHeight` and
+ * `clientHeight` are integers rounded from fractional layout, so content that
+ * fits to within a pixel reads as overflowing by one.
+ *
+ * Matching the rule keeps the components and the check that judges them saying
+ * the same thing about the same element. It is a property of the rule rather
+ * than a knob, so no component takes it as an input — but it is exported,
+ * because `side-panel-scrollable-content.spec.ts` pins it against axe's own
+ * buffer from both sides, and a spec that recopied the literal would pin the
+ * copy to itself.
+ */
+export const TN_SCROLLABLE_REGION_TOLERANCE_PX = 13;
+
+/**
+ * Whether `region` currently overflows on an axis it can actually scroll —
+ * `getScroll(elm, 13)` in axe-core 4.10.3, reimplemented rather than imported
+ * because `axe-core` is a devDependency and this runs in shipped code.
+ *
+ * BOTH HALVES MATTER, AND #248 ONLY HAD THE FIRST
+ * ----------------------------------------------
+ * The side panel measured `scrollHeight > clientHeight + 13` and stopped there,
+ * which was right for it and is wrong in general. An element whose content is
+ * wider than its box under `overflow-x: visible` does not scroll — the content
+ * spills out and is on screen — and axe does not report it. A measurement that
+ * skipped the style check would put a tab stop on `.tn-side-panel__content`
+ * whenever a caller projected a wide `<pre>` into it, which is the over-fix the
+ * tolerance exists to avoid, arriving by the other axis.
+ *
+ * `getComputedStyle` is feature-detected because this file is imported by
+ * components that render under SSR, where it does not exist. Reading as "does
+ * not scroll" is the safe answer there: nothing is focusable on a server, and
+ * the first measurement in the browser happens in `afterNextRender`.
+ */
+function overflows(region: HTMLElement): boolean {
+  const buffer = TN_SCROLLABLE_REGION_TOLERANCE_PX;
+  const overflowX = region.scrollWidth > region.clientWidth + buffer;
+  const overflowY = region.scrollHeight > region.clientHeight + buffer;
+
+  if (!overflowX && !overflowY) {
+    return false;
+  }
+  if (typeof getComputedStyle !== 'function') {
+    return false;
+  }
+
+  const style = getComputedStyle(region);
+  const scrolls = (value: string): boolean => value === 'auto' || value === 'scroll';
+
+  return (overflowX && scrolls(style.overflowX)) || (overflowY && scrolls(style.overflowY));
+}
+
+/**
+ * Track whether a scrolling region needs to carry a tab stop, and keep the
+ * answer current.
+ *
+ * **Must be called from an injection context** — a field initializer or the
+ * constructor — because it registers an `afterNextRender` and an `onDestroy`.
+ *
+ * The caller binds the returned signal to whatever attributes its own markup
+ * needs; see the note above on what each caller still decides. Everything the
+ * caller has to get right beyond that binding is in here.
+ *
+ * WHAT THE SIGNAL IS, AND WHY IT IS NOT SIMPLY THE MEASUREMENT
+ * -----------------------------------------------------------
+ * It is the measurement, **latched on by focus**: true while the region
+ * overflows, and still true afterwards for as long as focus stays on a region
+ * that was already reachable when focus arrived. Focus retains a tab stop; it
+ * does not grant one — see the note on `reachable` at the end of this file for
+ * the caller that proved the difference matters.
+ *
+ * Content can stop overflowing while the region is focused: a validation
+ * message clears, an expander collapses, the panel widens. Dropping `tabindex`
+ * at that moment removes the tab stop from THE ELEMENT THAT HAS FOCUS, and a
+ * focused element that stops being focusable is blurred to `<body>` — so a
+ * keyboard user reading a panel would find themselves outside it, with the next
+ * Tab starting from the top of the page, because content they were not
+ * interacting with got shorter. That is a worse failure than the one this fixes,
+ * and it is caused by the fix.
+ *
+ * So focus holds the answer true until it leaves of its own accord. The `blur`
+ * that clears it has already happened by the time Angular writes the attribute
+ * away, so nothing is focused when the tab stop goes.
+ *
+ * A caller that keeps `role` and `aria-label` on the same signal keeps them for
+ * the same reason: a focused group that loses its name mid-read is announced as
+ * a bare "group" by the next thing said about it, which is the state the name
+ * exists to prevent.
+ *
+ * @param region The element that scrolls, read from inside an `effect` — so
+ *   pass a closure over a `viewChild`, not a captured element. Angular resolves
+ *   view queries before the effects that read them, and re-runs this one if the
+ *   query's answer changes. That is not a detail: `tn-drawer` renders its panel
+ *   from one of two `@if` branches on `mode`, so a responsive layout crossing
+ *   its breakpoint destroys the observed element and builds another, and a
+ *   helper that had bound to the first would silently stop measuring anything.
+ *   `undefined` — a query with nothing to answer with — is the resting state and
+ *   is not an error.
+ */
+export function tnScrollableRegion(
+  region: () => HTMLElement | null | undefined
+): Signal<boolean> {
+  const zone = inject(NgZone);
+  const destroyRef = inject(DestroyRef);
+
+  /**
+   * Whether the region currently overflows. Measured, not derived: nothing
+   * about a component's inputs says whether what a caller projected fits, and
+   * the answer changes with the viewport and with the content itself.
+   */
+  const overflowing = signal(false);
+
+  /**
+   * Whether the region itself holds focus.
+   *
+   * Listened for on the element rather than bound in each caller's template,
+   * because `focus` and `blur` do not bubble — so these report the region and
+   * not anything projected into it, and getting that wrong is exactly the kind
+   * of divergence a shared helper exists to prevent.
+   */
+  const focused = signal(false);
+
+  let resize: ResizeObserver | undefined;
+  let mutations: MutationObserver | undefined;
+
+  /**
+   * Read whether the region overflows, and record it.
+   *
+   * A layout read and nothing else, so it is safe to call from either observer:
+   * the only write it makes is to a signal, and the attributes that follow are
+   * written by Angular in its own pass rather than here. Setting the signal to
+   * the value it already holds is a no-op, which is what most calls are.
+   */
+  const measure = (element: HTMLElement): void => {
+    overflowing.set(overflows(element));
+  };
+
+  /**
+   * Point the `ResizeObserver` at the region and at each of its direct
+   * children, replacing whatever it was watching before.
+   *
+   * The children are the half that catches content growth no DOM mutation
+   * announces — see `watch` below. They are re-read rather than tracked
+   * incrementally because the set changes only when `childList` does, which is
+   * the callback this runs in, and a region's content is a handful of elements
+   * rather than a list.
+   *
+   * `disconnect` first: `observe` on an element already observed is a no-op, so
+   * without it a child that was removed would keep its registration and keep
+   * the observer alive.
+   */
+  const observeBoxes = (element: HTMLElement): void => {
+    if (!resize) {
+      return;
+    }
+    resize.disconnect();
+    resize.observe(element);
+    Array.from(element.children).forEach((child) => resize?.observe(child));
+  };
+
+  /**
+   * Keep the measurement current, from the two directions it can go stale.
+   *
+   * A scroll container overflows when its content is bigger than its box, and
+   * either half can change on its own — so both are watched, by the instrument
+   * that can see them:
+   *
+   * - **The box.** A viewport resize, a narrower panel or a re-laid-out parent
+   *   reflows the content.
+   * - **The content.** A caller's form revealing a validation message changes
+   *   `scrollHeight` while the region's own size stays exactly the same, so a
+   *   `ResizeObserver` on the region alone never fires for it.
+   *
+   * `MutationObserver` catches the second only when the growth IS a DOM change.
+   * Plenty of it is not: an image finishing loading, a webfont swapping in, a
+   * class toggle opening an expander. What all of those DO change is the size of
+   * the child that holds them, which is why the `ResizeObserver` is pointed at
+   * the region's direct children as well as at the region. Layout propagates, so
+   * a grandchild growing grows the child that contains it.
+   *
+   * `attributes` is therefore deliberately NOT observed. The class toggle above
+   * arrives as a resize instead, and watching attributes would mean watching the
+   * ones the caller writes from this very measurement — the measurement called
+   * from its own result.
+   *
+   * Both observers are feature-detected, because neither exists during SSR and
+   * `ResizeObserver` does not exist under jsdom — where the fallback is the
+   * single reading taken when the region is attached, and a region that reads
+   * as fitting is the safe answer either way.
+   *
+   * Outside the Angular zone, for the reason `initial-focus.ts` gives for its
+   * retries: a projected form mutates on every keystroke, and a zone-patched
+   * callback would be a change detection pass for each one. The signal notifies
+   * Angular by itself when the answer actually changes.
+   */
+  const watch = (element: HTMLElement): void => {
+    zone.runOutsideAngular(() => {
+      if (typeof ResizeObserver !== 'undefined') {
+        resize = new ResizeObserver(() => measure(element));
+      }
+
+      if (typeof MutationObserver !== 'undefined') {
+        mutations = new MutationObserver(() => {
+          // Which elements exist has just changed, so what is observed has to
+          // change with it before the region is measured again.
+          observeBoxes(element);
+          measure(element);
+        });
+        mutations.observe(element, { childList: true, subtree: true, characterData: true });
+      }
+
+      observeBoxes(element);
+    });
+  };
+
+  const onFocus = (): void => focused.set(true);
+  const onBlur = (): void => focused.set(false);
+
+  /**
+   * The element everything above is currently bound to, so that a re-render
+   * that replaces it is a rebind rather than a second set of observers on a
+   * detached node.
+   */
+  let attached: HTMLElement | undefined;
+
+  const detach = (): void => {
+    resize?.disconnect();
+    mutations?.disconnect();
+    resize = undefined;
+    mutations = undefined;
+
+    attached?.removeEventListener('focus', onFocus);
+    attached?.removeEventListener('blur', onBlur);
+    attached = undefined;
+
+    // The element that held focus has gone, and no `blur` is owed for it —
+    // leaving this true would keep the caller's attributes on an element that
+    // no longer exists, and put them straight back onto its replacement.
+    focused.set(false);
+    overflowing.set(false);
+  };
+
+  /**
+   * Bind to whatever the query answers with, and rebind when that changes.
+   *
+   * An `effect` rather than `afterNextRender`, because the element is not
+   * necessarily the same one for the life of the component — see the note on
+   * `region`. Angular resolves view queries before running the effects that
+   * read them, so the element is rendered by the time this sees it, and the
+   * first `measure` here is the reading a platform without a `ResizeObserver`
+   * has to live on.
+   */
+  effect(() => {
+    const element = region() ?? undefined;
+    if (element === attached) {
+      return;
+    }
+
+    detach();
+    if (!element) {
+      return;
+    }
+
+    attached = element;
+    element.addEventListener('focus', onFocus);
+    element.addEventListener('blur', onBlur);
+
+    measure(element);
+    watch(element);
+  });
+
+  destroyRef.onDestroy(detach);
+
+  /**
+   * The answer the caller binds to: the measurement, plus the one thing that
+   * keeps it true after the measurement goes false.
+   *
+   * NOT `overflowing() || focused()`, which is what this was until a caller
+   * that focuses its own region proved it wrong. `tn-drawer` moves focus to the
+   * panel when a modal drawer opens (`tnFocusOnOpen`, #227), so under that
+   * reading every `over` drawer became a tab stop the moment it opened, whether
+   * or not anything scrolled — the over-fix the tolerance exists to prevent,
+   * arriving through the focus half instead.
+   *
+   * Focus RETAINS a tab stop; it does not grant one. So the state carried
+   * across is the previous answer, and focus only holds it: a region that was
+   * reachable when focus arrived stays reachable until focus leaves, and one
+   * that was not stays not.
+   *
+   * An `effect` rather than a `computed` with a captured variable, because a
+   * computed is lazy — it re-derives only when something reads it, so a growth
+   * and a shrink that both happened between two reads would collapse into "not
+   * overflowing, focused" and drop the tab stop out from under a keyboard user.
+   * The latch has to see every transition, which means being eager.
+   */
+  const reachable = signal(false);
+  effect(() => {
+    const isOverflowing = overflowing();
+    const hasFocus = focused();
+    reachable.set(isOverflowing || (hasFocus && untracked(reachable)));
+  });
+
+  return reachable.asReadonly();
+}

--- a/projects/truenas-ui/src/lib/a11y/scrollable-region.ts
+++ b/projects/truenas-ui/src/lib/a11y/scrollable-region.ts
@@ -88,7 +88,7 @@ export const TN_SCROLLABLE_REGION_TOLERANCE_PX = 13;
  * `getComputedStyle` is feature-detected because this file is imported by
  * components that render under SSR, where it does not exist. Reading as "does
  * not scroll" is the safe answer there: nothing is focusable on a server, and
- * the first measurement in the browser happens in `afterNextRender`.
+ * the browser takes its own first measurement as soon as the region binds.
  */
 function overflows(region: HTMLElement): boolean {
   const buffer = TN_SCROLLABLE_REGION_TOLERANCE_PX;
@@ -113,7 +113,7 @@ function overflows(region: HTMLElement): boolean {
  * answer current.
  *
  * **Must be called from an injection context** — a field initializer or the
- * constructor — because it registers an `afterNextRender` and an `onDestroy`.
+ * constructor — because it registers an `effect` and an `onDestroy`.
  *
  * The caller binds the returned signal to whatever attributes its own markup
  * needs; see the note above on what each caller still decides. Everything the
@@ -346,10 +346,15 @@ export function tnScrollableRegion(
    * that was not stays not.
    *
    * An `effect` rather than a `computed` with a captured variable, because a
-   * computed is lazy — it re-derives only when something reads it, so a growth
-   * and a shrink that both happened between two reads would collapse into "not
+   * computed is lazy: it re-derives only when something reads it, and nothing
+   * reads this one while the region is off screen or the view is detached — so
+   * a growth and a shrink spanning that gap would collapse into "not
    * overflowing, focused" and drop the tab stop out from under a keyboard user.
-   * The latch has to see every transition, which means being eager.
+   *
+   * An effect coalesces too, and that is harmless where the laziness is not: it
+   * runs once per change detection, so the pair it can miss is a growth and a
+   * shrink between two RENDERS — a state the DOM never showed anyone, and so
+   * one nobody can have been standing on.
    */
   const reachable = signal(false);
   effect(() => {

--- a/projects/truenas-ui/src/lib/drawer/drawer-content-scrollable.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-content-scrollable.spec.ts
@@ -1,0 +1,266 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TN_DRAWER_CONTENT_LABEL, TnDrawerContentComponent } from './drawer-content.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TN_SCROLLABLE_REGION_TOLERANCE_PX } from '../a11y/scrollable-region';
+import {
+  MockResizeObserver,
+  scrollingTo,
+  staticScroller,
+} from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards the keyboard reachability of the page content beside a drawer (#270).
+ *
+ * WHAT THE DEFECT IS
+ * ------------------
+ * `tn-drawer-content`'s host is `overflow: auto` and its whole template is
+ * `<ng-content />`, so this is the element an application's page scrolls in.
+ * It carried no `tabindex` and no role, and an application whose page holds no
+ * tabbable control — a dashboard of read-only cards, a log view — matched axe's
+ * `scrollable-region-focusable` exactly: an element that scrolls, is not in the
+ * tab order, and contains nothing that is.
+ *
+ * The stakes are higher here than on the drawer's own panel, because the
+ * content below this fold is most of a page rather than the rest of a menu.
+ *
+ * WHAT IT IS NOT ALLOWED TO BECOME
+ * --------------------------------
+ * A landmark. `drawer-container.component.ts` sets out why `role="main"`
+ * belongs to the application and not to this library, and `names the region
+ * without claiming the page's main landmark` below is what keeps the fix from
+ * quietly taking it.
+ */
+
+@Component({
+  selector: 'tn-drawer-content-scroll-host',
+  standalone: true,
+  imports: [TnDrawerContentComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger">Elsewhere</button>
+    <tn-drawer-content [ariaLabel]="label()">
+      <p>Page body</p>
+      @if (extra()) {
+        <p id="extra">More body than fits</p>
+      }
+    </tn-drawer-content>
+  `,
+})
+class DrawerContentScrollHostComponent {
+  extra = signal(false);
+  label = signal(TN_DRAWER_CONTENT_LABEL);
+}
+
+describe('tn-drawer-content scrolling region (#270)', () => {
+  let fixture: ComponentFixture<DrawerContentScrollHostComponent>;
+  let host: DrawerContentScrollHostComponent;
+  let restoreResizeObserver: () => void;
+
+  /** The visible height every case here measures against. */
+  const REGION_HEIGHT = 200;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawerContentScrollHostComponent],
+    }).compileComponents();
+
+    restoreResizeObserver = MockResizeObserver.install();
+
+    fixture = TestBed.createComponent(DrawerContentScrollHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    restoreResizeObserver();
+  });
+
+  function region(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-drawer-content') as HTMLElement;
+  }
+
+  async function mutateContent(mutate: () => void): Promise<void> {
+    mutate();
+    fixture.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+  }
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control. Built from static markup so it keeps saying what
+     * axe does about an unfixed scroll container after this component stops
+     * being one — without it, every `violated).toEqual([])` below would also
+     * pass if the rule stopped matching altogether.
+     */
+    it('still reports a scroll container that nothing can focus', async () => {
+      const { root, region: scroller } = staticScroller(400, REGION_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, scroller, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('a page whose content overflows', () => {
+    beforeEach(async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+    });
+
+    it('makes the region a tab stop', () => {
+      expect(region().getAttribute('tabindex')).toBe('0');
+    });
+
+    it('names the region without claiming the page\'s main landmark', () => {
+      expect(region().getAttribute('role')).toBe('group');
+      expect(region().getAttribute('aria-label')).toBe(TN_DRAWER_CONTENT_LABEL);
+    });
+
+    it('lets a consumer say what the region holds', async () => {
+      await mutateContent(() => host.label.set('Pool details'));
+      expect(region().getAttribute('aria-label')).toBe('Pool details');
+    });
+
+    it('raises no scrollable-region-focusable violation, and does evaluate the rule', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, region(), ['scrollable-region-focusable']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('scrollable-region-focusable');
+    });
+
+    it('puts no disallowed ARIA on the region it just named', async () => {
+      const { violated } = await axeResult(
+        fixture.nativeElement,
+        region(),
+        ['aria-allowed-role', 'aria-allowed-attr', 'aria-valid-attr-value'],
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    it('gives the region back when the content shrinks to fit', async () => {
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(region().getAttribute('role')).toBeNull();
+      expect(region().getAttribute('aria-label')).toBeNull();
+    });
+  });
+
+  describe('a page whose content fits', () => {
+    /**
+     * The over-fix guard. Every application that uses a drawer renders this
+     * element, so an unconditional tab stop here is an extra stop on every page
+     * in the product — and one that reports nothing to axe either way, because
+     * the rule does not match an element that does not scroll.
+     */
+    it('leaves the region unmarked', async () => {
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(region().getAttribute('role')).toBeNull();
+      expect(region().getAttribute('aria-label')).toBeNull();
+    });
+
+    /** The tolerance, from both sides of the line axe draws. */
+    it('starts marking exactly where axe starts reporting', async () => {
+      scrollingTo(region(), REGION_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+
+      scrollingTo(region(), REGION_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX + 1, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('when the content stops overflowing UNDER a keyboard user', () => {
+    /**
+     * Taking `tabindex` off an element that currently has focus makes the
+     * browser blur it to `<body>`. On this element that means a keyboard user
+     * reading a page is dropped to the top of the document because something
+     * they were not interacting with got shorter. jsdom does not implement that
+     * behaviour, so what is asserted is the CONDITION — the attributes are
+     * never taken off while the region holds focus.
+     */
+    it('keeps the tab stop and the name while the region holds focus', async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      region().focus();
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(region());
+
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+      expect(region().getAttribute('role')).toBe('group');
+      expect(region().getAttribute('aria-label')).toBe(TN_DRAWER_CONTENT_LABEL);
+    });
+
+    it('gives it up once focus leaves of its own accord', async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      region().focus();
+      fixture.detectChanges();
+
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(trigger);
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(region().getAttribute('role')).toBeNull();
+    });
+  });
+
+  describe('what the measurement follows', () => {
+    /**
+     * The box-changed direction: the drawer opens beside it, the same content
+     * reflows taller, and NOTHING about the DOM changed. That is a
+     * `ResizeObserver` callback and no mutation record at all — and on this
+     * component it is the ORDINARY path, because opening a `side` drawer is
+     * exactly what narrows this element.
+     */
+    it('re-measures when the region resizes, with no DOM mutation', () => {
+      expect(MockResizeObserver.targets()).toContain(region());
+      expect(region().getAttribute('tabindex')).toBeNull();
+
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      MockResizeObserver.emit();
+      fixture.detectChanges();
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+    });
+
+    /**
+     * The child-resized direction, which a `MutationObserver` cannot see. The
+     * registration is the assertion: the mock fires every observer it holds, so
+     * a callback alone would look identical if only the region were watched.
+     */
+    it('watches the region\'s direct children too', async () => {
+      await mutateContent(() => host.extra.set(true));
+
+      const child = region().querySelector('#extra') as HTMLElement;
+      expect(MockResizeObserver.targets()).toContain(child);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/drawer/drawer-content.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-content.component.ts
@@ -1,9 +1,78 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, inject, input } from '@angular/core';
+import { tnScrollableRegion } from '../a11y/scrollable-region';
 
+/**
+ * The name this region takes when it becomes focusable (#270).
+ *
+ * A focusable element with no accessible name is announced as a bare "group",
+ * which tells a listener that something has been reached and nothing about what
+ * it is.
+ *
+ * "Content" rather than "Main content", and `role="group"` rather than
+ * `role="main"`: the landmark belongs to the application, not to this library —
+ * `drawer-container.component.ts` sets out why, and a component that claimed it
+ * would give a page two `main`s the moment the page declared its own. A group
+ * is not summarised in a landmarks list, so this names the scroll region
+ * without competing with the page's own structure.
+ *
+ * Overridable through `ariaLabel`, on the same reasoning as
+ * `TN_SIDE_PANEL_CONTENT_LABEL`: a string this library renders into a
+ * consumer's UI has to be translatable, and a consumer who knows what the
+ * region holds can say so. Exported so specs assert against it by name rather
+ * than by a copied literal.
+ */
+export const TN_DRAWER_CONTENT_LABEL = 'Content';
+
+/**
+ * The page content that sits beside a `tn-drawer` inside a
+ * `tn-drawer-container`.
+ *
+ * WHY IT CARRIES A TAB STOP SOMETIMES AND NO LANDMARK EVER (#270)
+ * --------------------------------------------------------------
+ * The host is `overflow: auto`, so everything an application puts beside its
+ * drawer scrolls in this element — and axe's `scrollable-region-focusable`
+ * reports a scroll container that is neither in the tab order nor holds
+ * anything that is. That is not a technicality here: this is the element that
+ * holds a page, so content below its fold is most of the page, and a keyboard
+ * user with no pointer could not reach it.
+ *
+ * The tab stop follows the measurement rather than being permanent, because
+ * this component wraps every page that uses a drawer and a stop that announces
+ * a group and does nothing would land on all of them. `tnScrollableRegion`
+ * holds the measurement, the observers that keep it current, and the rule that
+ * decides when it may be taken away again; see `../a11y/scrollable-region.ts`.
+ *
+ * The role is still not a landmark. `drawer-container.component.ts` explains
+ * why `role="main"` belongs to the application rather than to this library, and
+ * nothing about needing a tab stop changes that — see
+ * `TN_DRAWER_CONTENT_LABEL`.
+ */
 @Component({
   selector: 'tn-drawer-content',
   standalone: true,
   template: '<ng-content />',
   styleUrl: './drawer-content.component.scss',
+  host: {
+    '[attr.tabindex]': 'keyboardReachable() ? "0" : null',
+    '[attr.role]': 'keyboardReachable() ? "group" : null',
+    '[attr.aria-label]': 'keyboardReachable() ? ariaLabel() : null',
+  },
 })
-export class TnDrawerContentComponent {}
+export class TnDrawerContentComponent {
+  private readonly hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /**
+   * Accessible name for the scrolling region, which is named only while it is
+   * focusable — see `TN_DRAWER_CONTENT_LABEL`. Override it to translate it, or
+   * to say what the region holds ("Pool details").
+   */
+  ariaLabel = input<string>(TN_DRAWER_CONTENT_LABEL);
+
+  /**
+   * Whether the region carries the tab stop, its role and its name — which is
+   * NOT the same question as whether it currently overflows. All three are
+   * gated together, and held on while the region has focus; the reasoning for
+   * both is in `../a11y/scrollable-region.ts`.
+   */
+  protected keyboardReachable = tnScrollableRegion(() => this.hostRef.nativeElement);
+}

--- a/projects/truenas-ui/src/lib/drawer/drawer-scrollable-panel.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-scrollable-panel.spec.ts
@@ -1,0 +1,381 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnDrawerComponent } from './drawer.component';
+import type { TnDrawerMode } from './drawer.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TN_SCROLLABLE_REGION_TOLERANCE_PX } from '../a11y/scrollable-region';
+import {
+  MockResizeObserver,
+  scrollingTo,
+  staticScroller,
+} from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards the keyboard reachability of the drawer's scrolling panel (#270).
+ *
+ * WHAT THE DEFECT IS
+ * ------------------
+ * `.tn-drawer__panel` is `overflow-y: auto`, so whatever a caller projects into
+ * a drawer scrolls in that element. It carried `tabindex="-1"` — a focus TARGET
+ * for `tnFocusOnOpen` (#227), not a tab stop — and nothing else, so a drawer
+ * holding only static content matched axe's `scrollable-region-focusable`: an
+ * element that scrolls, is not in the tab order, and contains nothing that is.
+ * The part below the fold was then unreachable from a keyboard.
+ *
+ * This is the same defect #248 fixed on `tn-side-panel`, reached for the fourth
+ * time by a component written from it — the pattern `initial-focus.ts` records
+ * for #214, #218 and #227. The measurement is shared now
+ * (`../a11y/scrollable-region.ts`); what this file guards is that THIS
+ * component is wired to it and marks the right element.
+ *
+ * WHY ONLY `tabindex` MOVES
+ * -------------------------
+ * Unlike the side panel's bare `<section>`, this element already carries a role
+ * and a name in both modes — a named `role="dialog"` or `role="navigation"`.
+ * Adding `role="group"` would replace the model the drawer declares with a
+ * description of its scrollbar, so the fix here is the tab stop and nothing
+ * else, and `keeps the panel's own role and name` below is what holds that.
+ */
+
+@Component({
+  selector: 'tn-drawer-scroll-host',
+  standalone: true,
+  imports: [TnDrawerComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger" (click)="opened.set(true)">Open</button>
+    <tn-drawer ariaLabel="Navigation" [mode]="mode()" [(opened)]="opened">
+      <p>Drawer body</p>
+      @if (extra()) {
+        <p id="extra">More body than fits</p>
+      }
+    </tn-drawer>
+  `,
+})
+class DrawerScrollHostComponent {
+  mode = signal<TnDrawerMode>('over');
+  opened = signal(false);
+  /** Projects another paragraph, which is a content mutation the panel re-measures on. */
+  extra = signal(false);
+}
+
+describe('tn-drawer scrolling panel (#270)', () => {
+  let fixture: ComponentFixture<DrawerScrollHostComponent>;
+  let host: DrawerScrollHostComponent;
+  let restoreResizeObserver: () => void;
+
+  /** The visible height every case here measures against. */
+  const PANEL_HEIGHT = 200;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawerScrollHostComponent],
+    }).compileComponents();
+
+    restoreResizeObserver = MockResizeObserver.install();
+
+    fixture = TestBed.createComponent(DrawerScrollHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // The over-mode overlay is portaled to document.body and only removed on
+    // destroy, so without this every later fixture scans the previous one's
+    // panel too.
+    fixture.destroy();
+    restoreResizeObserver();
+  });
+
+  /**
+   * The panel, wherever it currently lives: inline in the host in `side` mode,
+   * portaled to `<body>` in `over` mode. Asked of the document for that reason.
+   */
+  function panel(): HTMLElement {
+    return document.querySelector('.tn-drawer__panel') as HTMLElement;
+  }
+
+  /** The element axe is pointed at as the scan root — the panel's own parent. */
+  function scanRoot(): HTMLElement {
+    return panel().parentElement as HTMLElement;
+  }
+
+  async function openDrawer(): Promise<void> {
+    host.opened.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  /**
+   * Change the projected content and let the drawer notice.
+   *
+   * A `MutationObserver` callback is delivered on a microtask, so the wait is
+   * what makes this the production path rather than a direct call into the
+   * component: the spec mutates the DOM exactly as a caller's own template
+   * would, and reads back what the component did about it.
+   */
+  async function mutateContent(mutate: () => void): Promise<void> {
+    mutate();
+    fixture.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+  }
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control, built from static markup rather than from the
+     * component, so that it keeps saying what axe does about an unfixed scroll
+     * container after the component stops being one. Without it, every
+     * `violated).toEqual([])` below would also pass if the rule stopped
+     * matching altogether.
+     *
+     * `tabindex="-1"` is on it deliberately: that is what the panel carried
+     * before this fix, and the point of the control is that `-1` does not
+     * answer the rule. `focusable-element` checks whether the element is in the
+     * TAB ORDER, which `-1` is not.
+     */
+    it('still reports a scroll container whose only tabindex is -1', async () => {
+      const { root, region } = staticScroller(400, PANEL_HEIGHT);
+      region.setAttribute('tabindex', '-1');
+      region.setAttribute('role', 'dialog');
+      region.setAttribute('aria-label', 'Navigation');
+
+      try {
+        const { violated } = await axeResult(root, region, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('an over-mode drawer whose content overflows', () => {
+    beforeEach(async () => {
+      await openDrawer();
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+    });
+
+    it('makes the panel a tab stop', () => {
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+
+    it('keeps the panel\'s own role and name, and adds no group', () => {
+      expect(panel().getAttribute('role')).toBe('dialog');
+      expect(panel().getAttribute('aria-label')).toBe('Navigation');
+    });
+
+    it('raises no scrollable-region-focusable violation, and does evaluate the rule', async () => {
+      const { violated, evaluated } = await axeResult(
+        scanRoot(), panel(), ['scrollable-region-focusable']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('scrollable-region-focusable');
+    });
+
+    it('gives the tab stop back when the content shrinks to fit', async () => {
+      // Focus first, and off the panel. An `over` drawer opens with focus ON
+      // its panel (`tnFocusOnOpen`, #227), and the tab stop is deliberately
+      // held while the focused region has it — see the focus cases below. This
+      // one is about the measurement, so it asks the question with nobody
+      // standing on the answer.
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+
+      scrollingTo(panel(), PANEL_HEIGHT, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      // Back to the resting `-1`, not to no attribute at all: the panel is
+      // still what `tnFocusOnOpen` moves focus to when a modal drawer opens,
+      // and an element with no `tabindex` cannot be focused programmatically.
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+  });
+
+  describe('a side-mode drawer', () => {
+    /**
+     * The defect is not modal-only. A `side` drawer is persistent navigation
+     * with the same `overflow-y: auto` panel, and a long nav list is exactly
+     * the content that overflows it.
+     */
+    it('marks the panel too', async () => {
+      host.mode.set('side');
+      await openDrawer();
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+      expect(panel().getAttribute('role')).toBe('navigation');
+    });
+
+    /**
+     * The measurement has to follow the panel across a mode change, and this is
+     * the case a helper bound once to one element would fail: `@if (mode() !==
+     * 'over')` destroys the element it measured and builds another. A
+     * responsive layout crossing its breakpoint does exactly this.
+     */
+    it('follows the panel when the mode changes under it', async () => {
+      await openDrawer();
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+      expect(panel().getAttribute('tabindex')).toBe('0');
+
+      host.mode.set('side');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // A different element, which has not been measured yet — so it starts at
+      // the resting value rather than inheriting the old one's answer.
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      MockResizeObserver.emit();
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('a drawer whose content fits', () => {
+    /**
+     * The over-fix guard. Every drawer in this library renders this panel, so
+     * an unconditional tab stop here is an extra stop in every one of them —
+     * and one that reports nothing to axe either way, because the rule does not
+     * match an element that does not scroll.
+     */
+    it('leaves the panel at its resting tabindex', async () => {
+      await openDrawer();
+      scrollingTo(panel(), PANEL_HEIGHT, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+
+    /**
+     * The tolerance, from both sides of it. `scrollHeight` and `clientHeight`
+     * are integers rounded from fractional layout, so a panel whose content
+     * fits can read as overflowing by a pixel — and axe would not call that a
+     * scroll container either, because its own matcher ignores an overflow
+     * below 13px.
+     */
+    it('starts marking exactly where axe starts reporting', async () => {
+      await openDrawer();
+      scrollingTo(panel(), PANEL_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+
+      scrollingTo(panel(), PANEL_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX + 1, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('when the content stops overflowing UNDER a keyboard user', () => {
+    /**
+     * The failure the fix can cause, rather than the one it fixes — the same
+     * one `side-panel-scrollable-content.spec.ts` guards, asserted here because
+     * this component reaches it through a different attribute.
+     *
+     * On this element the browser consequence is milder than the side panel's:
+     * `0` falls back to `-1` rather than to nothing, and `-1` is still
+     * focusable, so focus is not dropped to `<body>`. What is asserted is the
+     * condition either way, because the rule lives in the shared helper and a
+     * caller that stopped honouring it would silently stop honouring it for the
+     * side panel's `<section>` too.
+     */
+    beforeEach(async () => {
+      await openDrawer();
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      panel().focus();
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(panel());
+    });
+
+    it('keeps the tab stop while the panel holds focus', async () => {
+      scrollingTo(panel(), PANEL_HEIGHT, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+      expect(document.activeElement).toBe(panel());
+    });
+
+    /**
+     * The other direction, and the one this component is the reason for: focus
+     * RETAINS a tab stop, it does not grant one.
+     *
+     * An `over` drawer opens with focus on its panel, so a helper reading
+     * "overflowing OR focused" made every modal drawer a tab stop the moment it
+     * opened, whether or not anything scrolled. `leaves the panel at its
+     * resting tabindex` above is the same guard on the ordinary path; this one
+     * says it about a panel that is demonstrably focused.
+     */
+    it('does not grant a tab stop to a fitting panel that has focus', async () => {
+      scrollingTo(panel(), PANEL_HEIGHT, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+      panel().focus();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(panel());
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('gives it up once focus leaves of its own accord', async () => {
+      scrollingTo(panel(), PANEL_HEIGHT, PANEL_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(trigger);
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+  });
+
+  describe('what the measurement follows', () => {
+    /**
+     * The box-changed direction: the drawer narrows, the same content reflows
+     * taller, and NOTHING about the DOM changed. That is a `ResizeObserver`
+     * callback and no mutation record at all.
+     */
+    it('re-measures when the panel resizes, with no DOM mutation', async () => {
+      await openDrawer();
+      expect(MockResizeObserver.targets()).toContain(panel());
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+
+      scrollingTo(panel(), 400, PANEL_HEIGHT);
+      MockResizeObserver.emit();
+      fixture.detectChanges();
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+
+    /**
+     * The child-resized direction, which a `MutationObserver` cannot see: an
+     * image finishing loading or a webfont swapping in changes how tall a child
+     * is and produces no mutation record. The registration is the assertion —
+     * the mock fires every observer it holds, so a callback alone would look
+     * identical if only the panel were watched.
+     */
+    it('watches the panel\'s direct children too', async () => {
+      await openDrawer();
+      await mutateContent(() => host.extra.set(true));
+
+      const child = panel().querySelector('#extra') as HTMLElement;
+      expect(MockResizeObserver.targets()).toContain(child);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.html
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.html
@@ -20,11 +20,39 @@
   is `tnAccessibleName`'s, and its reasoning is set out there.
 -->
 
+<!--
+  THE PANEL IS THE ELEMENT THAT SCROLLS (#270)
+  --------------------------------------------
+  `.tn-drawer__panel` is `overflow-y: auto`, so whatever a caller projects into
+  a drawer scrolls inside this element — and axe's `scrollable-region-focusable`
+  reports a scroll container that is neither in the tab order nor holds anything
+  that is. `tabindex="-1"` does not answer it: that is a focus TARGET for
+  `tnFocusOnOpen`, not a tab stop, and a drawer holding only static content —
+  a details pane, a legend — has no tabbable descendant to satisfy the rule
+  either. A keyboard user could then not reach the part below the fold.
+
+  So the resting `-1` becomes `0` while the panel actually overflows.
+  `panelKeyboardReachable` is `tnScrollableRegion`'s, shared with
+  `tn-side-panel` and three others; the component says what it measures and why
+  the answer is held true while the panel has focus.
+
+  Only `tabindex` moves. Unlike the side panel's bare `<section>`, this element
+  already carries a role and a name in both modes — a named `role="dialog"` or
+  `role="navigation"` — so it is announced as itself when focus lands on it, and
+  a `role="group"` here would replace the model the drawer declares with a
+  description of its scrollbar.
+
+  Both branches carry `#panel`, and only one of them is ever rendered. That is
+  what makes the measurement follow a drawer whose `mode` changes at runtime:
+  the `@if` destroys one element and builds the other, and the query re-answers.
+-->
+
 <!-- Side mode: panel renders inline -->
 @if (mode() !== 'over') {
   <div
-    tabindex="-1"
+    #panel
     tnTestIdType="drawer"
+    [attr.tabindex]="panelKeyboardReachable() ? '0' : '-1'"
     [class]="drawerClasses()"
     [style.width]="width()"
     [attr.role]="panelRole()"
@@ -56,9 +84,10 @@
       target it focuses — see `../a11y/initial-focus.ts`.
     -->
     <div
+      #panel
       #overPanel
-      tabindex="-1"
       tnTestIdType="drawer"
+      [attr.tabindex]="panelKeyboardReachable() ? '0' : '-1'"
       [class]="drawerClasses()"
       [style.width]="width()"
       [attr.role]="panelRole()"

--- a/projects/truenas-ui/src/lib/drawer/drawer.component.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/core';
 import { tnAccessibleName } from '../a11y/accessible-name';
 import { tnFocusOnOpen } from '../a11y/initial-focus';
+import { tnScrollableRegion } from '../a11y/scrollable-region';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 import { tnTransitionLifecycle } from '../utils/transition-lifecycle';
 
@@ -152,6 +153,36 @@ export class TnDrawerComponent implements OnDestroy {
    * so a `side` drawer never renders it.
    */
   private overPanelRef = viewChild<ElementRef<HTMLElement>>('overPanel');
+
+  /**
+   * Whichever panel is currently rendered — the `side` one or the `over` one.
+   *
+   * Both template branches carry `#panel` and the `@if` on `mode` renders
+   * exactly one, so this is "the drawer's panel" without the caller having to
+   * ask which mode it is in. A drawer whose `mode` changes at runtime destroys
+   * one element and builds the other, and this query re-answers with it.
+   */
+  private panelRef = viewChild<ElementRef<HTMLElement>>('panel');
+
+  /**
+   * Whether the panel carries a real tab stop rather than its resting `-1`
+   * (#270).
+   *
+   * `.tn-drawer__panel` is the element with `overflow-y: auto`, so a drawer
+   * whose projected content is taller than it is scrolls here — and until this
+   * ticket nothing about it was reachable from a keyboard unless the caller
+   * happened to project a tabbable control. The measurement, the observers that
+   * keep it current and the rule that decides when the tab stop may be given
+   * back are `tnScrollableRegion`'s; see `../a11y/scrollable-region.ts`, which
+   * is also where the reasoning for holding it on while the panel has focus is
+   * set out.
+   *
+   * A field initializer rather than the constructor, because it registers an
+   * `effect` and so needs an injection context.
+   */
+  protected panelKeyboardReachable = tnScrollableRegion(
+    () => this.panelRef()?.nativeElement
+  );
 
   /** Focus trap should be active only in 'over' mode when open */
   protected trapFocus = computed(() => this.mode() === 'over' && this.opened());

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.html
@@ -93,10 +93,10 @@
       The gate is `contentKeyboardReachable`, which is the measurement OR the
       region's own focus, not the measurement alone. Content that stops
       overflowing while the region is focused would otherwise take the tab stop
-      off the focused element and blur a keyboard user out of the open panel;
-      `contentKeyboardReachable` on the component says why in full. `focus` and
-      `blur` do not bubble, so they report this `<section>` rather than anything
-      projected into it.
+      off the focused element and blur a keyboard user out of the open panel.
+      Both halves are `tnScrollableRegion`'s, in `../a11y/scrollable-region.ts`,
+      which says why in full — including why it listens for this element's own
+      `focus`/`blur` itself rather than leaving each caller to bind them.
 
       `role="group"` rather than the `region` a named `<section>` would imply:
       `region` is a landmark, and a landmark named the same thing in every panel
@@ -108,9 +108,7 @@
       class="tn-side-panel__content"
       [attr.tabindex]="contentKeyboardReachable() ? '0' : null"
       [attr.role]="contentKeyboardReachable() ? 'group' : null"
-      [attr.aria-label]="contentKeyboardReachable() ? contentAriaLabel() : null"
-      (focus)="contentFocused.set(true)"
-      (blur)="contentFocused.set(false)">
+      [attr.aria-label]="contentKeyboardReachable() ? contentAriaLabel() : null">
       <ng-content />
     </section>
 

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.ts
@@ -2,7 +2,7 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule, DOCUMENT } from '@angular/common';
 import {
   Component, Directive, input, output, model, computed, effect, inject, signal,
-  contentChildren, viewChild, afterNextRender, DestroyRef, NgZone,
+  contentChildren, viewChild, afterNextRender, DestroyRef,
 } from '@angular/core';
 import type { ElementRef, OnDestroy } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -11,6 +11,7 @@ import { take } from 'rxjs';
 import type { Observable } from 'rxjs';
 import { tnAccessibleName } from '../a11y/accessible-name';
 import { tnFocusOnOpen } from '../a11y/initial-focus';
+import { TN_SCROLLABLE_REGION_TOLERANCE_PX, tnScrollableRegion } from '../a11y/scrollable-region';
 import { TnIconRegistryService } from '../icon/icon-registry.service';
 import { TnIconButtonComponent } from '../icon-button/icon-button.component';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
@@ -57,21 +58,14 @@ export const TN_SIDE_PANEL_CONTENT_LABEL = 'Panel content';
  * How far the content has to exceed the region before the region counts as
  * scrolling (#248).
  *
- * This is axe's own number: `scrollable-region-focusable` matches through
- * `getScroll(node, 13)`, so it ignores an overflow smaller than this and would
- * not report a region that has one. Measuring with a bare `>` instead would put
- * a tab stop on panels the rule considers fine — and `scrollHeight` and
- * `clientHeight` are integers rounded from fractional layout, so a panel whose
- * content fits to within a pixel reads as overflowing by one.
- *
- * Matching the rule keeps the component and the check that judges it saying the
- * same thing about the same panel. It is a property of the rule rather than a
- * knob, so it is not an input and consumers have no reason to read it — but it
- * is exported, because `side-panel-scrollable-content.spec.ts` pins it against
- * axe's own buffer from both sides, and a spec that recopied the literal would
- * pin the copy to itself.
+ * **This is now `TN_SCROLLABLE_REGION_TOLERANCE_PX`**, which is axe's own 13px
+ * buffer and lives with the measurement it belongs to (#270). The alias stays
+ * because it is what `side-panel-scrollable-content.spec.ts` pins against axe
+ * from both sides, and that spec is a guard on this component rather than on
+ * the helper — see `../a11y/scrollable-region.ts` for what the number is and
+ * why it is copied from the rule at all.
  */
-export const TN_SIDE_PANEL_OVERFLOW_TOLERANCE_PX = 13;
+export const TN_SIDE_PANEL_OVERFLOW_TOLERANCE_PX = TN_SCROLLABLE_REGION_TOLERANCE_PX;
 
 /**
  * Directive to mark an element as a side-panel footer action.
@@ -138,7 +132,6 @@ export class TnSidePanelComponent implements OnDestroy {
   private iconRegistry = inject(TnIconRegistryService);
   private document = inject(DOCUMENT);
   private destroyRef = inject(DestroyRef);
-  private zone = inject(NgZone);
 
   private overlayRef = viewChild.required<ElementRef>('overlay');
   private panelRef = viewChild.required<ElementRef<HTMLElement>>('panel');
@@ -146,55 +139,25 @@ export class TnSidePanelComponent implements OnDestroy {
   protected initialized = signal(false);
 
   /**
-   * Whether the content region currently overflows (#248).
+   * Whether the content region carries the tab stop, its role and its name
+   * (#248) — which is NOT the same question as whether it currently overflows.
    *
-   * Measured, not derived: nothing about the panel's inputs says whether what a
-   * caller projected fits, and the answer changes with the viewport and with
-   * the content itself. See `measureContentOverflow` for what keeps it current.
+   * The measurement, the two observers that keep it current and the focus rule
+   * that decides when the attributes may be taken off again are all
+   * `tnScrollableRegion`'s (#270); this component decides only what to put on
+   * the element, which is the part that differs between the five regions in
+   * this library that scroll. `../a11y/scrollable-region.ts` sets out why the
+   * answer is held true while the region has focus, and why `role` and
+   * `aria-label` are gated on the same signal as `tabindex` rather than left on.
    *
-   * This is the measurement on its own. What the region is actually marked with
-   * is `contentKeyboardReachable`, which is this OR the region's own focus.
+   * Read in `afterNextRender`, which is where the helper takes its first
+   * measurement — before the overlay is portaled to `<body>` below, which does
+   * not affect it: `.tn-side-panel__overlay` is `position: fixed; inset: 0`, so
+   * its size comes from the viewport rather than from its parent.
    */
-  protected contentScrollable = signal(false);
-
-  /**
-   * Whether the content region itself currently holds focus (#248).
-   *
-   * Tracked from the region's own `focus`/`blur`, which do not bubble, so this
-   * is about the `<section>` and not about anything a caller projected into it.
-   * See `contentKeyboardReachable` for what it is for.
-   */
-  protected contentFocused = signal(false);
-
-  /**
-   * Whether the region carries the tab stop, its role and its name — which is
-   * NOT the same question as whether it currently overflows (#248).
-   *
-   * Content can stop overflowing while the region is focused: a validation
-   * message clears, an expander collapses, the panel widens. Dropping
-   * `tabindex` at that moment removes the tab stop from the ELEMENT THAT HAS
-   * FOCUS, and a focused element that stops being focusable is blurred to
-   * `<body>` — so a keyboard user reading a panel would find themselves outside
-   * the open dialog, with the next Tab starting from the top of the page,
-   * because content they were not interacting with got shorter. That is a worse
-   * failure than the one this ticket fixes, and it is caused by the fix.
-   *
-   * So focus holds the attributes on until it leaves of its own accord. The
-   * `blur` that clears this signal has already happened by the time Angular
-   * writes the attribute away, so nothing is focused when the tab stop goes,
-   * and the region is not a tab stop for the NEXT Tab through the panel.
-   *
-   * Retaining `role` and `aria-label` alongside `tabindex` rather than only the
-   * tabindex: a focused group that loses its name mid-read is announced as a
-   * bare "group" on the next thing a screen reader says about it, and the
-   * unlabelled group is the state the name exists to prevent.
-   */
-  protected contentKeyboardReachable = computed(
-    () => this.contentScrollable() || this.contentFocused()
+  protected contentKeyboardReachable = tnScrollableRegion(
+    () => this.contentRef().nativeElement
   );
-
-  private contentResize?: ResizeObserver;
-  private contentMutations?: MutationObserver;
 
   // Two-way bindable via [(open)]
   open = model<boolean>(false);
@@ -364,15 +327,10 @@ export class TnSidePanelComponent implements OnDestroy {
     afterNextRender(() => {
       this.document.body.appendChild(this.overlayRef().nativeElement);
       this.initialized.set(true);
-      this.measureContentOverflow();
-      this.watchContentOverflow();
     });
   }
 
   ngOnDestroy(): void {
-    this.contentResize?.disconnect();
-    this.contentMutations?.disconnect();
-
     const overlay = this.overlayRef().nativeElement as HTMLElement;
 
     // A panel destroyed WHILE OPEN never runs the close branch of the effect
@@ -434,110 +392,6 @@ export class TnSidePanelComponent implements OnDestroy {
     // exactly when this event is late: a panel reopened while the close was
     // still animating reads `open() === true` on the stale close's event.
     this.lifecycle.transitionEnded();
-  }
-
-  /**
-   * Read whether the content region overflows, and record it (#248).
-   *
-   * A layout read and nothing else, so it is safe to call from either observer
-   * below: the only write it makes is to a signal, and the attributes that
-   * follow are written by Angular in its own pass rather than here. Setting the
-   * signal to the value it already holds is a no-op, which is what most calls
-   * are.
-   */
-  private measureContentOverflow(): void {
-    const content = this.contentRef().nativeElement;
-    this.contentScrollable.set(
-      content.scrollHeight > content.clientHeight + TN_SIDE_PANEL_OVERFLOW_TOLERANCE_PX
-    );
-  }
-
-  /**
-   * Keep that measurement current, from the two directions it can go stale.
-   *
-   * A scroll container overflows when its content is taller than its box, and
-   * either half can change on its own — so both are watched, by the instrument
-   * that can see them:
-   *
-   * - **The box.** The panel is full-height and `width` is an input, so a
-   *   viewport resize or a narrower panel reflows the content.
-   * - **The content.** A caller's form revealing a validation message changes
-   *   `scrollHeight` while the region's own size stays exactly the same, so a
-   *   `ResizeObserver` on the region alone never fires for it.
-   *
-   * `MutationObserver` catches the second only when the growth IS a DOM change.
-   * Plenty of it is not: an image finishing loading, a webfont swapping in, a
-   * class toggle opening an expander. What all of those DO change is the size
-   * of the child that holds them, which is why the `ResizeObserver` is pointed
-   * at the region's direct children as well as at the region — see
-   * `observeContentBoxes`. Layout propagates, so a grandchild growing grows the
-   * child that contains it.
-   *
-   * `attributes` is therefore deliberately NOT observed. The class toggle above
-   * arrives as a resize instead, and watching attributes would mean watching
-   * the ones this measurement itself writes onto the observed element — the
-   * measurement called from its own result.
-   *
-   * Both are feature-detected, because neither exists during SSR and
-   * `ResizeObserver` does not exist under jsdom — where the fallback is the
-   * single `afterNextRender` reading, and a region that reads as fitting is the
-   * safe answer either way.
-   *
-   * Outside the Angular zone, for the reason `../a11y/initial-focus.ts` gives
-   * for its retries: a projected form mutates on every keystroke, and a
-   * zone-patched callback would be a change detection pass for each one. The
-   * signal notifies Angular by itself when the answer actually changes.
-   */
-  private watchContentOverflow(): void {
-    const content = this.contentRef().nativeElement;
-
-    this.zone.runOutsideAngular(() => {
-      if (typeof ResizeObserver !== 'undefined') {
-        this.contentResize = new ResizeObserver(() => this.measureContentOverflow());
-      }
-
-      if (typeof MutationObserver !== 'undefined') {
-        this.contentMutations = new MutationObserver(() => {
-          // Which elements exist has just changed, so what is observed has to
-          // change with it before the region is measured again.
-          this.observeContentBoxes();
-          this.measureContentOverflow();
-        });
-        this.contentMutations.observe(content, {
-          childList: true,
-          subtree: true,
-          characterData: true,
-        });
-      }
-
-      this.observeContentBoxes();
-    });
-  }
-
-  /**
-   * Point the `ResizeObserver` at the content region and at each of its direct
-   * children, replacing whatever it was watching before.
-   *
-   * The children are the half that catches content growth no DOM mutation
-   * announces — see `watchContentOverflow`. They are re-read rather than
-   * tracked incrementally because the set changes only when `childList` does,
-   * which is the callback this runs in, and a panel's content is a handful of
-   * elements rather than a list.
-   *
-   * `disconnect` first: `observe` on an element already observed is a no-op, so
-   * without it a child that was removed would keep its registration and keep
-   * the observer alive.
-   */
-  private observeContentBoxes(): void {
-    const resize = this.contentResize;
-    if (!resize) {
-      return;
-    }
-
-    const content = this.contentRef().nativeElement;
-    resize.disconnect();
-    resize.observe(content);
-    Array.from(content.children).forEach((child) => resize.observe(child));
   }
 
   private restoreFocus(): void {

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel-scrollable-content.spec.ts
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel-scrollable-content.spec.ts
@@ -1,0 +1,305 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TN_TAB_PANEL_CONTENT_LABEL, TnTabPanelComponent } from './tab-panel.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TN_SCROLLABLE_REGION_TOLERANCE_PX } from '../a11y/scrollable-region';
+import {
+  MockResizeObserver,
+  scrollingTo,
+  staticScroller,
+} from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards the keyboard reachability of a tab panel's scrolling content (#270).
+ *
+ * WHAT THE DEFECT IS, AND WHY THE PANEL'S OWN TAB STOP DID NOT COVER IT
+ * ---------------------------------------------------------------------
+ * `.tn-tab-panel__content` is `overflow: auto` and is a CHILD of the
+ * `role="tabpanel"` wrapper. The wrapper was already `tabindex="0"` while
+ * active, which is the ARIA tabs pattern's answer to a panel holding no control
+ * of its own — but it is the wrong element for scrolling twice over. axe's
+ * `scrollable-region-focusable` looks at whether the SCROLL CONTAINER is
+ * focusable or holds something focusable, and an ancestor's tab stop is
+ * neither; and a browser scrolls the nearest scrollable ANCESTOR of what has
+ * focus, so standing on the wrapper scrolled the page instead of the panel.
+ *
+ * WHAT THE FIX DOES INSTEAD OF MARKING BOTH
+ * -----------------------------------------
+ * The tab stop MOVES rather than multiplying. Marking the region as well as the
+ * wrapper would satisfy the rule and put two stops in a row — "tab panel", then
+ * "group" — on every scrolling panel, for one region. So the wrapper keeps
+ * `tabindex="0"` while the content fits and drops to `-1` when the region takes
+ * it, which leaves exactly one stop either way and puts it on the element that
+ * scrolls. `-1` rather than nothing: the wrapper is still what a tab's
+ * `aria-controls` points at and still has to be focusable programmatically.
+ */
+
+@Component({
+  selector: 'tn-tab-panel-scroll-host',
+  standalone: true,
+  imports: [TnTabPanelComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger">Elsewhere</button>
+    <tn-tab-panel [label]="label()">
+      <p>Panel body</p>
+      @if (extra()) {
+        <p id="extra">More body than fits</p>
+      }
+    </tn-tab-panel>
+  `,
+})
+class TabPanelScrollHostComponent {
+  extra = signal(false);
+  label = signal('');
+}
+
+describe('tn-tab-panel scrolling content region (#270)', () => {
+  let fixture: ComponentFixture<TabPanelScrollHostComponent>;
+  let host: TabPanelScrollHostComponent;
+  let restoreResizeObserver: () => void;
+
+  /** The visible height every case here measures against. */
+  const REGION_HEIGHT = 200;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabPanelScrollHostComponent],
+    }).compileComponents();
+
+    restoreResizeObserver = MockResizeObserver.install();
+
+    fixture = TestBed.createComponent(TabPanelScrollHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    // A panel is inactive until its parent `tn-tabs` says otherwise, and an
+    // inactive one is `display: none` — which axe exempts and no user can
+    // scroll. Every case here is about the active panel, so this is setup
+    // rather than a case of its own.
+    const panelDebugEl = fixture.debugElement.children
+      .find((child) => child.componentInstance instanceof TnTabPanelComponent);
+    (panelDebugEl?.componentInstance as TnTabPanelComponent).isActive.set(true);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    restoreResizeObserver();
+  });
+
+  /** The `role="tabpanel"` wrapper. */
+  function panel(): HTMLElement {
+    return fixture.nativeElement.querySelector('[role="tabpanel"]') as HTMLElement;
+  }
+
+  /** The element that actually scrolls. */
+  function region(): HTMLElement {
+    return fixture.nativeElement.querySelector('.tn-tab-panel__content') as HTMLElement;
+  }
+
+  async function mutateContent(mutate: () => void): Promise<void> {
+    mutate();
+    fixture.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+  }
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control, and it is specifically the shape this component
+     * had: a scroll container with no tab stop, inside a focusable wrapper. The
+     * wrapper's `tabindex="0"` is on the control deliberately — the point is
+     * that it does not answer the rule, because the rule asks about the scroll
+     * container and its DESCENDANTS.
+     */
+    it('still reports a scroll container inside a focusable wrapper', async () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<div role="tabpanel" tabindex="0">'
+        + '<div class="scroller"><p>Panel body</p></div>'
+        + '</div>';
+      document.body.appendChild(root);
+
+      const scroller = root.querySelector('.scroller') as HTMLElement;
+      scrollingTo(scroller, 400, REGION_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, scroller, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+
+    /**
+     * And the same rule on a bare scroll container, so that the control above
+     * is read as "the wrapper did not help" rather than as "the rule fires on
+     * anything".
+     */
+    it('reports a bare one too', async () => {
+      const { root, region: scroller } = staticScroller(400, REGION_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, scroller, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('a panel whose content overflows', () => {
+    beforeEach(async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+    });
+
+    it('moves the tab stop onto the region that scrolls', () => {
+      expect(region().getAttribute('tabindex')).toBe('0');
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('names the region, so it is not announced as an unlabelled group', () => {
+      expect(region().getAttribute('role')).toBe('group');
+      expect(region().getAttribute('aria-label')).toBe(TN_TAB_PANEL_CONTENT_LABEL);
+    });
+
+    it('prefers the panel\'s own label, which is what its tab says', async () => {
+      await mutateContent(() => host.label.set('Datasets'));
+      expect(region().getAttribute('aria-label')).toBe('Datasets');
+    });
+
+    it('falls back when the label is only whitespace', async () => {
+      await mutateContent(() => host.label.set('   '));
+      expect(region().getAttribute('aria-label')).toBe(TN_TAB_PANEL_CONTENT_LABEL);
+    });
+
+    it('raises no scrollable-region-focusable violation, and does evaluate the rule', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, region(), ['scrollable-region-focusable']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('scrollable-region-focusable');
+    });
+
+    it('puts no disallowed ARIA on the region or the panel', async () => {
+      const { violated } = await axeResult(
+        fixture.nativeElement,
+        [region(), panel()],
+        ['aria-allowed-role', 'aria-allowed-attr', 'aria-valid-attr-value'],
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    it('hands the tab stop back to the panel when the content shrinks to fit', async () => {
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(region().getAttribute('role')).toBeNull();
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('a panel whose content fits', () => {
+    /**
+     * The over-fix guard, and the half that says the ARIA tabs pattern still
+     * holds: an active panel is reachable whether or not it scrolls, because a
+     * panel with no control of its own has to be.
+     */
+    it('leaves the tab stop on the panel and the region unmarked', async () => {
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(panel().getAttribute('tabindex')).toBe('0');
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(region().getAttribute('role')).toBeNull();
+      expect(region().getAttribute('aria-label')).toBeNull();
+    });
+
+    /** The tolerance, from both sides of the line axe draws. */
+    it('starts marking exactly where axe starts reporting', async () => {
+      scrollingTo(region(), REGION_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+
+      scrollingTo(region(), REGION_HEIGHT + TN_SCROLLABLE_REGION_TOLERANCE_PX + 1, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('when the content stops overflowing UNDER a keyboard user', () => {
+    /**
+     * The failure the fix can cause rather than the one it fixes: taking
+     * `tabindex` off a focused element blurs it to `<body>`, and here that
+     * would drop a keyboard user out of the tab panel entirely — the wrapper
+     * takes its own stop back at the same moment, so there is nothing beside it
+     * to catch them. jsdom does not implement the blur, so the CONDITION is
+     * what is asserted.
+     */
+    it('keeps both the region\'s stop and the panel\'s -1 while the region has focus', async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      region().focus();
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(region());
+
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+      expect(region().getAttribute('aria-label')).toBe(TN_TAB_PANEL_CONTENT_LABEL);
+      expect(panel().getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('hands it back once focus leaves of its own accord', async () => {
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(true));
+
+      region().focus();
+      fixture.detectChanges();
+
+      scrollingTo(region(), REGION_HEIGHT, REGION_HEIGHT);
+      await mutateContent(() => host.extra.set(false));
+
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+
+      expect(region().getAttribute('tabindex')).toBeNull();
+      expect(panel().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('what the measurement follows', () => {
+    /**
+     * The box-changed direction: the window narrows, the same content reflows
+     * taller, and NOTHING about the DOM changed.
+     */
+    it('re-measures when the region resizes, with no DOM mutation', () => {
+      expect(MockResizeObserver.targets()).toContain(region());
+      expect(region().getAttribute('tabindex')).toBeNull();
+
+      scrollingTo(region(), 400, REGION_HEIGHT);
+      MockResizeObserver.emit();
+      fixture.detectChanges();
+
+      expect(region().getAttribute('tabindex')).toBe('0');
+    });
+
+    /** The child-resized direction, which a `MutationObserver` cannot see. */
+    it('watches the region\'s direct children too', async () => {
+      await mutateContent(() => host.extra.set(true));
+
+      const child = region().querySelector('#extra') as HTMLElement;
+      expect(MockResizeObserver.targets()).toContain(child);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.html
@@ -1,3 +1,29 @@
+<!--
+  WHICH OF THESE TWO ELEMENTS IS THE TAB STOP (#270)
+  --------------------------------------------------
+  Exactly one of them, and which one depends on whether the content scrolls.
+
+  The ARIA tabs pattern makes a tabpanel focusable so that a panel holding no
+  control of its own can still be reached — which is what `tabindex="0"` below
+  was for. But `.tn-tab-panel__content` is the element with `overflow: auto`,
+  and it is a CHILD of the panel: focus on the panel scrolls the page rather
+  than the region, because a browser scrolls the nearest scrollable ANCESTOR of
+  what has focus. So a panel taller than its box left the part below the fold
+  unreachable from a keyboard, and axe reported it as
+  `scrollable-region-focusable`.
+
+  Marking both would satisfy the rule and put two stops in a row on every
+  scrolling panel — "tab panel", then "group" — for one region. Instead the
+  stop moves to whichever element is the useful one to stand on: the scroll
+  container while there is something to scroll, the panel otherwise. The panel
+  keeps `tabindex="-1"` in that case, so it stays a focus target for anything
+  that moves focus to it programmatically and stays what its tab's
+  `aria-controls` points at.
+
+  `contentKeyboardReachable` is `tnScrollableRegion`'s, shared with
+  `tn-side-panel` and three others; `../a11y/scrollable-region.ts` says what it
+  measures and why it is held true while the region has focus.
+-->
 <div
   role="tabpanel"
   tnTestIdType="tab-panel"
@@ -6,10 +32,23 @@
   [attr.id]="panelId()"
   [attr.aria-hidden]="!isActive()"
   [attr.aria-labelledby]="hasTab() ? tabId() : null"
-  [attr.tabindex]="isActive() ? 0 : -1"
+  [attr.tabindex]="isActive() && !contentKeyboardReachable() ? 0 : -1"
 >
   @if (shouldRender()) {
-    <div class="tn-tab-panel__content">
+    <!--
+      `role="group"` and a name arrive with the tab stop and leave with it, for
+      the reason the side panel's region gives: a focusable element with no
+      accessible name is announced as a bare "group". The name is the tab's own
+      label where there is one — the panel is named that way too, and a listener
+      who has just moved off the tab hears the same words for the region it
+      opened.
+    -->
+    <div
+      #contentRegion
+      class="tn-tab-panel__content"
+      [attr.tabindex]="contentKeyboardReachable() ? '0' : null"
+      [attr.role]="contentKeyboardReachable() ? 'group' : null"
+      [attr.aria-label]="contentKeyboardReachable() ? contentLabel() : null">
       <ng-content />
     </div>
   }

--- a/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
+++ b/projects/truenas-ui/src/lib/tab-panel/tab-panel.component.ts
@@ -2,10 +2,24 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import type { TemplateRef} from '@angular/core';
 import { Component, input, viewChild, ElementRef, inject, computed, signal } from '@angular/core';
+import { tnScrollableRegion } from '../a11y/scrollable-region';
 import { tabDomId, tabPanelDomId } from '../tabs/tab-ids';
 import { TnTestIdDirective, type TnTestIdValue } from '../test-id';
 
 let nextUnownedGroupId = 0;
+
+/**
+ * The name the scrolling content region takes when it becomes focusable and the
+ * panel has no `label` to name it from (#270).
+ *
+ * A focusable element with no accessible name is announced as a bare "group".
+ * A panel rendered outside a `tn-tabs`, or one whose caller left `label` empty,
+ * has no better name available — so this is the last resort rather than the
+ * usual case, and `contentLabel` prefers the label every time there is one.
+ *
+ * Exported so specs assert against it by name rather than by a copied literal.
+ */
+export const TN_TAB_PANEL_CONTENT_LABEL = 'Tab panel content';
 
 @Component({
   selector: 'tn-tab-panel',
@@ -20,6 +34,32 @@ export class TnTabPanelComponent {
   testId = input<TnTestIdValue>(undefined);
 
   content = viewChild.required<TemplateRef<unknown>>('content');
+
+  /**
+   * The scrolling content region, which is `.tn-tab-panel__content` — the
+   * element the stylesheet gives `overflow: auto`, not the `role="tabpanel"`
+   * wrapper around it. Optional because it lives inside `@if (shouldRender())`,
+   * so a lazy panel that has never been active does not render it.
+   *
+   * The template ref is `#contentRegion` and not `#content`, which is taken:
+   * the `content` query above asks for a `TemplateRef` under that name, and
+   * naming a real element `#content` would hand it an `ElementRef` instead.
+   */
+  private contentRef = viewChild<ElementRef<HTMLElement>>('contentRegion');
+
+  /**
+   * Whether the content region carries the tab stop, its role and its name —
+   * and, conversely, whether the `role="tabpanel"` wrapper gives its own up.
+   *
+   * `.tn-tab-panel__content` is what scrolls, so it is what a keyboard user
+   * has to be able to stand on to read past the fold (#270). The measurement,
+   * the observers behind it and the rule that holds the answer true while the
+   * region has focus are `tnScrollableRegion`'s; the template says why the two
+   * elements trade one tab stop rather than carrying two.
+   */
+  protected contentKeyboardReachable = tnScrollableRegion(
+    () => this.contentRef()?.nativeElement
+  );
 
   // Internal properties set by parent TnTabsComponent (public signals for parent control)
   index = signal<number>(0);
@@ -48,6 +88,24 @@ export class TnTabPanelComponent {
 
   /** The id of the tab that labels this panel, for `aria-labelledby`. */
   tabId = computed(() => tabDomId(this.groupId(), this.index()));
+
+  /**
+   * What the scrolling content region is named while it carries the tab stop.
+   *
+   * The panel's own `label` where there is one, because that is what its tab
+   * says and a listener arriving from the tab hears the same words for the
+   * region it opened. `aria-labelledby` pointing at the tab would be the other
+   * way to say it and is not used here: the tab lives in a sibling component,
+   * so the IDREF resolves only inside a `tn-tabs`, and a panel rendered on its
+   * own would be left unnamed by exactly the route that was supposed to name
+   * it — the `--tn-error-text` hazard in another shape.
+   *
+   * Trimmed, because a whitespace-only label names the region with nothing,
+   * which is the state `TN_TAB_PANEL_CONTENT_LABEL` exists to prevent.
+   */
+  protected contentLabel = computed(
+    () => this.label().trim() || TN_TAB_PANEL_CONTENT_LABEL
+  );
 
   classes = computed(() => {
     const classes = ['tn-tab-panel'];

--- a/projects/truenas-ui/src/lib/table/table-scroll-region.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-scroll-region.spec.ts
@@ -1,0 +1,291 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TnTableTesting } from './table-testing';
+import { TN_TABLE_SCROLL_REGION_LABEL, TnTableComponent } from './table.component';
+import { axeResult } from '../a11y/axe-testing';
+import { TN_SCROLLABLE_REGION_TOLERANCE_PX } from '../a11y/scrollable-region';
+import { scrollingTo, staticScroller } from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards the keyboard reachability of the table's own horizontal scroll region
+ * (#270).
+ *
+ * WHAT THE DEFECT IS
+ * ------------------
+ * `:host` is `overflow-x: auto` — the stylesheet explains why the scrollport is
+ * the host and not `.tn-table__table` — so a table wider than its container
+ * scrolls on the host element. Whether anything in it is reachable from a
+ * keyboard depends entirely on how the consumer configured it: sortable headers
+ * and clickable rows render `tabindex="0"`, and a table with neither renders
+ * none. Every feature input on this component is opt-in and defaults off, so
+ * the DEFAULT table is the one that matched axe's
+ * `scrollable-region-focusable` — a scroll container that is not in the tab
+ * order and holds nothing that is, with its trailing columns unreachable.
+ *
+ * WHY THE MEASUREMENT AND NOT `isScrollMode()`
+ * --------------------------------------------
+ * They answer different questions. `--scroll` says which LAYOUT the container's
+ * width selected; this asks whether the content actually exceeds the box, which
+ * is what axe asks and what decides whether there is anything to scroll to. A
+ * narrow table in scroll mode has no overflow and needs no tab stop.
+ *
+ * HOW THE OVERFLOW IS REPRODUCED HERE
+ * -----------------------------------
+ * jsdom has no layout engine, so `scrollWidth` and `clientWidth` are `0` on
+ * every element. `scrollingTo` stubs both and sets `overflow-x` inline, which
+ * is what axe's `getScroll` and `tnScrollableRegion` each read. These tests are
+ * therefore a reproduction of the RULE rather than of the rendering: whether a
+ * given table overflows at a given width is a question only `yarn test-sb` can
+ * answer.
+ */
+
+interface Row { id: number; name: string }
+
+const ROWS: Row[] = [
+  { id: 1, name: 'alpha' },
+  { id: 2, name: 'beta' },
+];
+
+@Component({
+  selector: 'tn-table-scroll-region-host',
+  standalone: true,
+  imports: [TnTableComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <button type="button" id="trigger">Elsewhere</button>
+    <tn-table
+      mobileLayout="scroll"
+      [dataSource]="rows()"
+      [displayedColumns]="['id', 'name']"
+      [clickable]="clickable()"
+      [scrollRegionAriaLabel]="label()" />
+  `,
+})
+class TableScrollRegionHostComponent {
+  rows = signal<Row[]>(ROWS);
+  /** The other route to satisfying the rule: rows that are themselves tab stops. */
+  clickable = signal(false);
+  label = signal(TN_TABLE_SCROLL_REGION_LABEL);
+}
+
+describe('tn-table horizontal scroll region (#270)', () => {
+  let fixture: ComponentFixture<TableScrollRegionHostComponent>;
+  let host: TableScrollRegionHostComponent;
+  let restoreResizeObserver: () => void;
+
+  /** The visible width every case here measures against. */
+  const HOST_WIDTH = 400;
+
+  beforeEach(async () => {
+    // The table's own stand-in rather than the one in
+    // `../a11y/scrollable-region-testing`: `tn-table` reads
+    // `entries[0].contentRect.width` to choose its layout, and this is the
+    // supported way to push a width through it. `tnScrollableRegion` ignores
+    // the entries and re-measures the host, so one observer serves both.
+    restoreResizeObserver = TnTableTesting.installResizeObserver();
+
+    await TestBed.configureTestingModule({
+      imports: [TableScrollRegionHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableScrollRegionHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    restoreResizeObserver();
+  });
+
+  function table(): HTMLElement {
+    return fixture.nativeElement.querySelector('tn-table') as HTMLElement;
+  }
+
+  /** Re-measure through the observer, which is the path a real resize takes. */
+  function reflow(): void {
+    TnTableTesting.emitContainerWidth(HOST_WIDTH);
+    fixture.detectChanges();
+  }
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control, on the horizontal axis, built from static markup so
+     * that it keeps saying what axe does about an unfixed scroll container
+     * after this component stops being one.
+     */
+    it('still reports a horizontally scrolling container that nothing can focus', async () => {
+      const { root, region } = staticScroller(900, HOST_WIDTH, 'horizontal');
+
+      try {
+        const { violated } = await axeResult(root, region, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('a table wider than its container', () => {
+    beforeEach(() => {
+      scrollingTo(table(), 900, HOST_WIDTH, 'horizontal');
+      reflow();
+    });
+
+    it('makes the host a tab stop', () => {
+      expect(table().getAttribute('tabindex')).toBe('0');
+    });
+
+    it('names the region, so it is not announced as an unlabelled group', () => {
+      expect(table().getAttribute('role')).toBe('group');
+      expect(table().getAttribute('aria-label')).toBe(TN_TABLE_SCROLL_REGION_LABEL);
+    });
+
+    it('lets a consumer say what the table holds', () => {
+      host.label.set('Storage pools');
+      fixture.detectChanges();
+      expect(table().getAttribute('aria-label')).toBe('Storage pools');
+    });
+
+    it('falls back when the consumer passes whitespace', () => {
+      host.label.set('   ');
+      fixture.detectChanges();
+      expect(table().getAttribute('aria-label')).toBe(TN_TABLE_SCROLL_REGION_LABEL);
+    });
+
+    it('raises no scrollable-region-focusable violation, and does evaluate the rule', async () => {
+      const { violated, evaluated } = await axeResult(
+        fixture.nativeElement, table(), ['scrollable-region-focusable']
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).toContain('scrollable-region-focusable');
+    });
+
+    it('puts no disallowed ARIA on the host it just named', async () => {
+      const { violated } = await axeResult(
+        fixture.nativeElement,
+        table(),
+        ['aria-allowed-role', 'aria-allowed-attr', 'aria-valid-attr-value'],
+      );
+
+      expect(violated).toEqual([]);
+    });
+
+    it('gives the tab stop back when the table stops overflowing', () => {
+      scrollingTo(table(), HOST_WIDTH, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBeNull();
+      expect(table().getAttribute('role')).toBeNull();
+      expect(table().getAttribute('aria-label')).toBeNull();
+    });
+  });
+
+  describe('a table that fits its container', () => {
+    /**
+     * The over-fix guard. Every `tn-table` in the product renders this host, so
+     * an unconditional tab stop here is an extra stop on every table — and one
+     * that reports nothing to axe either way, because the rule does not match
+     * an element that does not scroll.
+     */
+    it('leaves the host unmarked', () => {
+      scrollingTo(table(), HOST_WIDTH, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBeNull();
+      expect(table().getAttribute('role')).toBeNull();
+      expect(table().getAttribute('aria-label')).toBeNull();
+    });
+
+    /** The tolerance, from both sides of the line axe draws. */
+    it('starts marking exactly where axe starts reporting', () => {
+      scrollingTo(
+        table(), HOST_WIDTH + TN_SCROLLABLE_REGION_TOLERANCE_PX, HOST_WIDTH, 'horizontal'
+      );
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBeNull();
+
+      scrollingTo(
+        table(), HOST_WIDTH + TN_SCROLLABLE_REGION_TOLERANCE_PX + 1, HOST_WIDTH, 'horizontal'
+      );
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('a table that already holds tab stops', () => {
+    /**
+     * The rule is satisfied either way for a clickable table — its rows are
+     * `tabindex="0"`, so `focusable-content` answers it — and the host is
+     * marked anyway.
+     *
+     * That is deliberate and is not the same claim as "the rule needs it". A
+     * row's tab stop lets a keyboard user reach a ROW; it does not let them
+     * scroll the columns sideways, and a table can have twelve columns and two
+     * rows. Marking on the measurement rather than on whether some descendant
+     * happens to be tabbable also means the answer does not change when a
+     * consumer toggles `clickable`.
+     */
+    it('marks the host regardless, because a row stop is not a scroll stop', async () => {
+      host.clickable.set(true);
+      fixture.detectChanges();
+      scrollingTo(table(), 900, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBe('0');
+
+      const { violated } = await axeResult(
+        fixture.nativeElement, table(), ['scrollable-region-focusable']
+      );
+      expect(violated).toEqual([]);
+    });
+  });
+
+  describe('when the table stops overflowing UNDER a keyboard user', () => {
+    /**
+     * Taking `tabindex` off a focused element blurs it to `<body>`, so a
+     * keyboard user who has tabbed to a table to scroll it would be dropped to
+     * the top of the document because a column got narrower. jsdom does not
+     * implement the blur, so the CONDITION is what is asserted: the attributes
+     * are not taken off while the host holds focus.
+     */
+    it('keeps the tab stop and the name while the host holds focus', () => {
+      scrollingTo(table(), 900, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      table().focus();
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(table());
+
+      scrollingTo(table(), HOST_WIDTH, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      expect(table().getAttribute('tabindex')).toBe('0');
+      expect(table().getAttribute('role')).toBe('group');
+      expect(table().getAttribute('aria-label')).toBe(TN_TABLE_SCROLL_REGION_LABEL);
+    });
+
+    it('gives it up once focus leaves of its own accord', () => {
+      scrollingTo(table(), 900, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      table().focus();
+      fixture.detectChanges();
+
+      scrollingTo(table(), HOST_WIDTH, HOST_WIDTH, 'horizontal');
+      reflow();
+
+      const trigger = fixture.nativeElement.querySelector('#trigger') as HTMLElement;
+      trigger.focus();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(trigger);
+      expect(table().getAttribute('tabindex')).toBeNull();
+      expect(table().getAttribute('role')).toBeNull();
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -18,6 +18,7 @@ import {
   signal,
 } from '@angular/core';
 import type { OnInit } from '@angular/core';
+import { tnScrollableRegion } from '../a11y/scrollable-region';
 import { TnCheckboxComponent } from '../checkbox/checkbox.component';
 import { TnEmptyComponent } from '../empty/empty.component';
 import { TnIconComponent } from '../icon/icon.component';
@@ -35,6 +36,26 @@ import { TnTestIdDirective } from '../test-id';
 // from template literals or marker calls; a name returned from a component
 // getter is invisible to it, so the icons would be dropped from the generated
 // sprite and render as nothing. Keep the literals in the template.
+
+/**
+ * The name the table's scroll region falls back to when the consumer has not
+ * said what the table holds (#270).
+ *
+ * A focusable element with no accessible name is announced as a bare "group",
+ * which tells a listener that something has been reached and nothing about what
+ * it is. "Table" is a poor name and is deliberately the fallback rather than
+ * the expectation — `scrollRegionAriaLabel` is how a consumer says something
+ * useful, and it is the one input on this component whose default is worth
+ * overriding on sight.
+ *
+ * No dev-mode warning goes with it, unlike `tnAccessibleName`'s fallbacks: this
+ * name is rendered only on a table that is WIDER THAN ITS CONTAINER, which
+ * depends on the consumer's layout rather than on their markup, so the warning
+ * would fire on a viewport rather than on a mistake.
+ *
+ * Exported so specs assert against it by name rather than by a copied literal.
+ */
+export const TN_TABLE_SCROLL_REGION_LABEL = 'Table';
 
 export interface TnTableDataSource<T = unknown> {
   data?: T[];
@@ -123,6 +144,12 @@ function getExpandDuration(): string {
     '[class.tn-table--scroll]': 'isScrollMode()',
     '[style.--tn-table-active-bg]': 'activeBg()',
     '[style.--tn-table-active-indicator]': 'activeIndicator()',
+    // The host is the element that scrolls (see `overflow-x` in the stylesheet
+    // and `scrollKeyboardReachable` below), so it is the element that has to be
+    // reachable when it does. All three arrive and leave together.
+    '[attr.tabindex]': 'scrollKeyboardReachable() ? "0" : null',
+    '[attr.role]': 'scrollKeyboardReachable() ? "group" : null',
+    '[attr.aria-label]': 'scrollKeyboardReachable() ? resolvedScrollRegionLabel() : null',
   },
 })
 export class TnTableComponent<T = unknown> implements OnInit {
@@ -139,6 +166,45 @@ export class TnTableComponent<T = unknown> implements OnInit {
    */
   private focusBeforeLoading: HTMLElement | null = null;
 
+  /**
+   * Whether the host carries a tab stop, `role="group"` and a name because it
+   * is currently scrolling (#270).
+   *
+   * `:host` is `overflow-x: auto` — the stylesheet says why the scrollport is
+   * the host and not `.tn-table__table` — so a table wider than its container
+   * scrolls HERE, and axe's `scrollable-region-focusable` reports a scroll
+   * container that is neither in the tab order nor holds anything that is.
+   *
+   * Which this table is depends entirely on how it was configured: sortable
+   * headers and clickable rows are `tabindex="0"`, so a table with either
+   * satisfies the rule through its content, and a plain read-only one — the
+   * default of every input on this component — satisfies nothing and leaves its
+   * trailing columns unreachable from a keyboard.
+   *
+   * Gated on the measurement rather than on `isScrollMode()`: that class says
+   * which LAYOUT the container's width selected, and this asks whether the
+   * content actually exceeds the box, which is a different question and the one
+   * axe asks. The measurement, the observers behind it and the rule that holds
+   * the answer true while the host has focus are `tnScrollableRegion`'s.
+   *
+   * A field initializer rather than the constructor, because it registers an
+   * `effect` and so needs an injection context.
+   */
+  protected scrollKeyboardReachable = tnScrollableRegion(
+    () => this.elementRef.nativeElement as HTMLElement
+  );
+
+  /**
+   * The scroll region's name, falling back when a consumer passes whitespace.
+   *
+   * Blank is not a name: an `aria-label=" "` names the group as emptily as no
+   * label at all, and axe agrees — the same rule `tnAccessibleName` applies to
+   * every other name in this library.
+   */
+  protected resolvedScrollRegionLabel = computed(
+    () => this.scrollRegionAriaLabel().trim() || TN_TABLE_SCROLL_REGION_LABEL
+  );
+
   // --- Core inputs ---
   dataSource = input<TnTableDataSource<T> | T[]>([]);
   displayedColumns = input<string[]>([]);
@@ -154,6 +220,18 @@ export class TnTableComponent<T = unknown> implements OnInit {
   emptyDescription = input<string>('');
 
   emptyIcon = input<string>('');
+
+  /**
+   * Accessible name for the table's own scroll region, used only while the host
+   * actually scrolls — see `scrollKeyboardReachable` and
+   * `TN_TABLE_SCROLL_REGION_LABEL`.
+   *
+   * Set it to say what the table holds ("Storage pools"). It names the SCROLL
+   * REGION rather than the table: a table's own structure is announced from its
+   * rows and headers, and this is the box around it that a keyboard user stands
+   * on to scroll sideways.
+   */
+  scrollRegionAriaLabel = input<string>(TN_TABLE_SCROLL_REGION_LABEL);
 
   // --- Feature inputs (all opt-in) ---
   selectable = input<boolean>(false);


### PR DESCRIPTION
Fixes #270.

`scrollable-region-focusable` fires on any element that scrolls, is not in the tab order, and holds nothing that is. #248 fixed one instance of it — `.tn-side-panel__content` — and the fix was not one line, which is the whole argument of this ticket: axe's own 13px buffer, a `ResizeObserver` on the region **and on its direct children**, a `MutationObserver`, and a focus rule deciding when the tab stop may be taken away again. Copying that into a second component is how the lenient copy gets made.

`lib/a11y/scrollable-region.ts` is now the one copy, as `tnScrollableRegion(() => element)`.

## The survey (acceptance criterion 1)

Every rule in `projects/truenas-ui/src/lib` that sets `overflow`, `overflow-x` or `overflow-y` to `auto` or `scroll` — thirteen, in eleven files, read out of the stylesheets rather than recalled.

| element | file | verdict |
|---|---|---|
| `.tn-side-panel__content` | `side-panel.component.scss:99` | **Fixed in #248.** Moved onto the shared helper here |
| `.tn-drawer__panel` | `drawer.component.scss:29` | **Needed one — has one.** `tabindex="-1"` is a focus target, not a tab stop |
| `tn-drawer-content` `:host` | `drawer-content.component.scss:5` | **Needed one — has one.** The element a whole page scrolls in |
| `.tn-tab-panel__content` | `tab-panel.component.scss:27` | **Needed one — has one.** The wrapper's tab stop is on an ancestor, which the rule does not read and a browser does not scroll from |
| `tn-table` `:host` | `table.component.scss:12` | **Needed one — has one.** Horizontal; satisfied by content only when the consumer opted into `sortable` or `clickable` |
| `.tn-chip-input__dropdown` | `chip-input.component.scss:56` | **Already satisfied.** The scroll container IS the `role="listbox"`, and the input's `aria-controls` points at it, so axe's matcher excludes it as a combobox popup |
| `.tn-tabs__header` (×2, `max-width: 768px`) | `tabs.component.scss:79,90` | **Already satisfied.** It holds the `<button role="tab">` tabs, and the roving tabindex leaves the active one at `0` |
| `.tn-file-picker-breadcrumb` (×2, `max-width: 768px`) | `file-picker.component.scss:179`, `file-picker-popup.component.scss:489` | **Already satisfied.** A `<nav>` of `<button>` segments |
| `.tn-file-picker-content` | `file-picker-popup.component.scss:112` | **Already satisfied.** It holds a `tn-table` rendered with `[clickable]="true"`, whose rows are `tabindex="0"` |
| `.tn-select-options` | `select.component.scss:114` | **Matched, and a tab stop is the wrong fix** — see below |
| `.tn-autocomplete__dropdown` | `autocomplete.component.scss:56` | **Matched, and a tab stop is the wrong fix** — see below |

### The two that are matched and are not fixed here

`tn-select` and `tn-autocomplete` are combobox popups, and axe excludes those from this rule by design — `scrollable-region-focusable-matches` calls `isComboboxPopup(vNode)` and skips the node when it is one. Both miss the exclusion on a technicality: it tests the SCROLL CONTAINER's own role, and in these two the scroll is on a wrapper rather than on the `role="listbox"` element. `.tn-select-options` is a plain `<div>` inside the listbox; `.tn-autocomplete__dropdown` is a plain `<div>` around it. `tn-chip-input` puts `overflow-y` on the listbox itself and is excluded.

**It is not a real unreachable region.** Every option is reached with the arrow keys through the input's `aria-activedescendant`, which is the pattern the exclusion exists for, and `tabindex="0"` on a combobox popup is what ARIA tells you not to do — options are deliberately `tabindex="-1"` and never take DOM focus.

The fix that is right is to move the scroll onto the listbox element, which also moves the panel's `max-height` and, on the autocomplete, the `(scroll)` handler that drives its paging. That is a change to the overlay's layout, and this machine cannot open a browser to see what it does. Proposed as its own ticket in a comment on #270 rather than guessed at here.

## What the shared helper does, and two things #248's copy did not

- **axe's 13px buffer.** `getScroll(node, 13)`, so a region that reads as overflowing by a pixel — `scrollHeight` and `clientHeight` are integers rounded from fractional layout — is not marked, because the rule would not report it either.
- **The computed `overflow` on the overflowing axis.** *New.* Content wider than an `overflow-x: visible` box does not scroll; it spills out and is on screen, and `getScroll` returns nothing for it. #248 measured height alone, which was right for a panel whose stylesheet sets `overflow-x: hidden` and is wrong in general — and `tn-table` needs it, because its scroll is the horizontal one.
- **Both observers**, the `ResizeObserver` pointed at the region and at each direct child. The children are what catch content growth that produces no mutation record — an image loading, a webfont swapping.
- **Focus RETAINS a tab stop; it does not grant one.** *New, and a defect the migration surfaced.* `#248`'s reading was `overflowing || focused`, which is correct for a region a user can only reach by tabbing to it. `tn-drawer` focuses its own panel when a modal drawer opens (`tnFocusOnOpen`, #227), so under that reading **every `over` drawer became a tab stop the moment it opened**, scrolling or not. The latch carries the previous answer instead: reachable while overflowing, and still reachable afterwards only for as long as focus stays on a region that already was. `does not grant a tab stop to a fitting panel that has focus` in `drawer-scrollable-panel.spec.ts` is the guard.
- **It rebinds when the element is replaced.** `tn-drawer` renders its panel from one of two `@if` branches on `mode`, so a responsive layout crossing its breakpoint destroys the observed element and builds another. Both branches carry `#panel`; the helper reads the query inside an `effect` and follows it.

### Why a helper and not a directive

The ticket allows either. A directive has to own `tabindex`, `role` and `aria-label` through host bindings, and a host binding wins over a template binding for the same attribute — so on `tn-drawer`, whose panel already binds `[attr.role]="panelRole()"` and `[attr.aria-label]`, it would clobber a named `role="dialog"` with `null`. What is shared is the measurement and the focus rule, which is the subtle part; each component keeps its attribute policy, which is the part that legitimately differs. That is also the shape of `tnAccessibleName` and `tnFocusOnOpen` next door.

## What each component puts on its element, and why they differ

- **`tn-side-panel`** — unchanged behaviour. `tabindex`, `role="group"` and `aria-label` on a bare `<section>`. `TN_SIDE_PANEL_OVERFLOW_TOLERANCE_PX` is kept as an alias of the shared constant, because `side-panel-scrollable-content.spec.ts` pins it against axe from both sides.
- **`tn-drawer`** — `tabindex` only, `-1` at rest and `0` while scrolling. The panel is already a named `role="dialog"` or `role="navigation"`; a `role="group"` here would replace the model the drawer declares with a description of its scrollbar.
- **`tn-drawer-content`** — `tabindex`, `role="group"` and a name, overridable through a new `ariaLabel` input. **Not `role="main"`**: `drawer-container.component.ts` sets out why the landmark belongs to the application, and a group is not summarised in a landmarks list.
- **`tn-tab-panel`** — the tab stop **moves** rather than multiplying. Marking the scroll container as well as the `role="tabpanel"` wrapper would put two stops in a row for one region, so the wrapper keeps `tabindex="0"` while the content fits and drops to `-1` when the region takes it. `-1` rather than nothing: it is still what a tab's `aria-controls` points at. The region is named from the panel's own `label`, which is what its tab says.
- **`tn-table`** — `tabindex`, `role="group"` and a name on the host, from a new `scrollRegionAriaLabel` input defaulting to `"Table"`. Marked on the measurement rather than on whether some descendant happens to be tabbable: a row's tab stop lets a keyboard user reach a row, not scroll twelve columns sideways, and the answer should not change when a consumer toggles `clickable`.

## Specs

One per changed component, in the shape of `side-panel-scrollable-content.spec.ts`: a static positive control, axe on the real component, the tolerance from both sides, the over-fix guard, the focus cases, and both observer directions.

`lib/a11y/scrollable-region-testing.ts` holds `scrollingTo()`, `staticScroller()` and the `ResizeObserver` stand-in, for the reason `axe-testing.ts` gives for its own existence — and specifically because the inline `overflow` is not optional: a spec that stubbed only the sizes would assert against a rule that never matched.

**`side-panel-scrollable-content.spec.ts` is unchanged and passes** (acceptance criterion 3). It keeps its own private copies of the two testing stand-ins deliberately: it is the guard the measurement moved out from under, and a spec edited in the same commit as the thing it guards proves less.

## Checks

Run locally, all green: `yarn lint`, `yarn test` (142 suites, 4053 tests), `yarn test:scripts` (4 suites, 42 tests), `yarn build`.

**`yarn test-sb` was not run here** — the Storybook interaction tests need a browser this machine does not have, so acceptance criterion 5 is the one thing about this change I could not verify locally. It runs on this PR and is worth watching: five components now render a conditional `tabindex`.

## Review

`local-review.py` exit **0** — the project's own reviewer, same rubric and threshold as the required check, in a separate process. Nothing at MEDIUM or above. Six LOWs. One was fixed, because it was three docblock claims that had come to say the opposite of the code beside them once the helper moved from `afterNextRender` to an element-tracking `effect`; that is the second commit and it is prose only. The other five are recorded here rather than acted on, since every fix is a new diff and a new diff reopens the round:

- **`tab-panel.component.html:49`** — the tab stop moves to `.tn-tab-panel__content`, which has no `:focus-visible` rule, so a scrolling panel loses the themed focus ring `.tn-tab-panel` has. Real, and worth a follow-up: it is a stylesheet line, and it applies to `tn-drawer-content` and `tn-table`'s host too, neither of which has one either. Not fixed here because "add a focus ring to three components" is a visual change and no browser can check it on this machine.
- **`scrollable-region.ts:106`** — `scrolls()` accepts only `auto` and `scroll`, and the finding says axe treats everything except `visible`/`hidden` as scrollable. **Checked against the source and it does not:** `isScrollable` in axe-core 4.10.3 is `['scroll', 'auto'].includes(overflowProp)`, which is what this copies. `clip` and `overlay` diverge from the browser's own behaviour, not from axe's, and matching axe is the point — the component and the check that judges it have to say the same thing about the same element.
- **`scrollable-region-testing.ts:52`** — `scrollingTo` always sets the inline `overflow`, so nothing exercises the new computed-style half of `overflows()` and it could be deleted green. Fair, and it wants a case of its own: an element with stubbed sizes and `overflow: visible`, asserting the region is NOT marked and that axe does not report it either.
- **`scrollable-region.ts:264`** — the `MutationObserver` re-registers every child observer and forces a layout read on a `characterData`-only mutation, which is costly under `tn-table`'s subtree. Worth measuring: a text change cannot alter the child SET, so the re-registration is wasted on that branch specifically, and `characterData` is the one mutation kind that fires per keystroke inside a projected form. This is #248's shape carried over verbatim rather than something this diff introduces, and narrowing it is a behaviour change on five components at once.
- **`table.component.ts:234`** — the new `scrollRegionAriaLabel` and `tn-drawer-content`'s new `ariaLabel` have no Storybook `argTypes` and no story variant. True. Both are inputs whose effect is only visible on a container narrow enough to overflow, which is a story of its own rather than a control on an existing one, and neither can be checked here without a browser.
