### PR TITLE
NAS-142550 / 27.0.0-BETA.1 / refactor(a11y): extract the per-palette contrast spec harness

### DIFF
--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -669,9 +669,11 @@ that makes a failing colour look passing.
 
 **`themePalettes(css)` reads the tokens; `contrast()` measures one against the
 surface it renders on.** That pairing — a token and the background behind it — is
-the form every one of those scripts actually needed. Pass the text of
-`styles/themes.css`; the module takes CSS rather than reading the file, so the
-resolution rules can be covered against a fixture that no theme retune breaks.
+the form every one of those scripts actually needed. The module takes CSS text
+rather than reading the file, so the resolution rules can be covered against a
+fixture that no theme retune breaks — and so nothing in it depends on Node. A
+spec measuring the shipped palette does not call it with a path of its own; see
+the next section.
 
 **`declares()` and `color()` answer different questions.** `color()` resolves the
 way the browser does, following `var()` chains and inheriting from `:root`;
@@ -695,6 +697,48 @@ layout engine to find what is actually painted behind an element; under jsdom it
 reports `incomplete`, which `axeResult()` treats as an error. What these
 assertions measure is the palette as shipped, against the surface the spec names.
 See `theme/error-text-contrast.spec.ts` for the shape.
+
+### Measuring the shipped palette in every theme
+
+**Use `lib/a11y/palette-contrast-testing.ts`. Do not read `themes.css` yourself
+and do not write the loop again.** #197 shared the arithmetic and the duplication
+moved up one level: nine specs each read the stylesheet, cross-checked what they
+found against the theme registry, dropped the palettes missing a token, and then
+looped palette × token × surface. Review counted the copies twice unprompted, on
+PR #264 and again on PR #281 (#295).
+
+**Three calls, in this order.** They declare cases as well as returning data, so
+call them in the `describe` body:
+
+```ts
+const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
+testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
+```
+
+- `itMeasuresEveryRegisteredPalette()` loads the stylesheet and holds what it
+  finds to `TN_THEME_DEFINITIONS`. Getting the palettes and being held to the
+  registry is deliberately one call: a theme that stops being recognised — a
+  renamed class, a block that drops `--tn-bg1` — otherwise goes unmeasured while
+  every remaining case still passes.
+- `itDeclares(palettes, tokens)` asserts each palette declares them **itself**,
+  and returns the ones that do. One list, asserted and filtered on, so a palette
+  dropping out of the cases below always leaves something red.
+- `testEachPalette(palettes, pairings, minimum)` measures each
+  `{ token, surface, where? }` on each palette, one case and one message format
+  apiece. `minimum` is a ratio, not a text size: pass `AA_MINIMUM.normal` for body
+  text and the 3:1 SC 1.4.11 floor for a fill, a border or an icon.
+
+**`THEME_STYLESHEET` is the one place that decides which copy is measured.**
+`.storybook/public/themes.css` is a tracked copy that Storybook serves, and
+`theme/themes-css-copy.spec.ts` is what keeps the two byte-identical. A spec
+holding its own path is how one comes to measure the copy the library does not
+render from.
+
+**A spec whose exclusions are per palette keeps its own loop and uses
+`paletteContrastCases` instead** — `theme/text-token-surface-contrast.spec.ts`
+excuses individual (palette, token, surface) triples through `KNOWN_GAPS`, which
+is not something a per-pairing list can express. It still takes the loader and the
+registry cases from here.
 
 ### Reading a stylesheet back in a spec
 

--- a/docs/component_conventions.md
+++ b/docs/component_conventions.md
@@ -734,11 +734,12 @@ testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
 holding its own path is how one comes to measure the copy the library does not
 render from.
 
-**A spec whose exclusions are per palette keeps its own loop and uses
-`paletteContrastCases` instead** — `theme/text-token-surface-contrast.spec.ts`
-excuses individual (palette, token, surface) triples through `KNOWN_GAPS`, which
-is not something a per-pairing list can express. It still takes the loader and the
-registry cases from here.
+**A spec whose exclusions are per palette calls `paletteContrastCases` and
+declares its own cases** — `theme/text-token-surface-contrast.spec.ts` excuses
+individual (palette, token, surface) triples through `KNOWN_GAPS`, which a
+per-pairing list cannot express. That gets the same palette × pairing walk
+without the case `testEachPalette` would declare, so the loop is still written
+once.
 
 ### Reading a stylesheet back in a spec
 

--- a/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.spec.ts
@@ -7,6 +7,8 @@ import {
   registeredSelectors,
   THEME_STYLESHEET,
 } from './palette-contrast-testing';
+import * as paletteContrastTesting from './palette-contrast-testing';
+import * as publicApi from '../../public-api';
 import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
@@ -42,6 +44,31 @@ const FIXTURE = `
     --tn-fg1: #ffffff;
   }
 `;
+
+/**
+ * The docblock in `palette-contrast-testing.ts` says this module must not be
+ * exported, and this is what holds it to that — the same guard
+ * `contrast-testing.spec.ts` and `axe-testing.spec.ts` carry, and it matters
+ * more here. Those two are merely useless to a consumer; this one imports `fs`,
+ * so an `export * from './lib/a11y/palette-contrast-testing'` added to
+ * `public-api.ts` by the same reflex that exported `icon-testing` and
+ * `toast-testing` would pull a Node builtin into the ng-packagr build. Nothing
+ * in this repository would fail — the library builds, and the break lands on
+ * whoever bundles the package for a browser.
+ *
+ * The names are derived from the module rather than restated, for the reason
+ * `axe-testing.spec.ts` gives: a guard keyed to a string literal covers one name
+ * and not the module, and both a rename and a second export walk out from under
+ * it without breaking anything. `Object.hasOwn` rather than `in`, so a
+ * public-api export named after an `Object.prototype` key does not fail this for
+ * a reason unrelated to the claim.
+ */
+describe('palette-contrast-testing is not part of the public API', () => {
+  it('exports nothing that public-api.ts also exports', () => {
+    expect(Object.keys(publicApi).filter((name) => Object.hasOwn(paletteContrastTesting, name)))
+      .toEqual([]);
+  });
+});
 
 describe('palette-contrast-testing', () => {
   describe('THEME_STYLESHEET', () => {

--- a/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.spec.ts
+++ b/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.spec.ts
@@ -1,0 +1,168 @@
+import { existsSync } from 'fs';
+import { themePalettes } from './contrast-testing';
+import {
+  missingTokens,
+  paletteContrastCases,
+  registeredPalettes,
+  registeredSelectors,
+  THEME_STYLESHEET,
+} from './palette-contrast-testing';
+import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
+
+/**
+ * The pure half of `palette-contrast-testing.ts`: the loader, the registry list,
+ * and the two functions the case-declaring wrappers are built on.
+ *
+ * `itMeasuresEveryRegisteredPalette`, `itDeclares` and `testEachPalette` are not
+ * exercised here — they call `it` and `expect`, so testing them would mean
+ * running a jest runner inside a jest runner. They are covered by the nine specs
+ * that call them: every one fails loudly if the cases stop being declared, and
+ * that is the property worth protecting. What IS tested here is everything those
+ * three do besides declaring a case, because that is where a wrong answer would
+ * be silent.
+ *
+ * Fixture CSS rather than `themes.css` wherever the answer would otherwise
+ * depend on colours that are free to change — the same rule
+ * `contrast-testing.spec.ts` follows.
+ */
+
+/**
+ * Two palettes, three tokens, chosen so every ratio below is one anybody can
+ * check by hand: black on white is 21:1, and mid-grey #767676 on white is
+ * 4.54:1.
+ */
+const FIXTURE = `
+  :root {
+    --tn-bg1: #ffffff;
+    --tn-fg1: #000000;
+    --tn-fg2: #767676;
+  }
+  .tn-dark {
+    --tn-bg1: #000000;
+    --tn-fg1: #ffffff;
+  }
+`;
+
+describe('palette-contrast-testing', () => {
+  describe('THEME_STYLESHEET', () => {
+    it('is the copy under src/styles, which is the one the library builds from', () => {
+      // `.storybook/public/themes.css` is the other copy and it is build output.
+      // A spec measuring that one would report on a palette this library does
+      // not render from; `theme/themes-css-copy.spec.ts` is what keeps the two
+      // byte-identical, and this is the decision that file is the other half of.
+      expect(THEME_STYLESHEET.split(/[\\/]/).slice(-2)).toEqual(['styles', 'themes.css']);
+    });
+
+    it('exists', () => {
+      // A path that has stopped resolving would otherwise surface as nine specs
+      // failing to collect with an ENOENT naming a file nobody moved on purpose.
+      expect(existsSync(THEME_STYLESHEET)).toBe(true);
+    });
+  });
+
+  describe('registeredSelectors', () => {
+    it('is :root followed by one class selector per registered theme', () => {
+      expect(registeredSelectors()).toEqual([
+        ':root',
+        ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`),
+      ]);
+    });
+
+    it('grows with the theme registry rather than with a list kept here', () => {
+      // The property the nine specs rely on: a palette added to
+      // TN_THEME_DEFINITIONS is measured with no spec edit at all.
+      expect(registeredSelectors()).toHaveLength(TN_THEME_DEFINITIONS.length + 1);
+    });
+  });
+
+  describe('registeredPalettes', () => {
+    it('finds exactly the registered surfaces in the shipped stylesheet', () => {
+      // Sorted both sides: this is about the SET, and the stylesheet's own order
+      // is not something a palette spec should be pinning.
+      expect(registeredPalettes().map((palette) => palette.selector).sort())
+        .toEqual([...registeredSelectors()].sort());
+    });
+  });
+
+  describe('missingTokens', () => {
+    const [root, dark] = themePalettes(FIXTURE);
+
+    it('is empty when the palette declares all of them', () => {
+      expect(missingTokens(root, ['--tn-bg1', '--tn-fg1', '--tn-fg2'])).toEqual([]);
+    });
+
+    it('names the ones the palette does not declare, in the order asked', () => {
+      expect(missingTokens(dark, ['--tn-fg2', '--tn-bg1', '--tn-nothing']))
+        .toEqual(['--tn-fg2', '--tn-nothing']);
+    });
+
+    it('counts a token inherited from :root as missing', () => {
+      // The whole reason this asks `declares` rather than `color`: `.tn-dark`
+      // resolves `--tn-fg2` perfectly well, to a value tuned for a white
+      // background. A theme quietly inheriting a colour chosen for a different
+      // surface is the defect, not the fallback working.
+      expect(dark.color('--tn-fg2')).toBe('#767676');
+      expect(missingTokens(dark, ['--tn-fg2'])).toEqual(['--tn-fg2']);
+    });
+  });
+
+  describe('paletteContrastCases', () => {
+    const palettes = themePalettes(FIXTURE);
+
+    it('measures every pairing on every palette', () => {
+      const cases = paletteContrastCases(palettes, [
+        { token: '--tn-fg1', surface: '--tn-bg1' },
+        { token: '--tn-fg1', surface: '--tn-bg1', where: 'again' },
+      ]);
+      expect(cases).toHaveLength(palettes.length * 2);
+    });
+
+    it('carries both colours, the ratio and its label', () => {
+      const [measured] = paletteContrastCases(palettes, [
+        { token: '--tn-fg2', surface: '--tn-bg1' },
+      ]);
+      expect(measured).toEqual({
+        selector: ':root',
+        token: '--tn-fg2',
+        colour: '#767676',
+        surface: '--tn-bg1',
+        surfaceColour: '#ffffff',
+        ratio: expect.closeTo(4.54, 2),
+        ratioLabel: '4.54:1',
+        note: '',
+      });
+    });
+
+    it('resolves each pairing against the palette it is measured on', () => {
+      // The point of the whole harness: `--tn-fg1` on `--tn-bg1` is black on
+      // white in one palette and white on black in the other, and both are 21:1.
+      const cases = paletteContrastCases(palettes, [{ token: '--tn-fg1', surface: '--tn-bg1' }]);
+      expect(cases.map(({ selector, colour, surfaceColour, ratioLabel }) =>
+        `${selector} ${colour} on ${surfaceColour} ${ratioLabel}`)).toEqual([
+        ':root #000000 on #ffffff 21.00:1',
+        '.tn-dark #ffffff on #000000 21.00:1',
+      ]);
+    });
+
+    it('makes `where` a note ready to append to a case title', () => {
+      const [measured] = paletteContrastCases(palettes, [
+        { token: '--tn-fg1', surface: '--tn-bg1', where: 'the page canvas' },
+      ]);
+      expect(measured.note).toBe(' — the page canvas');
+    });
+
+    it('throws, naming the palette and the token, when a pairing cannot be resolved', () => {
+      // Rather than reaching the maths as `NaN` — `NaN >= 4.5` is silently
+      // `false`, which reads as a contrast failure rather than as the typo it is.
+      expect(() => paletteContrastCases(palettes, [
+        { token: '--tn-not-a-token', surface: '--tn-bg1' },
+      ])).toThrow('--tn-not-a-token');
+    });
+
+    it('is empty when there is nothing to pair', () => {
+      // What `testEachPalette`'s "there are pairings to measure" case is about.
+      expect(paletteContrastCases(palettes, [])).toEqual([]);
+      expect(paletteContrastCases([], [{ token: '--tn-fg1', surface: '--tn-bg1' }])).toEqual([]);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.ts
@@ -1,0 +1,273 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { ThemePalette} from './contrast-testing';
+import { formatRatio, themePalettes } from './contrast-testing';
+import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
+
+/**
+ * The per-palette half of a contrast spec: which stylesheet is measured, which
+ * themed surfaces have to be found in it, and the case that measures one token
+ * on one surface in every one of them.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * #197 moved the WCAG maths and the theme-token lookup into
+ * `contrast-testing.ts`, and the duplication moved up one level rather than
+ * going away. What each spec still assembled for itself was the harness around
+ * that arithmetic: read `themes.css`, cross-check the palettes found in it
+ * against the theme registry, drop the ones missing a token, then loop palette ×
+ * token × surface and assert. Review counted the copies twice without being
+ * asked — on PR #264 ("this block is now the fourth verbatim copy of the same
+ * harness"), and again on PR #281 five days later. Nine spec files carried it
+ * when this was written (#295).
+ *
+ * Four independent loops are four chances to miss a palette or assert against
+ * the wrong surface, which is the class of defect #197 was filed to prevent, one
+ * layer up from where that fix landed.
+ *
+ * WHY THESE FUNCTIONS DECLARE CASES RATHER THAN RETURNING DATA
+ * ------------------------------------------------------------
+ * `itMeasuresEveryRegisteredPalette` and `itDeclares` call `it` themselves and
+ * hand back what they measured. A spec that reads the palettes WITHOUT the
+ * registry cases is precisely the hole this exists to close — a theme that stops
+ * being recognised, because its class was renamed or its block dropped
+ * `--tn-bg1`, goes unmeasured while every remaining case still passes — so
+ * getting the palettes and being held to the registry is deliberately one call
+ * rather than two a spec can do half of.
+ *
+ * The pure halves are exported separately (`missingTokens`,
+ * `paletteContrastCases`) so that `palette-contrast-testing.spec.ts` can assert
+ * on them without a jest runner inside a jest runner.
+ *
+ * WHAT THIS IS NOT
+ * ----------------
+ * Not the arithmetic — that is `contrast-testing.ts`, and nothing here
+ * re-derives any of it. Not a stylesheet parser — that is `scss-testing.ts`.
+ *
+ * Not a home for every contrast case. `testEachPalette` measures a THEME TOKEN
+ * on a THEME SURFACE, which is the shape eight of the nine specs needed.
+ * `chip-contrast.spec.ts` and `inline-code-contrast.spec.ts` also measure
+ * literals and translucent washes composited over a surface, and they keep their
+ * own case builders for those while using the loader and the registry cases from
+ * here.
+ *
+ * Not exported from `public-api.ts`, and must not be — the same rule as
+ * `contrast-testing.ts` and `axe-testing.ts`. These assertions are about this
+ * library's own palette and no consumer has a use for them.
+ *
+ * THIS ONE ALSO READS THE FILESYSTEM AND CALLS `it`, which the other two do not,
+ * so the rule is sharper here than it is for them. `contrast-testing.ts` takes
+ * the stylesheet TEXT precisely so that nothing in it depends on Node; deciding
+ * WHICH file that text comes from is this module's whole job, so the `fs` import
+ * lands here and nowhere else. Nothing a browser bundles may import it —
+ * `ng-packagr` builds from `public-api.ts` and Storybook builds from the stories,
+ * so neither reaches this today, and exporting it from either is what would
+ * break them.
+ */
+
+/**
+ * The stylesheet every palette spec measures, named ONCE.
+ *
+ * `.storybook/public/themes.css` is a tracked copy of this file, and it is the
+ * one Storybook serves — so a spec reaching for the copy would report on a
+ * palette the library does not render from, and a spec reaching for this one
+ * while the copy had drifted would report on a palette Storybook does not show.
+ * Neither is a judgement call a spec should be making on its own, which is why
+ * the path is here and not in nine `const STYLES_DIR` lines.
+ *
+ * What keeps the two the same file is `theme/themes-css-copy.spec.ts`, which
+ * asserts they are byte-identical and names `yarn copy-themes` as the fix. This
+ * constant is the other half of that arrangement: one decision about which copy
+ * is authoritative, and one case holding the other to it.
+ */
+export const THEME_STYLESHEET = join(__dirname, '../../styles/themes.css');
+
+/**
+ * Every themed surface declared in `THEME_STYLESHEET`, in the order they appear.
+ *
+ * Prefer `itMeasuresEveryRegisteredPalette`, which is this plus the cases that
+ * hold the result to the theme registry.
+ */
+export function registeredPalettes(): ThemePalette[] {
+  return themePalettes(readFileSync(THEME_STYLESHEET, 'utf8'));
+}
+
+/**
+ * The selector each registered theme renders under, `:root` first.
+ *
+ * Derived from `TN_THEME_DEFINITIONS` rather than listed, so that adding a
+ * palette needs no spec edit — and so that a palette which stops being
+ * recognised fails rather than quietly leaving every remaining case passing.
+ */
+export function registeredSelectors(): string[] {
+  return [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+}
+
+/**
+ * The palettes in `THEME_STYLESHEET`, held to the theme registry by two cases
+ * this declares.
+ *
+ * The first compares the whole list both ways at once, so a palette that has
+ * gone missing and one that has appeared unregistered both name themselves. The
+ * second is per selector, so a failure sits under the theme it is about rather
+ * than only in the diff of a list.
+ *
+ * Call it inside a `describe` body, at collection time — which is where a spec
+ * builds its cases anyway, since a case title carrying a measured ratio has to
+ * be built before the case runs.
+ */
+export function itMeasuresEveryRegisteredPalette(): ThemePalette[] {
+  const palettes = registeredPalettes();
+  const expected = registeredSelectors();
+
+  it('found every registered themed surface in themes.css', () => {
+    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expected].sort());
+  });
+
+  it.each(expected)('%s is a themed surface found in themes.css', (selector) => {
+    expect(palettes.map((palette) => palette.selector)).toContain(selector);
+  });
+
+  return palettes;
+}
+
+/**
+ * Which of `tokens` this palette does not declare ITSELF.
+ *
+ * Not the same question as whether the token resolves: a theme that omits one
+ * still renders, inheriting `:root`'s value — a colour chosen for different
+ * backgrounds. Every caller here wants the stricter question, because a token
+ * that is tuned per theme falling back to `:root` is the defect rather than the
+ * fallback working.
+ */
+export function missingTokens(palette: ThemePalette, tokens: readonly string[]): string[] {
+  return tokens.filter((token) => !palette.declares(token));
+}
+
+/**
+ * Declares the case holding every palette to `tokens`, and returns the ones fit
+ * to measure.
+ *
+ * ONE list, asserted and filtered on. A palette dropping out of the returned set
+ * is therefore always accompanied by a failing case here — filtering on a wider
+ * set than the assertion covers is how a palette leaves the contrast cases with
+ * nothing red anywhere.
+ *
+ * The title is built from the list rather than spelling it out, so a token added
+ * to a spec's `REQUIRED_TOKENS` cannot leave the case name describing the old
+ * set.
+ */
+export function itDeclares(
+  palettes: readonly ThemePalette[],
+  tokens: readonly string[],
+): ThemePalette[] {
+  const declarations = palettes.map((palette) => ({
+    selector: palette.selector,
+    missing: missingTokens(palette, tokens),
+  }));
+
+  it.each(declarations)(`$selector declares ${tokens.join(', ')} itself`, ({ missing }) => {
+    expect(missing).toEqual([]);
+  });
+
+  return palettes.filter((palette) => missingTokens(palette, tokens).length === 0);
+}
+
+/** A theme token painted on a theme surface, and what puts it there. */
+export interface ContrastPairing {
+  /** The token painted. */
+  readonly token: string;
+  /** The token naming the surface it is painted on. */
+  readonly surface: string;
+  /**
+   * What paints it there, or the role the token plays. Appended to the case
+   * title, so a failure says which call site it is about rather than only which
+   * two tokens.
+   */
+  readonly where?: string;
+}
+
+/** One measured pairing on one palette, with everything its case title needs. */
+export interface PaletteContrastCase {
+  selector: string;
+  token: string;
+  colour: string;
+  surface: string;
+  surfaceColour: string;
+  ratio: number;
+  ratioLabel: string;
+  /** `where`, ready to concatenate — empty when the pairing named none. */
+  note: string;
+}
+
+/**
+ * Every `pairing` measured on every palette, built outside the cases.
+ *
+ * Outside because the case titles carry the measured ratio, and a title is
+ * needed before the case runs. A token that resolves to nothing, or to something
+ * that is not a colour, therefore throws while the file is collecting — naming
+ * the palette and the token, rather than reaching the maths as `NaN` and failing
+ * a contrast case for a reason that has nothing to do with contrast.
+ */
+export function paletteContrastCases(
+  palettes: readonly ThemePalette[],
+  pairings: readonly ContrastPairing[],
+): PaletteContrastCase[] {
+  return palettes.flatMap((palette) => pairings.map((pairing) => {
+    const ratio = palette.contrast(pairing.token, pairing.surface);
+    return {
+      selector: palette.selector,
+      token: pairing.token,
+      colour: palette.color(pairing.token),
+      surface: pairing.surface,
+      surfaceColour: palette.color(pairing.surface),
+      ratio,
+      ratioLabel: formatRatio(ratio),
+      note: pairing.where === undefined ? '' : ` — ${pairing.where}`,
+    };
+  }));
+}
+
+/**
+ * Declares one case per palette per pairing: this token, on this surface, clears
+ * `minimum`.
+ *
+ * ONE failure-message format for all of them. The measured ratio and both
+ * colours are in the title, so a failure names the palette, the pair and the
+ * number it came to; the assertion is `toBeGreaterThanOrEqual`, so the failure
+ * output carries the floor it missed by rather than "expected true".
+ *
+ * `minimum` is a ratio rather than a `TextSize` because not every caller is
+ * asking about text: pass `AA_MINIMUM.normal` for body text, `AA_MINIMUM.large`
+ * for 18pt and up, and the 3:1 non-text floor for a fill, a border or a focus
+ * ring. Whichever it is, the constant belongs in the calling spec, next to the
+ * sentence explaining why that threshold is the right one for those call sites.
+ *
+ * Compared unrounded, as `contrast-testing.ts` insists: a pair measuring 4.4999
+ * does not clear AA, however it formats.
+ */
+export function testEachPalette(
+  palettes: readonly ThemePalette[],
+  pairings: readonly ContrastPairing[],
+  minimum: number,
+): void {
+  const cases = paletteContrastCases(palettes, pairings);
+
+  it('there are pairings to measure', () => {
+    // `it.each` on an empty table is a jest collection error, which says only
+    // that the table was empty. This says which of the two inputs was: a spec
+    // whose palettes were all filtered out, or one whose pairing list is empty.
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  if (cases.length === 0) {
+    return;
+  }
+
+  it.each(cases)(
+    '$selector: $token ($colour) on $surface ($surfaceColour) measures $ratioLabel$note',
+    ({ ratio }) => {
+      expect(ratio).toBeGreaterThanOrEqual(minimum);
+    }
+  );
+}

--- a/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.ts
+++ b/projects/truenas-ui/src/lib/a11y/palette-contrast-testing.ts
@@ -37,7 +37,11 @@ import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
  *
  * The pure halves are exported separately (`missingTokens`,
  * `paletteContrastCases`) so that `palette-contrast-testing.spec.ts` can assert
- * on them without a jest runner inside a jest runner.
+ * on them without a jest runner inside a jest runner — and so that a spec whose
+ * exclusions the shared case cannot express still gets the walk rather than
+ * writing a tenth copy of it. `text-token-surface-contrast.spec.ts` is that
+ * spec: `KNOWN_GAPS` excuses individual (palette, token, surface) triples, which
+ * a per-pairing list has no way to say.
  *
  * WHAT THIS IS NOT
  * ----------------
@@ -254,9 +258,11 @@ export function testEachPalette(
   const cases = paletteContrastCases(palettes, pairings);
 
   it('there are pairings to measure', () => {
-    // `it.each` on an empty table is a jest collection error, which says only
-    // that the table was empty. This says which of the two inputs was: a spec
-    // whose palettes were all filtered out, or one whose pairing list is empty.
+    // Nothing to measure is not a passing suite, and `it.each` on an empty table
+    // is a jest COLLECTION error — it takes the whole file down before the cases
+    // above it are reported, so the declaration failure that emptied the palette
+    // list is never shown. This reports it as one ordinary red case instead,
+    // underneath the ones that say why.
     expect(cases.length).toBeGreaterThan(0);
   });
 

--- a/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/chip/chip-contrast.spec.ts
@@ -6,8 +6,12 @@ import {
   contrastRatio,
   formatRatio,
   meetsAa,
-  themePalettes,
 } from '../a11y/contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  registeredSelectors,
+} from '../a11y/palette-contrast-testing';
 import type { ScssRule } from '../a11y/scss-testing';
 import {
   flattenSelector,
@@ -15,7 +19,6 @@ import {
   scssRules,
   tokenOf,
 } from '../a11y/scss-testing';
-import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
 
 /**
  * Every surface `tn-chip` paints, measured against the label it paints on it,
@@ -59,7 +62,6 @@ import { TN_THEME_DEFINITIONS } from '../theme/theme.constants';
  * `--tn-error-text`.
  */
 
-const STYLES_DIR = join(__dirname, '../../styles');
 const CHIP_SCSS = join(__dirname, 'chip.component.scss');
 
 /**
@@ -256,20 +258,17 @@ function tally(pairings: readonly string[]): Record<string, number> {
 }
 
 describe('tn-chip label contrast (#238)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
   const scss = readFileSync(CHIP_SCSS, 'utf8');
-  const palettes = themePalettes(css);
   const rules = scssRules(scss, 'chip.component.scss');
+  const expectedSelectors = registeredSelectors();
 
-  // Derived from the theme registry rather than hardcoded: a themed surface
-  // that stops being recognised — a renamed class, a block that drops
-  // `--tn-bg1` — would otherwise go unmeasured while every remaining case
-  // still passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expectedSelectors].sort());
-  });
+  // Inheriting `:root`'s value is not the same as having one: High Contrast
+  // rendered white on its own #4784ac at 4.07:1 for exactly that reason, and
+  // `color` would have resolved it and reported a number without complaint. Only
+  // the palettes that pass are measured below — one that does not has already
+  // failed, and measuring it would add a second failure saying the same thing in
+  // worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
   describe('the table above still describes chip.component.scss', () => {
     const chipRule = rules.find((rule) => rule.selector === '.tn-chip');
@@ -394,29 +393,8 @@ describe('tn-chip label contrast (#238)', () => {
     });
   });
 
-  describe('every palette declares both halves of every pair itself', () => {
-    const declarations = palettes.map((palette) => ({
-      selector: palette.selector,
-      missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-    }));
-
-    it.each(declarations)('$selector declares every token the chip reads', ({ missing }) => {
-      // Inheriting `:root`'s value is not the same as having one: High
-      // Contrast rendered white on its own #4784ac at 4.07:1 for exactly that
-      // reason, and `color` would have resolved it and reported a number
-      // without complaint.
-      expect(missing).toEqual([]);
-    });
-  });
-
   describe('every pair clears AA on every palette', () => {
-    // Only surfaces that passed the declaration check are measured — a palette
-    // missing a token has already failed, and measuring it would add a second
-    // failure saying the same thing in worse words. If that leaves nothing,
-    // `it.each` errors on an empty array rather than reporting a suite with no
-    // contrast cases in it as green.
-    const cases = palettes
-      .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+    const cases = measured
       .flatMap((palette) =>
         CHIP_SURFACES.map((surface) => {
           const ratio = palette.contrast(surface.foreground, surface.background);
@@ -542,8 +520,7 @@ describe('tn-chip label contrast (#238)', () => {
       expect(AA_MINIMUM.normal).toBe(4.5);
     });
 
-    const cases = palettes
-      .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+    const cases = measured
       .flatMap((palette) =>
         CLOSE_SURFACES.map((surface) => {
           // Two steps, in the order a browser paints them: the circle's own

--- a/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/pipes/label-markup/inline-code-contrast.spec.ts
@@ -6,10 +6,9 @@ import {
   contrastRatio,
   formatRatio,
   meetsAa,
-  themePalettes,
 } from '../../a11y/contrast-testing';
+import { itMeasuresEveryRegisteredPalette } from '../../a11y/palette-contrast-testing';
 import { flattenSelector, scssRules, tokenOf } from '../../a11y/scss-testing';
-import { TN_THEME_DEFINITIONS } from '../../theme/theme.constants';
 
 /**
  * The `<code>` span `label-markup.inline-code` paints, measured against the
@@ -57,7 +56,6 @@ import { TN_THEME_DEFINITIONS } from '../../theme/theme.constants';
  */
 
 const LIB_DIR = join(__dirname, '../..');
-const STYLES_DIR = join(__dirname, '../../../styles');
 const MIXIN_SCSS = join(__dirname, '_label-markup.scss');
 
 /**
@@ -333,17 +331,7 @@ function resolved(palette: ThemePalette, colour: string): string {
 }
 
 describe('a <code> span in a label clears AA wherever the mixin is included (#262)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
-
-  // Derived from the theme registry rather than hardcoded: a themed surface that
-  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
-  // would otherwise go unmeasured while every remaining case still passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expectedSelectors].sort());
-  });
+  const palettes = itMeasuresEveryRegisteredPalette();
 
   /**
    * What the mixin itself paints, read out of `_label-markup.scss`.

--- a/projects/truenas-ui/src/lib/theme/error-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/error-text-contrast.spec.ts
@@ -1,7 +1,13 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { AA_MINIMUM, contrastRatio, meetsAa } from '../a11y/contrast-testing';
+import type {
+  ContrastPairing} from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  testEachPalette,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * `--tn-red` is tuned toward the 3:1 border/icon minimum, not the 4.5:1 text
@@ -35,15 +41,21 @@ import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/cont
  * browser: it is about the palette, not about a rendered page. `yarn test-sb`
  * is what checks the page.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the per-palette harness is `lib/a11y/palette-contrast-testing.ts` (#295);
  * nothing is re-derived here. `primary-text-contrast.spec.ts` is the same shape
  * for `--tn-primary-text`, and `semantic-status-contrast.spec.ts` for the four
  * `--tn-<status>` tokens.
  */
 
-const STYLES_DIR = join(__dirname, '../../styles');
 const LIB_DIR = join(__dirname, '..');
 const STORIES_DIR = join(__dirname, '../../stories');
+
+/** Every surface the token guarantees, and what paints it. */
+const PAIRINGS: readonly ContrastPairing[] = [
+  { token: '--tn-error-text', surface: '--tn-bg1', where: 'the page canvas' },
+  { token: '--tn-error-text', surface: '--tn-bg2', where: 'the card and panel surface' },
+];
 
 /**
  * Declared by each theme itself, not inherited from `:root`. `--tn-error-text`
@@ -149,85 +161,23 @@ function sourceFiles(directory: string, extensions: readonly string[]): string[]
     .sort();
 }
 
-interface ThemeCase {
-  selector: string;
-  errorText: string;
-  bg1: string;
-  bg2: string;
-  bg1Ratio: number;
-  bg2Ratio: number;
-  bg1RatioLabel: string;
-  bg2RatioLabel: string;
-}
-
 describe('--tn-error-text contrast (#186, #234)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
-
-  // Derived from the theme registry rather than hardcoded: a themed surface
-  // that stops being recognised — a renamed class, a block that drops
-  // `--tn-bg1` — would otherwise go unmeasured while every remaining case still
-  // passed. Tying the count to TN_THEME_DEFINITIONS plus :root, and naming every
-  // registered selector below, fails on exactly which surface went missing.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  it.each(declarations)('$selector declares --tn-bg1, --tn-bg2 and --tn-error-text itself', ({ missing }) => {
-    expect(missing).toEqual([]);
-  });
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words. If that leaves nothing to
-  // measure, `it.each` errors on the empty array rather than reporting a suite
-  // with no contrast cases in it as green.
-  const cases: ThemeCase[] = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
-    .map((palette) => {
-      const bg1Ratio = palette.contrast('--tn-error-text', '--tn-bg1');
-      const bg2Ratio = palette.contrast('--tn-error-text', '--tn-bg2');
-      return {
-        selector: palette.selector,
-        errorText: palette.color('--tn-error-text'),
-        bg1: palette.color('--tn-bg1'),
-        bg2: palette.color('--tn-bg2'),
-        bg1Ratio,
-        bg2Ratio,
-        bg1RatioLabel: formatRatio(bg1Ratio),
-        bg2RatioLabel: formatRatio(bg2Ratio),
-      };
-    });
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
   // `normal`, not `large`: the call sites are validation messages, step errors,
   // outline-button labels and table status cells at body size or smaller, so
-  // 4.5:1 applies rather than 3:1. The measured ratio is in each case's title,
-  // so a failure names the colour and the number it came to as well as the
-  // theme it belongs to.
-  it.each(cases)(
-    '$selector: $errorText on --tn-bg1 ($bg1) measures $bg1RatioLabel',
-    ({ bg1Ratio }) => {
-      expect(meetsAa(bg1Ratio, 'normal')).toBe(true);
-    }
-  );
+  // 4.5:1 applies rather than 3:1.
+  testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
 
-  it.each(cases)(
-    '$selector: $errorText on --tn-bg2 ($bg2) measures $bg2RatioLabel',
-    ({ bg2Ratio }) => {
-      expect(meetsAa(bg2Ratio, 'normal')).toBe(true);
-    }
-  );
+  it('the threshold those cases use is the AA one for normal text', () => {
+    // The number 4.5 appears in this file only through AA_MINIMUM, and this is
+    // what stops that indirection from hiding a change to it: a `normal` that
+    // moved would otherwise re-title every case above and still pass.
+    expect(AA_MINIMUM.normal).toBe(4.5);
+  });
 
   describe('the call sites that read it', () => {
     const stylesheets = sourceFiles(LIB_DIR, ['.scss']).map((file) => ({

--- a/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
@@ -101,7 +101,8 @@ const TEXT_TOKENS = ['--tn-fg1', '--tn-fg2'];
  * than the assertion — which the out-read cases used to have, requiring the text
  * tokens while only the muted ones were asserted — lets a palette leave those
  * cases with nothing red anywhere: exactly the silent coverage loss
- * `expectedSelectors` exists to prevent, one layer down.
+ * `itMeasuresEveryRegisteredPalette`'s registry cases exist to prevent, one
+ * layer down.
  */
 const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...TEXT_TOKENS, ...MUTED_TOKENS];
 

--- a/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/muted-fg-contrast.spec.ts
@@ -1,7 +1,11 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { formatRatio, themePalettes } from '../a11y/contrast-testing';
+import { formatRatio } from '../a11y/contrast-testing';
+import type {
+  ContrastPairing} from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  testEachPalette,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * `--tn-fg3` and `--tn-fg4` were documented as text roles — "muted text
@@ -40,13 +44,12 @@ import { formatRatio, themePalettes } from '../a11y/contrast-testing';
  * is regenerated from the one measured here rather than read as it was
  * committed. `themes-css-copy.spec.ts` keeps the committed copy honest anyway.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the per-palette harness is `lib/a11y/palette-contrast-testing.ts` (#295);
  * nothing is re-derived here. `primary-text-contrast.spec.ts` and
  * `semantic-status-contrast.spec.ts` are the same shape at the 4.5:1 text
  * threshold.
  */
-
-const STYLES_DIR = join(__dirname, '../../styles');
 
 /**
  * WCAG 2.1 SC 1.4.11, the minimum for user interface components and graphical
@@ -103,6 +106,14 @@ const TEXT_TOKENS = ['--tn-fg1', '--tn-fg2'];
 const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...TEXT_TOKENS, ...MUTED_TOKENS];
 
 /**
+ * Both muted tokens on both surfaces — the full cross product, built from the
+ * two lists rather than written out, so a token or a surface added above is
+ * measured without a second edit here.
+ */
+const PAIRINGS: readonly ContrastPairing[] = MUTED_TOKENS.flatMap((token) =>
+  Object.entries(SURFACES).map(([surface, where]) => ({ token, surface, where })));
+
+/**
  * Muted-over-text inversions that are real, recorded as the PAIR that inverts
  * and why.
  *
@@ -127,85 +138,21 @@ const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...TEXT_TOKENS, ...MUTED_TOKE
  */
 const OUTREADS_TEXT: Readonly<Record<string, { pairs: string[]; why: string }>> = {};
 
-interface ThemeCase {
-  selector: string;
-  token: string;
-  colour: string;
-  ratios: string;
-  failing: string[];
-}
-
 describe('--tn-fg3/--tn-fg4 non-text contrast (#240)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
-  // Derived from the theme registry rather than hardcoded: a themed surface
-  // that stops being recognised — a renamed class, a block that drops
-  // `--tn-bg1` — would otherwise go unmeasured while every remaining case still
-  // passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  // Titled from the list rather than spelling it out, so a token added to
-  // REQUIRED_TOKENS cannot leave the case name describing the old set.
-  it.each(declarations)(
-    `$selector declares ${REQUIRED_TOKENS.join(', ')} itself`,
-    ({ missing }) => {
-      expect(missing).toEqual([]);
-    }
-  );
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words. If that leaves nothing to
-  // measure, `it.each` errors on the empty array rather than reporting a suite
-  // with no contrast cases in it as green.
-  const cases: ThemeCase[] = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
-    .flatMap((palette) => MUTED_TOKENS.map((token) => {
-      const measured = Object.keys(SURFACES).map((surface) => ({
-        surface,
-        ratio: palette.contrast(token, surface),
-      }));
-      return {
-        selector: palette.selector,
-        token,
-        colour: palette.color(token),
-        ratios: measured
-          .map(({ surface, ratio }) => `${surface.slice(5)} ${formatRatio(ratio)}`)
-          .join(', '),
-        // Listed rather than reduced to a boolean, so a failure prints the
-        // surface and the number instead of "expected true". Compared
-        // unrounded: a pair measuring 2.999 does not clear 3:1, however it
-        // formats.
-        failing: measured
-          .filter(({ ratio }) => ratio < NON_TEXT_MINIMUM)
-          .map(({ surface, ratio }) => `${surface} (${SURFACES[surface]}): ${formatRatio(ratio)}`),
-      };
-    }));
-
-  it.each(cases)('$selector: $token is $colour — $ratios', ({ failing }) => {
-    expect(failing).toEqual([]);
-  });
+  // The 3:1 non-text floor, not an AA text one: these two tokens are for icon
+  // and glyph strokes, decorative marks and inactive affordances.
+  testEachPalette(measured, PAIRINGS, NON_TEXT_MINIMUM);
 
   // Two tokens on the same surface that measure the same are one token with two
   // names. This is what stopped the retune from flattening the ramp while it
   // chased the minimum: in `.tn-blue` and `.tn-midnight` the fix for --tn-fg4
   // pushed it past where --tn-fg3 was, and --tn-fg3 had to move with it.
-  const ramp = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+  const ramp = measured
     .flatMap((palette) => Object.keys(SURFACES).map((surface) => ({
       selector: palette.selector,
       surface,
@@ -224,8 +171,7 @@ describe('--tn-fg3/--tn-fg4 non-text contrast (#240)', () => {
   // pins --tn-fg3 against --tn-fg4, which is the pair the retune moved together;
   // it says nothing about either landing on top of a token that carries actual
   // text, which is what raising a 3:1 token risks.
-  const ranked = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
+  const ranked = measured
     .flatMap((palette) => Object.keys(SURFACES).map((surface) => {
       const ratio = (token: string) => palette.contrast(token, surface);
       const recordedPairs = OUTREADS_TEXT[palette.selector]?.pairs ?? [];
@@ -237,7 +183,7 @@ describe('--tn-fg3/--tn-fg4 non-text contrast (#240)', () => {
         .filter((text) => ratio(muted) >= ratio(text))
         .map((text) => ({
           pair: `${muted}/${text}`,
-          measured:
+          reading:
             `${muted} ${formatRatio(ratio(muted))} over ${text} ${formatRatio(ratio(text))}`,
         })));
       return {
@@ -248,7 +194,7 @@ describe('--tn-fg3/--tn-fg4 non-text contrast (#240)', () => {
           .join(', '),
         unrecorded: outreading
           .filter(({ pair }) => !recordedPairs.includes(pair))
-          .map(({ measured }) => measured),
+          .map(({ reading }) => reading),
         // Recorded pairs that have STOPPED inverting. #265 retuning --tn-fg1
         // fills this, which is what fails the case below and forces the entry
         // out; a pair recorded under a name nothing measures fills it too.
@@ -284,7 +230,7 @@ describe('--tn-fg3/--tn-fg4 non-text contrast (#240)', () => {
   }
 
   it('every palette recorded in OUTREADS_TEXT was measured', () => {
-    const measured = ranked.map(({ selector }) => selector);
-    expect(Object.keys(OUTREADS_TEXT).filter((selector) => !measured.includes(selector))).toEqual([]);
+    const ranking = ranked.map(({ selector }) => selector);
+    expect(Object.keys(OUTREADS_TEXT).filter((selector) => !ranking.includes(selector))).toEqual([]);
   });
 });

--- a/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/primary-text-contrast.spec.ts
@@ -1,7 +1,13 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { AA_MINIMUM, contrastRatio, meetsAa } from '../a11y/contrast-testing';
+import type {
+  ContrastPairing} from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  testEachPalette,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * `--tn-primary` is tuned for the 3:1 non-text minimum — fills, borders and
@@ -24,13 +30,19 @@ import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/cont
  * can honestly be made without a browser: it is about the palette rather than
  * about a rendered page. `yarn test-sb` is what checks the page.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the per-palette harness is `lib/a11y/palette-contrast-testing.ts` (#295);
  * nothing is re-derived here. `error-text-contrast.spec.ts` is the same shape
  * for `--tn-error-text`.
  */
 
-const STYLES_DIR = join(__dirname, '../../styles');
 const LIB_DIR = join(__dirname, '..');
+
+/** Every surface the token guarantees, and what paints it. */
+const PAIRINGS: readonly ContrastPairing[] = [
+  { token: '--tn-primary-text', surface: '--tn-bg1', where: 'the page canvas' },
+  { token: '--tn-primary-text', surface: '--tn-bg2', where: 'the card and panel surface' },
+];
 
 /**
  * Declared by each theme itself, not inherited from `:root`. `--tn-primary-text`
@@ -104,82 +116,22 @@ function scssFiles(directory: string): string[] {
     .sort();
 }
 
-interface ThemeCase {
-  selector: string;
-  primaryText: string;
-  bg1: string;
-  bg2: string;
-  bg1Ratio: number;
-  bg2Ratio: number;
-  bg1RatioLabel: string;
-  bg2RatioLabel: string;
-}
-
 describe('--tn-primary-text contrast (#242)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
-
-  // Derived from the theme registry rather than hardcoded: a themed surface that
-  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
-  // would otherwise go unmeasured while every remaining case still passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  it.each(declarations)('$selector declares --tn-bg1, --tn-bg2 and --tn-primary-text itself', ({ missing }) => {
-    expect(missing).toEqual([]);
-  });
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words. If that leaves nothing to
-  // measure, `it.each` errors on the empty array rather than reporting a suite
-  // with no contrast cases in it as green.
-  const cases: ThemeCase[] = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
-    .map((palette) => {
-      const bg1Ratio = palette.contrast('--tn-primary-text', '--tn-bg1');
-      const bg2Ratio = palette.contrast('--tn-primary-text', '--tn-bg2');
-      return {
-        selector: palette.selector,
-        primaryText: palette.color('--tn-primary-text'),
-        bg1: palette.color('--tn-bg1'),
-        bg2: palette.color('--tn-bg2'),
-        bg1Ratio,
-        bg2Ratio,
-        bg1RatioLabel: formatRatio(bg1Ratio),
-        bg2RatioLabel: formatRatio(bg2Ratio),
-      };
-    });
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
   // `normal`, not `large`: the call sites are links, breadcrumbs, labels and
   // calendar dates at body size or smaller, so 4.5:1 applies rather than 3:1.
-  // The measured ratio is in each case's title, so a failure names the colour
-  // and the number it came to as well as the theme it belongs to.
-  it.each(cases)(
-    '$selector: $primaryText on --tn-bg1 ($bg1) measures $bg1RatioLabel',
-    ({ bg1Ratio }) => {
-      expect(meetsAa(bg1Ratio, 'normal')).toBe(true);
-    }
-  );
+  testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
 
-  it.each(cases)(
-    '$selector: $primaryText on --tn-bg2 ($bg2) measures $bg2RatioLabel',
-    ({ bg2Ratio }) => {
-      expect(meetsAa(bg2Ratio, 'normal')).toBe(true);
-    }
-  );
+  it('the threshold those cases use is the AA one for normal text', () => {
+    // The number 4.5 appears in this file only through AA_MINIMUM, and this is
+    // what stops that indirection from hiding a change to it: a `normal` that
+    // moved would otherwise re-title every case above and still pass.
+    expect(AA_MINIMUM.normal).toBe(4.5);
+  });
 
   describe('the call sites that read it', () => {
     const files = scssFiles(LIB_DIR).map((file) => ({

--- a/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/semantic-status-contrast.spec.ts
@@ -1,7 +1,13 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { AA_MINIMUM, contrastRatio, meetsAa } from '../a11y/contrast-testing';
+import type {
+  ContrastPairing} from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  testEachPalette,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * `--tn-info`, `--tn-warning`, `--tn-error` and `--tn-success` were read by
@@ -31,12 +37,12 @@ import { contrastRatio, formatRatio, meetsAa, themePalettes } from '../a11y/cont
  * browser: it is about the palette, not about a rendered page. `yarn test-sb`
  * is what checks the page.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197).
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the per-palette harness is `lib/a11y/palette-contrast-testing.ts` (#295).
  * `primary-text-contrast.spec.ts` and `error-text-contrast.spec.ts` are the
  * same shape for `--tn-primary-text` and `--tn-error-text`.
  */
 
-const STYLES_DIR = join(__dirname, '../../styles');
 const LIB_DIR = join(__dirname, '..');
 const STORIES_DIR = join(__dirname, '../../stories');
 
@@ -61,6 +67,14 @@ const SURFACES: Readonly<Record<string, string>> = {
  * sees that, where `color` would resolve it and quietly report a number.
  */
 const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...STATUS_TOKENS];
+
+/**
+ * Every status colour on every surface it is drawn on — the full cross product,
+ * built from the two lists rather than written out, so a token or a surface
+ * added above is measured without a second edit here.
+ */
+const PAIRINGS: readonly ContrastPairing[] = STATUS_TOKENS.flatMap((token) =>
+  Object.entries(SURFACES).map(([surface, where]) => ({ token, surface, where })));
 
 /**
  * How a reader must spell each token: the same chain as
@@ -148,75 +162,21 @@ function readers(): Reader[] {
   ];
 }
 
-interface ThemeCase {
-  selector: string;
-  token: string;
-  colour: string;
-  ratios: string;
-  failing: string[];
-}
-
 describe('semantic status token contrast (#233)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
-  // Derived from the theme registry rather than hardcoded: a themed surface
-  // that stops being recognised — a renamed class, a block that drops
-  // `--tn-bg1` — would otherwise go unmeasured while every remaining case still
-  // passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
+  // `normal`, not `large`: banner headings, status chips and error messages are
+  // body size or smaller, so 4.5:1 applies rather than 3:1.
+  testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
 
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  it.each(declarations)(
-    '$selector declares the four status tokens and the three surfaces itself',
-    ({ missing }) => {
-      expect(missing).toEqual([]);
-    }
-  );
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words. If that leaves nothing to
-  // measure, `it.each` errors on the empty array rather than reporting a suite
-  // with no contrast cases in it as green.
-  const cases: ThemeCase[] = palettes
-    .filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)))
-    .flatMap((palette) => STATUS_TOKENS.map((token) => {
-      const measured = Object.keys(SURFACES).map((surface) => ({
-        surface,
-        ratio: palette.contrast(token, surface),
-      }));
-      return {
-        selector: palette.selector,
-        token,
-        colour: palette.color(token),
-        ratios: measured
-          .map(({ surface, ratio }) => `${surface.slice(5)} ${formatRatio(ratio)}`)
-          .join(', '),
-        // Listed rather than reduced to a boolean, so a failure prints the
-        // surface and the number instead of "expected true". `normal`, not
-        // `large`: banner headings, status chips and error messages are body
-        // size or smaller, so 4.5:1 applies rather than 3:1.
-        failing: measured
-          .filter(({ ratio }) => !meetsAa(ratio, 'normal'))
-          .map(({ surface, ratio }) => `${surface} (${SURFACES[surface]}): ${formatRatio(ratio)}`),
-      };
-    }));
-
-  it.each(cases)('$selector: $token is $colour — $ratios', ({ failing }) => {
-    expect(failing).toEqual([]);
+  it('the threshold those cases use is the AA one for normal text', () => {
+    // The number 4.5 appears in this file only through AA_MINIMUM, and this is
+    // what stops that indirection from hiding a change to it: a `normal` that
+    // moved would otherwise re-title every case above and still pass.
+    expect(AA_MINIMUM.normal).toBe(4.5);
   });
 
   describe('the components that read them', () => {

--- a/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/story-token-declarations.spec.ts
@@ -1,7 +1,6 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
 import { join, relative } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { themePalettes } from '../a11y/contrast-testing';
+import { itMeasuresEveryRegisteredPalette } from '../a11y/palette-contrast-testing';
 
 /**
  * Every custom property a story file reads with `var()` must be one that EVERY
@@ -70,7 +69,6 @@ import { themePalettes } from '../a11y/contrast-testing';
  */
 
 const STORIES_DIR = join(__dirname, '../../stories');
-const THEMES_CSS = join(__dirname, '../../styles/themes.css');
 
 /**
  * Custom properties `src/stories/` reads that NO palette declares, with the
@@ -204,11 +202,17 @@ function storyReferences(): Reference[] {
 }
 
 describe('custom properties read by the story files (#268, #280)', () => {
-  // `themePalettes` walks the braces and strips comments before reading any
-  // declaration, so a commented-out `--x: …` does not count as declared and a
-  // recorded ratio sitting next to a token is not mistaken for one. The regex
-  // this spec used to build its own set did neither.
-  const palettes = themePalettes(readFileSync(THEMES_CSS, 'utf8'));
+  // `themePalettes`, behind `itMeasuresEveryRegisteredPalette`, walks the braces
+  // and strips comments before reading any declaration — so a commented-out
+  // `--x: …` does not count as declared, and a recorded ratio sitting next to a
+  // token is not mistaken for one. The regex this spec used to build its own set
+  // did neither.
+  //
+  // The registry cases come with it: a palette that stops being recognised — a
+  // renamed class, a block that drops `--tn-bg1` — would otherwise leave every
+  // case below passing while asking about one palette fewer, which is the
+  // any-palette hole this spec was strengthened to close.
+  const palettes = itMeasuresEveryRegisteredPalette();
   const references = storyReferences();
 
   /** The palettes that declare `property` themselves, in stylesheet order. */
@@ -220,21 +224,6 @@ describe('custom properties read by the story files (#268, #280)', () => {
   const missingFrom = (property: string): string[] => palettes
     .filter((palette) => !palette.declares(property))
     .map((palette) => palette.selector);
-
-  // Derived from the theme registry rather than hardcoded, as
-  // `text-fg-contrast.spec.ts` does it: a palette that stops being recognised —
-  // a renamed class, a block that drops `--tn-bg1` — would otherwise leave every
-  // case below passing while asking about one palette fewer, which is the
-  // any-palette hole this spec was strengthened to close.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
 
   // Guards the cases below, which are vacuously true against an empty scan: a
   // walk that silently stopped finding story files would leave them passing.

--- a/projects/truenas-ui/src/lib/theme/text-fg-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-fg-contrast.spec.ts
@@ -1,7 +1,11 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
-import { AA_MINIMUM, formatRatio, meetsAa, themePalettes } from '../a11y/contrast-testing';
+import { AA_MINIMUM, formatRatio } from '../a11y/contrast-testing';
+import type {
+  ContrastPairing} from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  testEachPalette,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * The three tokens `theming.mdx` documents as text — `--tn-fg1` (headings and
@@ -38,13 +42,12 @@ import { AA_MINIMUM, formatRatio, meetsAa, themePalettes } from '../a11y/contras
  * can honestly be made without a browser: it is about the palette rather than
  * about a rendered page. `yarn test-sb` is what checks the page.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the per-palette harness is `lib/a11y/palette-contrast-testing.ts` (#295);
  * nothing is re-derived here. `primary-text-contrast.spec.ts` and
  * `error-text-contrast.spec.ts` are the same shape for the companion tokens,
  * and `muted-fg-contrast.spec.ts` is it at the 3:1 non-text threshold.
  */
-
-const STYLES_DIR = join(__dirname, '../../styles');
 
 /**
  * The surfaces the guarantee covers, and what paints them. Not `--tn-bg3` or
@@ -78,6 +81,17 @@ const TEXT_TOKENS: Readonly<Record<string, string>> = {
 const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...Object.keys(TEXT_TOKENS)];
 
 /**
+ * Every text token on every surface the guarantee covers — the full cross
+ * product, built from the two records rather than written out, so a token or a
+ * surface added above is measured without a second edit here. The role and the
+ * surface's name travel with the pairing, so a failure says what the token is
+ * for and what paints the thing behind it.
+ */
+const PAIRINGS: readonly ContrastPairing[] = Object.entries(TEXT_TOKENS)
+  .flatMap(([token, role]) => Object.entries(SURFACES)
+    .map(([surface, surfaceName]) => ({ token, surface, where: `${role} on ${surfaceName}` })));
+
+/**
  * Palettes where `--tn-fg2` reads at least as well as `--tn-fg1`, with why.
  *
  * Their order relative to each other is a per-theme choice and is not a defect
@@ -107,18 +121,6 @@ const REQUIRED_TOKENS = [...Object.keys(SURFACES), ...Object.keys(TEXT_TOKENS)];
  */
 const FG2_OUTREADS_FG1: Readonly<Record<string, string>> = {};
 
-interface TokenCase {
-  selector: string;
-  token: string;
-  role: string;
-  colour: string;
-  surface: string;
-  surfaceName: string;
-  surfaceColour: string;
-  ratio: number;
-  ratioLabel: string;
-}
-
 interface RampCase {
   selector: string;
   surface: string;
@@ -129,69 +131,12 @@ interface RampCase {
 }
 
 describe('--tn-fg1/--tn-fg2/--tn-alt-fg1 text contrast (#265)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
-  // Derived from the theme registry rather than hardcoded: a themed surface that
-  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
-  // would otherwise go unmeasured while every remaining case still passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes).toHaveLength(expectedSelectors.length);
-  });
-
-  it.each(expectedSelectors)('%s is a themed surface found in themes.css', (selector) => {
-    expect(palettes.map((palette) => palette.selector)).toContain(selector);
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  // Titled from the list rather than spelling it out, so a token added to
-  // REQUIRED_TOKENS cannot leave the case name describing the old set.
-  it.each(declarations)(
-    `$selector declares ${REQUIRED_TOKENS.join(', ')} itself`,
-    ({ missing }) => {
-      expect(missing).toEqual([]);
-    }
-  );
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words. If that leaves nothing to
-  // measure, `it.each` errors on the empty array rather than reporting a suite
-  // with no contrast cases in it as green.
-  const measured = palettes.filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)));
-
-  const cases: TokenCase[] = measured.flatMap((palette) => Object.entries(TEXT_TOKENS)
-    .flatMap(([token, role]) => Object.entries(SURFACES).map(([surface, surfaceName]) => {
-      const ratio = palette.contrast(token, surface);
-      return {
-        selector: palette.selector,
-        token,
-        role,
-        colour: palette.color(token),
-        surface,
-        surfaceName,
-        surfaceColour: palette.color(surface),
-        ratio,
-        ratioLabel: formatRatio(ratio),
-      };
-    })));
-
-  // The measured ratio is in each case's title, so a failure names the colour
-  // and the number it came to as well as the theme and the surface it belongs
-  // to. Compared unrounded: a pair measuring 4.4999 does not clear AA, however
-  // it formats.
-  it.each(cases)(
-    '$selector: $token — $role — is $colour on $surface ($surfaceColour, $surfaceName) at $ratioLabel',
-    ({ ratio }) => {
-      expect(meetsAa(ratio, 'normal')).toBe(true);
-    }
-  );
+  testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
 
   describe('the ramp the three tokens make', () => {
     const ramp: RampCase[] = measured.flatMap((palette) => Object.keys(SURFACES).map((surface) => {

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -6,7 +6,12 @@ import {
   formatRatio,
   meetsAa,
 } from '../a11y/contrast-testing';
-import { itDeclares, itMeasuresEveryRegisteredPalette } from '../a11y/palette-contrast-testing';
+import type { ContrastPairing, PaletteContrastCase } from '../a11y/palette-contrast-testing';
+import {
+  itDeclares,
+  itMeasuresEveryRegisteredPalette,
+  paletteContrastCases,
+} from '../a11y/palette-contrast-testing';
 
 /**
  * The text tokens, measured on the surfaces `text-fg-contrast.spec.ts`
@@ -88,11 +93,14 @@ const REQUIRED_TOKENS = [
   ...Object.keys(TEXT_TOKENS).filter((token) => token !== '--tn-topbar-txt'),
 ];
 
-/** One (token, surface) pairing, with the call sites that create it. */
-interface Pairing {
-  readonly token: string;
-  readonly surface: string;
-  /** Where this pairing happens, so a failure names something to go and look at. */
+/**
+ * One (token, surface) pairing, with the call sites that create it.
+ *
+ * `ContrastPairing` leaves `where` optional; every entry here has one, and the
+ * narrowing is what keeps a new pairing from arriving without saying where to go
+ * and look when it fails.
+ */
+interface Pairing extends ContrastPairing {
   readonly where: string;
 }
 
@@ -472,18 +480,8 @@ function scssFiles(directory: string): string[] {
     .sort();
 }
 
-interface PairingCase {
-  selector: string;
-  token: string;
-  role: string;
-  colour: string;
-  surface: string;
-  surfaceName: string;
-  surfaceColour: string;
-  where: string;
-  ratio: number;
-  ratioLabel: string;
-}
+/** A measured pairing, with the two names this file's case titles add. */
+type PairingCase = PaletteContrastCase & { role: string; surfaceName: string };
 
 describe('text tokens on the surfaces outside the --tn-bg1/--tn-bg2 guarantee (#277)', () => {
   // Only the palettes that declare every required token are measured — one that
@@ -491,20 +489,15 @@ describe('text tokens on the surfaces outside the --tn-bg1/--tn-bg2 guarantee (#
   // a second failure saying the same thing in worse words.
   const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
-  const cases: PairingCase[] = measured.flatMap((palette) => PAIRINGS.map((pairing) => {
-    const ratio = palette.contrast(pairing.token, pairing.surface);
-    return {
-      selector: palette.selector,
-      token: pairing.token,
-      role: TEXT_TOKENS[pairing.token],
-      colour: palette.color(pairing.token),
-      surface: pairing.surface,
-      surfaceName: SURFACES[pairing.surface],
-      surfaceColour: palette.color(pairing.surface),
-      where: pairing.where,
-      ratio,
-      ratioLabel: formatRatio(ratio),
-    };
+  // Through `paletteContrastCases` rather than a loop of its own — the same
+  // palette × pairing walk the shared `testEachPalette` does, without the case
+  // it would declare, because what a pairing is held to here depends on whether
+  // `KNOWN_GAPS` records it. That is a per-palette exclusion rather than a
+  // per-pairing one, so the cases are declared below instead.
+  const cases: PairingCase[] = paletteContrastCases(measured, PAIRINGS).map((one) => ({
+    ...one,
+    role: TEXT_TOKENS[one.token],
+    surfaceName: SURFACES[one.surface],
   }));
 
   const excused = new Map(

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -97,8 +97,10 @@ const REQUIRED_TOKENS = [
  * One (token, surface) pairing, with the call sites that create it.
  *
  * `ContrastPairing` leaves `where` optional; every entry here has one, and the
- * narrowing is what keeps a new pairing from arriving without saying where to go
- * and look when it fails.
+ * narrowing is what keeps a new pairing from arriving with nothing recorded
+ * about what puts it on the page. It is documentation rather than output — the
+ * case titles below name the token, the surface and the ratio, and a reader
+ * chasing one comes back to this table for the call sites.
  */
 interface Pairing extends ContrastPairing {
   readonly where: string;

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -1,13 +1,12 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { TN_THEME_DEFINITIONS } from './theme.constants';
 import {
   AA_MINIMUM,
   contrastRatio,
   formatRatio,
   meetsAa,
-  themePalettes,
 } from '../a11y/contrast-testing';
+import { itDeclares, itMeasuresEveryRegisteredPalette } from '../a11y/palette-contrast-testing';
 
 /**
  * The text tokens, measured on the surfaces `text-fg-contrast.spec.ts`
@@ -43,11 +42,15 @@ import {
  * can honestly be made without a browser: it is about the palette rather than
  * about a rendered page. `yarn test-sb` is what checks the page.
  *
- * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197);
- * nothing is re-derived here.
+ * The maths and the token lookup are `lib/a11y/contrast-testing.ts` (#197) and
+ * the palette loader and the registry cases are
+ * `lib/a11y/palette-contrast-testing.ts` (#295); nothing is re-derived here.
+ * The cases themselves stay in this file rather than using that module's
+ * `testEachPalette`: what a pairing is held to here depends on whether
+ * `KNOWN_GAPS` records it, which is a per-palette exclusion rather than a
+ * per-pairing one.
  */
 
-const STYLES_DIR = join(__dirname, '../../styles');
 const LIB_DIR = join(__dirname, '..');
 
 /** The surfaces outside the `--tn-bg1`/`--tn-bg2` guarantee, and what paints them. */
@@ -483,36 +486,10 @@ interface PairingCase {
 }
 
 describe('text tokens on the surfaces outside the --tn-bg1/--tn-bg2 guarantee (#277)', () => {
-  const css = readFileSync(join(STYLES_DIR, 'themes.css'), 'utf8');
-  const palettes = themePalettes(css);
-
-  // Derived from the theme registry rather than hardcoded: a themed surface that
-  // stops being recognised — a renamed class, a block that drops `--tn-bg1` —
-  // would otherwise go unmeasured while every remaining case still passed.
-  const expectedSelectors = [':root', ...TN_THEME_DEFINITIONS.map((theme) => `.${theme.className}`)];
-
-  it('found every registered themed surface in themes.css', () => {
-    expect(palettes.map((palette) => palette.selector).sort()).toEqual([...expectedSelectors].sort());
-  });
-
-  const declarations = palettes.map((palette) => ({
-    selector: palette.selector,
-    missing: REQUIRED_TOKENS.filter((token) => !palette.declares(token)),
-  }));
-
-  // Titled from the list rather than spelling it out, so a token added to
-  // REQUIRED_TOKENS cannot leave the case name describing the old set.
-  it.each(declarations)(
-    `$selector declares ${REQUIRED_TOKENS.join(', ')} itself`,
-    ({ missing }) => {
-      expect(missing).toEqual([]);
-    }
-  );
-
-  // Only the surfaces that passed the check above are measured — a palette
-  // missing a token has already failed, and measuring it would add a second
-  // failure saying the same thing in worse words.
-  const measured = palettes.filter((palette) => REQUIRED_TOKENS.every((token) => palette.declares(token)));
+  // Only the palettes that declare every required token are measured — one that
+  // does not has already failed inside `itDeclares`, and measuring it would add
+  // a second failure saying the same thing in worse words.
+  const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
 
   const cases: PairingCase[] = measured.flatMap((palette) => PAIRINGS.map((pairing) => {
     const ratio = palette.contrast(pairing.token, pairing.surface);

--- a/projects/truenas-ui/src/lib/theme/themes-css-copy.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/themes-css-copy.spec.ts
@@ -15,9 +15,9 @@ import { join } from 'path';
  * copy: `storybook`, `build-storybook`, `sb` and `sbh` each run `copy-assets`
  * — and so `copy-themes` — before anything is built, and CI's Storybook
  * Interaction Tests job runs `yarn build-storybook` before `test-sb`. So the
- * served palette is always regenerated from `src/styles/`, and the four
- * contrast specs measuring `src/styles/themes.css` are measuring the file that
- * reaches the page.
+ * served palette is always regenerated from `src/styles/`, and the specs
+ * measuring `src/styles/themes.css` are measuring the file that reaches the
+ * page.
  *
  * WHAT IT DOES BREAK is the repository: two files that claim to be the same file
  * and are not, one of them the copy a reader is most likely to open, and a
@@ -25,10 +25,11 @@ import { join } from 'path';
  * resync is `yarn copy-themes`, which is what a failure here means — never an
  * edit to the copy itself.
  *
- * `primary-text-contrast.spec.ts`, `error-text-contrast.spec.ts`,
- * `semantic-status-contrast.spec.ts` and `muted-fg-contrast.spec.ts` are the
- * specs that read `src/styles/themes.css`; this is what keeps the other copy
- * from telling a different story.
+ * Which of the two copies a spec reads is not each spec's decision to make:
+ * `a11y/palette-contrast-testing.ts` names `src/styles/themes.css` once, as
+ * `THEME_STYLESHEET`, and every palette spec loads through it (#295). This file
+ * is the other half of that arrangement — one decision about which copy is
+ * authoritative, and one case holding the other to it.
  */
 
 const STYLES_DIR = join(__dirname, '../../styles');


### PR DESCRIPTION
Fixes #295

## What was wrong

#197 shared the WCAG arithmetic and the duplication moved up one level rather
than going away. Nine specs each read `src/styles/themes.css`, cross-checked what
they found against `TN_THEME_DEFINITIONS`, dropped the palettes missing a token,
and then looped palette × token × surface. Review counted the copies twice
without being asked — on PR #264 (*"this block is now the fourth verbatim copy of
the same harness"*) and again on PR #281 five days later.

Four independent loops are four chances to miss a palette or assert against the
wrong surface, which is the class of defect #197 was filed to prevent, one layer
up from where that fix landed.

## What this adds

`projects/truenas-ui/src/lib/a11y/palette-contrast-testing.ts`, the layer above
`contrast-testing.ts`:

| Export | What it does |
|---|---|
| `THEME_STYLESHEET` | Names `src/styles/themes.css` **once** |
| `itMeasuresEveryRegisteredPalette()` | Loads it, declares the cases holding what it finds to the theme registry, returns the palettes |
| `itDeclares(palettes, tokens)` | Declares the per-palette `declares` case, returns the palettes fit to measure |
| `testEachPalette(palettes, pairings, minimum)` | One case per palette per pairing, one failure-message format |
| `missingTokens`, `paletteContrastCases`, `registeredPalettes`, `registeredSelectors` | The pure halves the three above are built on |

A spec is now three lines of harness:

```ts
const measured = itDeclares(itMeasuresEveryRegisteredPalette(), REQUIRED_TOKENS);
testEachPalette(measured, PAIRINGS, AA_MINIMUM.normal);
```

**Getting the palettes and being held to the registry is deliberately one call.**
A spec that reads the palettes without the registry cases is the hole this exists
to close — a theme that stops being recognised, because its class was renamed or
its block dropped `--tn-bg1`, goes unmeasured while every remaining case still
passes.

### Against the acceptance criteria

- **A single exported helper iterates `themePalettes` and asserts a token/surface
  pair, with one failure-message format.** `testEachPalette`. Title:
  `$selector: $token ($colour) on $surface ($surfaceColour) measures $ratioLabel$note`.
  It asserts `toBeGreaterThanOrEqual`, so the failure output carries the floor it
  missed by rather than `expected true`.
- **The four existing copies call it instead of carrying their own loop.** All
  four named in the ticket do: `primary-text-contrast`,
  `semantic-status-contrast`, `error-text-contrast`, `muted-fg-contrast`.
  `text-fg-contrast` is the fifth. Nine specs in total now load through the
  module.
- **Which stylesheet is measured is decided in one place.** `THEME_STYLESHEET`.
  `themes-css-copy.spec.ts` — which keeps `.storybook/public/themes.css`
  byte-identical to it — is updated to point at that decision instead of naming
  four specs as the readers.
- **Adding a palette requires no spec edit; a spec that would miss it fails.**
  `registeredSelectors()` derives from `TN_THEME_DEFINITIONS`, and the registry
  case compares the whole list both ways.
- **Existing contrast assertions still pass unchanged.** Measured, below.

## Nothing asserts less

The failure mode the ticket names — *"a green run that asserts less"* — checked
by counting rather than by reading. On the ten specs that existed before, run at
`origin/main` and then on this branch:

**939 → 1064.** Every one of the 125 is an addition, and they account for the
delta exactly:

| Where | Δ | Why |
|---|---|---|
| `semantic-status-contrast` | +72 | A case per (palette, token, **surface**) rather than one per (palette, token) listing failing surfaces |
| `muted-fg-contrast` | +18 | Same split |
| `text-token-surface`, `chip-contrast`, `inline-code-contrast` | +9 each | Each carried the whole-list registry case but not the per-selector one |
| the five using `testEachPalette` | +1 each | The `there are pairings to measure` guard |
| `primary-text`, `error-text`, `semantic-status` | +1 each | An `AA_MINIMUM.normal` pin, which `text-fg` and `text-token-surface` already had |

Three specs also get a **strictly stronger** registry case: `toHaveLength` became
a sorted list comparison, which names the surface that went missing or turned up
unregistered instead of only the count.

## What is not converted, and why

- **`chip-contrast.spec.ts`** and **`inline-code-contrast.spec.ts`** composite
  translucent washes (`compositeColor`) and resolve literal colours like `white`,
  which a `{ token, surface }` pairing cannot express. They take the loader and
  the registry cases and keep their own case builders.
- **`text-token-surface-contrast.spec.ts`** excuses individual
  (palette, token, surface) triples through `KNOWN_GAPS` — a per-palette
  exclusion, not a per-pairing one. It calls `paletteContrastCases` for the walk
  and declares its own cases, so the loop is still written once.
- **`story-token-declarations.spec.ts`** is not a contrast spec; it takes the
  loader and the registry cases only.

## Checks run locally

`yarn lint`, `yarn test` (144 suites, **4230** tests), `yarn test:scripts` (42),
`yarn build`, `yarn build-storybook` — all green.

**`Storybook Interaction Tests` was not run**: it needs a real browser, which
this machine has no way to provide. Nothing here touches a component, a template
or a stylesheet — the diff is spec files, one new spec-only module and one
documentation section — so that job has no new surface to exercise.

The Storybook build was run deliberately rather than skipped. The new module is
the first non-spec `.ts` under `src/lib/` to import `fs`, and a browser bundle
reaching it would break; `ng-packagr` builds from `public-api.ts` and Storybook
builds from the stories, so neither does. A guard case now holds it out of
`public-api.ts` — the same guard `contrast-testing.spec.ts` and
`axe-testing.spec.ts` carry, added here after the local review pointed out that
the docblock said so and nothing enforced it.

## Local review

Two rounds. The `local-review.py` reviewer is the same one the required check
runs, so **its verdict here is the check's own, not a subagent's**.

Round 1 found one MEDIUM — the missing `public-api.ts` guard above — and two
LOWs. Round 2 came back with nothing at or above MEDIUM, which ends the local
loop. The third commit after it fixes two of that round's LOWs and touches no
executable code: both were comments left describing something the extraction had
moved, which makes the diff itself wrong rather than merely unpolished.

**LOWs left unfixed, deliberately** — each is worth a look and none blocks:

- `itDeclares` recomputes `missingTokens` for its filter rather than reusing the
  `declarations` array it asserted on, so the "one list, asserted and filtered
  on" invariant holds by convention rather than by construction. Correct today,
  and the two would have to be edited apart to diverge.
- The `expect(AA_MINIMUM.normal).toBe(4.5)` pin is now in five specs. It could
  live once beside `testEachPalette`, which is what introduced the bare-number
  indirection it guards.
- The `import type { ... }` braces `yarn lint:fix` produced in five specs and the
  new module split across lines in a way that reads as an auto-fix artefact.
  `yarn lint` is green on it.

## Also updated

`docs/component_conventions.md` gains a **Measuring the shipped palette in every
theme** section under the existing contrast one: the three calls in order, what
each is for, and the two shapes that keep their own case builders. The section
above it said to pass the text of `styles/themes.css`, which is no longer what a
palette spec does; it now points forward instead.
