### PR TITLE
NAS-142551 / 27.0.0-BETA.1 / feat(banner): give TnBannerHarness an API for the actions it projects

### DIFF
--- a/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
@@ -41,12 +41,12 @@ export class TnBannerActionHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a banner action
    * with a specific label.
    *
-   * @param options Options for filtering which action instances are considered a match.
-   * @returns A `HarnessPredicate` configured with the given options.
-   *
    * Scope it to the action slot when composing a locator by hand — unscoped, it
    * matches any `[tnBannerAction]` element on the page, which is why
    * `TnBannerHarness` always passes an `ancestor`.
+   *
+   * @param options Options for filtering which action instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
    *
    * @example
    * ```typescript

--- a/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
@@ -44,10 +44,14 @@ export class TnBannerActionHarness extends ComponentHarness {
    * @param options Options for filtering which action instances are considered a match.
    * @returns A `HarnessPredicate` configured with the given options.
    *
+   * Scope it to the action slot when composing a locator by hand — unscoped, it
+   * matches any `[tnBannerAction]` element on the page, which is why
+   * `TnBannerHarness` always passes an `ancestor`.
+   *
    * @example
    * ```typescript
    * const retry = await loader.getHarness(
-   *   TnBannerActionHarness.with({ label: 'Retry' })
+   *   TnBannerActionHarness.with({ label: 'Retry', ancestor: '.tn-banner__action' })
    * );
    * ```
    */

--- a/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner-action.harness.ts
@@ -1,0 +1,115 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+/**
+ * Harness for a single action projected into a `tn-banner`'s action slot.
+ *
+ * Reach these through `TnBannerHarness.getActions()` / `clickAction()` rather
+ * than loading them directly — on their own they would also match a
+ * `[tnBannerAction]` element that some other component projects.
+ *
+ * `[tnBannerAction]` is an attribute directive with no element restriction, so
+ * an action is whatever the caller projected: a `tn-button`, a plain `<a>`, a
+ * native `<button>`. This harness covers all of them rather than assuming
+ * `tn-button`, which is why `TnBannerHarness` does not simply locate
+ * `TnButtonHarness` the way `TnDialogHarness` does — a dialog's footer takes
+ * `tn-button`s, a banner's action slot takes anything.
+ *
+ * @example
+ * ```typescript
+ * const banner = await loader.getHarness(TnBannerHarness);
+ * const actions = await banner.getActions();
+ * expect(await actions[0].getLabel()).toBe('Retry');
+ * await actions[0].click();
+ * ```
+ */
+export class TnBannerActionHarness extends ComponentHarness {
+  /**
+   * The selector for the host element of a banner action.
+   */
+  static hostSelector = '[tnBannerAction]';
+
+  // A `tn-button` renders its text into a dedicated label span and its click
+  // target into an inner `button`/`a`. A plain projected element — `<a
+  // tnBannerAction>`, `<button tnBannerAction>` — is both of those itself, and
+  // matches neither locator. Both are optional so one harness covers either
+  // shape, falling back to the host.
+  private _buttonLabel = this.locatorForOptional('.storybook-button__label');
+  private _innerControl = this.locatorForOptional('button, a');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a banner action
+   * with a specific label.
+   *
+   * @param options Options for filtering which action instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * const retry = await loader.getHarness(
+   *   TnBannerActionHarness.with({ label: 'Retry' })
+   * );
+   * ```
+   */
+  static with(options: BannerActionHarnessFilters = {}) {
+    return new HarnessPredicate(TnBannerActionHarness, options)
+      .addOption('label', options.label, (harness, label) =>
+        HarnessPredicate.stringMatches(harness.getLabel(), label)
+      );
+  }
+
+  /**
+   * Gets the action's label text.
+   *
+   * For a projected `tn-button` this is the button's own label, read from its
+   * label span so a rendered icon's sprite-fallback glyphs never leak in — the
+   * same rule `TnButtonHarness.getLabel()` follows. For anything else it is the
+   * element's trimmed text content.
+   *
+   * @returns Promise resolving to the action's label, trimmed of whitespace.
+   *
+   * @example
+   * ```typescript
+   * const [action] = await banner.getActions();
+   * expect(await action.getLabel()).toBe('Learn more');
+   * ```
+   */
+  async getLabel(): Promise<string> {
+    const buttonLabel = await this._buttonLabel();
+    if (buttonLabel) {
+      return (await buttonLabel.text()).trim();
+    }
+    const host = await this.host();
+    return (await host.text()).trim();
+  }
+
+  /**
+   * Clicks the action.
+   *
+   * Clicks the inner `button`/`a` when the action is a component that renders
+   * one — a `tn-button` listens on that inner element, and a click dispatched
+   * at the `tn-button` host would not reach it. Otherwise clicks the projected
+   * element itself.
+   *
+   * @returns Promise that resolves when the click action is complete.
+   *
+   * @example
+   * ```typescript
+   * const [action] = await banner.getActions();
+   * await action.click();
+   * ```
+   */
+  async click(): Promise<void> {
+    const inner = await this._innerControl();
+    const target = inner ?? (await this.host());
+    return target.click();
+  }
+}
+
+/**
+ * A set of criteria that can be used to filter a list of `TnBannerActionHarness` instances.
+ */
+export interface BannerActionHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the action's label text. Supports string or regex matching. */
+  label?: string | RegExp;
+}

--- a/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
@@ -4,8 +4,9 @@ import { provideHttpClient } from '@angular/common/http';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture} from '@angular/core/testing';
-import { TnBannerComponent } from './banner.component';
+import { TnBannerComponent, TnBannerActionDirective } from './banner.component';
 import { TnBannerHarness } from './banner.harness';
+import { TnButtonComponent } from '../button/button.component';
 import { TnIconTesting } from '../icon/icon-testing';
 
 // Test host component for harness testing
@@ -20,6 +21,53 @@ class TestHostComponent {
   message = signal<string | undefined>(undefined);
   type = signal<'info' | 'warning' | 'error' | 'success'>('info');
 }
+
+// Both shapes the banner already renders in its own stories: a projected
+// `tn-button`, and a projected plain element. They are in one host so a lookup
+// that silently understood only one of them fails here rather than in a
+// consumer's test.
+@Component({
+  selector: 'tn-action-host',
+  standalone: true,
+  imports: [TnBannerComponent, TnBannerActionDirective, TnButtonComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-banner heading="Disk Error Detected" message="Pool 'tank' has degraded disks." type="error">
+      <tn-button tnBannerAction label="Show Me" (onClick)="record('Show Me')" />
+      <a tnBannerAction href="#" (click)="recordLink($event)">View Documentation</a>
+    </tn-banner>
+  `
+})
+class ActionHostComponent {
+  clicked: string[] = [];
+
+  record(label: string): void {
+    this.clicked.push(label);
+  }
+
+  recordLink(event: MouseEvent): void {
+    event.preventDefault();
+    this.record('View Documentation');
+  }
+}
+
+// A control in the DEFAULT content slot alongside a real action. The default
+// slot only renders when neither heading nor message is set.
+@Component({
+  selector: 'tn-mixed-content-host',
+  standalone: true,
+  imports: [TnBannerComponent, TnBannerActionDirective, TnButtonComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-banner type="warning">
+      <div>
+        <tn-button label="In Content" />
+      </div>
+      <tn-button tnBannerAction label="Real Action" />
+    </tn-banner>
+  `
+})
+class MixedContentHostComponent {}
 
 describe('TnBannerHarness', () => {
   let hostComponent: TestHostComponent;
@@ -132,5 +180,115 @@ describe('TnBannerHarness', () => {
       TnBannerHarness.with({ textContains: 'fxn()' })
     );
     expect(banner).toBeTruthy();
+  });
+
+  it('should report no actions on a banner that projects none', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    expect(await banner.getActions()).toEqual([]);
+  });
+
+  it('should name the empty action list when clicking on a banner with no actions', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    await expect(banner.clickAction('Retry')).rejects.toThrow(
+      'No banner action found with label matching: Retry. Actions present: (none)'
+    );
+  });
+});
+
+describe('TnBannerHarness actions', () => {
+  let hostComponent: ActionHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ActionHostComponent],
+      providers: [
+        provideHttpClient(),
+        TnIconTesting.jest.providers()
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(ActionHostComponent);
+    hostComponent = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should return every projected action, whatever element it is', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    const actions = await banner.getActions();
+
+    // A lookup built on TnButtonHarness would report 1 here and drop the
+    // anchor, which is the failure this method exists to avoid.
+    expect(actions).toHaveLength(2);
+    expect(await actions[0].getLabel()).toBe('Show Me');
+    expect(await actions[1].getLabel()).toBe('View Documentation');
+  });
+
+  it('should click a tn-button action by label', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    await banner.clickAction('Show Me');
+
+    expect(hostComponent.clicked).toEqual(['Show Me']);
+  });
+
+  it('should click a non-button action by label', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    await banner.clickAction('View Documentation');
+
+    expect(hostComponent.clicked).toEqual(['View Documentation']);
+  });
+
+  it('should click an action matched by regex', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    await banner.clickAction(/documentation/i);
+
+    expect(hostComponent.clicked).toEqual(['View Documentation']);
+  });
+
+  it('should click an action found through an individual harness', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    const [button] = await banner.getActions();
+    await button.click();
+
+    expect(hostComponent.clicked).toEqual(['Show Me']);
+  });
+
+  it('should throw naming the label and the actions present when nothing matches', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+
+    await expect(banner.clickAction('Dismiss')).rejects.toThrow(
+      'No banner action found with label matching: Dismiss. '
+        + 'Actions present: "Show Me", "View Documentation"'
+    );
+    expect(hostComponent.clicked).toEqual([]);
+  });
+});
+
+describe('TnBannerHarness action scoping', () => {
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MixedContentHostComponent],
+      providers: [
+        provideHttpClient(),
+        TnIconTesting.jest.providers()
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(MixedContentHostComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should ignore a control in the default content slot', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+    const actions = await banner.getActions();
+
+    expect(actions).toHaveLength(1);
+    expect(await actions[0].getLabel()).toBe('Real Action');
+
+    await expect(banner.clickAction('In Content')).rejects.toThrow(
+      'No banner action found with label matching: In Content. Actions present: "Real Action"'
+    );
   });
 });

--- a/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.spec.ts
@@ -53,6 +53,14 @@ class ActionHostComponent {
 
 // A control in the DEFAULT content slot alongside a real action. The default
 // slot only renders when neither heading nor message is set.
+//
+// The in-content button carries `tnBannerAction` ON PURPOSE, and removing it
+// would make this suite pass whether or not the harness scopes its lookups.
+// `ng-content select="[tnBannerAction]"` matches only top-level projected
+// nodes, so this one is nested a level down, falls through to the default
+// slot, and renders inside `.tn-banner__main` — a `[tnBannerAction]` element
+// that is not an action. Only the `ancestor: '.tn-banner__action'` filter
+// tells it apart; `TnBannerActionHarness.hostSelector` alone would match it.
 @Component({
   selector: 'tn-mixed-content-host',
   standalone: true,
@@ -61,7 +69,7 @@ class ActionHostComponent {
   template: `
     <tn-banner type="warning">
       <div>
-        <tn-button label="In Content" />
+        <tn-button tnBannerAction label="In Content" />
       </div>
       <tn-button tnBannerAction label="Real Action" />
     </tn-banner>

--- a/projects/truenas-ui/src/lib/banner/banner.harness.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.harness.ts
@@ -1,9 +1,11 @@
 import type { BaseHarnessFilters } from '@angular/cdk/testing';
-import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate, parallel } from '@angular/cdk/testing';
+import { TnBannerActionHarness } from './banner-action.harness';
 
 /**
  * Harness for interacting with tn-banner in tests.
- * Provides simple text-based querying for existence checks.
+ * Provides text-based querying for existence checks, and access to the actions
+ * the banner projects into its action slot.
  *
  * @example
  * ```typescript
@@ -19,6 +21,9 @@ import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
  * const hasBanner = await loader.hasHarness(
  *   TnBannerHarness.with({ textContains: /success/i })
  * );
+ *
+ * // Press one of the banner's actions
+ * await errorBanner.clickAction('Retry');
  * ```
  */
 export class TnBannerHarness extends ComponentHarness {
@@ -26,6 +31,12 @@ export class TnBannerHarness extends ComponentHarness {
    * The selector for the host element of an `TnBannerComponent` instance.
    */
   static hostSelector = 'tn-banner';
+
+  // Scoped to `.tn-banner__action` so a control the caller projected into the
+  // default content slot is never mistaken for an action.
+  private _actions = this.locatorForAll(
+    TnBannerActionHarness.with({ ancestor: '.tn-banner__action' })
+  );
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a banner
@@ -75,6 +86,68 @@ export class TnBannerHarness extends ComponentHarness {
   async getText(): Promise<string> {
     const host = await this.host();
     return (await host.text()).trim();
+  }
+
+  /**
+   * Gets every action the banner projects into its action slot, in DOM order.
+   *
+   * Actions are not necessarily `tn-button`s — `[tnBannerAction]` is an
+   * attribute directive that takes any element — so these come back as
+   * `TnBannerActionHarness`, which reads a label and clicks whatever was
+   * projected. Nothing is filtered out by element type.
+   *
+   * @returns Promise resolving to an array of `TnBannerActionHarness` instances.
+   *
+   * @example
+   * ```typescript
+   * const banner = await loader.getHarness(TnBannerHarness);
+   * const actions = await banner.getActions();
+   * expect(actions).toHaveLength(2);
+   * expect(await actions[0].getLabel()).toBe('Retry');
+   * ```
+   */
+  async getActions(): Promise<TnBannerActionHarness[]> {
+    return this._actions();
+  }
+
+  /**
+   * Clicks one of the banner's actions by its label, matching the first in DOM
+   * order. Only matches inside the `.tn-banner__action` slot, not controls in
+   * the banner's default content.
+   *
+   * Named `clickAction` rather than `TnDialogHarness`'s `clickActionButton`
+   * because a banner action need not be a button: a projected `<a
+   * tnBannerAction>` is reached by this method exactly as a `tn-button` is.
+   *
+   * @param label The action label to match. Supports string or regex.
+   * @throws Error naming the label, and the labels actually present, if nothing matches.
+   *
+   * @example
+   * ```typescript
+   * const banner = await loader.getHarness(
+   *   TnBannerHarness.with({ textContains: 'network error' })
+   * );
+   * await banner.clickAction('Retry');
+   * await banner.clickAction(/learn more/i);
+   * ```
+   */
+  async clickAction(label: string | RegExp): Promise<void> {
+    const matches = await this.locatorForAll(
+      TnBannerActionHarness.with({ label, ancestor: '.tn-banner__action' })
+    )();
+    if (matches.length === 0) {
+      // Naming what IS there turns the common miss — a label that reads
+      // differently once rendered — from a hunt through the DOM into a diff.
+      const actions = await this._actions();
+      const labels = await parallel(() => actions.map((action) => action.getLabel()));
+      const present = labels.length
+        ? labels.map((found) => JSON.stringify(found)).join(', ')
+        : '(none)';
+      throw new Error(
+        `No banner action found with label matching: ${label}. Actions present: ${present}`
+      );
+    }
+    await matches[0].click();
   }
 }
 

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -11,6 +11,7 @@ export * from './lib/drawer/drawer.harness';
 export * from './lib/disk-icon/disk-icon.component';
 export * from './lib/banner/banner.component';
 export * from './lib/banner/banner.harness';
+export * from './lib/banner/banner-action.harness';
 export * from './lib/button/button.component';
 export * from './lib/button/button.harness';
 export * from './lib/icon-button/icon-button.component';

--- a/projects/truenas-ui/src/stories/banner.stories.ts
+++ b/projects/truenas-ui/src/stories/banner.stories.ts
@@ -11,8 +11,12 @@ tnIconMarker('alert', 'mdi');
 tnIconMarker('alert-circle', 'mdi');
 tnIconMarker('check-circle', 'mdi');
 
-// Load harness documentation
-const harnessDoc = loadHarnessDoc('banner');
+// Load harness documentation. `getActions()` hands back TnBannerActionHarness
+// instances, so that harness's own table is appended rather than left in a
+// section this component's docs never link to.
+const harnessDoc = [loadHarnessDoc('banner'), loadHarnessDoc('banner-action')]
+  .filter(Boolean)
+  .join('\n\n---\n\n');
 
 const meta: Meta<TnBannerComponent> = {
   title: 'Components/Banner',


### PR DESCRIPTION
Fixes #297

## What was wrong

`TnBannerHarness` exposed `getText()` and a `textContains` filter, and nothing
else. A test that needed to press a banner's action had to leave the harness and
query the DOM — which is the thing harnesses exist to stop, because it couples
the test to markup the component is free to change.

The actions are real API: `tn-banner` queries them with `contentChildren` and
renders a whole region only when they exist.

## What this adds

`TnBannerHarness.clickAction(label)` and `TnBannerHarness.getActions()`, plus
`TnBannerActionHarness` — the harness for one projected action.

```ts
const banner = await loader.getHarness(TnBannerHarness.with({ textContains: 'network error' }));
await banner.clickAction('Retry');
```

## The one thing that is not a straight copy, and how it went

`TnDialogHarness` solved this shape already, and the ticket asks for its names
and its `string | RegExp` signature. **A banner action is not necessarily a
`tn-button`**, though — `[tnBannerAction]` is an attribute directive with no
element restriction, and the banner's own stories project both
`<tn-button tnBannerAction>` (`WithActionButton`) and `<a tnBannerAction>`
(`WithActionLink`).

Locating `TnButtonHarness` the way the dialog does would have **silently skipped
the anchor**: `getActions()` reporting one fewer action than the banner renders,
and `clickAction('View Documentation')` throwing "not found" for something
plainly on screen. That is worse than no API, because it looks like a working
one.

So actions come back as `TnBannerActionHarness`, one per projected element
whatever its tag, and nothing is filtered out by element type. Per action:

| | How it resolves |
|---|---|
| **Label** | A `tn-button`'s dedicated label span when there is one — the rule `TnButtonHarness.getLabel()` already follows, so a rendered icon's sprite-fallback glyphs never leak in. The element's own trimmed text otherwise |
| **Click target** | The inner `button`/`a` when the action renders one, because a `tn-button` listens there and a click dispatched at its host element would never reach it. The projected element itself otherwise — an `<a tnBannerAction>` *is* its own click target |

Both locators are `locatorForOptional`, so the same harness covers a `tn-button`,
a plain `<a>`, a native `<button>` and a wrapper element without branching on
tag names. The reasoning is in the harness's own doc comment, next to the
methods, as the ticket asks.

### Naming

`clickAction` / `getActions` rather than the dialog's `clickActionButton` /
`getActionButtons` — the ticket's own worked example uses these, and "Button" in
the name would be false for half the shapes the method reaches. Everything else
follows the dialog: `string | RegExp`, first match in DOM order, throw rather
than resolve to `undefined`.

## Against the acceptance criteria

- **Click by label, `string | RegExp`, and return the actions found.**
  `clickAction()` and `getActions()`. Naming diverges only as stated above.
- **Both shapes reachable.** A projected `tn-button` and a projected `<a
  tnBannerAction>` are both clicked in the specs. Neither is covered "only in
  principle" — the multi-shape assertion counts them.
- **Scoped to `.tn-banner__action`.** Both methods pass
  `ancestor: '.tn-banner__action'`, so a control in the banner's default content
  slot is not an action.

  The spec that covers this puts `tnBannerAction` on the in-content control **on
  purpose**: `ng-content select="[tnBannerAction]"` matches only top-level
  projected nodes, so one nested inside a `<div>` falls through to the default
  slot and renders in `.tn-banner__main` — a `[tnBannerAction]` element that is
  not an action, which nothing but the `ancestor` filter tells apart. Deleting
  the option from both call sites makes `getActions()` return 2 and the suite go
  red, which is checked rather than assumed (see the round log).
- **A missing label throws naming the label.** It also names the labels actually
  present, which turns the common miss — a label that reads differently once
  rendered — from a DOM hunt into a diff.
- **`banner.harness.spec.ts` covers** clicking a `tn-button` action, clicking a
  non-button action, a label matching nothing, and a banner with no actions at
  all. Also regex matching, clicking through an individual action harness, and
  the slot-scoping case. 20 tests in the file, up from 11; 100% statement,
  branch, function and line coverage on both harness files.
- **Generated harness docs pick the new methods up.** Verified against the
  generated `harness-docs-loader.ts` after `yarn generate-harness-docs`: the
  `banner` table lists `getActions()` and `clickAction()`. The banner story
  appends `loadHarnessDoc('banner-action')` so the returned type's table is not
  stranded in a section nothing links to — the same array-and-join form
  `tree.stories.ts` already uses for `tree` / `tree-node`.

## Checks run locally

`yarn lint` and `yarn test` (144 suites, 4239 tests) on the current head, plus
`yarn generate-harness-docs` to confirm the table above. `yarn test:scripts`
(42), `yarn build` and `yarn build-storybook` were run on the first push and are
untouched by what came after it — the commits since change one attribute in a
test host's template and move one JSDoc paragraph.

**`Storybook Interaction Tests` was not run**: it needs a real browser, which
this machine has no way to provide. The diff is a new spec-only harness module,
harness methods, specs, one `public-api.ts` line and one story's doc-loading
line; no component, template or stylesheet changes, so that job has no new
surface to exercise. The two banner action stories it does exercise
(`WithActionButton`, `WithActionLink`) are unchanged.

## Local review

Two rounds. Both ran the same reviewer the required check runs, in a separate
process, so **these verdicts are the check's own rather than a subagent's.**

**Round 1** returned nothing at or above MEDIUM. One of its LOWs was fixed
afterwards because it made the diff wrong rather than merely unpolished: the
`@example` on `TnBannerActionHarness.with()` demonstrated the unscoped direct
load that the class doc immediately above it warns against.

**The required check's review then raised a MEDIUM that round 1 had missed**,
and it was right: the scoping suite passed with the `ancestor` option deleted
from both call sites, because the in-content control carried no
`tnBannerAction` and so was already excluded by
`TnBannerActionHarness.hostSelector`. The filter never got a chance to do work.
Fixed as described under the scoping criterion above, and confirmed by deleting
the option and watching the suite fail. The same round moved `with()`'s scoping
guidance above its block tags — after `@returns`, JSDoc read it as part of that
tag, and `generate-harness-docs.ts` only falls back to `@returns` when the
leading description is empty, so it never reached the Storybook table. It does
now.

**Round 2**, on that diff, returned nothing at or above MEDIUM. That ends the
local loop.

**LOWs left unfixed, deliberately** — each is worth a look and none blocks:

- **No `isDisabled()` on the action harness.** `click()` dispatches a synthetic
  click that a listener receives even on a `<button disabled>`, so a test can
  press an action a user could not. `TnButtonHarness` has the same shape, so
  this is a library-wide gap rather than something this diff introduces.
- **`getLabel()` has no `aria-label` fallback**, so an icon-only action would
  resolve to an empty label and could never be matched by `clickAction`. No such
  action exists in the banner's stories or specs.
- **`.storybook-button__label` and `'button, a'` are hardcoded here as well as
  in `TnButtonHarness`.** Renaming that class would quietly degrade this harness
  to full-host-text, and the new specs would still pass, because the button
  under test has no icon. Exporting the selector from the button harness would
  tie them together.
- **`.tn-banner__action` is written twice** — in `_actions` and in
  `clickAction`. One shared constant would stop a rename un-scoping one path and
  not the other.

## Also worth knowing, outside this ticket

`generate-harness-docs.ts` emits a method's parameter types into a Markdown
table cell without escaping, so any `string | RegExp` parameter breaks its row
at the `|`. This is pre-existing — `TnDialogHarness.clickActionButton()` renders
the same way on `main` today — and `clickAction()` now joins it. Not fixed here
because it is a change to shared doc tooling rather than to this ticket; it is
tracked as #300.
