### PR TITLE
NAS-142543 / 27.0.0-BETA.1 / fix(a11y): scroll the listbox, not the wrapper, in select and autocomplete

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -550,6 +550,36 @@ Stubbing only the sizes gives a rule that never matches and a spec that is green
 for nothing. `staticScroller()` is the positive control every such spec needs
 beside it.
 
+#### A combobox popup is the exception, and does NOT take a tab stop
+
+**Do not reach for `tnScrollableRegion` when the scrolling thing is a dropdown.**
+axe exempts a combobox popup from `scrollable-region-focusable` outright — its
+options are reached with the arrow keys through the input's
+`aria-activedescendant` and are `tabindex="-1"` on purpose, so giving the panel a
+tab stop would add a stop the ARIA pattern says should not be there.
+
+**The exemption tests the SCROLL CONTAINER'S OWN ROLE.** `isComboboxPopup` reads
+the node's role first and returns false for anything that is not `listbox`,
+`menu`, `tree`, `grid` or `dialog` — then resolves the combobox by
+`aria-controls`/`aria-owns` pointing at the node's id. So a role-less wrapper
+carrying the `overflow`, whether inside the listbox or around it, is reported
+even though the panel it belongs to is exempt. `tn-select` and `tn-autocomplete`
+both missed the exemption that way (#292).
+
+**So the `overflow` and the panel's `max-height` go on the `role="listbox"`
+element itself** — the shape `tn-chip-input`, `tn-select` and `tn-autocomplete`
+now share. Two consequences worth knowing before moving one: a `scroll` handler
+has to move with it, because a `scroll` event fires on the element that scrolls
+and does not bubble; and anything ARIA does not allow inside a listbox (a
+`role="status"` row for loading or no-results) is a SIBLING, so it ends up
+outside the scrolling area.
+
+**A spec for one asserts `evaluated` does NOT contain the rule.** "Excluded" and
+"passed" are different verdicts and only the first says the exemption applied —
+a pass would mean axe found something tabbable in the panel. Pair it with a
+control that takes the `aria-controls` away and gets the violation back; see
+`select-scrollable-dropdown.spec.ts`.
+
 ### Running axe in a spec
 
 **Use `lib/a11y/axe-testing.ts`. Do not write another axe wrapper.** Three specs

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -566,13 +566,20 @@ carrying the `overflow`, whether inside the listbox or around it, is reported
 even though the panel it belongs to is exempt. `tn-select` and `tn-autocomplete`
 both missed the exemption that way (#292).
 
-**So the `overflow` and the panel's `max-height` go on the `role="listbox"`
-element itself** — the shape `tn-chip-input`, `tn-select` and `tn-autocomplete`
-now share. Two consequences worth knowing before moving one: a `scroll` handler
-has to move with it, because a `scroll` event fires on the element that scrolls
-and does not bubble; and anything ARIA does not allow inside a listbox (a
-`role="status"` row for loading or no-results) is a SIBLING, so it ends up
-outside the scrolling area.
+**So the `overflow` goes on the `role="listbox"` element itself** — the shape
+`tn-chip-input`, `tn-select` and `tn-autocomplete` now share. Two consequences
+worth knowing before moving one: a `scroll` handler has to move with it, because
+a `scroll` event fires on the element that scrolls and does not bubble; and
+anything ARIA does not allow inside a listbox (a `role="status"` row for loading
+or no-results) is a SIBLING, so it ends up outside the scrolling area.
+
+**The panel's `max-height` follows the overflow only where the panel IS the
+listbox**, which is `tn-chip-input` and `tn-select`. A panel with a sibling row
+keeps its own cap: `tn-autocomplete` declares the max-height on the wrapper,
+which is a flex column, and the listbox scrolls inside whatever is left
+(`min-height: 0`, or a flex item floors at its content height and pushes the
+status row past the cap). A cap on the listbox alone would bound the options and
+let the panel grow past the number a caller asked for.
 
 **A spec for one asserts `evaluated` does NOT contain the rule.** "Excluded" and
 "passed" are different verdicts and only the first says the exemption applied —

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-scrollable-dropdown.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-scrollable-dropdown.spec.ts
@@ -1,0 +1,215 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { TnAutocompleteOption } from './autocomplete.component';
+import { TnAutocompleteComponent } from './autocomplete.component';
+import { axeResult } from '../a11y/axe-testing';
+import { scrollingTo, staticScroller } from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards which element of the `tn-autocomplete` panel scrolls (#292).
+ *
+ * WHAT THE DEFECT WAS
+ * -------------------
+ * axe's `scrollable-region-focusable` deliberately does not apply to a combobox
+ * popup — the options are reached with the arrow keys through the input's
+ * `aria-activedescendant` and are `tabindex="-1"` on purpose. But
+ * `isComboboxPopup` reads the SCROLL CONTAINER'S OWN ROLE, and
+ * `.tn-autocomplete__dropdown` is a plain `<div>` AROUND the `role="listbox"`.
+ * So axe matched the rule on the wrapper, found nothing tabbable inside it, and
+ * reported markup that follows the ARIA combobox pattern correctly.
+ *
+ * The fix moves the overflow onto the listbox, which is the shape
+ * `tn-chip-input` already had — and the `(scroll)` paging handler moves with
+ * it, because a `scroll` event fires on the element that scrolls and does not
+ * bubble. That half is guarded in `autocomplete.component.spec.ts`, beside the
+ * rest of the pagination.
+ *
+ * WHAT IT COSTS
+ * -------------
+ * The `role="status"` row — loading, and no-results — is a SIBLING of the
+ * listbox, because ARIA does not allow it inside one. Moving the scrollport
+ * down onto the listbox leaves that row outside the scrolling area, where it
+ * stays put while the options scroll under it.
+ *
+ * WHAT THESE SPECS CAN AND CANNOT SEE
+ * -----------------------------------
+ * jest does not compile a component's SCSS, so `scrollingTo` stands in for the
+ * stylesheet — see the docblock on `scrollable-region-testing.ts`. These are a
+ * reproduction of the RULE on this markup, not of the rendering.
+ */
+
+@Component({
+  selector: 'tn-autocomplete-scroll-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent],
+  template: '<tn-autocomplete placeholder="Search..." [options]="options()" />',
+})
+class AutocompleteScrollHostComponent {
+  options = signal<TnAutocompleteOption<string>[]>([
+    { label: 'Alpha', value: 'alpha' },
+    { label: 'Beta', value: 'beta' },
+    { label: 'Gamma', value: 'gamma' },
+  ]);
+}
+
+describe('tn-autocomplete dropdown scroll region (#292)', () => {
+  let fixture: ComponentFixture<AutocompleteScrollHostComponent>;
+  let overlayContainer: OverlayContainer;
+  let overlayEl: HTMLElement;
+
+  /** The visible height every case here measures against. */
+  const PANEL_HEIGHT = 200;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AutocompleteScrollHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AutocompleteScrollHostComponent);
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayEl = overlayContainer.getContainerElement();
+    fixture.detectChanges();
+
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // Dispose any overlay left attached so panels don't leak between specs.
+    overlayContainer.ngOnDestroy();
+    fixture.destroy();
+  });
+
+  const input = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('.tn-autocomplete__input') as HTMLInputElement;
+
+  /** The `role="listbox"`, which is also the scrollport. */
+  const listbox = (): HTMLElement => {
+    const found = overlayEl.querySelector<HTMLElement>('.tn-autocomplete__listbox');
+    if (!found) { throw new Error('the dropdown did not open'); }
+    return found;
+  };
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control, and it is specifically the shape this component
+     * had: a role-less scroll container AROUND a correctly wired combobox
+     * popup. The input and its `aria-controls` are on the control deliberately
+     * — the point is that the popup's exclusion does not reach the wrapper,
+     * because `isComboboxPopup` asks about the scroll container's own role.
+     */
+    it('still reports a role-less scroll container around the listbox', async () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<input type="text" role="combobox" aria-expanded="true"'
+        + ' aria-controls="control-listbox" aria-label="Search" />'
+        + '<div class="scroller">'
+        + '<div role="listbox" id="control-listbox">'
+        + '<div role="option" tabindex="-1" aria-selected="false">Alpha</div>'
+        + '</div></div>';
+      document.body.appendChild(root);
+
+      const scroller = root.querySelector('.scroller') as HTMLElement;
+      scrollingTo(scroller, 400, PANEL_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, scroller, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+
+    /**
+     * And the same rule on a bare scroll container, so that the control above
+     * is read as "the popup did not cover it" rather than as "the rule fires on
+     * anything".
+     */
+    it('reports a bare one too', async () => {
+      const { root, region } = staticScroller(400, PANEL_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, region, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('the open panel, scrolling', () => {
+    beforeEach(() => {
+      scrollingTo(listbox(), 400, PANEL_HEIGHT);
+    });
+
+    /**
+     * `evaluated` must NOT contain the rule, and that is the whole assertion:
+     * "excluded" and "passed" are different verdicts, and only the first one
+     * says the popup exemption applied. A pass would mean axe judged the panel
+     * to hold something tabbable, which nothing in this markup does.
+     */
+    it('is excluded from scrollable-region-focusable rather than passing it', async () => {
+      const { violated, evaluated } = await axeResult(
+        document.body,
+        [listbox()],
+        ['scrollable-region-focusable'],
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).not.toContain('scrollable-region-focusable');
+    });
+
+    /**
+     * The proof that the exclusion is what is doing the work — without this,
+     * the assertion above is also what an axe upgrade that stopped matching
+     * this element at all would produce. `isComboboxPopup` resolves the popup
+     * by looking for a `role="combobox"` that `aria-controls` or `aria-owns`
+     * the listbox's id, so taking both references away restores the report on
+     * an otherwise untouched panel.
+     */
+    it('is excluded because the input controls it, not because the rule went quiet', async () => {
+      input().removeAttribute('aria-controls');
+      input().removeAttribute('aria-owns');
+
+      const { violated } = await axeResult(
+        document.body,
+        [listbox()],
+        ['scrollable-region-focusable'],
+      );
+
+      expect(violated).toEqual(['scrollable-region-focusable']);
+    });
+
+    /**
+     * The DOM half of the fix, stated where the stylesheet cannot be read: the
+     * element that scrolls has to be the one carrying the popup role.
+     */
+    it('scrolls the element that is the listbox', () => {
+      expect(listbox().getAttribute('role')).toBe('listbox');
+      expect(listbox().id).toBe(input().getAttribute('aria-controls'));
+    });
+
+    /**
+     * What the move costs, asserted rather than left to be discovered: the
+     * status row is outside the scrollport now. It still renders and is still a
+     * live region, which is what "announced" rests on.
+     */
+    it('leaves the status row outside the scrollport, still announced', () => {
+      const status = overlayEl.querySelector<HTMLElement>('[role="status"]');
+
+      expect(status).toBeTruthy();
+      expect(listbox().contains(status)).toBe(false);
+
+      // And it is still the row a user sees, not merely an empty live region:
+      // emptying the options renders no-results into it, outside the listbox.
+      fixture.componentInstance.options.set([]);
+      fixture.detectChanges();
+
+      const noResults = overlayEl.querySelector<HTMLElement>('.tn-autocomplete__no-results');
+      expect(noResults).toBeTruthy();
+      expect(status?.contains(noResults)).toBe(true);
+      expect(listbox().contains(noResults)).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -33,7 +33,11 @@
      overflow/clipping. Attach/detach (driven by open()/close()) controls
      visibility; the input keeps DOM focus throughout. -->
 <ng-template #dropdownTemplate>
-  <div class="tn-autocomplete__dropdown">
+  <!-- The max-height is declared here, and inherits: it bounds the panel as a
+       whole AND the listbox inside it, which are two elements now. -->
+  <div
+    class="tn-autocomplete__dropdown"
+    [style.--tn-autocomplete-panel-max-height]="panelMaxHeightValue()">
 
     <!-- Per ARIA, a listbox may only contain option/group children, so the
          loading and no-results rows live OUTSIDE it as live-region siblings.
@@ -53,7 +57,6 @@
       role="listbox"
       [attr.id]="uid + '-dropdown'"
       [attr.aria-busy]="loading() ? true : null"
-      [style.--tn-autocomplete-panel-max-height]="panelMaxHeightValue()"
       (scroll)="onPanelScroll($event)">
       @if (hasResults()) {
         @for (option of filteredOptions(); track $index) {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -33,17 +33,28 @@
      overflow/clipping. Attach/detach (driven by open()/close()) controls
      visibility; the input keeps DOM focus throughout. -->
 <ng-template #dropdownTemplate>
-  <div
-    class="tn-autocomplete__dropdown"
-    [style.--tn-autocomplete-panel-max-height]="panelMaxHeightValue()"
-    (scroll)="onPanelScroll($event)">
+  <div class="tn-autocomplete__dropdown">
 
     <!-- Per ARIA, a listbox may only contain option/group children, so the
          loading and no-results rows live OUTSIDE it as live-region siblings.
          The listbox itself stays rendered (possibly empty) the whole time the
          panel is open, so the input's aria-controls always points at a real
-         element — including the loading-with-no-results-yet state. -->
-    <div role="listbox" [attr.id]="uid + '-dropdown'" [attr.aria-busy]="loading() ? true : null">
+         element — including the loading-with-no-results-yet state.
+
+         The listbox is also the scrollport, and has to be (#292): axe's
+         `scrollable-region-focusable` exempts a combobox popup, but it tests
+         the scroll container's OWN role, so the role-less wrapper that used to
+         carry the overflow was reported even though every option inside is
+         `tabindex="-1"` on purpose. The paging handler moves with the
+         overflow — a scroll event fires on the element that scrolls — and the
+         status row below stays outside the scrolling area. -->
+    <div
+      class="tn-autocomplete__listbox"
+      role="listbox"
+      [attr.id]="uid + '-dropdown'"
+      [attr.aria-busy]="loading() ? true : null"
+      [style.--tn-autocomplete-panel-max-height]="panelMaxHeightValue()"
+      (scroll)="onPanelScroll($event)">
       @if (hasResults()) {
         @for (option of filteredOptions(); track $index) {
           <div

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -51,6 +51,17 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   padding: 0.25rem 0;
+
+  // `panelMaxHeight` bounds the PANEL, and the panel is more than the scrolling
+  // part of it: the status row is a sibling of the listbox, so a cap on the
+  // listbox alone would let loading + no-results push the panel past it. The
+  // column is what makes both true at once — the listbox shrinks to whatever is
+  // left, and the status row keeps its height.
+  display: flex;
+  flex-direction: column;
+  // Default mirrors the `panelMaxHeight` input default; the bound custom
+  // property overrides it when a caller sets the input.
+  max-height: var(--tn-autocomplete-panel-max-height, 320px);
 }
 
 // The scrollport, and the `role="listbox"` element on purpose — see the
@@ -58,10 +69,14 @@
 // its child, so it sits below the scrolling area and stays visible while the
 // options scroll.
 .tn-autocomplete__listbox {
-  // Default mirrors the `panelMaxHeight` input default; the bound custom
-  // property overrides it when a caller sets the input.
+  // The cap in its own right, for a panel that is nothing but options — and
+  // never more than the wrapper's, which is the same value.
   max-height: var(--tn-autocomplete-panel-max-height, 320px);
   overflow-y: auto;
+  // A flex item floors at its content height. Without this the listbox refuses
+  // to shrink for the status row and pushes it past the panel's max-height,
+  // which is the cap this whole block exists to keep.
+  min-height: 0;
 }
 
 .tn-autocomplete__option {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -50,11 +50,18 @@
   border: 1px solid var(--tn-lines, #d1d5db);
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 0.25rem 0;
+}
+
+// The scrollport, and the `role="listbox"` element on purpose — see the
+// template comment above it (#292). The status row is its sibling rather than
+// its child, so it sits below the scrolling area and stays visible while the
+// options scroll.
+.tn-autocomplete__listbox {
   // Default mirrors the `panelMaxHeight` input default; the bound custom
   // property overrides it when a caller sets the input.
   max-height: var(--tn-autocomplete-panel-max-height, 320px);
   overflow-y: auto;
-  padding: 0.25rem 0;
 }
 
 .tn-autocomplete__option {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -4,6 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TnAutocompleteComponent, type TnAutocompleteOption } from './autocomplete.component';
+import { scrollingTo } from '../a11y/scrollable-region-testing';
 
 interface Country {
   code: string;
@@ -887,17 +888,54 @@ describe('TnAutocompleteComponent', () => {
 
     it('emits loadMore once per options page when scrolled to the bottom', () => {
       typeAsync('a');
-      const dropdown = overlayEl.querySelector('.tn-autocomplete__dropdown');
-      expect(dropdown).toBeTruthy();
+      // The listbox is the scrollport (#292), and a `scroll` event does not
+      // bubble — so the handler has to be bound to this element, not the panel
+      // wrapper around it, for a real scroll to reach it at all.
+      const listbox = overlayEl.querySelector('.tn-autocomplete__listbox');
+      expect(listbox).toBeTruthy();
+      expect(listbox?.getAttribute('role')).toBe('listbox');
 
-      dropdown?.dispatchEvent(new Event('scroll'));
-      dropdown?.dispatchEvent(new Event('scroll'));
+      listbox?.dispatchEvent(new Event('scroll'));
+      listbox?.dispatchEvent(new Event('scroll'));
       expect(asyncHost.loadMoreCount).toBe(1);
 
       // Appending the next page re-arms the emitter.
       asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
-      dropdown?.dispatchEvent(new Event('scroll'));
+      listbox?.dispatchEvent(new Event('scroll'));
+      expect(asyncHost.loadMoreCount).toBe(2);
+    });
+
+    it('pages from a scroll of the listbox once the panel is full', () => {
+      // The specs above run with jsdom's 0-sized panel, where the underfill
+      // check emits on every page and would account for the count on its own.
+      // Making the LISTBOX overflow silences that check — so the only thing
+      // that can move the count here is the scroll handler, and only if it is
+      // bound to the element that scrolls.
+      typeAsync('a');
+      expect(asyncHost.loadMoreCount).toBe(1);
+
+      const listbox = overlayEl
+        .querySelector<HTMLElement>('.tn-autocomplete__listbox') as HTMLElement;
+      scrollingTo(listbox, 400, 350);
+      // ...and scrolled to its end, which is the condition the handler pages
+      // on. jsdom keeps `scrollTop` at 0 whatever is assigned to it, having no
+      // layout to scroll.
+      Object.defineProperty(listbox, 'scrollTop', { value: 50, configurable: true });
+
+      // Re-arms the emitter, and proves the underfill check measures the
+      // listbox: against the wrapper it would still read 0 <= 0 and page.
+      asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
+      asyncFixture.detectChanges();
+      expect(asyncHost.loadMoreCount).toBe(1);
+
+      // A scroll of the wrapper is not a scroll of the scrollport, and a
+      // `scroll` event does not bubble — the browser never fires one there.
+      overlayEl.querySelector('.tn-autocomplete__dropdown')
+        ?.dispatchEvent(new Event('scroll'));
+      expect(asyncHost.loadMoreCount).toBe(1);
+
+      listbox.dispatchEvent(new Event('scroll'));
       expect(asyncHost.loadMoreCount).toBe(2);
     });
 
@@ -980,8 +1018,8 @@ describe('TnAutocompleteComponent', () => {
       asyncHost.options.set([...asyncHost.options(), { label: 'delta', value: 'delta' }]);
       asyncFixture.detectChanges();
 
-      const dropdown = overlayEl.querySelector('.tn-autocomplete__dropdown');
-      dropdown?.dispatchEvent(new Event('scroll'));
+      overlayEl.querySelector('.tn-autocomplete__listbox')
+        ?.dispatchEvent(new Event('scroll'));
       expect(asyncHost.loadMoreCount).toBe(1);
     });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -500,8 +500,11 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     // (effect timing vs. embedded-view refresh) — render them first so the
     // measurement below never sees a stale, shorter panel.
     this.panelViewRef?.detectChanges();
+    // The listbox rather than the panel wrapper: the wrapper does not scroll
+    // (#292), so its scrollHeight always equals its clientHeight and this
+    // check would read every panel as underfilled.
     const panel = this.overlayRef?.overlayElement
-      ?.querySelector<HTMLElement>('.tn-autocomplete__dropdown');
+      ?.querySelector<HTMLElement>('.tn-autocomplete__listbox');
     if (panel && panel.scrollHeight <= panel.clientHeight) {
       this.loadMorePending = true;
       this.loadMore.emit();

--- a/projects/truenas-ui/src/lib/select/select-scrollable-dropdown.spec.ts
+++ b/projects/truenas-ui/src/lib/select/select-scrollable-dropdown.spec.ts
@@ -1,0 +1,186 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { TnSelectOption } from './select.component';
+import { TnSelectComponent } from './select.component';
+import { axeResult } from '../a11y/axe-testing';
+import { scrollingTo, staticScroller } from '../a11y/scrollable-region-testing';
+
+/**
+ * Guards which element of the `tn-select` dropdown scrolls (#292).
+ *
+ * WHAT THE DEFECT WAS
+ * -------------------
+ * axe's `scrollable-region-focusable` deliberately does not apply to a combobox
+ * popup: `scrollable-region-focusable-matches` calls `isComboboxPopup` and skips
+ * the node when it is one, because the options in such a popup are reached with
+ * the arrow keys through the trigger's `aria-activedescendant` and are
+ * `tabindex="-1"` on purpose.
+ *
+ * That exclusion tests the SCROLL CONTAINER'S OWN ROLE — `isComboboxPopup`
+ * starts by reading the node's role and returns false for anything that is not
+ * a popup role. `.tn-select-options` is a plain `<div>` INSIDE the
+ * `role="listbox"`, so it missed the exclusion on a technicality: axe matched
+ * the rule on the wrapper, found nothing tabbable inside it, and reported
+ * markup that follows the ARIA combobox pattern correctly.
+ *
+ * The fix moves the overflow up one element, onto the listbox, which is the
+ * shape `tn-chip-input` already had.
+ *
+ * WHAT THESE SPECS CAN AND CANNOT SEE
+ * -----------------------------------
+ * jest does not compile a component's SCSS, so `scrollingTo` stands in for the
+ * stylesheet — see the docblock on `scrollable-region-testing.ts`. These are a
+ * reproduction of the RULE on this markup, not of the rendering; whether the
+ * panel overflows at its rendered size is `yarn test-sb`'s question.
+ *
+ * The dropdown is portaled into a CDK overlay on `document.body` rather than
+ * rendered inside the host, so every query and every scan root here is the
+ * document rather than `fixture.nativeElement`.
+ */
+
+@Component({
+  selector: 'tn-select-scroll-host',
+  standalone: true,
+  imports: [TnSelectComponent],
+  template: '<tn-select placeholder="Select a fruit" [options]="options()" />',
+})
+class SelectScrollHostComponent {
+  options = signal<TnSelectOption<string>[]>([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ]);
+}
+
+describe('tn-select dropdown scroll region (#292)', () => {
+  let fixture: ComponentFixture<SelectScrollHostComponent>;
+
+  /** The visible height every case here measures against. */
+  const PANEL_HEIGHT = 200;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectScrollHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectScrollHostComponent);
+    fixture.detectChanges();
+
+    (fixture.nativeElement.querySelector('.tn-select-trigger') as HTMLElement).click();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  /** The `role="listbox"` panel, which is also the scrollport. */
+  const listbox = (): HTMLElement => {
+    const found = document.querySelector<HTMLElement>('.tn-select-dropdown');
+    if (!found) { throw new Error('the dropdown did not open'); }
+    return found;
+  };
+
+  const trigger = (): HTMLElement =>
+    fixture.nativeElement.querySelector('.tn-select-trigger') as HTMLElement;
+
+  describe('what the reported defect looks like on this markup', () => {
+    /**
+     * The positive control, and it is specifically the shape this component
+     * had: a role-less scroll container INSIDE a correctly wired combobox
+     * popup. The trigger and the `aria-controls` are on the control
+     * deliberately — the point is that the popup's exclusion does not reach the
+     * wrapper, because `isComboboxPopup` asks about the scroll container's own
+     * role.
+     */
+    it('still reports a role-less scroll container inside the listbox', async () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<div role="combobox" tabindex="0" aria-expanded="true"'
+        + ' aria-controls="control-listbox" aria-label="Fruit">Apple</div>'
+        + '<div role="listbox" id="control-listbox">'
+        + '<div class="scroller">'
+        + '<div role="option" tabindex="-1" aria-selected="false">Apple</div>'
+        + '</div></div>';
+      document.body.appendChild(root);
+
+      const scroller = root.querySelector('.scroller') as HTMLElement;
+      scrollingTo(scroller, 400, PANEL_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, scroller, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+
+    /**
+     * And the same rule on a bare scroll container, so that the control above
+     * is read as "the popup did not cover it" rather than as "the rule fires on
+     * anything".
+     */
+    it('reports a bare one too', async () => {
+      const { root, region } = staticScroller(400, PANEL_HEIGHT);
+
+      try {
+        const { violated } = await axeResult(root, region, ['scrollable-region-focusable']);
+        expect(violated).toEqual(['scrollable-region-focusable']);
+      } finally {
+        root.remove();
+      }
+    });
+  });
+
+  describe('the open dropdown, scrolling', () => {
+    beforeEach(() => {
+      scrollingTo(listbox(), 400, PANEL_HEIGHT);
+    });
+
+    /**
+     * `evaluated` must NOT contain the rule, and that is the whole assertion:
+     * "excluded" and "passed" are different verdicts, and only the first one
+     * says the popup exemption applied. A pass would mean axe judged the panel
+     * to hold something tabbable, which nothing in this markup does.
+     */
+    it('is excluded from scrollable-region-focusable rather than passing it', async () => {
+      const { violated, evaluated } = await axeResult(
+        document.body,
+        [listbox()],
+        ['scrollable-region-focusable'],
+      );
+
+      expect(violated).toEqual([]);
+      expect(evaluated).not.toContain('scrollable-region-focusable');
+    });
+
+    /**
+     * The proof that the exclusion is what is doing the work — without this,
+     * the assertion above is also what an axe upgrade that stopped matching
+     * this element at all would produce. `isComboboxPopup` resolves the popup
+     * by looking for a `role="combobox"` that `aria-controls` or `aria-owns`
+     * the listbox's id, so taking that reference away restores the report on an
+     * otherwise untouched panel.
+     */
+    it('is excluded because the trigger controls it, not because the rule went quiet', async () => {
+      trigger().removeAttribute('aria-controls');
+
+      const { violated } = await axeResult(
+        document.body,
+        [listbox()],
+        ['scrollable-region-focusable'],
+      );
+
+      expect(violated).toEqual(['scrollable-region-focusable']);
+    });
+
+    /**
+     * The DOM half of the fix, stated where the stylesheet cannot be read: the
+     * element that scrolls has to be the one carrying the popup role.
+     */
+    it('scrolls the element that is the listbox', () => {
+      expect(listbox().getAttribute('role')).toBe('listbox');
+      expect(listbox().id).toBe(trigger().getAttribute('aria-controls'));
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/select/select.component.scss
+++ b/projects/truenas-ui/src/lib/select/select.component.scss
@@ -108,12 +108,19 @@
   border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-height: var(--tn-select-dropdown-max-height);
+
+  // The listbox is the scrollport, and it has to be the element that scrolls
+  // rather than the plain div inside it (#292). axe's
+  // `scrollable-region-focusable` exempts a combobox popup, but it tests the
+  // scroll container's OWN role — so a role-less wrapper carrying the overflow
+  // is reported even though every option inside is `tabindex="-1"` on purpose
+  // and is reached from the trigger's `aria-activedescendant`.
+  // `tn-chip-input` already has this shape.
+  overflow-y: auto;
 }
 
 .tn-select-options {
-  overflow-y: auto;
   padding: 0.25rem 0;
-  max-height: var(--tn-select-dropdown-max-height);
 }
 
 .tn-select-option {


### PR DESCRIPTION
Closes #292

## What was wrong

axe's `scrollable-region-focusable` deliberately exempts a combobox popup: the
options in one are reached with the arrow keys through the input's
`aria-activedescendant` and are `tabindex="-1"` on purpose, so there is nothing
to tab to and nothing to report.

`isComboboxPopup` resolves that exemption from the **scroll container's own
role** — it reads the node's role first and returns false for anything that is
not `listbox`/`menu`/`tree`/`grid`/`dialog`. Two components carried the
`overflow` on a role-less `<div>` beside the `role="listbox"` rather than on it,
and so missed the exemption on a technicality:

| component | scrolled | role of that element |
|---|---|---|
| `tn-select` | `.tn-select-options` | none — a plain `<div>` **inside** the listbox |
| `tn-autocomplete` | `.tn-autocomplete__dropdown` | none — a plain `<div>` **around** the listbox |
| `tn-chip-input` | `.tn-chip-input__dropdown` | `role="listbox"` — exempt, and already correct |

axe matched the rule on the two wrappers, found nothing tabbable inside them,
and reported markup that follows the ARIA combobox pattern correctly.

## What changed

The `overflow-y` now sits on the `role="listbox"` element in both components,
which is the shape `tn-chip-input` already had. Neither dropdown gains a tab
stop — that would add a stop the ARIA pattern says should not be there, and is
why `tnScrollableRegion` (#270) is the wrong tool here.

**`tn-select`** — the panel *is* the listbox, so this is the `overflow-y` and
the duplicated `max-height` moving up one element onto `.tn-select-dropdown`.
`.tn-select-options` keeps only its padding.

**`tn-autocomplete`** — two things moved with the scrollport rather than being
left behind:

- the `(scroll)` paging handler. A `scroll` event fires on the element that
  scrolls and **does not bubble**, so left on the wrapper it would never fire
  again and pagination would dead-end.
- `checkUnderfill`'s measurement, which compared the wrapper's `scrollHeight`
  to its `clientHeight`. The wrapper no longer scrolls, so those are now always
  equal — every panel would have read as underfilled and pagination would have
  requested a page per rendered page until the source ran out.

The `role="status"` row — loading, and no-results — is a **sibling** of the
listbox, because ARIA does not allow it inside one. So it is now outside the
scrolling area and stays put while the options scroll under it. That is a
visible layout change, and the ticket anticipates it.

`panelMaxHeight` still bounds the **panel**, not just the scrolling part of it:
the wrapper is a flex column capped at that value and the listbox shrinks to
whatever is left (`min-height: 0`, or a flex item floors at its content height
and pushes the status row past the cap). Caught by the local review as a MEDIUM
after the first round, which had left the cap on the listbox alone —
`panelMaxHeight=200` with a loading row rendered about 240px.

## Tests

`select-scrollable-dropdown.spec.ts` and
`autocomplete-scrollable-dropdown.spec.ts`, in the shape of
`tab-panel-scrollable-content.spec.ts` (#270). Each asserts `evaluated` does
**not** contain the rule — "excluded" and "passed" are different verdicts and
only the first says the exemption applied; a pass would mean axe judged the
panel to hold something tabbable, which nothing in this markup does.

Each carries two positive controls, because an empty `violated` is also what an
axe upgrade that stopped matching would produce:

- the pre-fix markup rebuilt by hand, **with the combobox wiring intact**, so it
  reads as "the exemption did not reach the wrapper" rather than "the rule fires
  on anything";
- the real panel with its `aria-controls` removed, which gets the violation
  back on an otherwise untouched component.

`autocomplete.component.spec.ts` gains a pagination case that stubs the listbox
as *overflowing* — under jsdom's 0-sized panel the underfill check accounts for
the whole count on its own, so the existing scroll specs would pass whether or
not the handler moved. With the panel full, the count moves only on a scroll of
the listbox, and a scroll of the wrapper does nothing.

## Checks run locally

- `yarn lint` — clean
- `yarn test` — 4065 passed, 144 suites
- `yarn test:scripts` — 42 passed
- `yarn build` — clean

**`yarn test-sb` could not be run here**, and it is the check that would answer
the last acceptance criterion. This host has no browser: chromium needs ten
system libraries that are not present, and `/` is mounted read-only so no
package can supply them. The Storybook Interaction Tests job in CI is the first
place this diff is rendered — the layout change to the autocomplete panel in
particular has been reasoned about rather than seen.

## Not changed, and why

Two LOWs from the local review, left for a reader rather than acted on:

- **The CSS half of the fix is unguarded.** jest does not compile component
  SCSS, so the specs stub `overflow` with `scrollingTo` and would stay green if
  the SCSS were reverted. That is a property of every
  `scrollable-region-focusable` spec in this library (see the docblock on
  `scrollable-region-testing.ts`); `yarn test-sb` is what closes it.
- **`.tn-autocomplete__listbox` declares a `max-height` the flex-column wrapper
  already enforces.** It is deliberate as an upper bound in its own right, but a
  reader is right that it is a second cap that could drift from the first.

Also of note: `docs/component_conventions.md` gains a subsection under Scrolling
Regions, because the next cycle handed a `scrollable-region-focusable` report on
a dropdown would otherwise reach for `tnScrollableRegion` and give a listbox a
tab stop — the one fix that is wrong here.
