### PR TITLE
NAS-142553 / 27.0.0-BETA.1 / fix(harness-docs): escape pipes so a union type cannot split its table row

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "jest --config ./projects/truenas-ui/jest.config.ts",
-    "test:scripts": "jest --config ./projects/truenas-ui/scripts/icon-sprite/jest.config.ts --rootDir ./projects/truenas-ui/scripts/icon-sprite",
+    "test:scripts": "jest --config ./projects/truenas-ui/scripts/jest.config.ts",
     "test-cc": "yarn jest --clearCache && yarn jest --config ./projects/truenas-ui/jest.config.ts",
     "test-coverage": "yarn jest --clearCache && yarn jest --config ./projects/truenas-ui/jest.config.ts --coverage",
     "test-sb": "test-storybook --config-dir projects/truenas-ui/.storybook",

--- a/projects/truenas-ui/scripts/harness-docs/jest.config.ts
+++ b/projects/truenas-ui/scripts/harness-docs/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.json',
+    }],
+  },
+  testMatch: ['<rootDir>/**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};
+
+export default config;

--- a/projects/truenas-ui/scripts/harness-docs/markdown-table.spec.ts
+++ b/projects/truenas-ui/scripts/harness-docs/markdown-table.spec.ts
@@ -1,0 +1,151 @@
+import {
+  escapeTableCell,
+  METHOD_TABLE_HEADER,
+  methodTableRow,
+  PROPERTY_TABLE_HEADER,
+  propertyTableRow,
+} from './markdown-table';
+
+/**
+ * Count the cells a Markdown parser reads out of one table row.
+ *
+ * The leading and trailing `|` are the row's own fences rather than delimiters, and a
+ * backslash-escaped `\|` is content — which is exactly the distinction under test, so it
+ * is spelled out here rather than borrowed from the code being tested.
+ */
+function cellsIn(row: string): number {
+  const trimmed = row.trim();
+
+  return trimmed.slice(1, -1).split(/(?<!\\)\|/).length;
+}
+
+/** The header's own first line decides how many cells every row below it must have. */
+const columnsOf = (header: string): number => cellsIn(header.split('\n')[0]);
+
+describe('escapeTableCell', () => {
+  it('escapes a pipe so it cannot end the cell', () => {
+    expect(escapeTableCell('string | RegExp')).toBe('string \\| RegExp');
+  });
+
+  it('escapes every pipe, not just the first', () => {
+    expect(escapeTableCell(`'asc' | 'desc' | '' | null`)).toBe(
+      `'asc' \\| 'desc' \\| '' \\| null`
+    );
+  });
+
+  it('uses the backslash escape rather than an HTML entity, which a code span would show literally', () => {
+    expect(escapeTableCell('A | B')).not.toContain('&#124;');
+  });
+
+  it('collapses newlines, because a row is one line', () => {
+    expect(escapeTableCell('first line\n  second line')).toBe('first line second line');
+  });
+
+  it('leaves a value with nothing to escape alone', () => {
+    expect(escapeTableCell('Promise<void>')).toBe('Promise<void>');
+  });
+});
+
+describe('methodTableRow', () => {
+  const columns = columnsOf(METHOD_TABLE_HEADER);
+
+  it('has a four-column header', () => {
+    expect(columns).toBe(4);
+  });
+
+  it('builds one row per union-typed parameter list, not one per union member', () => {
+    const row = methodTableRow({
+      name: 'clickActionButton',
+      parameters: 'string | RegExp',
+      returnType: 'Promise<void>',
+      description: 'Clicks an action button in the dialog footer by its label.',
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+
+  it('keeps the row intact when the union is in the return type', () => {
+    const row = methodTableRow({
+      name: 'getPlaceholder',
+      parameters: '',
+      returnType: 'Promise<string | null>',
+      description: 'Gets the placeholder text of the input.',
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+
+  it('keeps the row intact when the parameters and the return type both carry unions', () => {
+    const row = methodTableRow({
+      name: 'getCardSortDirection',
+      parameters: `number, 'enter' | 'space'`,
+      returnType: `Promise<'asc' | 'desc' | '' | null>`,
+      description: 'Gets the active sort direction in the card layout.',
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+
+  it('keeps the row intact when the description itself contains a pipe', () => {
+    const row = methodTableRow({
+      name: 'getType',
+      parameters: '',
+      returnType: 'Promise<string>',
+      description: 'Reads the native type: button | submit | reset.',
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+
+  it('puts the description in the Description column', () => {
+    const row = methodTableRow({
+      name: 'clickAction',
+      parameters: 'string | RegExp',
+      returnType: 'Promise<void>',
+      description: "Clicks one of the banner's actions by its label.",
+    });
+    const cells = row.trim().slice(1, -1).split(/(?<!\\)\|/);
+
+    expect(cells[3].trim()).toBe("Clicks one of the banner's actions by its label.");
+  });
+
+  it('leaves the Parameters cell empty for a method that takes none', () => {
+    const row = methodTableRow({
+      name: 'getText',
+      parameters: '',
+      returnType: 'Promise<string>',
+      description: 'Gets the text.',
+    });
+    const cells = row.trim().slice(1, -1).split(/(?<!\\)\|/);
+
+    expect(cells[1].trim()).toBe('');
+  });
+});
+
+describe('propertyTableRow', () => {
+  const columns = columnsOf(PROPERTY_TABLE_HEADER);
+
+  it('has a three-column header', () => {
+    expect(columns).toBe(3);
+  });
+
+  it('builds one row per union-typed property', () => {
+    const row = propertyTableRow({
+      name: 'label',
+      type: 'string | RegExp',
+      description: "Filters by the action's label text.",
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+
+  it('keeps the row intact when the description contains a pipe', () => {
+    const row = propertyTableRow({
+      name: 'orientation',
+      type: 'string',
+      description: 'One of horizontal | vertical.',
+    });
+
+    expect(cellsIn(row)).toBe(columns);
+  });
+});

--- a/projects/truenas-ui/scripts/harness-docs/markdown-table.ts
+++ b/projects/truenas-ui/scripts/harness-docs/markdown-table.ts
@@ -1,0 +1,77 @@
+/**
+ * Markdown table rows for the harness documentation `scripts/generate-harness-docs.ts`
+ * generates.
+ *
+ * These live apart from the generator because that file calls `main()` at the bottom of
+ * the module, so importing anything out of it runs the whole build. Everything here is a
+ * pure function of its argument, which is what makes the row shape testable at all.
+ */
+
+/** A harness method, reduced to the fields a table row renders. */
+export interface MethodRowInput {
+  name: string;
+  parameters: string;
+  returnType: string;
+  description: string;
+}
+
+/** An interface property, reduced to the fields a table row renders. */
+export interface PropertyRowInput {
+  name: string;
+  type: string;
+  description: string;
+}
+
+/** Header and delimiter rows for the Methods table. Four columns. */
+export const METHOD_TABLE_HEADER =
+  '| Method | Parameters | Returns | Description |\n' +
+  '|--------|------------|---------|-------------|\n';
+
+/** Header and delimiter rows for an interface's properties table. Three columns. */
+export const PROPERTY_TABLE_HEADER =
+  '| Property | Type | Description |\n' +
+  '|----------|------|-------------|\n';
+
+/**
+ * Render one value as the contents of a Markdown table cell.
+ *
+ * A `|` is a cell delimiter wherever it appears in a table row, and a code span does not
+ * protect it: the row is split into cells before its inline content is parsed, so a
+ * `string | RegExp` parameter arrives as two cells and every column after it shifts left
+ * by one. That is what dropped the Description column of every union-typed harness
+ * method.
+ *
+ * The backslash escape is read during that split, which is why `\|` works inside a code
+ * span and `&#124;` does not — an entity inside a code span renders as the six literal
+ * characters that spell it.
+ *
+ * Newlines collapse for the same reason: a row is one line, so a wrapped type or
+ * description would otherwise end the table partway through.
+ */
+export function escapeTableCell(value: string): string {
+  return value
+    .replace(/\s*\n+\s*/g, ' ')
+    .trim()
+    .replace(/\|/g, '\\|');
+}
+
+/** One row of the Methods table, newline included. */
+export function methodTableRow(method: MethodRowInput): string {
+  const parameters = method.parameters ? `\`${escapeTableCell(method.parameters)}\`` : '';
+
+  return (
+    `| \`${escapeTableCell(method.name)}()\`` +
+    ` | ${parameters}` +
+    ` | \`${escapeTableCell(method.returnType)}\`` +
+    ` | ${escapeTableCell(method.description)} |\n`
+  );
+}
+
+/** One row of an interface's properties table, newline included. */
+export function propertyTableRow(property: PropertyRowInput): string {
+  return (
+    `| \`${escapeTableCell(property.name)}\`` +
+    ` | \`${escapeTableCell(property.type)}\`` +
+    ` | ${escapeTableCell(property.description)} |\n`
+  );
+}

--- a/projects/truenas-ui/scripts/harness-docs/tsconfig.json
+++ b/projects/truenas-ui/scripts/harness-docs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "strict": true,
+    "types": ["jest", "node"],
+    "rootDir": ".",
+    "outDir": "../../dist/out-tsc/scripts"
+  },
+  "include": ["**/*.ts"]
+}

--- a/projects/truenas-ui/scripts/jest.config.ts
+++ b/projects/truenas-ui/scripts/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+/**
+ * `yarn test:scripts` — every build script under this directory that has tests.
+ *
+ * One Jest project per script package rather than one config rooted here, because
+ * `<rootDir>` inside a project config resolves to that project's own directory: each
+ * package keeps pointing ts-jest at its own `tsconfig.json`, and adding the next one
+ * costs a line here rather than a merge of compiler options.
+ */
+const config: Config = {
+  projects: [
+    '<rootDir>/harness-docs/jest.config.ts',
+    '<rootDir>/icon-sprite/jest.config.ts',
+  ],
+};
+
+export default config;

--- a/scripts/generate-harness-docs.ts
+++ b/scripts/generate-harness-docs.ts
@@ -13,6 +13,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
+import {
+  METHOD_TABLE_HEADER,
+  methodTableRow,
+  PROPERTY_TABLE_HEADER,
+  propertyTableRow,
+} from '../projects/truenas-ui/scripts/harness-docs/markdown-table';
 
 interface MethodInfo {
   name: string;
@@ -330,13 +336,10 @@ function generateMarkdown(info: HarnessInfo): string {
   // Methods table
   if (info.methods.length > 0) {
     md += `#### Methods\n\n`;
-    md += `| Method | Parameters | Returns | Description |\n`;
-    md += `|--------|------------|---------|-------------|\n`;
+    md += METHOD_TABLE_HEADER;
 
     info.methods.forEach(method => {
-      const desc = (method.description || '').replace(/\n+/g, ' ').trim();
-      const params = method.parameters ? `\`${method.parameters}\`` : '';
-      md += `| \`${method.name}()\` | ${params} | \`${method.returnType}\` | ${desc} |\n`;
+      md += methodTableRow(method);
     });
     md += `\n`;
   }
@@ -353,12 +356,10 @@ function generateMarkdown(info: HarnessInfo): string {
       }
 
       if (iface.properties.length > 0) {
-        md += `| Property | Type | Description |\n`;
-        md += `|----------|------|-------------|\n`;
+        md += PROPERTY_TABLE_HEADER;
 
         iface.properties.forEach(prop => {
-          const desc = (prop.description || '').replace(/\n+/g, ' ').trim();
-          md += `| \`${prop.name}\` | \`${prop.type}\` | ${desc} |\n`;
+          md += propertyTableRow(prop);
         });
         md += `\n`;
       }


### PR DESCRIPTION
Fixes #300

## What was wrong

`generate-harness-docs.ts` interpolated a method's parameter list, return type and
description straight into a Markdown table row. A `|` is a cell delimiter wherever it
appears in that row, and a code span does not protect it — the row is split into cells
*before* its inline content is parsed. So

```
| `clickActionButton()` | `string | RegExp` | `Promise<void>` | Clicks an action button ... |
```

is five cells against a four-column header: Returns and Description shift left by one and
the real description falls off the end.

**Measured on the generated `harness-docs-loader.ts` before the fix: 94 rows across the 38
harnesses had the wrong cell count.** Not just `string | RegExp` — every
`Promise<string | null>` return type, every union-typed filter property, and one row
(`TnTableHarness.getCardSortDirection()`, returning `Promise<'asc' | 'desc' | '' | null>`)
came out with **seven** cells.

## The fix

`escapeTableCell()` escapes each `|` as `\|`.

**`\|` rather than `&#124;`.** The ticket offers both; only the backslash works here.
Every one of these values is rendered inside a code span, and an HTML entity in a code
span renders as the six literal characters that spell it — `string &#124; RegExp` on
screen. The backslash escape is read during the row split, which is the stage that
matters. Confirmed by rendering the escaped row through `marked`, the GFM parser in this
repo's own dependencies: one row, four `<td>`s, and the cell reads `string | RegExp` with
no backslash left in it.

Newlines now collapse in **every** cell rather than only in descriptions. A row is one
line, so a parameter type written across two lines in a harness would end the table the
same way a wrapped description would; there is no such type today, and the asymmetry was
not deliberate.

## Where the code went, and why it moved at all

The acceptance criteria ask for a test in `projects/truenas-ui/scripts/`, run by
`yarn test:scripts`. `scripts/generate-harness-docs.ts` calls `main()` at module load, so
importing anything out of it runs the whole build — **nothing in that file can be
exercised by a spec while it stays there.** The row builders therefore move to
`projects/truenas-ui/scripts/harness-docs/markdown-table.ts`, next to their spec, and the
generator imports them. Both table headers move with them, so the header and the rows that
must line up with it are defined in one place.

`yarn test:scripts` was rooted at `projects/truenas-ui/scripts/icon-sprite`, so a spec
anywhere else under `scripts/` was run by nothing. It now points at a small
`projects/truenas-ui/scripts/jest.config.ts` listing one Jest project per script package.
That was chosen over one config rooted at `scripts/` because `<rootDir>` inside a project
config resolves to that project's own directory: **icon-sprite keeps its own `rootDir` and
`tsconfig.json`, untouched**, and its 42 tests run exactly as before.

## Against the acceptance criteria

- **A union-typed parameter list or return type renders as one aligned row.** The probe
  above re-run on the regenerated docs reports **0** rows with the wrong cell count, down
  from 94.
- **The fix is in the generator, not in the harnesses.** No harness file is touched by
  this diff.
- **Parameters, Returns, and the interface-properties table.** `methodTableRow()` escapes
  all four of its cells; `propertyTableRow()` escapes all three of its own, which is the
  `prop.type` column the ticket names.
- **Descriptions too.** Same helper, same call site — covered by a test for a method
  description and one for a property description.
- **A test in `projects/truenas-ui/scripts/`, in the `yarn test:scripts` suite.**
  `markdown-table.spec.ts`, 15 tests. Six of them assert a row's cell count equals the
  cell count of the header constant itself, rather than a hardcoded `4` — so a column
  added to one and not the other fails the suite. The spec counts cells with its own
  `(?<!\\)\|` split rather than borrowing one from the code under test, since "a
  backslash-escaped pipe is content, not a boundary" is the claim being tested.
- **`clickActionButton()` and `clickAction()` render their descriptions in the Description
  column.** Verified against the regenerated `harness-docs-loader.ts`: both now come out
  as 4 cells, with `` `string \| RegExp` `` in Parameters and the description in cell four.

## Checks run locally

`yarn lint`, `yarn test` (144 suites, 4239 tests), `yarn test:scripts` (5 suites, 57
tests — 42 existing plus 15 new), `yarn build`, and `yarn build-storybook`.

**`Storybook Interaction Tests` was not run**: it drives a real browser, which this
machine has no way to provide. The diff touches only the doc generator and a build-script
test; no component, template or stylesheet changes, so that job has no new surface to
exercise. What it would have shown — the table as rendered in the Docs tab — is checked
instead through `marked` and through the cell counts in the generated file, as described
above.

## Local review

One round, run by the same reviewer this PR's required check runs, in a separate process
— **so this verdict is the check's own rather than a subagent's.** It returned nothing at
or above MEDIUM, which ends the local loop.

**LOWs left unfixed, deliberately** — each is worth a look and none blocks:

- **`escapeTableCell` escapes `|` but not `\`.** A value containing a backslash
  immediately before a pipe would emit `\\|`, which renders as a literal backslash
  followed by a live delimiter. Nothing in any harness signature or JSDoc contains one
  today.
- **`generateLoaderFile()` is still unextracted and untested.** The escape survives into
  the loader only because that function replaces `\` before it replaces `` ` `` and `$`;
  the order is correct, and this diff verifies it end-to-end against the generated file,
  but nothing pins it.
- **The module sits under `projects/truenas-ui/scripts/` while its only consumer is
  `scripts/generate-harness-docs.ts` at the repo root**, so it is covered by two
  tsconfigs. That is where the acceptance criteria place the test, and module and spec are
  better kept together than split across the two trees.

## Also worth knowing, outside this ticket

`ng-package.json` copies `scripts/**/*` into the published package as an asset, and the
release job treats any change under `projects/truenas-ui/scripts/**` as a library change.
Putting the new module there therefore ships a doc-generator helper and its spec to npm
and cuts a patch release for a change the library itself does not contain. This is
pre-existing — icon-sprite's own `*.spec.ts` files already ship the same way — and
narrowing that asset glob is a packaging change rather than part of this fix.
