### PR TITLE
NAS-142545 / 27.0.0-BETA.1 / fix(a11y): theme Storybook docs pages instead of patching them tag by tag

### DIFF
--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -465,8 +465,9 @@ dark ink, and the chrome behind it is always `#282828`.
 
 The header of `projects/truenas-ui/src/styles/themes-storybook.css` lists the
 handful of roles no docs theme can reach, with what each measures and why it
-does or does not have a rule. `docs-theme-contrast.spec.ts` measures every
-colour in that file and fails if a new selector starts painting chrome.
+does or does not have a rule. `docs-theme-contrast.spec.ts` measures the theme
+keys Storybook draws as docs text and the literal colours that file ships, and
+fails if a new selector starts painting chrome.
 
 ## Animation & Transitions
 

--- a/docs/component_styling.md
+++ b/docs/component_styling.md
@@ -438,6 +438,36 @@ Components automatically work with all themes via CSS variables:
 
 **No theme-specific code needed in components.** Just use CSS variables.
 
+### Storybook docs pages are NOT themed by these variables
+
+A docs page has two parts and they are themed by different mechanisms:
+
+| Part | Themed by | Follows the theme switcher? |
+|---|---|---|
+| The story canvas — the box a component renders in | `--tn-*`, via a canvas rule in `themes-storybook.css` | **Yes** |
+| Everything else on the page — headings, prose, tables, code samples, the argstable | `parameters.docs.theme` in `.storybook/preview.ts` | **No** |
+
+Docs-page chrome is Storybook's own UI, so it takes the `truenasTheme` object
+that `manager.ts` also gives the manager, and it looks the same whichever
+palette the switcher is on. The switcher themes the **component**.
+
+**If a docs page renders unreadable text, do not add a tag to
+`themes-storybook.css`.** That file used to be a list of selectors forcing
+individual elements back to a dark colour, and the list is what #293 removed:
+`parameters.docs.theme` had never been set, so `ensure(undefined)` handed every
+docs page Storybook's *light* theme, and `code`, `h5` and the syntax
+highlighter's spans were simply never noticed. 442 failing text nodes on one
+page, the worst at 1.16:1.
+
+A `color:` set from a `--tn-*` token on anything but the canvas is the same bug
+with the colours swapped — three shipped palettes are light, so `--tn-fg2` is a
+dark ink, and the chrome behind it is always `#282828`.
+
+The header of `projects/truenas-ui/src/styles/themes-storybook.css` lists the
+handful of roles no docs theme can reach, with what each measures and why it
+does or does not have a rule. `docs-theme-contrast.spec.ts` measures every
+colour in that file and fails if a new selector starts painting chrome.
+
 ## Animation & Transitions
 
 Use subtle, performant animations:

--- a/projects/truenas-ui/.storybook/preview.ts
+++ b/projects/truenas-ui/.storybook/preview.ts
@@ -9,6 +9,7 @@ import 'zone.js';
 import { TnThemeService, TnTheme } from '../src/public-api';
 import { TnIconRegistryService } from '../src/lib/icon/icon-registry.service';
 import { TnSpriteLoaderService } from '../src/lib/icon/sprite-loader.service';
+import truenasTheme from './truenasTheme';
 
 /**
  * Register themes using Storybook's built-in theme switcher.
@@ -16,6 +17,32 @@ import { TnSpriteLoaderService } from '../src/lib/icon/sprite-loader.service';
 export const parameters: Preview['parameters'] = {
   backgrounds: {
     disabled: true,
+  },
+  /**
+   * The theme Storybook renders DOCS PAGES with. `manager.ts` gives the same
+   * object to the manager UI; this is the preview's half of the pair, and it
+   * was missing until #293.
+   *
+   * WHAT ITS ABSENCE DID, since "unset" sounds harmless. `DocsContainer` calls
+   * `ensure(theme)` on this value, and `ensure(undefined)` returns
+   * `convert(themes.light)` — Storybook's DEFAULT LIGHT theme, not a neutral
+   * one. So every docs page painted its text `#2E3338` and its code samples
+   * `#0000FF`/`#393A34` on a `#1E1E1E` page: 442 failing text nodes on the
+   * Dialog docs page alone, the worst at 1.16:1 against a 4.5:1 requirement.
+   * `themes-storybook.css` had been patching that back a tag at a time, and
+   * `code`, `h5` and the syntax highlighter's spans were never in that list.
+   *
+   * WHY IT IS NOT THE SWITCHED THEME. `withThemeByClassName` below themes the
+   * COMPONENT — it puts `.tn-dark`, `.tn-paper` and so on onto the preview,
+   * and `--tn-*` follows it. Docs-page chrome is Storybook's own UI, and this
+   * parameter is a fixed object that no global can vary, so chrome is themed
+   * once, here, exactly as the manager UI is. Three of the shipped palettes
+   * are LIGHT, and a docs page that took its ink from the switcher while its
+   * background came from this theme would be #293 again with the colours
+   * swapped.
+   */
+  docs: {
+    theme: truenasTheme,
   },
 };
 

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -51,8 +51,8 @@
    `theme.input.color` and `theme.input.background`, which is `inputTextColor`
    and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
 
-   WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
-   ------------------------------------------------------
+   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST OF TWO
+   --------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
    `createColors()`, and only FOUR of those roles come from the theme object:
    `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
@@ -72,7 +72,7 @@
 
      role                      value     ratio   painted on            here?
      color.dark                #5C6570   2.49:1  h6, blockquote        yes
-                                                 argstable object      no (1)
+                                                 argstable object      yes
                                                  control
      color.darkest             #2E3338   1.16:1  span.frame caption    no (2)
      code red2                 #9a050f   1.69:1  `diff` syntax         no (3)
@@ -81,20 +81,21 @@
      transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) inside `.docblock-argstable`, styled by emotion with a generated class.
-       These are DEFERRED, not unreachable, and the difference matters because
-       a rule this change deletes — `.docblock-argstable-body span` — was
-       exactly such a hook: an addon-docs class on the `tbody`, holding at
-       0,1,1 without `!important`. (`sb-unstyled` is orthogonal. It keeps
-       addon-docs' own typography off a RENDERED STORY; it does not stop a
-       hand-written selector matching inside the argstable, which is why that
-       rule worked.) What is missing is not a hook but a value: nothing here
-       writes `color:` with a literal hex on one, the way the override at the
-       bottom does for `h6`/`blockquote`, and the markup under the object
-       control is emotion-generated rather than a stable class. The argstable's
-       object control is the one of these that renders TODAY, on the six pages
-       declaring `control: 'object'`; it is the follow-up this change
-       deliberately does not reach.
+   (1) styled by emotion with a generated class, so there is no hand-written
+       selector to hold. Recorded rather than fixed, and neither renders on a
+       docs page here today: the required-arg marker needs an `argType` whose
+       `type.required` is set — `ArgRow` reads exactly that — and no story here
+       declares one, while the story-mount error renders only when a story
+       throws.
+
+       The argstable's object control was in this footnote until now and has
+       moved out, because its hook turned out to be a real one:
+       `.rejt-accordion-region` is a class addon-docs writes by hand in
+       `JsonNodeAccordion`, not an emotion hash. The rule this change deletes
+       looks like it already covered that control, and did not —
+       `.docblock-argstable-body span` carried no `!important`, and the
+       control's summary span carries its colour as an INLINE style, which no
+       selector beats without the flag. See the second override at the bottom.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
    (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
@@ -119,7 +120,7 @@
    today; it is here rather than dismissed, by footnote (4)'s standard.
 
    `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
-   docs text and the literal colour below, and fails if a rule outside the
+   docs text and every literal colour below, and fails if a rule outside the
    canvas selectors starts painting chrome text from a `--tn-*` token again. It
    does NOT measure every colour in `truenasTheme.js` — most of those paint the
    manager UI, which is `manager.ts`'s half of that object.
@@ -183,13 +184,14 @@ h1, h2, h3, h4,
 }
 
 /* ================================
-   THE ONE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
-   The table in the header is the full set; this is the only entry that both
-   renders here and has a hook that will still be there after a Storybook patch
-   release. Its value is the smallest hue-preserving lightness step off
-   Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
-   themes.css documents for `--tn-primary-text`. Ratios are against
-   `appContentBg` #282828 then `appBg` #1e1e1e.
+   THE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
+   The table in the header is the full set; `color.dark` is the only entry that
+   both renders here and has a hook that will still be there after a Storybook
+   patch release, and it renders in two places. Its replacement value is the
+   smallest hue-preserving lightness step off Storybook's own that clears 4.5:1
+   on BOTH docs surfaces — the method themes.css documents for
+   `--tn-primary-text`. Ratios are against `appContentBg` #282828 then `appBg`
+   #1e1e1e.
    ================================ */
 
 /* `theme.color.dark`, #5C6570 at 2.49:1. Scoped to the docs content and out of
@@ -199,4 +201,25 @@ h1, h2, h3, h4,
    against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
 .sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
   color: #86909b; /* 4.55:1, 5.14:1 */
+}
+
+/* `theme.color.dark` again, on the argstable's object control: the `{...} 3
+   keys` summary a `control: 'object'` row shows at rest, since `JsonTree`'s
+   default `isCollapsed` is `(keyPath, deep) => deep !== -1` and the root is
+   depth 0. Six pages here declare that control — card, select, menu,
+   radio-group, form-field, table-pager — so this is the one entry in the
+   header's table that a reader hits today rather than one edit away.
+
+   `!important` is not a specificity choice and cannot be traded for a longer
+   selector. `react-editable-json-tree` renders that summary as
+   `<span style={collapsed}>`, taking the colour from addon-docs'
+   `getCustomStyleFunction`, and an inline style beats every selector without
+   the flag.
+
+   `:not(.rejt-not-collapsed-delimiter)` keeps this off the `[`/`]` and `{`/`}`
+   an EXPANDED node draws, which are the region's other direct children. Those
+   carry no inline colour, so they inherit `theme.color.defaultText` at 10.96:1
+   and repainting them would be a downgrade. */
+.sbdocs-content .rejt-accordion-region > span:not(.rejt-not-collapsed-delimiter) {
+  color: #86909b !important; /* 4.55:1, 5.14:1 */
 }

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -88,9 +88,18 @@
        declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
        are one edit away, so they are recorded rather than dismissed.
 
-   `docs-theme-contrast.spec.ts` measures every colour written in this file and
-   in `truenasTheme.js`, and fails if a rule outside the canvas selectors below
-   starts painting chrome text from a `--tn-*` token again.
+   ONE SURFACE BELONGS IN THAT TABLE FROM THE OTHER SIDE. `color.darker`
+   (#454C54) is a constant too, and addon-docs fills every even `tr` of a docs
+   markdown table with it. Body text reads 6.46:1 there, but `colorSecondary`
+   reads 2.72:1 — so a LINK in a table row would be below AA. No cell in
+   `theming.mdx` or `icon-system.mdx` holds one today; it is here rather than
+   dismissed, by footnote (4)'s standard.
+
+   `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
+   docs text and the literal colour below, and fails if a rule outside the
+   canvas selectors starts painting chrome text from a `--tn-*` token again. It
+   does NOT measure every colour in `truenasTheme.js` — most of those paint the
+   manager UI, which is `manager.ts`'s half of that object.
    ================================ */
 
 /* ================================
@@ -115,9 +124,13 @@ html, body {
   background-color: var(--tn-bg1) !important;
 }
 
-/* `!important` because addon-docs paints both of these itself —
-   `getBlockBackgroundStyle(theme)` on `.sbdocs-preview`, from the docs theme —
-   and the component's surface is what should show through. */
+/* `!important` for `.sbdocs-preview`, which addon-docs paints itself through
+   `getBlockBackgroundStyle(theme)` from the docs theme — the component's
+   surface is what should show through. `.docs-story` gets no background from
+   addon-docs at all (`StyledPreview` gives it only padding), so the flag is
+   carried rather than needed on that half; the two are one rule because they
+   are one surface, and splitting them to drop a redundant flag would say the
+   two are different things. */
 .docs-story,
 .sbdocs-preview {
   background-color: var(--tn-bg2) !important;

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -38,18 +38,35 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
-   ONE DELETION IS NOT COVERED BY THAT RULE AND IS DELIBERATE. The form-field
-   block set `background-color` and `color` together, which is the retention
-   criterion above, and two of its three selectors were docs chrome
-   (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
-   `input:not([role="switch"])`, was scoped to nothing: this file is linked
-   from `preview-head.html`, so it reached every native `input` inside every
-   RENDERED STORY, overriding the component's own SCSS with `!important`.
-   Removing it is the only change here that touches the story canvas rather
-   than the chrome, and what it restores is the component's real styling.
-   Docs-page controls keep their colours from the theme instead —
-   `theme.input.color` and `theme.input.background`, which is `inputTextColor`
-   and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+   FOUR REMOVALS TOUCH THE STORY CANVAS AND NOT ONLY THE CHROME, and all four
+   are the same shape: a bare-tag selector in a file `preview-head.html` links
+   into the PREVIEW IFRAME, so it reached every RENDERED STORY as well as the
+   docs page it was written for. Each is deliberate, and what they restore is
+   the component's own styling on its own canvas.
+
+   - The form-field rule set `background-color` and `color` together, which is
+     the retention criterion above, and two of its three selectors were docs
+     chrome (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
+     `input:not([role="switch"])`, was scoped to nothing and overrode every
+     component's own SCSS with `!important`. Docs-page controls keep their
+     colours from the theme instead — `theme.input.color` and
+     `theme.input.background`, which is `inputTextColor` and `inputBg` in
+     `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+   - `p, li, td { color: var(--tn-fg2) !important }`, and the
+     `color: var(--tn-fg1) !important` dropped from the `h1`–`h4` rule below.
+     Both are text colour from a switcher token, which is exactly what the
+     rule above prohibits, and both landed inside stories too.
+   - `thead, th { background-color: var(--tn-topbar); color:
+     var(--tn-topbar-txt) !important }`. This is the one with a consequence
+     worth naming rather than just a justification: it was the only ambient
+     `th` fill in `src/styles/`, and `month-view.component.scss` leans on it —
+     "The header's fill comes from the ambient table styling, so round the
+     outer corners of the row rather than painting a background of our own."
+     So the Calendar and Date Range Picker stories now render their weekday
+     band unfilled. The component never painted its own header, so a real
+     application always looked like that; what this rule did was make
+     Storybook look better than the product. Recorded here and proposed as a
+     follow-up on the calendar, rather than fixed by putting the crutch back.
 
    WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST OF TWO
    --------------------------------------------------------
@@ -167,8 +184,9 @@ html, body {
 
 /* ================================
    TYPEFACE
-   Predates #293 and is left alone, but not left unexplained, because the
-   obvious reading of it is wrong: this does NOT put the header face on docs
+   Its `font-family` predates #293 and is left alone (its `color` is one of the
+   four removals above), but not left unexplained, because the obvious reading
+   of what remains is wrong: this does NOT put the header face on docs
    headings. addon-docs styles the same elements through `toGlobalSelector` at
    0,1,0 and spreads a reset setting `fontFamily: theme.typography.fonts.base`,
    so a docs heading renders in `fontBase` and this 0,0,1 rule loses. Where it

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -77,8 +77,10 @@
        change deliberately does not reach.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
-   (3) `red2` is #9a050f in BOTH syntax palettes, the one entry the dark
-       palette did not retune. It has a stable hook — `.token.deleted` — and
+   (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
+       entry it paints with and left this. (`blue2` is shared too, at #00009f,
+       and is not in this table because `create()` never references it, so it
+       paints nothing.) `red2` has a stable hook — `.token.deleted` — and
        still gets no rule: this Storybook registers eleven Prism grammars and
        `diff` is not among them, so no sample can emit that token and the
        selector would be dead by (2)'s own argument. Worse, forcing a colour

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -38,6 +38,19 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
+   ONE DELETION IS NOT COVERED BY THAT RULE AND IS DELIBERATE. The form-field
+   block set `background-color` and `color` together, which is the retention
+   criterion above, and two of its three selectors were docs chrome
+   (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
+   `input:not([role="switch"])`, was scoped to nothing: this file is linked
+   from `preview-head.html`, so it reached every native `input` inside every
+   RENDERED STORY, overriding the component's own SCSS with `!important`.
+   Removing it is the only change here that touches the story canvas rather
+   than the chrome, and what it restores is the component's real styling.
+   Docs-page controls keep their colours from the theme instead —
+   `theme.input.color` and `theme.input.background`, which is `inputTextColor`
+   and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+
    WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
    ------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
@@ -68,13 +81,20 @@
      transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) inside `.docblock-argstable`, which addon-docs marks `sb-unstyled`, or
-       styled by emotion with a generated class. Either way there is no hook a
-       hand-written selector can hold that a Storybook patch release will not
-       move silently — which is a worse failure than the one it would fix. The
-       argstable's object control is the one of these that renders TODAY, on
-       the six pages declaring `control: 'object'`; it is the follow-up this
-       change deliberately does not reach.
+   (1) inside `.docblock-argstable`, styled by emotion with a generated class.
+       These are DEFERRED, not unreachable, and the difference matters because
+       a rule this change deletes — `.docblock-argstable-body span` — was
+       exactly such a hook: an addon-docs class on the `tbody`, holding at
+       0,1,1 without `!important`. (`sb-unstyled` is orthogonal. It keeps
+       addon-docs' own typography off a RENDERED STORY; it does not stop a
+       hand-written selector matching inside the argstable, which is why that
+       rule worked.) What is missing is not a hook but a value: nothing here
+       writes `color:` with a literal hex on one, the way the override at the
+       bottom does for `h6`/`blockquote`, and the markup under the object
+       control is emotion-generated rather than a stable class. The argstable's
+       object control is the one of these that renders TODAY, on the six pages
+       declaring `control: 'object'`; it is the follow-up this change
+       deliberately does not reach.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
    (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
@@ -93,9 +113,10 @@
    ONE SURFACE BELONGS IN THAT TABLE FROM THE OTHER SIDE. `color.darker`
    (#454C54) is a constant too, and addon-docs fills every even `tr` of a docs
    markdown table with it. Body text reads 6.46:1 there, but `colorSecondary`
-   reads 2.72:1 — so a LINK in a table row would be below AA. No cell in
-   `theming.mdx` or `icon-system.mdx` holds one today; it is here rather than
-   dismissed, by footnote (4)'s standard.
+   reads 2.72:1 — so a LINK in a table row would be below AA. Three MDX files
+   here ship markdown tables — `theming.mdx`, `icon-system.mdx` and
+   `design-system-proposal-v2.mdx` — and no cell in any of them holds a link
+   today; it is here rather than dismissed, by footnote (4)'s standard.
 
    `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
    docs text and the literal colour below, and fails if a rule outside the

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -38,35 +38,53 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
-   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST
-   -------------------------------------------------
+   WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
+   ------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
    `createColors()`, and only FOUR of those roles come from the theme object:
    `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
    and `red2` in both of the syntax palettes — is a constant shared by the
-   light and dark bases, so no docs theme can reach it. The overrides below are
-   derived from that function rather than noticed one at a time, which is the
-   whole difference between this list and the one it replaces.
+   light and dark bases, so no docs theme can reach it. The table below is that
+   function's leftovers, enumerated from it rather than noticed one at a time,
+   which is the whole difference between this and the list it replaces: a
+   reader can tell it is complete, and can tell which entries got a rule.
 
-   Storybook paints docs TEXT with these unreachable roles. Measured against
-   `appContentBg` (#282828), the surface `DocsWrapper` and the syntax
-   highlighter's own wrapper both paint:
+   Storybook paints docs TEXT with these unreachable roles. Ratios are against
+   `appContentBg` (#282828), which `DocsWrapper` paints behind the page and the
+   syntax highlighter's wrapper paints again behind an MDX code fence. A Canvas
+   "Show code" block is the exception and is NOT this surface: `Preview` passes
+   `dark: true`, which re-wraps the block in `convert(themes.dark)`, so it sits
+   on #222325 — near enough that nothing below changes verdict, far enough that
+   quoting one number for both would be wrong.
 
      role                      value     ratio   painted on            here?
      color.dark                #5C6570   2.49:1  h6, blockquote        yes
-     code red2 (.token.deleted) #9a050f  1.69:1  diff syntax           yes
-     color.darkest             #2E3338   1.16:1  span.frame caption    no (1)
-     color.negative            #FF4400   4.27:1  required-arg marker   no (2)
-     color.orange              #FC521F   4.47:1  story-mount error     no (2)
-     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (2,3)
+                                                 argstable object      no (1)
+                                                 control
+     color.darkest             #2E3338   1.16:1  span.frame caption    no (2)
+     code red2                 #9a050f   1.69:1  `diff` syntax         no (3)
+     color.negative            #FF4400   4.27:1  required-arg marker   no (1)
+     color.orange              #FC521F   4.47:1  story-mount error     no (1)
+     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) reachable, but nothing here emits `span.frame` markup — a dead selector
+   (1) inside `.docblock-argstable`, which addon-docs marks `sb-unstyled`, or
+       styled by emotion with a generated class. Either way there is no hook a
+       hand-written selector can hold that a Storybook patch release will not
+       move silently — which is a worse failure than the one it would fix. The
+       argstable's object control is the one of these that renders TODAY, on
+       the six pages declaring `control: 'object'`; it is the follow-up this
+       change deliberately does not reach.
+   (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
-   (2) styled by emotion with a generated class and no stable hook. A selector
-       for these would be a hash that a Storybook patch release changes
-       silently, which is a worse failure than the one it fixes.
-   (3) neither renders on any docs page in this repository today: no story
+   (3) `red2` is #9a050f in BOTH syntax palettes, the one entry the dark
+       palette did not retune. It has a stable hook — `.token.deleted` — and
+       still gets no rule: this Storybook registers eleven Prism grammars and
+       `diff` is not among them, so no sample can emit that token and the
+       selector would be dead by (2)'s own argument. Worse, forcing a colour
+       there would also hit a `<Source dark={false}>` block, whose wrapper is
+       `themes.light` white.
+   (4) neither renders on any docs page in this repository today: no story
        declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
        are one edit away, so they are recorded rather than dismissed.
 
@@ -112,10 +130,16 @@ html, body {
 
 /* ================================
    TYPEFACE
-   `create()` accepts `fontBase` and `fontCode` and has no third slot, so the
-   header face is the one typographic choice the docs theme cannot carry.
-   Colour is deliberately absent: these headings take `theme.color.defaultText`
-   (#dedede, 10.96:1 on #282828) like the rest of the docs chrome.
+   Predates #293 and is left alone, but not left unexplained, because the
+   obvious reading of it is wrong: this does NOT put the header face on docs
+   headings. addon-docs styles the same elements through `toGlobalSelector` at
+   0,1,0 and spreads a reset setting `fontFamily: theme.typography.fonts.base`,
+   so a docs heading renders in `fontBase` and this 0,0,1 rule loses. Where it
+   does apply is a heading a story renders, outside addon-docs' reach.
+
+   Colour is deliberately absent either way: docs headings take
+   `theme.color.defaultText` (#dedede, 10.96:1 on #282828) like the rest of the
+   chrome, which is the whole point of #293.
    ================================ */
 h1, h2, h3, h4,
 .sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3, .sbdocs-title h4 {
@@ -123,9 +147,10 @@ h1, h2, h3, h4,
 }
 
 /* ================================
-   THE ROLES `truenasTheme` CANNOT REACH
-   See the table in the header for the full set and why these two are the ones
-   with rules. Both values are the smallest hue-preserving lightness step off
+   THE ONE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
+   The table in the header is the full set; this is the only entry that both
+   renders here and has a hook that will still be there after a Storybook patch
+   release. Its value is the smallest hue-preserving lightness step off
    Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
    themes.css documents for `--tn-primary-text`. Ratios are against
    `appContentBg` #282828 then `appBg` #1e1e1e.
@@ -138,19 +163,4 @@ h1, h2, h3, h4,
    against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
 .sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
   color: #86909b; /* 4.55:1, 5.14:1 */
-}
-
-/* The syntax highlighter's `deleted` token. `red2` is #9a050f in BOTH of
-   Storybook's syntax palettes — the one entry the dark palette did not
-   retune — so it is 1.69:1 wherever a diff is highlighted, on the light theme
-   and on the dark one alike.
-
-   `!important` rather than more selectors: emotion styles this from the
-   highlighter's wrapper at the same specificity this rule can reach, and the
-   order its <style> is injected in relative to a static stylesheet is not
-   something to depend on. Nothing in this repository renders a diff sample
-   today; the rule is here because the palette ships broken, not because a page
-   was seen failing. */
-.sbdocs .token.deleted {
-  color: #f9535e !important; /* 4.51:1, 5.10:1 */
 }

--- a/projects/truenas-ui/.storybook/public/themes-storybook.css
+++ b/projects/truenas-ui/.storybook/public/themes-storybook.css
@@ -6,77 +6,151 @@
    in Storybook development environment.
 
    DO NOT import this file in production builds.
-   It is imported only in .storybook/preview.ts
+   `.storybook/preview-head.html` links it as `./themes.css`'s neighbour out of
+   `.storybook/public/`, which `yarn copy-themes` regenerates from this file —
+   edit this one, and `themes-css-copy.spec.ts` fails if the two drift.
+
+   WHAT THIS FILE IS FOR, AND WHAT IT IS NO LONGER FOR (#293)
+   ----------------------------------------------------------
+   Docs pages are themed by `parameters.docs.theme` in `preview.ts`, which is
+   the same `truenasTheme` object `manager.ts` gives the manager UI. That
+   parameter did not exist until #293, and its absence is not the no-op it
+   sounds like: `DocsContainer` calls `ensure(theme)`, and `ensure(undefined)`
+   returns `convert(themes.light)` — Storybook's DEFAULT LIGHT theme. So every
+   docs page rendered light-theme ink on the TrueNAS dark palette, and this
+   file had grown a list of tag selectors forcing back the elements someone
+   had noticed. `code`, `h5` and the syntax highlighter's spans were never in
+   that list: 442 failing text nodes on the Dialog docs page alone, the worst
+   at 1.16:1 against a 4.5:1 requirement.
+
+   THE RULE THAT REPLACED THE LIST
+   -------------------------------
+   Docs-page CHROME is Storybook's, and is themed through `truenasTheme`. It
+   does not follow the theme switcher, for the same reason the manager UI does
+   not — the switcher themes the COMPONENT. The only thing this file paints
+   from `--tn-*` tokens is the surface a story is rendered on.
+
+   That is not a tidiness argument. A rule setting only a `color:` from a
+   `--tn-*` token was the original bug wearing the other mask: three shipped
+   palettes are LIGHT — `.tn-blue`, `.tn-paper`, `.tn-high-contrast` — so
+   `--tn-fg2` is a dark ink, and after #293 it would have been painted on
+   chrome that is always `#282828`. Every such rule is gone. What remains sets
+   a foreground and its own background together, from the same palette, so it
+   stays self-consistent on all nine.
+
+   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST
+   -------------------------------------------------
+   `convert()` in `storybook/theming` builds `theme.color` from
+   `createColors()`, and only FOUR of those roles come from the theme object:
+   `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
+   and `red2` in both of the syntax palettes — is a constant shared by the
+   light and dark bases, so no docs theme can reach it. The overrides below are
+   derived from that function rather than noticed one at a time, which is the
+   whole difference between this list and the one it replaces.
+
+   Storybook paints docs TEXT with these unreachable roles. Measured against
+   `appContentBg` (#282828), the surface `DocsWrapper` and the syntax
+   highlighter's own wrapper both paint:
+
+     role                      value     ratio   painted on            here?
+     color.dark                #5C6570   2.49:1  h6, blockquote        yes
+     code red2 (.token.deleted) #9a050f  1.69:1  diff syntax           yes
+     color.darkest             #2E3338   1.16:1  span.frame caption    no (1)
+     color.negative            #FF4400   4.27:1  required-arg marker   no (2)
+     color.orange              #FC521F   4.47:1  story-mount error     no (2)
+     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (2,3)
+                                                 header, Typeset label
+
+   (1) reachable, but nothing here emits `span.frame` markup — a dead selector
+       would be worse than a documented omission.
+   (2) styled by emotion with a generated class and no stable hook. A selector
+       for these would be a hash that a Storybook patch release changes
+       silently, which is a worse failure than the one it fixes.
+   (3) neither renders on any docs page in this repository today: no story
+       declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
+       are one edit away, so they are recorded rather than dismissed.
+
+   `docs-theme-contrast.spec.ts` measures every colour written in this file and
+   in `truenasTheme.js`, and fails if a rule outside the canvas selectors below
+   starts painting chrome text from a `--tn-*` token again.
    ================================ */
 
 /* ================================
-   Let's apply these variables to
-   the preview and story book docs elements
+   THE COMPONENT'S CANVAS
+   The only rules here that follow the theme switcher, because the surface a
+   story renders on is the component's and not Storybook's. Each sets its
+   foreground and its background from the same palette.
    ================================ */
 
-html, body, #storybook-docs > .sbdocs-wrapper {
+/* The preview iframe's own page. This is the story canvas outside docs; on a
+   docs page `DocsWrapper` covers it, painting `theme.background.content` at
+   `min-height: 100vh`.
+
+   `!important` predates #293 and is kept: Storybook's preview injects base
+   styles onto the document it owns, and which of the two lands last is not
+   something a static stylesheet can decide. #293 is about the docs CHROME
+   painting the wrong ink, and this rule is not that — dropping the flag here
+   would be an unrelated change to how stories render. */
+html, body {
   font-family: var(--tn-font-family-body);
   color: var(--tn-fg2) !important;
   background-color: var(--tn-bg1) !important;
 }
 
-h1, h2, h3,h4,
-.sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3,.sbdocs-title h4 {
-  font-family: var(--tn-font-family-header);
-  color: var(--tn-fg1) !important;
-}
-
-p, li, td {
-  color: var(--tn-fg2) !important;
-}
-
+/* `!important` because addon-docs paints both of these itself —
+   `getBlockBackgroundStyle(theme)` on `.sbdocs-preview`, from the docs theme —
+   and the component's surface is what should show through. */
 .docs-story,
-.sb-bar,
-.sbdocs-wrapper td,
 .sbdocs-preview {
   background-color: var(--tn-bg2) !important;
   color: var(--tn-fg2) !important;
-}
-
-thead, th {
-  background-color: var(--tn-topbar);
-  color: var(--tn-topbar-txt) !important;
-}
-
-/* Form field styles */
-input:not([role="switch"]),
-.sbdocs-wrapper select,
-.sbdocs-wrapper textarea {
-  background-color: var(--tn-bg1) !important;
-  color: var(--tn-fg2) !important;
-}
-
-.docblock-code-toggle {
-  background-color: var(--tn-btn-default-bg) !important;
-  color: var(--tn-btn-default-txt) !important;
-}
-
-.docblock-argstable-body span {
-  color: var(--tn-fg1);
-  background-color: unset;
-  border: unset;
 }
 
 .docs-story > div {
   background-color: unset;
 }
 
-.docblock-source > div {
-  background: #000000 !important;
-  color: #dedede;
-  border: unset;
+/* ================================
+   TYPEFACE
+   `create()` accepts `fontBase` and `fontCode` and has no third slot, so the
+   header face is the one typographic choice the docs theme cannot carry.
+   Colour is deliberately absent: these headings take `theme.color.defaultText`
+   (#dedede, 10.96:1 on #282828) like the rest of the docs chrome.
+   ================================ */
+h1, h2, h3, h4,
+.sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3, .sbdocs-title h4 {
+  font-family: var(--tn-font-family-header);
 }
 
-.docblock-source button {
-  background: var(--tn-bg2) !important;
-  color: var(--tn-fg2);
+/* ================================
+   THE ROLES `truenasTheme` CANNOT REACH
+   See the table in the header for the full set and why these two are the ones
+   with rules. Both values are the smallest hue-preserving lightness step off
+   Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
+   themes.css documents for `--tn-primary-text`. Ratios are against
+   `appContentBg` #282828 then `appBg` #1e1e1e.
+   ================================ */
+
+/* `theme.color.dark`, #5C6570 at 2.49:1. Scoped to the docs content and out of
+   `.sb-unstyled`, which is the class addon-docs uses to keep its own
+   typography off a rendered story — an `h6` inside a component must keep the
+   component's colour. `:where()` contributes no specificity, so this is 0,2,0
+   against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
+.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
+  color: #86909b; /* 4.55:1, 5.14:1 */
 }
 
-.docblock-source {
-  border: solid 1px var(--tn-alt-bg2) !important;
+/* The syntax highlighter's `deleted` token. `red2` is #9a050f in BOTH of
+   Storybook's syntax palettes — the one entry the dark palette did not
+   retune — so it is 1.69:1 wherever a diff is highlighted, on the light theme
+   and on the dark one alike.
+
+   `!important` rather than more selectors: emotion styles this from the
+   highlighter's wrapper at the same specificity this rule can reach, and the
+   order its <style> is injected in relative to a static stylesheet is not
+   something to depend on. Nothing in this repository renders a diff sample
+   today; the rule is here because the palette ships broken, not because a page
+   was seen failing. */
+.sbdocs .token.deleted {
+  color: #f9535e !important; /* 4.51:1, 5.10:1 */
 }

--- a/projects/truenas-ui/.storybook/truenasTheme.js
+++ b/projects/truenas-ui/.storybook/truenasTheme.js
@@ -6,7 +6,22 @@ const truenasColors = {
   red: '#CE2929',
   magenta: '#C006C7',
   violet: '#7617D8',
-  blue: '#0095D5', // WCAG fix #007db3
+  /* Drawn as TEXT by Storybook, not only as a fill: `colorSecondary` below is
+     `theme.color.secondary`, which addon-docs uses for every link on a docs
+     page and for the argstable's expand controls. #0095D5 measured 4.39:1 on
+     `appContentBg` (#282828) — short of the 4.5:1 body-text minimum, and
+     invisible as a failure for as long as docs pages were rendering in
+     Storybook's light theme anyway (#293).
+
+     #0099db is `--tn-primary-text` from themes.css, which that file tuned as
+     the smallest hue-preserving lightness step clearing 4.5:1 on --tn-bg1 and
+     --tn-bg2 — #1E1E1E and #282828, the same pair `appBg` and `appContentBg`
+     declare below. The value that was already right for these two surfaces,
+     rather than a second one derived the same way.
+
+     4.62:1 on appContentBg, 5.22:1 on appBg. `#007db3` in the note this
+     replaces was the fix for a LIGHT background and is 3.22:1 here. */
+  blue: '#0099db',
   cyan: '#00d0d6',
   green: '#71BF44',
   pink: '#ffc0cb',

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -54,9 +54,36 @@ import { AA_MINIMUM, contrastRatio, formatRatio } from '../a11y/contrast-testing
 const STORYBOOK_DIR = join(__dirname, '../../../.storybook');
 const STYLES_DIR = join(__dirname, '../../styles');
 
-const themeSource = readFileSync(join(STORYBOOK_DIR, 'truenasTheme.js'), 'utf8');
-const previewSource = readFileSync(join(STORYBOOK_DIR, 'preview.ts'), 'utf8');
-const managerSource = readFileSync(join(STORYBOOK_DIR, 'manager.ts'), 'utf8');
+/**
+ * Comments out of the three sources this spec reads as text, because to a regex
+ * a commented-out line is a live one — and both directions of that are ordinary
+ * edits rather than hypotheticals.
+ *
+ * - Comment the `docs:` block out while debugging and the wiring cases below
+ *   stay green while every docs page falls back to `ensure(undefined)`, which
+ *   is exactly the #293 regression those cases exist to catch.
+ * - Leave a superseded value above the live one and `themeValue`'s `.exec()`
+ *   returns the FIRST match, so the suite measures a colour that is not
+ *   shipped. `truenasTheme.js` already carries old hexes in trailing comments
+ *   on its `colorPrimary`/`colorSecondary` lines, so this is the file's
+ *   existing habit.
+ *
+ * Stripped once at read time, the way `cssRules` and `maxBraceDepth` already
+ * strip the stylesheet. A line comment is only recognised where the `//` is not
+ * preceded by a `:`, which is what leaves `brandUrl: 'https://truenas.com'`
+ * intact. The stylesheet is NOT put through this — `//` is not a CSS comment,
+ * and its two readers strip block comments separately for the reason given on
+ * `maxBraceDepth`.
+ */
+function stripJsComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+const themeSource = stripJsComments(readFileSync(join(STORYBOOK_DIR, 'truenasTheme.js'), 'utf8'));
+const previewSource = stripJsComments(readFileSync(join(STORYBOOK_DIR, 'preview.ts'), 'utf8'));
+const managerSource = stripJsComments(readFileSync(join(STORYBOOK_DIR, 'manager.ts'), 'utf8'));
 const storybookCss = readFileSync(join(STYLES_DIR, 'themes-storybook.css'), 'utf8');
 
 /**

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -42,9 +42,20 @@ import { AA_MINIMUM, contrastRatio, formatRatio } from '../a11y/contrast-testing
  *
  * It measures the two theme keys Storybook draws as docs TEXT, and not every
  * colour `truenasTheme.js` declares. `barTextColor`, `barSelectedColor`,
- * `inputTextColor`, `colorPrimary`, `textInverseColor` and the rest of the
- * `truenasColors` bag are outside it: those paint the MANAGER, which is
- * `manager.ts`'s side of the same object and not what #293 was about.
+ * `colorPrimary`, `textInverseColor` and the rest of the `truenasColors` bag
+ * are outside it: those paint the MANAGER, which is `manager.ts`'s side of the
+ * same object and not what #293 was about.
+ *
+ * `inputTextColor` and `inputBg` are outside it for a different reason, and
+ * calling them manager-only stopped being true the moment this change wired
+ * `parameters.docs.theme`. `convert()` maps them to `theme.input.color` and
+ * `theme.input.background`, which `@storybook/components`' `Form.Input`,
+ * `Select` and `Textarea` read — and those are what the docs argstable renders
+ * every `control:` with. Before this change those controls took `themes.light`'s
+ * input colours; after it they take these two. They are a self-consistent PAIR
+ * out of one palette — #dedede on #1e1e1e, 12.39:1 — so they are recorded here
+ * rather than measured as a text role against the surfaces above: neither is
+ * drawn on a surface the other does not supply.
  *
  * The roles Storybook paints from constants no theme can reach are enumerated
  * in `themes-storybook.css`'s header — one has a rule, the rest are recorded
@@ -423,8 +434,12 @@ describe('Storybook docs-page theming (#293)', () => {
     );
 
     // The override is most of the reason this file still has rules at all after
-    // the theme was wired. If it were ever deleted, the case above would measure
-    // nothing and pass — a suite that has stopped checking, reported as green.
+    // the theme was wired. If it were ever deleted, `literalCases` would be
+    // empty — and `it.each([])` throws rather than passing, so the suite would
+    // go red either way. What this case adds is WHICH claim broke: an
+    // unattributed `.each` called with an empty Array of table data reads as a
+    // fault in the spec, and this reads as the stylesheet having stopped
+    // shipping the thing the case above measures.
     it('the documented override is still here to measure', () => {
       expect(literals.length).toBeGreaterThan(0);
     });

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -35,12 +35,20 @@ import { AA_MINIMUM, contrastRatio, formatRatio } from '../a11y/contrast-testing
  *   the same claim in the same shape as `muted-fg-contrast.spec.ts` and its
  *   three siblings, one stylesheet over.
  *
- * WHAT IT CANNOT SEE, stated so the green is not read as more than it is. It
- * does not render anything, so it cannot catch a selector that stops matching —
- * a Storybook release renaming `.sbdocs-content`, say. It measures colours and
- * the wiring that chooses them. The roles Storybook paints from constants no
- * theme can reach are enumerated in `themes-storybook.css`'s header, with the
- * two that have rules here and the four that do not and why.
+ * WHAT IT CANNOT SEE, stated so the green is not read as more than it is.
+ *
+ * It does not render anything, so it cannot catch a selector that stops
+ * matching — a Storybook release renaming `.sbdocs-content`, say.
+ *
+ * It measures the two theme keys Storybook draws as docs TEXT, and not every
+ * colour `truenasTheme.js` declares. `barTextColor`, `barSelectedColor`,
+ * `inputTextColor`, `colorPrimary`, `textInverseColor` and the rest of the
+ * `truenasColors` bag are outside it: those paint the MANAGER, which is
+ * `manager.ts`'s side of the same object and not what #293 was about.
+ *
+ * The roles Storybook paints from constants no theme can reach are enumerated
+ * in `themes-storybook.css`'s header — one has a rule, the rest are recorded
+ * with the reason each does not.
  */
 
 const STORYBOOK_DIR = join(__dirname, '../../../.storybook');
@@ -62,12 +70,20 @@ const storybookCss = readFileSync(join(STYLES_DIR, 'themes-storybook.css'), 'utf
  * that would rot the moment a Storybook release moved a block from one to
  * another.
  *
- * ONE DOCS SURFACE IS NOT IN THIS LIST and cannot be: a Canvas "Show code"
- * block is re-wrapped in `convert(themes.dark)` — `Preview` passes `dark: true`
- * unconditionally — so it renders on Storybook's #222325 rather than on
- * anything `truenasTheme` declares. No theme value reaches it, so there is
- * nothing here that could regress it; the colours measured below are 4.81:1 and
- * better there as it happens, and `themes-storybook.css` says so beside them.
+ * TWO DOCS SURFACES ARE NOT IN THIS LIST AND CANNOT BE, because neither comes
+ * from a `create()` key this file can read:
+ *
+ * - A Canvas "Show code" block is re-wrapped in `convert(themes.dark)` —
+ *   `Preview` passes `dark: true` unconditionally — so it renders on
+ *   Storybook's #222325. `#86909b`, the one literal `themes-storybook.css`
+ *   ships, is 4.85:1 there.
+ * - Every even `tr` of a docs markdown table is filled with `color.darker`
+ *   (#454C54), a constant. Body text on it is `#dedede` at 6.46:1, but
+ *   `colorSecondary` is 2.72:1 — so a LINK inside a table row is below AA.
+ *   Nothing renders one today: `theming.mdx` and `icon-system.mdx` have
+ *   tables, and no cell in either holds a link. Recorded rather than fixed,
+ *   and named in `themes-storybook.css`'s table by the same standard the
+ *   entries there use.
  */
 const SURFACE_KEYS = ['appContentBg', 'appBg', 'barBg'] as const;
 
@@ -293,12 +309,28 @@ describe('Storybook docs-page theming (#293)', () => {
       }
     );
 
-    // `it.each` on an empty table is an error, but a table built from two
-    // constant lists cannot be empty by accident — what it can be is built from
-    // the wrong lists. This pins the count so a key silently dropping out of
-    // either takes a case with it and says so.
+    // What was actually measured, spelled out rather than counted.
+    //
+    // The counted form — `toHaveLength(TEXT_KEYS.length * SURFACE_KEYS.length)`
+    // — is the shape this case had, and it cannot fail: `cases` is built by
+    // mapping those two lists, so both sides of the comparison move together.
+    // Dropping two entries from `SURFACE_KEYS` took the suite from 24 cases to
+    // 16 with this still green, which is the coverage loss it was written to
+    // catch, reported as success.
+    //
+    // Naming the pairs is what makes it a claim about something outside the
+    // arithmetic. A role or a surface that disappears fails here whatever the
+    // list lengths do, and adding one has to be written down rather than
+    // silently absorbed.
     it('measured every text role against every surface', () => {
-      expect(cases).toHaveLength(TEXT_KEYS.length * SURFACE_KEYS.length);
+      expect(cases.map(({ textKey, surface }) => `${textKey} on ${surface}`)).toEqual([
+        'textColor on appContentBg',
+        'textColor on appBg',
+        'textColor on barBg',
+        'colorSecondary on appContentBg',
+        'colorSecondary on appBg',
+        'colorSecondary on barBg',
+      ]);
     });
   });
 

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -58,8 +58,9 @@ import { AA_MINIMUM, contrastRatio, formatRatio } from '../a11y/contrast-testing
  * drawn on a surface the other does not supply.
  *
  * The roles Storybook paints from constants no theme can reach are enumerated
- * in `themes-storybook.css`'s header — one has a rule, the rest are recorded
- * with the reason each does not.
+ * in `themes-storybook.css`'s header — `color.dark` has a rule in each of the
+ * two places it renders, and the rest are recorded with the reason each does
+ * not.
  */
 
 const STORYBOOK_DIR = join(__dirname, '../../../.storybook');
@@ -386,10 +387,11 @@ describe('Storybook docs-page theming (#293)', () => {
     // fails this case until someone adds it here — which is the point: #293 was
     // a list of tag overrides that grew one noticed element at a time and could
     // not be told apart from a complete one by reading it. This is the reading.
-    it('only the canvas selectors and the one documented override paint anything', () => {
+    it('only the canvas selectors and the documented overrides paint anything', () => {
       expect(painters.map((rule) => rule.selector).sort()).toEqual([
         ...Object.keys(CANVAS_SELECTORS),
         '.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *)',
+        '.sbdocs-content .rejt-accordion-region > span:not(.rejt-not-collapsed-delimiter)',
       ].sort());
     });
 
@@ -405,11 +407,12 @@ describe('Storybook docs-page theming (#293)', () => {
       }
     );
 
-    // The override for the one role no docs theme can reach and a selector can.
-    // Its value is literal hex precisely because the surface under it does not
-    // follow the switcher, so it is measured against every surface the theme
-    // declares. Written as a list rather than as that one case, so a second
-    // override added later is measured without anyone remembering to.
+    // The overrides for the one role no docs theme can reach and a selector
+    // can. Their values are literal hex precisely because the surface under
+    // them does not follow the switcher, so each is measured against every
+    // surface the theme declares. Written as a list rather than as one case
+    // per rule, so a third override added later is measured without anyone
+    // remembering to.
     const literals = rules.flatMap((rule) => rule.declarations
       .filter(({ property, value }) => PAINTING_PROPERTIES.includes(property)
         && /#[0-9a-f]{3,8}\b/i.test(value))
@@ -433,15 +436,18 @@ describe('Storybook docs-page theming (#293)', () => {
       }
     );
 
-    // The override is most of the reason this file still has rules at all after
-    // the theme was wired. If it were ever deleted, `literalCases` would be
-    // empty — and `it.each([])` throws rather than passing, so the suite would
-    // go red either way. What this case adds is WHICH claim broke: an
-    // unattributed `.each` called with an empty Array of table data reads as a
-    // fault in the spec, and this reads as the stylesheet having stopped
-    // shipping the thing the case above measures.
-    it('the documented override is still here to measure', () => {
-      expect(literals.length).toBeGreaterThan(0);
+    // The overrides are most of the reason this file still has rules at all
+    // after the theme was wired. Naming them is what makes the case above a
+    // claim about something: `literalCases` is built by mapping `literals`, so
+    // an override that stopped carrying a literal hex — swapped for a `var()`,
+    // or deleted — would simply contribute no cases and the `.each` would stay
+    // green over the ones that remain. Deleting BOTH is the only shape the
+    // arithmetic catches on its own, because `it.each([])` throws.
+    it('both documented overrides are still here to measure', () => {
+      expect(literals.map(({ selector }) => selector).sort()).toEqual([
+        '.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *)',
+        '.sbdocs-content .rejt-accordion-region > span:not(.rejt-not-collapsed-delimiter)',
+      ].sort());
     });
   });
 });

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -1,0 +1,319 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { AA_MINIMUM, contrastRatio, formatRatio } from '../a11y/contrast-testing';
+
+/**
+ * The check #293 asked for: something that goes red when a Storybook DOCS page
+ * regresses to unreadable text.
+ *
+ * WHAT WENT WRONG, because the guard only makes sense against it. `preview.ts`
+ * never set `parameters.docs.theme`. `DocsContainer` calls `ensure(theme)` on
+ * that value and `ensure(undefined)` returns `convert(themes.light)` — not a
+ * neutral default but Storybook's LIGHT theme — so every docs page painted its
+ * body text `#2E3338` and its code samples `#0000FF`/`#393A34` on a `#1E1E1E`
+ * page. 442 failing text nodes on the Dialog docs page alone, the worst at
+ * 1.16:1 against a 4.5:1 requirement. `themes-storybook.css` had been patching
+ * that back one tag at a time and `code`, `h5` and the highlighter's spans were
+ * never in the list.
+ *
+ * WHY THIS SPEC AND NOT A `test-sb` ASSERTION, which was the other option the
+ * ticket named. Three reasons, in order of weight:
+ *
+ * - The test runner drives STORIES. Docs entries are a separate index type and
+ *   visiting them is extra configuration, but that is the smaller half: what a
+ *   browser could then assert is axe's `color-contrast`, which samples the
+ *   nodes a particular page happens to render. Every number below is about the
+ *   THEME, so it holds for pages nobody has written yet — which is exactly how
+ *   `h5` and `code` were missed the first time.
+ * - It would measure a page instead of the cause. A docs page reading
+ *   correctly is compatible with `parameters.docs.theme` having been deleted
+ *   and the tag list having grown back, which is the state #293 started from.
+ *   The first two cases here fail on that directly.
+ * - `yarn test-sb` needs a browser, and this repository's contrast specs have
+ *   settled on measuring the shipped values instead — see the note in
+ *   `contrast-testing.ts` on why jsdom cannot decide axe's rule. This spec is
+ *   the same claim in the same shape as `muted-fg-contrast.spec.ts` and its
+ *   three siblings, one stylesheet over.
+ *
+ * WHAT IT CANNOT SEE, stated so the green is not read as more than it is. It
+ * does not render anything, so it cannot catch a selector that stops matching —
+ * a Storybook release renaming `.sbdocs-content`, say. It measures colours and
+ * the wiring that chooses them. The roles Storybook paints from constants no
+ * theme can reach are enumerated in `themes-storybook.css`'s header, with the
+ * two that have rules here and the four that do not and why.
+ */
+
+const STORYBOOK_DIR = join(__dirname, '../../../.storybook');
+const STYLES_DIR = join(__dirname, '../../styles');
+
+const themeSource = readFileSync(join(STORYBOOK_DIR, 'truenasTheme.js'), 'utf8');
+const previewSource = readFileSync(join(STORYBOOK_DIR, 'preview.ts'), 'utf8');
+const managerSource = readFileSync(join(STORYBOOK_DIR, 'manager.ts'), 'utf8');
+const storybookCss = readFileSync(join(STYLES_DIR, 'themes-storybook.css'), 'utf8');
+
+/**
+ * The surfaces a docs page paints, by the `create()` key that sets each.
+ *
+ * `appContentBg` is the one most things land on: `DocsWrapper` paints it behind
+ * the whole page, and the syntax highlighter's own wrapper paints it again
+ * behind every code sample. `appBg` backs the argstable's section rows and
+ * `barBg` the canvas toolbar. All three are measured for every foreground
+ * rather than each foreground against the one surface it was found on — which
+ * is the assumption that would rot the moment a Storybook release moved a
+ * block from one to another.
+ */
+const SURFACE_KEYS = ['appContentBg', 'appBg', 'barBg'] as const;
+
+/**
+ * The `create()` keys whose values Storybook paints as docs TEXT.
+ *
+ * There are only four settable colour roles — `convert()` rebuilds
+ * `theme.color` from `createColors()`, which reads `colorPrimary`,
+ * `colorSecondary`, `textColor` and `textInverseColor` and takes everything
+ * else from constants — and two of those four are drawn as text on these
+ * surfaces:
+ *
+ * - `textColor` becomes `color.defaultText`, which addon-docs uses for body
+ *   copy, headings, table cells and `code`. Fifteen call sites.
+ * - `colorSecondary` becomes `color.secondary`, which is every link on a docs
+ *   page and the argstable's expand controls. Eight call sites.
+ *
+ * `colorPrimary` is NOT here, and its absence is the measured kind rather than
+ * the forgotten kind: `theme.color.primary` appears nowhere in addon-docs, so
+ * the brand magenta never becomes docs text and holding it to a text threshold
+ * would fail this suite over a colour nobody reads. `textInverseColor` is drawn
+ * on a `colorPrimary` fill, not on any surface here.
+ */
+const TEXT_KEYS = ['textColor', 'colorSecondary'] as const;
+
+/**
+ * `truenasTheme.js` is a small hand-written literal, so it is read as text
+ * rather than imported: `storybook/theming` ships ESM that this project's jest
+ * transform does not process, and a spec that cannot run is worth less than one
+ * that reads the file the build reads.
+ *
+ * Every lookup throws rather than returning undefined. A key this cannot find
+ * is a file that has been restructured, and answering `NaN` to the contrast
+ * maths would report that as a colour failure — the mistake
+ * `contrast-testing.ts` documents at length.
+ */
+function themeValue(key: string): string {
+  const direct = new RegExp(`\\b${key}:\\s*'([^']+)'`).exec(themeSource);
+  if (direct) {
+    return direct[1];
+  }
+  // `colorSecondary: truenasColors.blue` — one indirection through the palette
+  // object at the top of the file, and no deeper. Resolving arbitrary
+  // expressions here would be re-implementing the module loader badly; this
+  // handles the one shape the file uses and refuses everything else.
+  const indirect = new RegExp(`\\b${key}:\\s*truenasColors\\.(\\w+)`).exec(themeSource);
+  if (indirect) {
+    const named = new RegExp(`\\b${indirect[1]}:\\s*'([^']+)'`).exec(themeSource);
+    if (!named) {
+      throw new Error(`truenasTheme.js: ${key} reads truenasColors.${indirect[1]}, which is not declared`);
+    }
+    return named[1];
+  }
+  throw new Error(
+    `truenasTheme.js: no value found for ${key}. `
+    + 'This spec reads the file as text; a restructure has to be reflected here.'
+  );
+}
+
+/** One `selector { … }` rule in `themes-storybook.css`, comments already gone. */
+interface CssRule {
+  selector: string;
+  declarations: { property: string; value: string }[];
+}
+
+/**
+ * The rules in `themes-storybook.css`.
+ *
+ * A flat regex rather than the brace walk in `contrast-testing.ts`, and the
+ * case below asserts the file stays flat — no `@media`, no nesting — so the two
+ * cannot disagree silently. That file's parser is not exported and this is the
+ * one stylesheet in the repository written entirely by hand for Storybook.
+ */
+function cssRules(css: string): CssRule[] {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  return [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, selector, body]) => ({
+    selector: selector.trim().replace(/\s+/g, ' '),
+    declarations: [...body.matchAll(/([\w-]+)\s*:\s*([^;]+)(?:;|$)/g)].map(([, property, value]) => ({
+      property: property.trim(),
+      value: value.trim(),
+    })),
+  }));
+}
+
+/**
+ * The selectors allowed to paint from a `--tn-*` token, and what each is.
+ *
+ * This is the rule #293 replaced a tag list with: the theme switcher themes the
+ * COMPONENT, so only the surface a story renders on may follow it. Docs-page
+ * chrome is Storybook's and is themed through `parameters.docs.theme`.
+ *
+ * A rule that sets a `color:` from a token on anything else is #293 with the
+ * colours swapped — three of the nine shipped palettes are light, so `--tn-fg2`
+ * is a dark ink, and the chrome behind it is now always `#282828` whatever the
+ * switcher says. The case below is what stops that growing back.
+ */
+const CANVAS_SELECTORS: Readonly<Record<string, string>> = {
+  'html, body': 'the preview iframe page — the story canvas outside docs',
+  '.docs-story, .sbdocs-preview': 'the story canvas inside a docs page',
+  '.docs-story > div': 'the wrapper addon-docs puts around a rendered story',
+};
+
+/**
+ * Properties whose value cannot fail a contrast check.
+ *
+ * `font-family` is the one typographic choice `create()` cannot carry — it
+ * takes `fontBase` and `fontCode` and has no header slot — so the heading rule
+ * legitimately reads a token. Listing the property rather than the selector
+ * keeps the exemption from covering a `color:` that appears beside it later.
+ */
+const COLOURLESS_PROPERTIES = ['font-family'];
+
+/** Properties that put a colour on the page, and so have to be measured. */
+const PAINTING_PROPERTIES = ['color', 'background-color', 'background'];
+
+describe('Storybook docs-page theming (#293)', () => {
+  const rules = cssRules(storybookCss);
+
+  describe('the docs theme is wired to the preview at all', () => {
+    // The regression that started #293, and the one a rendered page cannot
+    // distinguish from a healthy one for as long as a tag list is compensating.
+    it('preview.ts sets parameters.docs.theme', () => {
+      expect(previewSource).toMatch(/docs:\s*\{[\s\S]*?theme:\s*truenasTheme/);
+    });
+
+    it('preview.ts takes that theme from ./truenasTheme', () => {
+      expect(previewSource).toMatch(/import\s+truenasTheme\s+from\s+'\.\/truenasTheme'/);
+    });
+
+    // The manager UI and the docs pages have to agree, or the chrome around a
+    // docs page is one theme and the page itself another. Asserted as "the same
+    // module", which is as far as reading the source can go.
+    it('manager.ts gives the same theme to the manager UI', () => {
+      expect(managerSource).toMatch(/from\s+'\.\/truenasTheme'/);
+      expect(managerSource).toMatch(/theme:\s*truenasTheme/);
+    });
+
+    // Everything below measures against a dark surface. A theme that flipped to
+    // `base: 'light'` would keep every ratio here true and still hand the docs
+    // page the light SYNTAX palette, which `base` alone selects.
+    it('truenasTheme is a dark-base theme, so the syntax palette is the dark one', () => {
+      expect(themeSource).toMatch(/base:\s*'dark'/);
+    });
+  });
+
+  describe('the colours truenasTheme paints docs text with', () => {
+    const surfaces = SURFACE_KEYS.map((key) => ({ key, colour: themeValue(key) }));
+
+    // Read back rather than assumed: `contrastRatio` refuses a translucent
+    // background, and a surface declared as anything it cannot parse would
+    // otherwise fail every case below with the same message.
+    it.each(surfaces)('$key is an opaque colour ($colour)', ({ colour }) => {
+      expect(() => contrastRatio('#ffffff', colour)).not.toThrow();
+    });
+
+    const cases = TEXT_KEYS.flatMap((textKey) => {
+      const colour = themeValue(textKey);
+      return surfaces.map(({ key, colour: surface }) => {
+        const ratio = contrastRatio(colour, surface);
+        return {
+          textKey,
+          colour,
+          surface: key,
+          surfaceColour: surface,
+          // Formatted for the title, compared unrounded below — a pair
+          // measuring 4.4999 does not clear AA however it prints.
+          ratio: formatRatio(ratio),
+          value: ratio,
+        };
+      });
+    });
+
+    it.each(cases)(
+      '$textKey $colour on $surface $surfaceColour — $ratio',
+      ({ value }) => {
+        expect(value).toBeGreaterThanOrEqual(AA_MINIMUM.normal);
+      }
+    );
+
+    // `it.each` on an empty table is an error, but a table built from two
+    // constant lists cannot be empty by accident — what it can be is built from
+    // the wrong lists. This pins the count so a key silently dropping out of
+    // either takes a case with it and says so.
+    it('measured every text role against every surface', () => {
+      expect(cases).toHaveLength(TEXT_KEYS.length * SURFACE_KEYS.length);
+    });
+  });
+
+  describe('themes-storybook.css', () => {
+    it('is flat — no at-rules and no nesting, which is what the parser here assumes', () => {
+      const stripped = storybookCss.replace(/\/\*[\s\S]*?\*\//g, '');
+      expect(stripped).not.toMatch(/@\w/);
+      expect(rules.every((rule) => !rule.selector.includes('}'))).toBe(true);
+    });
+
+    const painters = rules.filter((rule) => rule.declarations
+      .some(({ property }) => PAINTING_PROPERTIES.includes(property)));
+
+    // Every rule that puts a colour on the page, listed. A NEW painting rule
+    // fails this case until someone adds it here — which is the point: #293 was
+    // a list of tag overrides that grew one noticed element at a time and could
+    // not be told apart from a complete one by reading it. This is the reading.
+    it('only the canvas selectors and the two documented overrides paint anything', () => {
+      expect(painters.map((rule) => rule.selector).sort()).toEqual([
+        ...Object.keys(CANVAS_SELECTORS),
+        '.sbdocs .token.deleted',
+        '.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *)',
+      ].sort());
+    });
+
+    const tokenPainters = rules.flatMap((rule) => rule.declarations
+      .filter(({ property, value }) => value.includes('var(--tn-')
+        && !COLOURLESS_PROPERTIES.includes(property))
+      .map(({ property, value }) => ({ selector: rule.selector, property, value })));
+
+    it.each(tokenPainters)(
+      '$selector paints $property from $value, and is a canvas selector',
+      ({ selector }) => {
+        expect(Object.keys(CANVAS_SELECTORS)).toContain(selector);
+      }
+    );
+
+    // The overrides for the roles no docs theme can reach. Their values are
+    // literal hex precisely because the surface under them does not follow the
+    // switcher, so each is measured against every surface the theme declares.
+    const literals = rules.flatMap((rule) => rule.declarations
+      .filter(({ property, value }) => PAINTING_PROPERTIES.includes(property)
+        && /#[0-9a-f]{3,8}\b/i.test(value))
+      .map(({ property, value }) => ({
+        selector: rule.selector,
+        property,
+        colour: (/#[0-9a-f]{3,8}\b/i.exec(value) as RegExpExecArray)[0],
+      })));
+
+    const literalCases = literals.flatMap(({ selector, property, colour }) => SURFACE_KEYS
+      .map((key) => {
+        const surface = themeValue(key);
+        const ratio = contrastRatio(colour, surface);
+        return { selector, property, colour, surface: key, ratio: formatRatio(ratio), value: ratio };
+      }));
+
+    it.each(literalCases)(
+      '$selector $property $colour on $surface — $ratio',
+      ({ value }) => {
+        expect(value).toBeGreaterThanOrEqual(AA_MINIMUM.normal);
+      }
+    );
+
+    // The two overrides are the whole reason this file still exists after the
+    // theme was wired. If they were ever deleted, the case above would measure
+    // nothing and pass — a suite that has stopped checking, reported as green.
+    it('the documented overrides are still here to measure', () => {
+      expect(literals.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/docs-theme-contrast.spec.ts
@@ -55,12 +55,19 @@ const storybookCss = readFileSync(join(STYLES_DIR, 'themes-storybook.css'), 'utf
  * The surfaces a docs page paints, by the `create()` key that sets each.
  *
  * `appContentBg` is the one most things land on: `DocsWrapper` paints it behind
- * the whole page, and the syntax highlighter's own wrapper paints it again
- * behind every code sample. `appBg` backs the argstable's section rows and
- * `barBg` the canvas toolbar. All three are measured for every foreground
- * rather than each foreground against the one surface it was found on — which
- * is the assumption that would rot the moment a Storybook release moved a
- * block from one to another.
+ * the whole page, and the syntax highlighter's wrapper paints it again behind
+ * an MDX code fence. `appBg` backs the argstable's section rows and `barBg` the
+ * canvas toolbar. All three are measured for every foreground rather than each
+ * foreground against the one surface it was found on — which is the assumption
+ * that would rot the moment a Storybook release moved a block from one to
+ * another.
+ *
+ * ONE DOCS SURFACE IS NOT IN THIS LIST and cannot be: a Canvas "Show code"
+ * block is re-wrapped in `convert(themes.dark)` — `Preview` passes `dark: true`
+ * unconditionally — so it renders on Storybook's #222325 rather than on
+ * anything `truenasTheme` declares. No theme value reaches it, so there is
+ * nothing here that could regress it; the colours measured below are 4.81:1 and
+ * better there as it happens, and `themes-storybook.css` says so beside them.
  */
 const SURFACE_KEYS = ['appContentBg', 'appBg', 'barBg'] as const;
 
@@ -76,7 +83,15 @@ const SURFACE_KEYS = ['appContentBg', 'appBg', 'barBg'] as const;
  * - `textColor` becomes `color.defaultText`, which addon-docs uses for body
  *   copy, headings, table cells and `code`. Fifteen call sites.
  * - `colorSecondary` becomes `color.secondary`, which is every link on a docs
- *   page and the argstable's expand controls. Eight call sites.
+ *   page. Eight call sites.
+ *
+ * Measured against the bare surfaces the theme declares, which is the claim
+ * these cases make and the limit of it. `Expandable` in the argstable composes
+ * a `hsl(0 0 100 / 0.02)` wash of its own, so `colorSecondary` renders there on
+ * #2c2c2c at 4.36:1 rather than the 4.62:1 below. Not measured here and not
+ * fixed: it needs a `type.detail`, which docgen would supply and `angular.json`
+ * has compodoc off, so nothing renders it today. Recorded because the number is
+ * real and a future reader should not have to rediscover it.
  *
  * `colorPrimary` is NOT here, and its absence is the measured kind rather than
  * the forgotten kind: `theme.color.primary` appears nowhere in addon-docs, so
@@ -120,6 +135,36 @@ function themeValue(key: string): string {
   );
 }
 
+/**
+ * How deep the braces in `css` nest: 1 for a flat stylesheet, 0 for one with no
+ * rules at all, 2 for the first `@media` or nested selector.
+ *
+ * A character walk over the raw text, deliberately not sharing anything with
+ * `cssRules` — a parser cannot be the witness for the property it silently
+ * relies on. Throws on unbalanced braces rather than returning a depth, because
+ * every count after the imbalance is meaningless and a number here would be
+ * read as one.
+ */
+function maxBraceDepth(css: string): number {
+  let depth = 0;
+  let deepest = 0;
+  for (const character of css.replace(/\/\*[\s\S]*?\*\//g, '')) {
+    if (character === '{') {
+      depth += 1;
+      deepest = Math.max(deepest, depth);
+    } else if (character === '}') {
+      depth -= 1;
+      if (depth < 0) {
+        throw new Error('themes-storybook.css: a } closes a block that was never opened');
+      }
+    }
+  }
+  if (depth !== 0) {
+    throw new Error(`themes-storybook.css: ${depth} block(s) left open`);
+  }
+  return deepest;
+}
+
 /** One `selector { … }` rule in `themes-storybook.css`, comments already gone. */
 interface CssRule {
   selector: string;
@@ -133,6 +178,14 @@ interface CssRule {
  * case below asserts the file stays flat — no `@media`, no nesting — so the two
  * cannot disagree silently. That file's parser is not exported and this is the
  * one stylesheet in the repository written entirely by hand for Storybook.
+ *
+ * Flatness has to be measured OUTSIDE this function, on the raw text, which is
+ * the whole reason `maxBraceDepth` exists separately. Everything a nested rule
+ * would break happens inside the regex: `([^{}]+)` cannot capture a `}`, so
+ * `.a { color: red; .b { color: blue; } }` yields one rule whose selector is
+ * `color: red; .b` and whose outer declaration is gone. Asked afterwards
+ * whether any selector contains a brace, this parser always answers no — a
+ * check that cannot fail, over exactly the input that broke it.
  */
 function cssRules(css: string): CssRule[] {
   const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -253,7 +306,7 @@ describe('Storybook docs-page theming (#293)', () => {
     it('is flat — no at-rules and no nesting, which is what the parser here assumes', () => {
       const stripped = storybookCss.replace(/\/\*[\s\S]*?\*\//g, '');
       expect(stripped).not.toMatch(/@\w/);
-      expect(rules.every((rule) => !rule.selector.includes('}'))).toBe(true);
+      expect(maxBraceDepth(storybookCss)).toBe(1);
     });
 
     const painters = rules.filter((rule) => rule.declarations
@@ -263,10 +316,9 @@ describe('Storybook docs-page theming (#293)', () => {
     // fails this case until someone adds it here — which is the point: #293 was
     // a list of tag overrides that grew one noticed element at a time and could
     // not be told apart from a complete one by reading it. This is the reading.
-    it('only the canvas selectors and the two documented overrides paint anything', () => {
+    it('only the canvas selectors and the one documented override paint anything', () => {
       expect(painters.map((rule) => rule.selector).sort()).toEqual([
         ...Object.keys(CANVAS_SELECTORS),
-        '.sbdocs .token.deleted',
         '.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *)',
       ].sort());
     });
@@ -283,9 +335,11 @@ describe('Storybook docs-page theming (#293)', () => {
       }
     );
 
-    // The overrides for the roles no docs theme can reach. Their values are
-    // literal hex precisely because the surface under them does not follow the
-    // switcher, so each is measured against every surface the theme declares.
+    // The override for the one role no docs theme can reach and a selector can.
+    // Its value is literal hex precisely because the surface under it does not
+    // follow the switcher, so it is measured against every surface the theme
+    // declares. Written as a list rather than as that one case, so a second
+    // override added later is measured without anyone remembering to.
     const literals = rules.flatMap((rule) => rule.declarations
       .filter(({ property, value }) => PAINTING_PROPERTIES.includes(property)
         && /#[0-9a-f]{3,8}\b/i.test(value))
@@ -309,10 +363,10 @@ describe('Storybook docs-page theming (#293)', () => {
       }
     );
 
-    // The two overrides are the whole reason this file still exists after the
-    // theme was wired. If they were ever deleted, the case above would measure
+    // The override is most of the reason this file still has rules at all after
+    // the theme was wired. If it were ever deleted, the case above would measure
     // nothing and pass — a suite that has stopped checking, reported as green.
-    it('the documented overrides are still here to measure', () => {
+    it('the documented override is still here to measure', () => {
       expect(literals.length).toBeGreaterThan(0);
     });
   });

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -51,8 +51,8 @@
    `theme.input.color` and `theme.input.background`, which is `inputTextColor`
    and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
 
-   WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
-   ------------------------------------------------------
+   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST OF TWO
+   --------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
    `createColors()`, and only FOUR of those roles come from the theme object:
    `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
@@ -72,7 +72,7 @@
 
      role                      value     ratio   painted on            here?
      color.dark                #5C6570   2.49:1  h6, blockquote        yes
-                                                 argstable object      no (1)
+                                                 argstable object      yes
                                                  control
      color.darkest             #2E3338   1.16:1  span.frame caption    no (2)
      code red2                 #9a050f   1.69:1  `diff` syntax         no (3)
@@ -81,20 +81,21 @@
      transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) inside `.docblock-argstable`, styled by emotion with a generated class.
-       These are DEFERRED, not unreachable, and the difference matters because
-       a rule this change deletes — `.docblock-argstable-body span` — was
-       exactly such a hook: an addon-docs class on the `tbody`, holding at
-       0,1,1 without `!important`. (`sb-unstyled` is orthogonal. It keeps
-       addon-docs' own typography off a RENDERED STORY; it does not stop a
-       hand-written selector matching inside the argstable, which is why that
-       rule worked.) What is missing is not a hook but a value: nothing here
-       writes `color:` with a literal hex on one, the way the override at the
-       bottom does for `h6`/`blockquote`, and the markup under the object
-       control is emotion-generated rather than a stable class. The argstable's
-       object control is the one of these that renders TODAY, on the six pages
-       declaring `control: 'object'`; it is the follow-up this change
-       deliberately does not reach.
+   (1) styled by emotion with a generated class, so there is no hand-written
+       selector to hold. Recorded rather than fixed, and neither renders on a
+       docs page here today: the required-arg marker needs an `argType` whose
+       `type.required` is set — `ArgRow` reads exactly that — and no story here
+       declares one, while the story-mount error renders only when a story
+       throws.
+
+       The argstable's object control was in this footnote until now and has
+       moved out, because its hook turned out to be a real one:
+       `.rejt-accordion-region` is a class addon-docs writes by hand in
+       `JsonNodeAccordion`, not an emotion hash. The rule this change deletes
+       looks like it already covered that control, and did not —
+       `.docblock-argstable-body span` carried no `!important`, and the
+       control's summary span carries its colour as an INLINE style, which no
+       selector beats without the flag. See the second override at the bottom.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
    (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
@@ -119,7 +120,7 @@
    today; it is here rather than dismissed, by footnote (4)'s standard.
 
    `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
-   docs text and the literal colour below, and fails if a rule outside the
+   docs text and every literal colour below, and fails if a rule outside the
    canvas selectors starts painting chrome text from a `--tn-*` token again. It
    does NOT measure every colour in `truenasTheme.js` — most of those paint the
    manager UI, which is `manager.ts`'s half of that object.
@@ -183,13 +184,14 @@ h1, h2, h3, h4,
 }
 
 /* ================================
-   THE ONE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
-   The table in the header is the full set; this is the only entry that both
-   renders here and has a hook that will still be there after a Storybook patch
-   release. Its value is the smallest hue-preserving lightness step off
-   Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
-   themes.css documents for `--tn-primary-text`. Ratios are against
-   `appContentBg` #282828 then `appBg` #1e1e1e.
+   THE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
+   The table in the header is the full set; `color.dark` is the only entry that
+   both renders here and has a hook that will still be there after a Storybook
+   patch release, and it renders in two places. Its replacement value is the
+   smallest hue-preserving lightness step off Storybook's own that clears 4.5:1
+   on BOTH docs surfaces — the method themes.css documents for
+   `--tn-primary-text`. Ratios are against `appContentBg` #282828 then `appBg`
+   #1e1e1e.
    ================================ */
 
 /* `theme.color.dark`, #5C6570 at 2.49:1. Scoped to the docs content and out of
@@ -199,4 +201,25 @@ h1, h2, h3, h4,
    against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
 .sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
   color: #86909b; /* 4.55:1, 5.14:1 */
+}
+
+/* `theme.color.dark` again, on the argstable's object control: the `{...} 3
+   keys` summary a `control: 'object'` row shows at rest, since `JsonTree`'s
+   default `isCollapsed` is `(keyPath, deep) => deep !== -1` and the root is
+   depth 0. Six pages here declare that control — card, select, menu,
+   radio-group, form-field, table-pager — so this is the one entry in the
+   header's table that a reader hits today rather than one edit away.
+
+   `!important` is not a specificity choice and cannot be traded for a longer
+   selector. `react-editable-json-tree` renders that summary as
+   `<span style={collapsed}>`, taking the colour from addon-docs'
+   `getCustomStyleFunction`, and an inline style beats every selector without
+   the flag.
+
+   `:not(.rejt-not-collapsed-delimiter)` keeps this off the `[`/`]` and `{`/`}`
+   an EXPANDED node draws, which are the region's other direct children. Those
+   carry no inline colour, so they inherit `theme.color.defaultText` at 10.96:1
+   and repainting them would be a downgrade. */
+.sbdocs-content .rejt-accordion-region > span:not(.rejt-not-collapsed-delimiter) {
+  color: #86909b !important; /* 4.55:1, 5.14:1 */
 }

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -88,9 +88,18 @@
        declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
        are one edit away, so they are recorded rather than dismissed.
 
-   `docs-theme-contrast.spec.ts` measures every colour written in this file and
-   in `truenasTheme.js`, and fails if a rule outside the canvas selectors below
-   starts painting chrome text from a `--tn-*` token again.
+   ONE SURFACE BELONGS IN THAT TABLE FROM THE OTHER SIDE. `color.darker`
+   (#454C54) is a constant too, and addon-docs fills every even `tr` of a docs
+   markdown table with it. Body text reads 6.46:1 there, but `colorSecondary`
+   reads 2.72:1 — so a LINK in a table row would be below AA. No cell in
+   `theming.mdx` or `icon-system.mdx` holds one today; it is here rather than
+   dismissed, by footnote (4)'s standard.
+
+   `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
+   docs text and the literal colour below, and fails if a rule outside the
+   canvas selectors starts painting chrome text from a `--tn-*` token again. It
+   does NOT measure every colour in `truenasTheme.js` — most of those paint the
+   manager UI, which is `manager.ts`'s half of that object.
    ================================ */
 
 /* ================================
@@ -115,9 +124,13 @@ html, body {
   background-color: var(--tn-bg1) !important;
 }
 
-/* `!important` because addon-docs paints both of these itself —
-   `getBlockBackgroundStyle(theme)` on `.sbdocs-preview`, from the docs theme —
-   and the component's surface is what should show through. */
+/* `!important` for `.sbdocs-preview`, which addon-docs paints itself through
+   `getBlockBackgroundStyle(theme)` from the docs theme — the component's
+   surface is what should show through. `.docs-story` gets no background from
+   addon-docs at all (`StyledPreview` gives it only padding), so the flag is
+   carried rather than needed on that half; the two are one rule because they
+   are one surface, and splitting them to drop a redundant flag would say the
+   two are different things. */
 .docs-story,
 .sbdocs-preview {
   background-color: var(--tn-bg2) !important;

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -38,18 +38,35 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
-   ONE DELETION IS NOT COVERED BY THAT RULE AND IS DELIBERATE. The form-field
-   block set `background-color` and `color` together, which is the retention
-   criterion above, and two of its three selectors were docs chrome
-   (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
-   `input:not([role="switch"])`, was scoped to nothing: this file is linked
-   from `preview-head.html`, so it reached every native `input` inside every
-   RENDERED STORY, overriding the component's own SCSS with `!important`.
-   Removing it is the only change here that touches the story canvas rather
-   than the chrome, and what it restores is the component's real styling.
-   Docs-page controls keep their colours from the theme instead —
-   `theme.input.color` and `theme.input.background`, which is `inputTextColor`
-   and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+   FOUR REMOVALS TOUCH THE STORY CANVAS AND NOT ONLY THE CHROME, and all four
+   are the same shape: a bare-tag selector in a file `preview-head.html` links
+   into the PREVIEW IFRAME, so it reached every RENDERED STORY as well as the
+   docs page it was written for. Each is deliberate, and what they restore is
+   the component's own styling on its own canvas.
+
+   - The form-field rule set `background-color` and `color` together, which is
+     the retention criterion above, and two of its three selectors were docs
+     chrome (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
+     `input:not([role="switch"])`, was scoped to nothing and overrode every
+     component's own SCSS with `!important`. Docs-page controls keep their
+     colours from the theme instead — `theme.input.color` and
+     `theme.input.background`, which is `inputTextColor` and `inputBg` in
+     `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+   - `p, li, td { color: var(--tn-fg2) !important }`, and the
+     `color: var(--tn-fg1) !important` dropped from the `h1`–`h4` rule below.
+     Both are text colour from a switcher token, which is exactly what the
+     rule above prohibits, and both landed inside stories too.
+   - `thead, th { background-color: var(--tn-topbar); color:
+     var(--tn-topbar-txt) !important }`. This is the one with a consequence
+     worth naming rather than just a justification: it was the only ambient
+     `th` fill in `src/styles/`, and `month-view.component.scss` leans on it —
+     "The header's fill comes from the ambient table styling, so round the
+     outer corners of the row rather than painting a background of our own."
+     So the Calendar and Date Range Picker stories now render their weekday
+     band unfilled. The component never painted its own header, so a real
+     application always looked like that; what this rule did was make
+     Storybook look better than the product. Recorded here and proposed as a
+     follow-up on the calendar, rather than fixed by putting the crutch back.
 
    WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST OF TWO
    --------------------------------------------------------
@@ -167,8 +184,9 @@ html, body {
 
 /* ================================
    TYPEFACE
-   Predates #293 and is left alone, but not left unexplained, because the
-   obvious reading of it is wrong: this does NOT put the header face on docs
+   Its `font-family` predates #293 and is left alone (its `color` is one of the
+   four removals above), but not left unexplained, because the obvious reading
+   of what remains is wrong: this does NOT put the header face on docs
    headings. addon-docs styles the same elements through `toGlobalSelector` at
    0,1,0 and spreads a reset setting `fontFamily: theme.typography.fonts.base`,
    so a docs heading renders in `fontBase` and this 0,0,1 rule loses. Where it

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -77,8 +77,10 @@
        change deliberately does not reach.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
-   (3) `red2` is #9a050f in BOTH syntax palettes, the one entry the dark
-       palette did not retune. It has a stable hook — `.token.deleted` — and
+   (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
+       entry it paints with and left this. (`blue2` is shared too, at #00009f,
+       and is not in this table because `create()` never references it, so it
+       paints nothing.) `red2` has a stable hook — `.token.deleted` — and
        still gets no rule: this Storybook registers eleven Prism grammars and
        `diff` is not among them, so no sample can emit that token and the
        selector would be dead by (2)'s own argument. Worse, forcing a colour

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -38,6 +38,19 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
+   ONE DELETION IS NOT COVERED BY THAT RULE AND IS DELIBERATE. The form-field
+   block set `background-color` and `color` together, which is the retention
+   criterion above, and two of its three selectors were docs chrome
+   (`.sbdocs-wrapper select`, `.sbdocs-wrapper textarea`). The third,
+   `input:not([role="switch"])`, was scoped to nothing: this file is linked
+   from `preview-head.html`, so it reached every native `input` inside every
+   RENDERED STORY, overriding the component's own SCSS with `!important`.
+   Removing it is the only change here that touches the story canvas rather
+   than the chrome, and what it restores is the component's real styling.
+   Docs-page controls keep their colours from the theme instead —
+   `theme.input.color` and `theme.input.background`, which is `inputTextColor`
+   and `inputBg` in `truenasTheme.js`, #dedede on #1e1e1e at 12.39:1.
+
    WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
    ------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
@@ -68,13 +81,20 @@
      transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) inside `.docblock-argstable`, which addon-docs marks `sb-unstyled`, or
-       styled by emotion with a generated class. Either way there is no hook a
-       hand-written selector can hold that a Storybook patch release will not
-       move silently — which is a worse failure than the one it would fix. The
-       argstable's object control is the one of these that renders TODAY, on
-       the six pages declaring `control: 'object'`; it is the follow-up this
-       change deliberately does not reach.
+   (1) inside `.docblock-argstable`, styled by emotion with a generated class.
+       These are DEFERRED, not unreachable, and the difference matters because
+       a rule this change deletes — `.docblock-argstable-body span` — was
+       exactly such a hook: an addon-docs class on the `tbody`, holding at
+       0,1,1 without `!important`. (`sb-unstyled` is orthogonal. It keeps
+       addon-docs' own typography off a RENDERED STORY; it does not stop a
+       hand-written selector matching inside the argstable, which is why that
+       rule worked.) What is missing is not a hook but a value: nothing here
+       writes `color:` with a literal hex on one, the way the override at the
+       bottom does for `h6`/`blockquote`, and the markup under the object
+       control is emotion-generated rather than a stable class. The argstable's
+       object control is the one of these that renders TODAY, on the six pages
+       declaring `control: 'object'`; it is the follow-up this change
+       deliberately does not reach.
    (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
    (3) `red2` is #9a050f in BOTH syntax palettes — the dark one retuned every
@@ -93,9 +113,10 @@
    ONE SURFACE BELONGS IN THAT TABLE FROM THE OTHER SIDE. `color.darker`
    (#454C54) is a constant too, and addon-docs fills every even `tr` of a docs
    markdown table with it. Body text reads 6.46:1 there, but `colorSecondary`
-   reads 2.72:1 — so a LINK in a table row would be below AA. No cell in
-   `theming.mdx` or `icon-system.mdx` holds one today; it is here rather than
-   dismissed, by footnote (4)'s standard.
+   reads 2.72:1 — so a LINK in a table row would be below AA. Three MDX files
+   here ship markdown tables — `theming.mdx`, `icon-system.mdx` and
+   `design-system-proposal-v2.mdx` — and no cell in any of them holds a link
+   today; it is here rather than dismissed, by footnote (4)'s standard.
 
    `docs-theme-contrast.spec.ts` measures the two theme keys Storybook draws as
    docs text and the literal colour below, and fails if a rule outside the

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -38,35 +38,53 @@
    a foreground and its own background together, from the same palette, so it
    stays self-consistent on all nine.
 
-   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST
-   -------------------------------------------------
+   WHY THE OVERRIDE AT THE BOTTOM IS A CLOSED LIST OF ONE
+   ------------------------------------------------------
    `convert()` in `storybook/theming` builds `theme.color` from
    `createColors()`, and only FOUR of those roles come from the theme object:
    `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
    and `red2` in both of the syntax palettes — is a constant shared by the
-   light and dark bases, so no docs theme can reach it. The overrides below are
-   derived from that function rather than noticed one at a time, which is the
-   whole difference between this list and the one it replaces.
+   light and dark bases, so no docs theme can reach it. The table below is that
+   function's leftovers, enumerated from it rather than noticed one at a time,
+   which is the whole difference between this and the list it replaces: a
+   reader can tell it is complete, and can tell which entries got a rule.
 
-   Storybook paints docs TEXT with these unreachable roles. Measured against
-   `appContentBg` (#282828), the surface `DocsWrapper` and the syntax
-   highlighter's own wrapper both paint:
+   Storybook paints docs TEXT with these unreachable roles. Ratios are against
+   `appContentBg` (#282828), which `DocsWrapper` paints behind the page and the
+   syntax highlighter's wrapper paints again behind an MDX code fence. A Canvas
+   "Show code" block is the exception and is NOT this surface: `Preview` passes
+   `dark: true`, which re-wraps the block in `convert(themes.dark)`, so it sits
+   on #222325 — near enough that nothing below changes verdict, far enough that
+   quoting one number for both would be wrong.
 
      role                      value     ratio   painted on            here?
      color.dark                #5C6570   2.49:1  h6, blockquote        yes
-     code red2 (.token.deleted) #9a050f  1.69:1  diff syntax           yes
-     color.darkest             #2E3338   1.16:1  span.frame caption    no (1)
-     color.negative            #FF4400   4.27:1  required-arg marker   no (2)
-     color.orange              #FC521F   4.47:1  story-mount error     no (2)
-     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (2,3)
+                                                 argstable object      no (1)
+                                                 control
+     color.darkest             #2E3338   1.16:1  span.frame caption    no (2)
+     code red2                 #9a050f   1.69:1  `diff` syntax         no (3)
+     color.negative            #FF4400   4.27:1  required-arg marker   no (1)
+     color.orange              #FC521F   4.47:1  story-mount error     no (1)
+     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (1,4)
                                                  header, Typeset label
 
-   (1) reachable, but nothing here emits `span.frame` markup — a dead selector
+   (1) inside `.docblock-argstable`, which addon-docs marks `sb-unstyled`, or
+       styled by emotion with a generated class. Either way there is no hook a
+       hand-written selector can hold that a Storybook patch release will not
+       move silently — which is a worse failure than the one it would fix. The
+       argstable's object control is the one of these that renders TODAY, on
+       the six pages declaring `control: 'object'`; it is the follow-up this
+       change deliberately does not reach.
+   (2) reachable, but nothing here emits `span.frame` markup — a dead selector
        would be worse than a documented omission.
-   (2) styled by emotion with a generated class and no stable hook. A selector
-       for these would be a hash that a Storybook patch release changes
-       silently, which is a worse failure than the one it fixes.
-   (3) neither renders on any docs page in this repository today: no story
+   (3) `red2` is #9a050f in BOTH syntax palettes, the one entry the dark
+       palette did not retune. It has a stable hook — `.token.deleted` — and
+       still gets no rule: this Storybook registers eleven Prism grammars and
+       `diff` is not among them, so no sample can emit that token and the
+       selector would be dead by (2)'s own argument. Worse, forcing a colour
+       there would also hit a `<Source dark={false}>` block, whose wrapper is
+       `themes.light` white.
+   (4) neither renders on any docs page in this repository today: no story
        declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
        are one edit away, so they are recorded rather than dismissed.
 
@@ -112,10 +130,16 @@ html, body {
 
 /* ================================
    TYPEFACE
-   `create()` accepts `fontBase` and `fontCode` and has no third slot, so the
-   header face is the one typographic choice the docs theme cannot carry.
-   Colour is deliberately absent: these headings take `theme.color.defaultText`
-   (#dedede, 10.96:1 on #282828) like the rest of the docs chrome.
+   Predates #293 and is left alone, but not left unexplained, because the
+   obvious reading of it is wrong: this does NOT put the header face on docs
+   headings. addon-docs styles the same elements through `toGlobalSelector` at
+   0,1,0 and spreads a reset setting `fontFamily: theme.typography.fonts.base`,
+   so a docs heading renders in `fontBase` and this 0,0,1 rule loses. Where it
+   does apply is a heading a story renders, outside addon-docs' reach.
+
+   Colour is deliberately absent either way: docs headings take
+   `theme.color.defaultText` (#dedede, 10.96:1 on #282828) like the rest of the
+   chrome, which is the whole point of #293.
    ================================ */
 h1, h2, h3, h4,
 .sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3, .sbdocs-title h4 {
@@ -123,9 +147,10 @@ h1, h2, h3, h4,
 }
 
 /* ================================
-   THE ROLES `truenasTheme` CANNOT REACH
-   See the table in the header for the full set and why these two are the ones
-   with rules. Both values are the smallest hue-preserving lightness step off
+   THE ONE ROLE `truenasTheme` CANNOT REACH AND A SELECTOR CAN
+   The table in the header is the full set; this is the only entry that both
+   renders here and has a hook that will still be there after a Storybook patch
+   release. Its value is the smallest hue-preserving lightness step off
    Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
    themes.css documents for `--tn-primary-text`. Ratios are against
    `appContentBg` #282828 then `appBg` #1e1e1e.
@@ -138,19 +163,4 @@ h1, h2, h3, h4,
    against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
 .sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
   color: #86909b; /* 4.55:1, 5.14:1 */
-}
-
-/* The syntax highlighter's `deleted` token. `red2` is #9a050f in BOTH of
-   Storybook's syntax palettes — the one entry the dark palette did not
-   retune — so it is 1.69:1 wherever a diff is highlighted, on the light theme
-   and on the dark one alike.
-
-   `!important` rather than more selectors: emotion styles this from the
-   highlighter's wrapper at the same specificity this rule can reach, and the
-   order its <style> is injected in relative to a static stylesheet is not
-   something to depend on. Nothing in this repository renders a diff sample
-   today; the rule is here because the palette ships broken, not because a page
-   was seen failing. */
-.sbdocs .token.deleted {
-  color: #f9535e !important; /* 4.51:1, 5.10:1 */
 }

--- a/projects/truenas-ui/src/styles/themes-storybook.css
+++ b/projects/truenas-ui/src/styles/themes-storybook.css
@@ -6,77 +6,151 @@
    in Storybook development environment.
 
    DO NOT import this file in production builds.
-   It is imported only in .storybook/preview.ts
+   `.storybook/preview-head.html` links it as `./themes.css`'s neighbour out of
+   `.storybook/public/`, which `yarn copy-themes` regenerates from this file —
+   edit this one, and `themes-css-copy.spec.ts` fails if the two drift.
+
+   WHAT THIS FILE IS FOR, AND WHAT IT IS NO LONGER FOR (#293)
+   ----------------------------------------------------------
+   Docs pages are themed by `parameters.docs.theme` in `preview.ts`, which is
+   the same `truenasTheme` object `manager.ts` gives the manager UI. That
+   parameter did not exist until #293, and its absence is not the no-op it
+   sounds like: `DocsContainer` calls `ensure(theme)`, and `ensure(undefined)`
+   returns `convert(themes.light)` — Storybook's DEFAULT LIGHT theme. So every
+   docs page rendered light-theme ink on the TrueNAS dark palette, and this
+   file had grown a list of tag selectors forcing back the elements someone
+   had noticed. `code`, `h5` and the syntax highlighter's spans were never in
+   that list: 442 failing text nodes on the Dialog docs page alone, the worst
+   at 1.16:1 against a 4.5:1 requirement.
+
+   THE RULE THAT REPLACED THE LIST
+   -------------------------------
+   Docs-page CHROME is Storybook's, and is themed through `truenasTheme`. It
+   does not follow the theme switcher, for the same reason the manager UI does
+   not — the switcher themes the COMPONENT. The only thing this file paints
+   from `--tn-*` tokens is the surface a story is rendered on.
+
+   That is not a tidiness argument. A rule setting only a `color:` from a
+   `--tn-*` token was the original bug wearing the other mask: three shipped
+   palettes are LIGHT — `.tn-blue`, `.tn-paper`, `.tn-high-contrast` — so
+   `--tn-fg2` is a dark ink, and after #293 it would have been painted on
+   chrome that is always `#282828`. Every such rule is gone. What remains sets
+   a foreground and its own background together, from the same palette, so it
+   stays self-consistent on all nine.
+
+   WHY THE OVERRIDES AT THE BOTTOM ARE A CLOSED LIST
+   -------------------------------------------------
+   `convert()` in `storybook/theming` builds `theme.color` from
+   `createColors()`, and only FOUR of those roles come from the theme object:
+   `primary`, `secondary`, `defaultText` and `inverseText`. Every other role —
+   and `red2` in both of the syntax palettes — is a constant shared by the
+   light and dark bases, so no docs theme can reach it. The overrides below are
+   derived from that function rather than noticed one at a time, which is the
+   whole difference between this list and the one it replaces.
+
+   Storybook paints docs TEXT with these unreachable roles. Measured against
+   `appContentBg` (#282828), the surface `DocsWrapper` and the syntax
+   highlighter's own wrapper both paint:
+
+     role                      value     ratio   painted on            here?
+     color.dark                #5C6570   2.49:1  h6, blockquote        yes
+     code red2 (.token.deleted) #9a050f  1.69:1  diff syntax           yes
+     color.darkest             #2E3338   1.16:1  span.frame caption    no (1)
+     color.negative            #FF4400   4.27:1  required-arg marker   no (2)
+     color.orange              #FC521F   4.47:1  story-mount error     no (2)
+     transparentize(.6, text)  ~#717171  3.02:1  argstable section     no (2,3)
+                                                 header, Typeset label
+
+   (1) reachable, but nothing here emits `span.frame` markup — a dead selector
+       would be worse than a documented omission.
+   (2) styled by emotion with a generated class and no stable hook. A selector
+       for these would be a hash that a Storybook patch release changes
+       silently, which is a worse failure than the one it fixes.
+   (3) neither renders on any docs page in this repository today: no story
+       declares `argTypes[…].table.category`, and no MDX uses `Typeset`. Both
+       are one edit away, so they are recorded rather than dismissed.
+
+   `docs-theme-contrast.spec.ts` measures every colour written in this file and
+   in `truenasTheme.js`, and fails if a rule outside the canvas selectors below
+   starts painting chrome text from a `--tn-*` token again.
    ================================ */
 
 /* ================================
-   Let's apply these variables to
-   the preview and story book docs elements
+   THE COMPONENT'S CANVAS
+   The only rules here that follow the theme switcher, because the surface a
+   story renders on is the component's and not Storybook's. Each sets its
+   foreground and its background from the same palette.
    ================================ */
 
-html, body, #storybook-docs > .sbdocs-wrapper {
+/* The preview iframe's own page. This is the story canvas outside docs; on a
+   docs page `DocsWrapper` covers it, painting `theme.background.content` at
+   `min-height: 100vh`.
+
+   `!important` predates #293 and is kept: Storybook's preview injects base
+   styles onto the document it owns, and which of the two lands last is not
+   something a static stylesheet can decide. #293 is about the docs CHROME
+   painting the wrong ink, and this rule is not that — dropping the flag here
+   would be an unrelated change to how stories render. */
+html, body {
   font-family: var(--tn-font-family-body);
   color: var(--tn-fg2) !important;
   background-color: var(--tn-bg1) !important;
 }
 
-h1, h2, h3,h4,
-.sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3,.sbdocs-title h4 {
-  font-family: var(--tn-font-family-header);
-  color: var(--tn-fg1) !important;
-}
-
-p, li, td {
-  color: var(--tn-fg2) !important;
-}
-
+/* `!important` because addon-docs paints both of these itself —
+   `getBlockBackgroundStyle(theme)` on `.sbdocs-preview`, from the docs theme —
+   and the component's surface is what should show through. */
 .docs-story,
-.sb-bar,
-.sbdocs-wrapper td,
 .sbdocs-preview {
   background-color: var(--tn-bg2) !important;
   color: var(--tn-fg2) !important;
-}
-
-thead, th {
-  background-color: var(--tn-topbar);
-  color: var(--tn-topbar-txt) !important;
-}
-
-/* Form field styles */
-input:not([role="switch"]),
-.sbdocs-wrapper select,
-.sbdocs-wrapper textarea {
-  background-color: var(--tn-bg1) !important;
-  color: var(--tn-fg2) !important;
-}
-
-.docblock-code-toggle {
-  background-color: var(--tn-btn-default-bg) !important;
-  color: var(--tn-btn-default-txt) !important;
-}
-
-.docblock-argstable-body span {
-  color: var(--tn-fg1);
-  background-color: unset;
-  border: unset;
 }
 
 .docs-story > div {
   background-color: unset;
 }
 
-.docblock-source > div {
-  background: #000000 !important;
-  color: #dedede;
-  border: unset;
+/* ================================
+   TYPEFACE
+   `create()` accepts `fontBase` and `fontCode` and has no third slot, so the
+   header face is the one typographic choice the docs theme cannot carry.
+   Colour is deliberately absent: these headings take `theme.color.defaultText`
+   (#dedede, 10.96:1 on #282828) like the rest of the docs chrome.
+   ================================ */
+h1, h2, h3, h4,
+.sbdocs-title h1, .sbdocs-title h2, .sbdocs-title h3, .sbdocs-title h4 {
+  font-family: var(--tn-font-family-header);
 }
 
-.docblock-source button {
-  background: var(--tn-bg2) !important;
-  color: var(--tn-fg2);
+/* ================================
+   THE ROLES `truenasTheme` CANNOT REACH
+   See the table in the header for the full set and why these two are the ones
+   with rules. Both values are the smallest hue-preserving lightness step off
+   Storybook's own that clears 4.5:1 on BOTH docs surfaces — the method
+   themes.css documents for `--tn-primary-text`. Ratios are against
+   `appContentBg` #282828 then `appBg` #1e1e1e.
+   ================================ */
+
+/* `theme.color.dark`, #5C6570 at 2.49:1. Scoped to the docs content and out of
+   `.sb-unstyled`, which is the class addon-docs uses to keep its own
+   typography off a rendered story — an `h6` inside a component must keep the
+   component's colour. `:where()` contributes no specificity, so this is 0,2,0
+   against the 0,1,0 of addon-docs' own `:where(h6:not(…))` rule. */
+.sbdocs-content :where(h6, blockquote):not(.sb-unstyled *) {
+  color: #86909b; /* 4.55:1, 5.14:1 */
 }
 
-.docblock-source {
-  border: solid 1px var(--tn-alt-bg2) !important;
+/* The syntax highlighter's `deleted` token. `red2` is #9a050f in BOTH of
+   Storybook's syntax palettes — the one entry the dark palette did not
+   retune — so it is 1.69:1 wherever a diff is highlighted, on the light theme
+   and on the dark one alike.
+
+   `!important` rather than more selectors: emotion styles this from the
+   highlighter's wrapper at the same specificity this rule can reach, and the
+   order its <style> is injected in relative to a static stylesheet is not
+   something to depend on. Nothing in this repository renders a diff sample
+   today; the rule is here because the palette ships broken, not because a page
+   was seen failing. */
+.sbdocs .token.deleted {
+  color: #f9535e !important; /* 4.51:1, 5.10:1 */
 }


### PR DESCRIPTION
Fixes #293

## What was wrong

`.storybook/preview.ts` never set `parameters.docs.theme`, and that is not the
no-op it sounds like. `DocsContainer` calls `ensure(theme)` on that value, and
`ensure(undefined)` returns `convert(themes.light)` — **Storybook's default
LIGHT theme, not a neutral one.** So every docs page painted its text `#2E3338`
and its code samples `#0000FF`/`#393A34` on a `#1E1E1E` page.

`themes-storybook.css` had been compensating with a list of tag selectors
forcing individual elements back to a dark colour. `code`, `h5` and the syntax
highlighter's spans were never in that list, which is the whole defect: an
allow-list that has to be extended every time the docs emit a tag nobody
thought of.

### Reproduced before it was fixed

No browser on this machine, so the reported behaviour was reproduced from the
shipped artefacts instead — which is where both halves of it live:

| what | measured |
|---|---|
| `ensure(undefined)` vs `ensure(themes.light)` | byte-identical objects |
| the applied `textColor` | `#2E3338` — the light theme's |
| on `--tn-bg2` `#282828` (`code`, table cells) | **1.16:1** |
| on `--tn-bg1` `#1E1E1E` (`h5`) | **1.31:1** |
| `.token.keyword` `#0000ff`, `.token.punctuation` `#393A34` | **1.94:1**, **1.45:1** |

Every figure in the ticket reproduces exactly.

## What changed

**1. `preview.ts` sets `docs.theme` to the same `truenasTheme` object
`manager.ts` gives the manager UI.** That is the structural fix, and `base:
'dark'` is also what selects the dark syntax palette.

**Why it is not the switched theme.** `withThemeByClassName` themes the
*component* — `--tn-*` follows it. Docs-page chrome is Storybook's own UI, and
`parameters.docs.theme` is a fixed object no global can vary, so chrome is
themed once, exactly as the manager is. Three of the nine shipped palettes are
**light**, and a docs page taking its ink from the switcher while its
background came from this theme would be #293 again with the colours swapped.

**2. `colorSecondary` moves to `#0099db`.** Storybook draws it as docs link
text (`theme.color.secondary`, eight call sites in addon-docs), and `#0095D5`
measured **4.39:1** on `appContentBg`. `#0099db` is `--tn-primary-text` from
`themes.css`, already tuned there as the smallest hue-preserving step clearing
4.5:1 on `--tn-bg1`/`--tn-bg2` — the *same pair* `appBg`/`appContentBg`
declare. 4.62:1 and 5.22:1.

This is the one change that reaches beyond the reported symptom: it also moves
the manager UI's accent. Flagged rather than buried.

**3. `themes-storybook.css` loses every rule that painted chrome text from a
`--tn-*` token,** and keeps the canvas rules — the surface a story renders on
is the component's and should follow the switcher. That is the principled cut
rather than a taste one: a rule setting only a `color:` from a token is the
original bug wearing the other mask, because on a light palette `--tn-fg2` is a
dark ink and the chrome behind it is now always `#282828`.

**Four removals reach past the chrome and into the story canvas, and all four
are deliberate.** Each was a bare-tag selector in a file `preview-head.html`
links into the **preview iframe**, so it landed inside every rendered story as
well as on the docs page it was written for. The stylesheet header names all
four rather than leaving them as unexplained removals:

- The form-field rule set a background and a foreground together, which is the
  retention criterion — but only two of its three selectors were docs chrome.
  The third, `input:not([role="switch"])`, was scoped to nothing and overrode
  every component's own SCSS with `!important`. Docs-page controls take their
  colours from the theme instead (`theme.input.color`/`.background` =
  `inputTextColor`/`inputBg`, #dedede on #1e1e1e, 12.39:1).
- `p, li, td { color: var(--tn-fg2) !important }` and the
  `color: var(--tn-fg1) !important` dropped from the `h1`–`h4` rule: text
  colour from a switcher token, which is exactly what the principle above
  forbids.
- `thead, th { background-color: var(--tn-topbar); color: var(--tn-topbar-txt)
  !important }`. **This one has a visible consequence and it is named rather
  than buried.** It was the only ambient `th` fill anywhere in `src/styles/`,
  and `month-view.component.scss` leans on exactly that — *"The header's fill
  comes from the ambient table styling, so round the outer corners of the row
  rather than painting a background of our own."* So the Calendar and Date
  Range Picker stories now render their weekday band unfilled. The component
  has never painted its own header, so a real application always looked that
  way; what the rule was doing was making Storybook look better than the
  product. Restoring it would put a switcher token back on chrome, so it is
  proposed as a follow-up ticket on the calendar instead.

What all four restore is the component's own styling on its own canvas.
Storybook Interaction Tests are green on this branch, including the
input-bearing stories.

**Why what remains is a closed list.** `convert()` builds `theme.color` from
`createColors()`, and only four roles come from the theme object: `primary`,
`secondary`, `defaultText`, `inverseText`. Everything else is a constant shared
by both bases, so no docs theme can reach it. The file's header enumerates
those leftovers *from that function* — with each one's measured ratio, what
paints it, and whether it got a rule. One role did: `color.dark`, 2.49:1, and
it renders in two places, so it has two rules (`h6`/`blockquote`, and the
argstable's object control — see below). The rest are recorded with the reason
they did not, which is that no rule has been *written* for them rather than
that none could be.

**4. The argstable's object control gets the second of those rules.** A
`control: 'object'` row shows a `{...} 3 keys` summary at rest — `JsonTree`'s
default `isCollapsed` is `(keyPath, deep) => deep !== -1` and the root is depth
0 — and `react-editable-json-tree` renders it as `<span style={collapsed}>`,
taking `theme.color.dark` #5C6570 **inline** from addon-docs'
`getCustomStyleFunction`. Six pages here declare that control: `card`,
`select`, `menu`, `radio-group`, `form-field`, `table-pager`.

Round five of the review read the deleted `.docblock-argstable-body span` rule
as what had been keeping that control readable. Half of that is right and the
mechanism is not, which decides what the fix has to be: that rule carried no
`!important`, and nothing beats an inline style without it, so **it never
painted this element on any palette.** What this change does move is the
surface underneath. `.sbdocs-wrapper td` used to fill the cell with
`--tn-bg2`, which follows the switcher, so on the three light palettes the
summary was dark ink on a light cell and read fine; it now sits on the docs
theme's `appContentBg` #282828 on all nine, at **2.49:1**. A regression on
three palettes and a pre-existing failure on the other six.

    .sbdocs-content .rejt-accordion-region > span:not(.rejt-not-collapsed-delimiter)

`.rejt-accordion-region` is a class addon-docs writes by hand in
`JsonNodeAccordion`, not an emotion hash, which is what makes it a hook by the
same standard the header's other entries are judged against. `!important` is
not a specificity choice here and cannot be traded for a longer selector. The
`:not()` keeps the rule off the `[`/`]` delimiters an expanded node draws:
those carry no inline colour, inherit `defaultText` at 10.96:1, and would be
*downgraded* by being repainted.

**5. `docs-theme-contrast.spec.ts`** measures those colours and the wiring that
chooses them. It reads `truenasTheme.js`, `preview.ts`, `manager.ts` and the
stylesheet as **text**, so all four are stripped of comments first: a
commented-out `docs:` block or a superseded hex left above a live one is
otherwise indistinguishable from shipped code to every regex in the file.

### Why this check and not a `test-sb` assertion

The ticket asked for one and said to justify the other. In order of weight:

- The test runner drives **stories**; what it could then assert is axe's
  `color-contrast` over whatever nodes a page happens to render. Every number
  here is about the **theme**, so it holds for pages nobody has written yet —
  which is exactly how `h5` and `code` were missed the first time.
- It would measure a page instead of the cause. A page reading correctly is
  compatible with `parameters.docs.theme` having been deleted and the tag list
  having grown back — the state #293 started from. The first cases here fail on
  that directly.
- `yarn test-sb` needs a browser, and this repo's four existing contrast specs
  have already settled on measuring shipped values (see `contrast-testing.ts`
  on why jsdom cannot decide axe's rule). This is the same claim in the same
  shape, one stylesheet over.

## Review rounds

Five local rounds, plus two rounds of the required PR review.

Rounds one and two each found **one MEDIUM, and both were assertions in the new
spec that could not fail** — `!selector.includes('}')` over a parser whose
capture cannot hold a `}`, then `toHaveLength(A.length * B.length)` over lists
that produced the thing being counted. Both are fixed and **each replacement
was verified red by probe** (nesting a rule; dropping two surface keys). Round
three returned nothing at MEDIUM or above.

**The PR review's first round found a third assertion in the same family, and
this is the interesting one.** The stylesheet had its comments stripped
everywhere it was parsed; the three JavaScript sources read as text never did.
So commenting
out `parameters.docs.theme` while debugging left the wiring case green over
docs pages that had fallen back to `ensure(undefined)` — #293 itself, reported
as passing — and a superseded value left above a live one would be measured
instead of the shipped one, because `themeValue` returns the first match.
`truenasTheme.js` already carries old hexes in trailing comments, so that is
the file's habit, not a hypothetical.

Fixed by stripping comments once at read time, and **verified in both
directions by probe**: commenting out the `docs:` block fails `preview.ts sets
parameters.docs.theme`, and `// textColor: '#333333',` above the live line
still measures `#dedede`. Round four then returned nothing at MEDIUM or above.

That pattern is worth stating plainly: a spec written to catch silent coverage
loss has now contained three instances of the silent coverage loss it was
written to catch, and the third survived three clean-ish rounds of its own
review.

Four LOW findings about **prose that no longer described the code beside it**
were also corrected, since a comment that states the opposite of its code is a
defect the reviewer happened to score low: the spec's claim that
`inputTextColor` paints only the manager, its claim that an emptied `literals`
list would pass silently (`it.each([])` throws), the stylesheet header's claim
that the argstable offers no hook a selector can hold (a rule *this change
deletes* was one), and its table-link audit naming two MDX files where three
ship tables. No rule, case or measured value changed with them.

**The PR review's second round returned one HIGH** — the argstable object
control — which is change 4 above. Its finding and its proposed mechanism
differ, and the difference is stated there rather than quietly worked around:
the deleted rule could not have been what kept that control readable, because
the colour it fights is inline. The regression is real anyway, by a different
route, so the fix lands.

**Round five, local, then returned nothing at MEDIUM or above**, which ends the
work. It did return three LOWs; two are recorded under *Not changed* below, and
the third is corrected because it made this diff's own documentation false —
the stylesheet header claimed the `input` rule was the only removal reaching
the story canvas, when three more had the same shape and one of them has a
visible consequence. That correction is prose only: no selector, case or
measured value moved with it.

## Checks run locally

From the earlier rounds, on the full diff:

- `yarn lint` — clean
- `yarn test` — 4089 passed, 145 suites
- `yarn test:scripts` — 42 passed
- `yarn build` — clean
- `yarn build-storybook` — clean (this is what verifies `preview.ts` compiles
  and the theme import resolves)

This round added a stylesheet rule and changed three places in the spec, so it
re-ran the full set rather than a subset:

- `yarn lint` — clean
- `yarn test` — **4092 passed, 145 suites**
- `yarn test:scripts` — 42 passed
- `yarn build` — clean

`.storybook/public/themes-storybook.css` was regenerated with `yarn
copy-themes`, which is what `themes-css-copy` checks. `yarn build-storybook`
was not re-run: nothing in this round touches `preview.ts`, `manager.ts` or
`truenasTheme.js`, which is what that job verifies compiles.

**`yarn test-sb` could not be run here.** This host has no browser: chromium
needs ten system libraries that are absent, and `/` is mounted read-only so no
package can supply them. **Nothing in this change has been seen rendered by
me** — the CI Storybook Interaction Tests job is the first place that happens,
and it is green on this branch. The layout consequences of removing the old
`!important` rules have been reasoned about against addon-docs' source rather
than observed.

## Not changed, and why

Findings from the local rounds and the PR review that are real and deliberately
out of scope. All were verified against `node_modules`. The ones about a colour
are recorded in the code beside the thing they concern as well as here; the
ones about what the new spec *asserts* are here only, because acting on any of
them widens the suite's coverage and that is a change needing a review round of
its own:

- **The Calendar and Date Range Picker weekday band renders unfilled in
  Storybook** now that the `thead, th` rule is gone. Explained in full under
  change 3. It is a real defect in `month-view.component.scss` — the component
  has never painted its own header — that this change uncovers rather than
  causes, so it is proposed as its own ticket rather than patched from a
  Storybook-only stylesheet.
- **A link inside a docs markdown table would be 2.72:1.** Even `tr`s are
  filled with `color.darker` (#454C54), a constant. Body text there is 6.46:1.
  Three MDX files ship tables — `theming.mdx`, `icon-system.mdx` and
  `design-system-proposal-v2.mdx` — and no cell in any of them holds a link.
- **`colorSecondary` reads 4.36:1 inside `Expandable`,** which washes its own
  background. Needs a `type.detail` that docgen would supply, and compodoc is
  off in `angular.json`.
- **The required-arg marker (4.27:1) and the story-mount error (4.47:1)** are
  emotion-styled with generated classes.
- **The argstable section header and `Typeset` label** composite to ~3.02:1 at
  40% opacity — unfixable by any `textColor`, since 40% of even pure white on
  `#282828` tops out around 3.6:1. Neither renders here: no story declares
  `argTypes[…].table.category` and no MDX uses `Typeset`.
- **`.token.deleted` (1.69:1) has a stable hook and still got no rule.** An
  override was written and then removed: this Storybook registers eleven Prism
  grammars and `diff` is not among them, so nothing can emit that token and the
  selector would have been dead — and the `!important` would also have forced
  the colour into a `<Source dark={false}>` block, which is white.
- **The `h1`–`h4` `font-family` rule does not reach docs headings.** The
  declaration predates this change and stays (its `color` did not — see change
  3); addon-docs styles those elements at 0,1,0 and spreads a reset setting
  `fontBase`, so the 0,0,1 rule loses. The comment now says that rather than
  the opposite.
- **`PAINTING_PROPERTIES` is narrower than the two claims built on it** (LOW,
  PR review). `border-color`, `outline-color`, `background-image`, `fill` and
  `box-shadow` also put colour on the page and are in neither the pinned
  selector list nor the literal-hex measurement, so a `border-color: #333` on
  a docs selector added later would not be caught. The token half does not
  have this hole — it filters by exclusion. Adding the five names is a change
  to what the suite asserts and belongs in its own round.
- **The `.sbdocs-title h1`–`h4` half of the typeface rule matches nothing**
  (LOW, local round). addon-docs' `Title` renders `className="sbdocs-title"`
  *on* the `h1`, so a descendant selector under it has no target. Those
  selectors predate this change and removing them is a stylesheet edit rather
  than a comment fix.
- **`html, body` sets `color` from `--tn-fg2` with `!important`, and nothing
  between `body` and the docs content re-anchors it** (LOW, local round and PR
  review). Any chrome text addon-docs does not colour explicitly would inherit
  it, which on a light palette is dark ink on `#282828`. Nothing observed falls
  into that gap — addon-docs colours its text nodes from the theme — and
  finding one needs the rendered page this host cannot produce, so it is
  recorded rather than guessed at.
- **`textMutedColor` is a settable `create()` key that `TEXT_KEYS` does not
  measure** (LOW, round five). The spec's completeness argument reasons over
  `theme.color.*`, which `convert()` rebuilds from `createColors()`;
  `textMutedColor` survives as a top-level key instead, and addon-docs paints
  it on the argstable's column headers. No failure today —
  `truenasTheme.js` does not set it, so it inherits `themes.dark`'s `#95999D`
  at 5.14:1 on `#282828` — but setting it later would go unmeasured. Adding it
  to `TEXT_KEYS` changes what the suite asserts and belongs in its own round.
- **`barTextColor` is excluded from `TEXT_KEYS` while `barBg` is in
  `SURFACE_KEYS`, and `barBg` may not be a docs surface at all** (two LOWs, PR
  review and round five). `theme.background.bar` appears nowhere in
  addon-docs; the docs Canvas action bar uses `background.content`. Since
  `barBg` and `appContentBg` are both `#282828` here, the three `barBg` cases
  are exact duplicates of the `appContentBg` ones — harmless, and conservative
  in the safe direction, but the docblock calling it "the canvas toolbar" is
  more than has been shown. Resolving it means removing a surface from the
  measured set, which is a coverage change and its own round.
- **The literal-hex measurement only matches `#rrggbb`** (LOW, PR review). A
  second override written as `rgb(...)` or `hsl(...)` would be skipped by
  `literalCases` even though `contrastRatio` parses `rgb()` fine. Same family
  as the `PAINTING_PROPERTIES` entry above, and the same reason for deferring:
  widening it changes what the suite asserts.

## Also of note

`docs/component_styling.md` gains a subsection under Themes. Without it the
next cycle handed a docs-contrast report would add another tag to
`themes-storybook.css` — which is the one fix that is wrong here, and the
reason the file had 442 failing text nodes behind it.
