### PR TITLE
NAS-142565 / 27.0.0-BETA.1 / chore(test): stop depending on zone.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,16 @@ This library requires Angular 20:
   "@angular/platform-browser": "^20.0.0",
   "@angular/platform-browser-dynamic": "^20.0.0",
   "@angular/router": "^20.0.0",
-  "rxjs": "^7.5.0",
-  "zone.js": "^0.15.0"
+  "rxjs": "^7.5.0"
 }
 ```
+
+**No `zone.js`.** Nothing under `src/lib/` touches the `Zone` global, and
+`@angular/core` marks `zone.js` optional, so this library runs the same under
+zone-based and zoneless change detection: a component that injects `NgZone`
+gets the real one or `NoopNgZone`, and behaves identically either way. An
+application that still uses zone change detection keeps its own `zone.js` —
+this library neither requires nor forbids it.
 
 ## Distribution
 

--- a/angular.json
+++ b/angular.json
@@ -27,11 +27,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "tsConfig": "projects/truenas-ui/tsconfig.spec.json",
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ]
+            "tsConfig": "projects/truenas-ui/tsconfig.spec.json"
           }
         },
         "storybook": {

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -8,6 +8,72 @@ Testing patterns and best practices for TrueNAS UI Components using Jest.
 - **Testing library:** @angular/core/testing
 - **Assertions:** Jest matchers
 - **Storybook tests:** @storybook/testing-library + @storybook/jest
+- **Change detection:** zoneless. There is no `zone.js` in this repository.
+
+## The suite is zoneless, and two habits do not survive that
+
+`setup-jest.ts` calls `setupZonelessTestEnv()`, so every spec runs the change
+detection an Angular 21 application gets by default. Two things follow, and both
+of them fail in ways that name the wrong culprit.
+
+**1. `fakeAsync` and `tick` are gone.** They are Zone APIs. A spec that reaches
+for them fails the whole file with *"zone-testing.js is needed for the
+fakeAsync() test helper but could not be found"*. Use Jest's own clock:
+
+```typescript
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+it('reports after the fallback window', () => {
+  openTheThing();
+  jest.advanceTimersByTime(400);   // was: tick(400)
+  expect(settled).toHaveBeenCalled();
+});
+```
+
+The one behavioural difference that bites: **`tick()` drained the microtask
+queue as well as the timer queue, and `advanceTimersByTime()` does not.**
+Anything waiting on a promise — a `MutationObserver` callback, a component
+harness action — needs a real `await`, so the test has to be `async`:
+
+```typescript
+async function settle(): Promise<void> {
+  jest.advanceTimersByTime(0);
+  await Promise.resolve();
+  fixture.detectChanges();
+}
+```
+
+**2. A test host must hold changing state in a `signal`.** Zoneless change
+detection refreshes what has been marked dirty, and a plain property assignment
+marks nothing — so `fixture.detectChanges()` renders nothing and dev mode then
+reports the stale binding as `NG0100:
+ExpressionChangedAfterItHasBeenCheckedError`, which reads as a bug in the
+component rather than as a spec that never re-rendered.
+
+```typescript
+@Component({ template: `<tn-thing [loading]="loading()" />` })
+class HostComponent {
+  loading = signal(false);          // not: loading = false;
+}
+
+it('reports loading', () => {
+  host.loading.set(true);           // not: host.loading = true;
+  fixture.detectChanges();
+  ...
+});
+```
+
+Only the fields the template READS need this. A field an output binding writes
+into (`(rowClick)="clicks.push($event)"`) is never read by a binding and can
+stay plain.
+
+**`fixture.whenStable()` waits for less than it used to.** Under Zone it meant
+"no pending macrotasks". Zoneless, it resolves once Angular's `PendingTasks` set
+is empty — and a bare `setTimeout` or `requestAnimationFrame` is not one of
+those. A spec waiting on a component's own timer (`tn-tooltip`'s show delay) or
+on an animation frame (`tn-tree-virtual-scroll-view`'s node stream) has to await
+that thing itself.
 
 ## Basic Test Structure
 
@@ -609,6 +675,15 @@ debugger;
 ### "Cannot set input"
 - Use `fixture.componentRef.setInput('name', value)` to set input signals in tests
 - Don't try to directly assign to input signals: `component.label = 'test'` won't work
+
+### "NG0100: ExpressionChangedAfterItHasBeenCheckedError" pointing at your test host
+- The host field the binding reads is a plain property, so nothing was marked
+  dirty and `detectChanges()` refreshed nothing — see *The suite is zoneless*
+  at the top. Hold it in a `signal` and `set()` it
+
+### "zone-testing.js is needed for the fakeAsync() test helper"
+- `fakeAsync`/`tick` do not exist here; use `jest.useFakeTimers()` and
+  `jest.advanceTimersByTime(ms)` — see *The suite is zoneless* at the top
 
 ## Examples
 

--- a/docs/component_testing.md
+++ b/docs/component_testing.md
@@ -32,9 +32,9 @@ it('reports after the fallback window', () => {
 ```
 
 The one behavioural difference that bites: **`tick()` drained the microtask
-queue as well as the timer queue, and `advanceTimersByTime()` does not.**
-Anything waiting on a promise — a `MutationObserver` callback, a component
-harness action — needs a real `await`, so the test has to be `async`:
+queue as well as the timer queue, and `advanceTimersByTime()` does not.** A
+`MutationObserver` callback is a microtask, so a spec waiting on one needs a
+real `await` and the test has to be `async`:
 
 ```typescript
 async function settle(): Promise<void> {
@@ -43,6 +43,13 @@ async function settle(): Promise<void> {
   fixture.detectChanges();
 }
 ```
+
+**A component harness action needs more than that**, and a fake clock does not
+help it at all: the harness environment awaits promises of its own between the
+action and the query, so the component's `setTimeout` has to land on a REAL
+macrotask before the harness looks. `tooltip.harness.spec.ts` is the worked
+example — it uses `await new Promise((resolve) => setTimeout(resolve))` and no
+fake timers.
 
 **2. A test host must hold changing state in a `signal`.** Zoneless change
 detection refreshes what has been marked dirty, and a plain property assignment

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "@angular/platform-browser-dynamic": "^19.0.0",
         "@angular/router": "^19.0.0",
         "rxjs": "~7.5.0",
-        "tslib": "^2.3.0",
-        "zone.js": "^0.15.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.0.0",
@@ -17435,12 +17434,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
-      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "node": ">=24"
   },
   "peerDependencies": {
-    "rxjs": "^7.5.0",
-    "zone.js": "^0.15.0"
+    "rxjs": "^7.5.0"
   },
   "dependencies": {
     "@material-design-icons/svg": "~0.14.13",
@@ -142,8 +141,7 @@
     "style-loader": "^4.0.0",
     "ts-jest": "~29.4.6",
     "typescript": "~5.9.3",
-    "wait-on": "^9.1.0",
-    "zone.js": "^0.15.1"
+    "wait-on": "^9.1.0"
   },
   "resolutions": {
     "caniuse-lite": "^1.0.30001764"

--- a/projects/truenas-ui/.storybook/preview.ts
+++ b/projects/truenas-ui/.storybook/preview.ts
@@ -5,7 +5,6 @@ import { provideRouter, withDisabledInitialNavigation } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { withThemeByClassName } from '@storybook/addon-themes';
 import { APP_INITIALIZER } from '@angular/core';
-import 'zone.js';
 import { TnThemeService, TnTheme } from '../src/public-api';
 import { TnIconRegistryService } from '../src/lib/icon/icon-registry.service';
 import { TnSpriteLoaderService } from '../src/lib/icon/sprite-loader.service';

--- a/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
+++ b/projects/truenas-ui/src/lib/banner/banner.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture} from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { TnBannerComponent, TnBannerActionDirective } from './banner.component';
@@ -28,14 +28,14 @@ class BannerWithoutActionTestComponent {}
   standalone: true,
   imports: [TnBannerComponent],
   template: `
-    <tn-banner [heading]="heading" [message]="message">
+    <tn-banner [heading]="heading()" [message]="message()">
       <div class="projected-content">Projected Content</div>
     </tn-banner>
   `
 })
 class BannerWithProjectedContentTestComponent {
-  heading: string | undefined = undefined;
-  message: string | undefined = undefined;
+  heading = signal<string | undefined>(undefined);
+  message = signal<string | undefined>(undefined);
 }
 
 describe('TnBannerComponent', () => {
@@ -250,7 +250,7 @@ describe('TnBannerComponent', () => {
 
     it('should not display projected content when heading is provided', () => {
       const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
-      hostFixture.componentInstance.heading = 'Real Heading';
+      hostFixture.componentInstance.heading.set('Real Heading');
       hostFixture.detectChanges();
 
       expect(hostFixture.nativeElement.querySelector('.projected-content')).toBeNull();
@@ -261,7 +261,7 @@ describe('TnBannerComponent', () => {
 
     it('should not display projected content when only message is provided', () => {
       const hostFixture = TestBed.createComponent(BannerWithProjectedContentTestComponent);
-      hostFixture.componentInstance.message = 'Real Message';
+      hostFixture.componentInstance.message.set('Real Message');
       hostFixture.detectChanges();
 
       expect(hostFixture.nativeElement.querySelector('.projected-content')).toBeNull();
@@ -278,7 +278,7 @@ describe('TnBannerComponent', () => {
       expect(hostFixture.nativeElement.querySelector('.tn-banner__icon')).toBeNull();
 
       // Structured mode: icon present
-      hostFixture.componentInstance.heading = 'Heading';
+      hostFixture.componentInstance.heading.set('Heading');
       hostFixture.detectChanges();
       expect(hostFixture.nativeElement.querySelector('.tn-banner__icon')).toBeTruthy();
     });

--- a/projects/truenas-ui/src/lib/button-toggle/button-toggle.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/button-toggle/button-toggle.harness.spec.ts
@@ -1,6 +1,6 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TnButtonToggleGroupComponent } from './button-toggle-group.component';
@@ -388,18 +388,18 @@ describe('TnButtonToggleGroup — initial FormControl value with @for loop', () 
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-button-toggle-group
-      [checkedBg]="bg"
-      [checkedColor]="color"
-      [checkedBorder]="border">
+      [checkedBg]="bg()"
+      [checkedColor]="color()"
+      [checkedBorder]="border()">
       <tn-button-toggle value="a">A</tn-button-toggle>
       <tn-button-toggle value="b">B</tn-button-toggle>
     </tn-button-toggle-group>
   `,
 })
 class ButtonToggleCheckedStyleTestComponent {
-  bg: string | null = null;
-  color: string | null = null;
-  border: string | null = null;
+  bg = signal<string | null>(null);
+  color = signal<string | null>(null);
+  border = signal<string | null>(null);
 }
 
 describe('TnButtonToggleGroup — checked style inputs', () => {
@@ -424,9 +424,9 @@ describe('TnButtonToggleGroup — checked style inputs', () => {
   });
 
   it('should set the CSS custom properties from inputs', () => {
-    component.bg = '#71BF44';
-    component.color = '#ffffff';
-    component.border = '#5fa036';
+    component.bg.set('#71BF44');
+    component.color.set('#ffffff');
+    component.border.set('#5fa036');
     fixture.detectChanges();
 
     const groupEl = fixture.nativeElement.querySelector('tn-button-toggle-group') as HTMLElement;
@@ -436,7 +436,7 @@ describe('TnButtonToggleGroup — checked style inputs', () => {
   });
 
   it('should accept CSS var() references', () => {
-    component.bg = 'var(--tn-primary)';
+    component.bg.set('var(--tn-primary)');
     fixture.detectChanges();
 
     const groupEl = fixture.nativeElement.querySelector('tn-button-toggle-group') as HTMLElement;

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -605,7 +605,13 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     const idx = this.highlightedIndex();
     const options = this.overlayRef?.overlayElement
       ?.querySelectorAll<HTMLElement>('.tn-chip-input__option');
-    options?.[idx]?.scrollIntoView({ block: 'nearest' });
+    // Guarded rather than called outright, the same way `tn-autocomplete` does
+    // it: jsdom implements no `scrollIntoView`, so an unguarded call throws
+    // `TypeError` in every spec that arrows through the suggestions. Zone used
+    // to swallow that, and #304 took the zone away.
+    if (options?.[idx]?.scrollIntoView) {
+      options[idx].scrollIntoView({ block: 'nearest' });
+    }
   }
 
   private open(): void {

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.spec.ts
@@ -372,12 +372,15 @@ class LabelledPrimitiveValueHostComponent {
   imports: [TnChipInputComponent, ReactiveFormsModule],
   template: `
     <form [formGroup]="form">
-      <tn-chip-input testId="tags" formControlName="regions" [options]="options" />
+      <tn-chip-input testId="tags" formControlName="regions" [options]="options()" />
     </form>
   `,
 })
 class AsyncOptionsHostComponent {
-  options: TnChipInputOption<string>[] = [];
+  // The one host here whose options ARRIVE after first render, which is the
+  // subject; a plain reassignment marks no view dirty under zoneless change
+  // detection, so the chip would keep its pre-load name (#304).
+  options = signal<TnChipInputOption<string>[]>([]);
   form = new FormGroup({ regions: new FormControl<string[]>(['us']) });
 }
 
@@ -526,7 +529,7 @@ describe('TnChipInputComponent test ids', () => {
       ?.getAttribute('data-testid');
     expect(chipId()).toBe('chip-tags-us');
 
-    fixture.componentInstance.options = [{ label: 'United States', value: 'us' }];
+    fixture.componentInstance.options.set([{ label: 'United States', value: 'us' }]);
     fixture.detectChanges();
     expect(chipId()).toBe('chip-tags-united-states');
   });

--- a/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/drawer/drawer-lifecycle.spec.ts
@@ -1,6 +1,6 @@
-import { Component, NgZone, signal } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TnDrawerComponent } from './drawer.component';
 import type { TnDrawerMode } from './drawer.component';
 import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
@@ -44,18 +44,21 @@ class TestHostComponent {
  *
  * WHY THE FIXTURE IS BUILT INSIDE EACH TEST, AND WHY THIS IS ITS OWN FILE
  * ----------------------------------------------------------------------
- * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
- * timer is only reachable by `tick()` if it was scheduled inside that
- * `fakeAsync` zone. This one is armed with `runOutsideAngular`, so it lands in
- * the zone `NgZone` was CONSTRUCTED in — and `TestBed` constructs that once,
- * lazily, at the FIRST `TestBed.createComponent` of the suite. A `beforeEach`
- * that creates a fixture
- * therefore fixes the zone for every test after it, and the fallback then fires
- * on the real clock a third of a second after the test has already finished.
+ * The fallback is a timer, so these tests have to be able to advance a clock to
+ * see it, and the fixture has to exist before the clock they advance is the one
+ * the timer lands on. Both of those held under Zone for a subtler reason —
+ * `runOutsideAngular` put the timer in the zone `NgZone` was CONSTRUCTED in,
+ * which `TestBed` did lazily at the suite's FIRST `createComponent`, so a
+ * `beforeEach` that built a fixture fixed the zone for every test after it and
+ * the fallback then fired on the real clock a third of a second after the test
+ * had finished.
  *
- * That is why this is a separate file rather than another `describe` in
- * `drawer.component.spec.ts`: sharing a suite means sharing that first
- * `createComponent`, and the fix is not local to the block that needs it.
+ * Zone is gone (#304) and the timer is now a plain `setTimeout` on Jest's fake
+ * clock, which has no such lazily-fixed identity. The shape is kept anyway: a
+ * per-test fixture is what keeps one test's armed fallback from reporting into
+ * the next one's spies, and this stays a separate file from
+ * `drawer.component.spec.ts` so a suite-wide `useFakeTimers` does not have to be
+ * imposed on specs that want a real clock.
  */
 describe('TnDrawerComponent lifecycle outputs', () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -65,6 +68,10 @@ describe('TnDrawerComponent lifecycle outputs', () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
     }).compileComponents();
+
+    // After `compileComponents`, so the fake clock is never the thing an
+    // awaited compile is waiting on.
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -74,9 +81,10 @@ describe('TnDrawerComponent lifecycle outputs', () => {
     // reference to.
     document.body.querySelectorAll('.tn-drawer__panel--over').forEach((el) => el.remove());
     document.body.querySelectorAll('.tn-drawer__backdrop').forEach((el) => el.remove());
+    jest.useRealTimers();
   });
 
-  /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
+  /** Build the fixture under test. Call first. */
   function createDrawer(mode: TnDrawerMode = 'side', opened = false): void {
     fixture = TestBed.createComponent(TestHostComponent);
     host = fixture.componentInstance;
@@ -105,114 +113,117 @@ describe('TnDrawerComponent lifecycle outputs', () => {
     panel.dispatchEvent(Object.assign(new Event('transitionend'), { propertyName: 'transform' }));
   }
 
-  it('emits openedComplete when no transitionend arrives', fakeAsync(() => {
+  it('emits openedComplete when no transitionend arrives', () => {
     createDrawer();
     setOpened(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
     expect(host.closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('emits closed when no transitionend arrives', fakeAsync(() => {
+  it('emits closed when no transitionend arrives', () => {
     createDrawer();
     setOpened(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     setOpened(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
     expect(host.closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits in over mode too, where the panel is portaled', fakeAsync(() => {
+  it('emits in over mode too, where the panel is portaled', () => {
     createDrawer('over');
     setOpened(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     setOpened(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
     expect(host.closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits once, not twice, when the transition does complete', fakeAsync(() => {
+  it('emits once, not twice, when the transition does complete', () => {
     createDrawer();
     setOpened(true);
     finishTransition();
 
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
 
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('ignores a transitionend that arrives after the fallback already fired', fakeAsync(() => {
+  it('ignores a transitionend that arrives after the fallback already fired', () => {
     createDrawer();
     setOpened(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     finishTransition();
 
     expect(host.openedComplete).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits nothing while the drawer stays closed', fakeAsync(() => {
+  it('emits nothing while the drawer stays closed', () => {
     createDrawer();
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('emits nothing for a drawer that RENDERS open, which never opened', fakeAsync(() => {
+  it('emits nothing for a drawer that RENDERS open, which never opened', () => {
     createDrawer('side', true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('still emits closed for a drawer that rendered open and is then closed', fakeAsync(() => {
+  it('still emits closed for a drawer that rendered open and is then closed', () => {
     createDrawer('side', true);
     setOpened(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits only the final state when a close interrupts an open', fakeAsync(() => {
+  it('emits only the final state when a close interrupts an open', () => {
     createDrawer();
     setOpened(true);
     setOpened(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).not.toHaveBeenCalled();
     expect(host.closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('does not hold NgZone unstable while the fallback is armed', fakeAsync(() => {
-    createDrawer();
-    setOpened(true);
+  /*
+   * WHERE 'does not hold NgZone unstable while the fallback is armed' WENT
+   * ---------------------------------------------------------------------
+   * This file used to assert
+   * `expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false)` right
+   * after an open, guarding the `runOutsideAngular` in
+   * `../utils/transition-lifecycle.ts`. #304 made the test suite zoneless, and
+   * with no Zone `NgZone` resolves to `NoopNgZone`, whose `hasPendingMacrotasks`
+   * is a hard-coded `false`. The assertion would have kept passing — including
+   * with the `runOutsideAngular` deleted — which is worse than not having it.
+   *
+   * It is DELETED HERE AND REPLACED, not dropped: `../utils/transition-lifecycle.spec.ts`
+   * covers the same guard by asserting that the fallback timer is the one armed
+   * inside `runOutsideAngular` and that the report goes back through
+   * `zone.run`, both of which fail if the calls are removed. That test is on the
+   * shared helper rather than on each of its two callers, which is where the
+   * behaviour lives.
+   */
 
-    // The timer is armed from an `effect`, which runs inside
-    // `ApplicationRef.tick()` inside `NgZone.run(...)`, so scheduling it
-    // without `runOutsideAngular` makes it an Angular-zone macrotask — and
-    // `fixture.whenStable()` and CDK's `forceStabilize()` would then block for
-    // the whole fallback window after every open and every close, in every
-    // downstream suite that toggles one of these components.
-    expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false);
-
-    tick(TN_TRANSITION_FALLBACK_MS);
-    expect(host.openedComplete).toHaveBeenCalledTimes(1);
-  }));
-
-  it('emits nothing after the drawer is destroyed mid-transition', fakeAsync(() => {
+  it('emits nothing after the drawer is destroyed mid-transition', () => {
     createDrawer();
     setOpened(true);
     fixture.destroy();
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.openedComplete).not.toHaveBeenCalled();
-  }));
+  });
 });

--- a/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/form-field/form-field.harness.spec.ts
@@ -1,6 +1,6 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import type { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
@@ -392,7 +392,7 @@ describe('TnFormFieldHarness', () => {
   imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
-    <tn-form-field label="Name" testId="name" [errorMessages]="stringMessages">
+    <tn-form-field label="Name" testId="name" [errorMessages]="stringMessages()">
       <tn-input [formControl]="nameControl" />
     </tn-form-field>
 
@@ -415,9 +415,13 @@ class ErrorMessagesHostComponent {
   unrelatedControl = new FormControl('', Validators.required);
   throwingControl = new FormControl('', Validators.required);
 
-  stringMessages: TnFormFieldErrorMessages = {
+  // A signal, not a plain field: this is the one override the specs REPLACE
+  // mid-test (a locale switch), and under zoneless change detection a plain
+  // reassignment marks nothing dirty, so the field would keep rendering the
+  // old message. The three below are only ever read.
+  stringMessages = signal<TnFormFieldErrorMessages>({
     required: 'Please enter a name',
-  };
+  });
 
   fnMessages: TnFormFieldErrorMessages = {
     minlength: (err) =>
@@ -500,7 +504,7 @@ describe('TnFormField per-field errorMessages', () => {
     expect(await field.getErrorMessage()).toBe('Please enter a name');
 
     // Change only the overrides (e.g. a locale switch) — no control status change.
-    host.stringMessages = { required: 'Updated message' };
+    host.stringMessages.set({ required: 'Updated message' });
     fixture.detectChanges();
 
     expect(await field.getErrorMessage()).toBe('Updated message');
@@ -525,7 +529,7 @@ describe('TnFormField per-field errorMessages', () => {
   it('should fall through to the built-in default when an override resolves to a blank string', async () => {
     const host = fixture.componentInstance;
     // e.g. a translation service returning '' for a missing key.
-    host.stringMessages = { required: '   ' };
+    host.stringMessages.set({ required: '   ' });
     host.nameControl.markAsTouched();
     host.nameControl.updateValueAndValidity();
     fixture.detectChanges();
@@ -613,7 +617,7 @@ describe('TnFormField global error resolver', () => {
   standalone: true,
   imports: [TnFormFieldComponent, TnInputComponent, ReactiveFormsModule],
   template: `
-    <tn-form-field label="Dataset" [tooltip]="tooltip" [tooltipSticky]="tooltipSticky">
+    <tn-form-field label="Dataset" [tooltip]="tooltip()" [tooltipSticky]="tooltipSticky()">
       <tn-input [formControl]="control" />
     </tn-form-field>
   `
@@ -622,8 +626,8 @@ class StickyHostComponent {
   control = new FormControl('');
   // Field help is plain text and never pinnable, so the flag is only observable through a message
   // that holds a link - but it still has to reach the directive to be settable at all.
-  tooltip = 'Read the <a href="#docs">docs</a>';
-  tooltipSticky = true;
+  tooltip = signal('Read the <a href="#docs">docs</a>');
+  tooltipSticky = signal(true);
 }
 
 describe('TnFormFieldComponent tooltipSticky', () => {
@@ -641,7 +645,7 @@ describe('TnFormFieldComponent tooltipSticky', () => {
       .injector.get(TnTooltipDirective);
     expect(tooltip.stickyEnabled()).toBe(true);
 
-    fixture.componentInstance.tooltipSticky = false;
+    fixture.componentInstance.tooltipSticky.set(false);
     fixture.detectChanges();
     expect(tooltip.stickyEnabled()).toBe(false);
   });
@@ -661,7 +665,7 @@ describe('TnFormFieldComponent tooltipSticky', () => {
     const button = fixture.debugElement.query(By.css('.tn-form-field-tooltip')).nativeElement;
     expect(button.getAttribute('aria-label')).toBe('Read the docs');
 
-    fixture.componentInstance.tooltip = 'Plain help text';
+    fixture.componentInstance.tooltip.set('Plain help text');
     fixture.detectChanges();
     expect(button.getAttribute('aria-label')).toBe('Plain help text');
   });

--- a/projects/truenas-ui/src/lib/form-section/form-section.component.spec.ts
+++ b/projects/truenas-ui/src/lib/form-section/form-section.component.spec.ts
@@ -1,6 +1,6 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -12,15 +12,15 @@ import { TnTooltipDirective } from '../tooltip/tooltip.directive';
   standalone: true,
   imports: [TnFormSectionComponent],
   template: `
-    <tn-form-section [heading]="heading" [tooltip]="tooltip" [tooltipSticky]="tooltipSticky">
+    <tn-form-section [heading]="heading()" [tooltip]="tooltip()" [tooltipSticky]="tooltipSticky()">
       <p class="projected">Projected field content</p>
     </tn-form-section>
   `,
 })
 class HostComponent {
-  heading = 'Network Settings';
-  tooltip = '';
-  tooltipSticky = true;
+  heading = signal('Network Settings');
+  tooltip = signal('');
+  tooltipSticky = signal(true);
 }
 
 describe('TnFormSectionComponent', () => {
@@ -64,7 +64,7 @@ describe('TnFormSectionComponent', () => {
   });
 
   it('names the group from the heading alone, not the tooltip text', () => {
-    host.tooltip = 'A long help sentence that must not pollute the group name.';
+    host.tooltip.set('A long help sentence that must not pollute the group name.');
     fixture.detectChanges();
 
     const fieldset = fixture.debugElement.query(By.css('fieldset.tn-form-section')).nativeElement;
@@ -79,20 +79,20 @@ describe('TnFormSectionComponent', () => {
   });
 
   it('drops aria-labelledby when there is no heading', () => {
-    host.heading = '';
+    host.heading.set('');
     fixture.detectChanges();
     const fieldset = fixture.debugElement.query(By.css('fieldset.tn-form-section')).nativeElement;
     expect(fieldset.getAttribute('aria-labelledby')).toBeNull();
   });
 
   it('omits the legend when no heading is set', () => {
-    host.heading = '';
+    host.heading.set('');
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.tn-form-section__legend'))).toBeNull();
   });
 
   it('renders lightweight label markup in the heading', () => {
-    host.heading = '**Storage** settings';
+    host.heading.set('**Storage** settings');
     fixture.detectChanges();
     const legend = fixture.debugElement.query(By.css('.tn-form-section__legend'));
     expect(legend.nativeElement.innerHTML).toContain('<strong>Storage</strong>');
@@ -101,25 +101,25 @@ describe('TnFormSectionComponent', () => {
   it('shows the tooltip button only when a tooltip is set', () => {
     expect(fixture.debugElement.query(By.css('.tn-form-section__tooltip'))).toBeNull();
 
-    host.tooltip = 'Controls how the interface reaches the network.';
+    host.tooltip.set('Controls how the interface reaches the network.');
     fixture.detectChanges();
 
     const tooltip = fixture.debugElement.query(By.css('.tn-form-section__tooltip'));
     expect(tooltip).toBeTruthy();
-    expect(tooltip.nativeElement.getAttribute('aria-label')).toBe(host.tooltip);
+    expect(tooltip.nativeElement.getAttribute('aria-label')).toBe(host.tooltip());
   });
 
   // Section help is plain text and never pinnable, so the flag is only observable through a
   // message that holds a link — but it still has to reach the directive to be settable at all.
   it('forwards tooltipSticky to the help button', () => {
-    host.tooltip = 'Read the <a href="#docs">docs</a>';
+    host.tooltip.set('Read the <a href="#docs">docs</a>');
     fixture.detectChanges();
 
     const button = fixture.debugElement.query(By.css('.tn-form-section__tooltip'));
     const tooltip = button.injector.get(TnTooltipDirective);
     expect(tooltip.stickyEnabled()).toBe(true);
 
-    host.tooltipSticky = false;
+    host.tooltipSticky.set(false);
     fixture.detectChanges();
     expect(tooltip.stickyEnabled()).toBe(false);
   });
@@ -128,7 +128,7 @@ describe('TnFormSectionComponent', () => {
   // link is exactly what this feature makes normal to pass. Announced raw it would be read out as
   // literal tags.
   it('names the help button with the message as text, not as markup', () => {
-    host.tooltip = 'Read the <a href="#docs">docs</a>';
+    host.tooltip.set('Read the <a href="#docs">docs</a>');
     fixture.detectChanges();
 
     const button = fixture.debugElement.query(By.css('.tn-form-section__tooltip'));
@@ -145,7 +145,7 @@ describe('TnFormSectionComponent', () => {
       const section = await loader.getHarness(TnFormSectionHarness);
       expect(await section.hasTooltip()).toBe(false);
 
-      host.tooltip = 'More info';
+      host.tooltip.set('More info');
       fixture.detectChanges();
       expect(await section.hasTooltip()).toBe(true);
     });

--- a/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
+++ b/projects/truenas-ui/src/lib/list-item/list-item.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { TnListItemComponent } from './list-item.component';
@@ -33,11 +33,11 @@ class TextSlotsHostComponent {}
   selector: 'tn-list-item-plain-test',
   standalone: true,
   imports: [TnListItemComponent],
-  template: `<tn-list-item [dense]="dense" [wrap]="wrap">Just text</tn-list-item>`,
+  template: `<tn-list-item [dense]="dense()" [wrap]="wrap()">Just text</tn-list-item>`,
 })
 class PlainHostComponent {
-  dense = false;
-  wrap = false;
+  dense = signal(false);
+  wrap = signal(false);
 }
 
 describe('TnListItemComponent', () => {
@@ -187,8 +187,8 @@ describe('TnListItemComponent', () => {
       expect(host.classList).not.toContain('tn-list-item--dense');
       expect(host.classList).not.toContain('tn-list-item--wrap');
 
-      fixture.componentInstance.dense = true;
-      fixture.componentInstance.wrap = true;
+      fixture.componentInstance.dense.set(true);
+      fixture.componentInstance.wrap.set(true);
       fixture.detectChanges();
 
       expect(host.classList).toContain('tn-list-item--dense');

--- a/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.component.spec.ts
@@ -1,7 +1,7 @@
 import { CdkMenu } from '@angular/cdk/menu';
 import { Component, getDebugNode, signal, viewChild } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
-import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TnMenuItemComponent } from './menu-item.component';
 import { TnMenuTriggerDirective } from './menu-trigger.directive';
 import type { TnMenuItem } from './menu.component';
@@ -32,10 +32,10 @@ function getBackdrop(): HTMLElement | null {
   standalone: true,
   imports: [TnMenuComponent, TnMenuTriggerDirective],
   template: `
-    <button class="trigger" [tnMenuTriggerFor]="menu" [tnMenuPosition]="position">Open</button>
+    <button class="trigger" [tnMenuTriggerFor]="menu" [tnMenuPosition]="position()">Open</button>
     <tn-menu
       #menu
-      [items]="items"
+      [items]="items()"
       (menuItemClick)="lastClicked = $event"
       (menuOpen)="opened = true"
       (menuClose)="closed = true"
@@ -43,7 +43,7 @@ function getBackdrop(): HTMLElement | null {
   `,
 })
 class MenuTestHostComponent {
-  items: TnMenuItem[] = [
+  items = signal<TnMenuItem[]>([
     { id: 'cut', label: 'Cut', icon: 'content_cut', shortcut: '⌘X' },
     { id: 'copy', label: 'Copy' },
     { id: 'disabled', label: 'Disabled', disabled: true },
@@ -52,8 +52,8 @@ class MenuTestHostComponent {
       { id: 'child-1', label: 'Child 1' },
       { id: 'child-2', label: 'Child 2' },
     ]},
-  ];
-  position: 'above' | 'below' | 'before' | 'after' = 'below';
+  ]);
+  position = signal<'above' | 'below' | 'before' | 'after'>('below');
   lastClicked: TnMenuItem | null = null;
   opened = false;
   closed = false;
@@ -109,10 +109,17 @@ describe('tn-menu with trigger', () => {
     host = fixture.componentInstance;
     fixture.detectChanges();
     triggerButton = fixture.nativeElement.querySelector('.trigger');
+
+    // The backdrop-click test has to let CDK's overlay teardown timers run, and
+    // #304 replaced `fakeAsync`/`flush` with Jest's clock. Enabled for the whole
+    // block rather than for that one test: no test here awaits anything, so a
+    // fake clock costs the others nothing and there is one place to find it.
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     host.trigger().closeMenu();
+    jest.useRealTimers();
   });
 
   // -- Opening & closing --------------------------------------------------
@@ -136,17 +143,17 @@ describe('tn-menu with trigger', () => {
     expect(host.closed).toBe(true);
   });
 
-  it('should close menu when backdrop is clicked', fakeAsync(() => {
+  it('should close menu when backdrop is clicked', () => {
     triggerButton.click();
     fixture.detectChanges();
 
     getBackdrop()!.click();
-    flush();
+    jest.runOnlyPendingTimers();
     fixture.detectChanges();
 
     expect(getMenuPanel()).toBeFalsy();
     expect(host.closed).toBe(true);
-  }));
+  });
 
   it('closes the menu on Tab so the browser can advance focus to the next element', () => {
     triggerButton.click();
@@ -303,10 +310,10 @@ describe('tn-menu with trigger', () => {
   });
 
   it('composes the item.testId override with the button prefix when provided', () => {
-    host.items = [
+    host.items.set([
       { id: 'cut', label: 'Cut', testId: 'custom-cut' },
       { id: 'copy', label: 'Copy' },
-    ];
+    ]);
     fixture.detectChanges();
 
     triggerButton.click();
@@ -382,7 +389,7 @@ describe('tn-menu with trigger', () => {
 
   for (const position of ['above', 'below', 'before', 'after'] as const) {
     it(`should open menu with "${position}" position`, () => {
-      host.position = position;
+      host.position.set(position);
       fixture.detectChanges();
 
       triggerButton.click();
@@ -410,6 +417,14 @@ describe('tn-menu as context menu', () => {
     host = fixture.componentInstance;
     fixture.detectChanges();
     contextArea = fixture.nativeElement.querySelector('.context-area');
+
+    // Every test in this block steps CDK's overlay timers; see the same note in
+    // 'tn-menu with trigger' above.
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   function rightClick(el: HTMLElement, x = 100, y = 100): void {
@@ -421,68 +436,68 @@ describe('tn-menu as context menu', () => {
     }));
   }
 
-  it('should open menu on right-click', fakeAsync(() => {
+  it('should open menu on right-click', () => {
     rightClick(contextArea);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     expect(getMenuPanel()).toBeTruthy();
     expect(host.opened).toBe(true);
-  }));
+  });
 
-  it('should render context menu items', fakeAsync(() => {
+  it('should render context menu items', () => {
     rightClick(contextArea);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     const labels = Array.from(document.querySelectorAll('.tn-menu-item-label'))
       .map(el => el.textContent?.trim());
     expect(labels).toContain('Cut');
     expect(labels).toContain('Copy');
-  }));
+  });
 
-  it('should close context menu and emit on item click', fakeAsync(() => {
+  it('should close context menu and emit on item click', () => {
     rightClick(contextArea);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     const cutButton = getMenuItems().find(
       el => el.textContent?.includes('Cut')
     )!;
     cutButton.click();
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     expect(host.lastClicked?.id).toBe('cut');
     expect(host.closed).toBe(true);
-  }));
+  });
 
-  it('should close previous context menu when opening a new one', fakeAsync(() => {
+  it('should close previous context menu when opening a new one', () => {
     rightClick(contextArea, 50, 50);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     rightClick(contextArea, 150, 150);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     // Only one menu panel should exist
     const panels = document.querySelectorAll('.tn-menu');
     expect(panels.length).toBe(1);
-  }));
+  });
 
-  it('should close context menu on backdrop click', fakeAsync(() => {
+  it('should close context menu on backdrop click', () => {
     rightClick(contextArea);
     fixture.detectChanges();
-    flush();
+    jest.runOnlyPendingTimers();
 
     getBackdrop()!.click();
-    flush();
+    jest.runOnlyPendingTimers();
     fixture.detectChanges();
 
     expect(getMenuPanel()).toBeFalsy();
     expect(host.closed).toBe(true);
-  }));
+  });
 });
 
 // ===========================================================================
@@ -778,16 +793,16 @@ describe('tn-menu focus restoration with <tn-button> trigger', () => {
   imports: [TnMenuComponent, TnMenuTriggerDirective],
   template: `
     <button class="trigger" [tnMenuTriggerFor]="menu">Open</button>
-    <tn-menu #menu [items]="items" [testId]="testId" />
+    <tn-menu #menu [items]="items()" [testId]="testId()" />
   `,
 })
 class BaseScopedMenuHostComponent {
-  items: TnMenuItem[] = [
+  items = signal<TnMenuItem[]>([
     { id: 'edit', label: 'Edit' },
     { id: 'delete', label: 'Delete' },
     { id: 'more', label: 'More', children: [{ id: 'rename', label: 'Rename' }] },
-  ];
-  testId: string | undefined = 'actions';
+  ]);
+  testId = signal<string | undefined>('actions');
   trigger = viewChild.required(TnMenuTriggerDirective);
 }
 
@@ -832,7 +847,7 @@ describe('tn-menu base-scoped test ids', () => {
   });
 
   it('falls back to the unscoped button-<id> when no base is set', () => {
-    host.testId = undefined;
+    host.testId.set(undefined);
     fixture.detectChanges();
 
     triggerButton.click();
@@ -843,10 +858,10 @@ describe('tn-menu base-scoped test ids', () => {
   });
 
   it('composes a per-item testId override with the button prefix', () => {
-    host.items = [
+    host.items.set([
       { id: 'edit', label: 'Edit', testId: 'totally-custom' },
       { id: 'delete', label: 'Delete' },
-    ];
+    ]);
     fixture.detectChanges();
 
     triggerButton.click();

--- a/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/menu/menu.harness.spec.ts
@@ -1,6 +1,6 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import type { HarnessLoader } from '@angular/cdk/testing';
-import { Component, viewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TnMenuTesting } from './menu-testing';
@@ -16,16 +16,16 @@ import { TnIconTesting } from '../icon/icon-testing';
   imports: [TnMenuComponent, TnMenuTriggerDirective, OverlayModule],
   template: `
     <button data-testid="trigger" [tnMenuTriggerFor]="menu">Open</button>
-    <tn-menu #menu [items]="items" />
+    <tn-menu #menu [items]="items()" />
   `
 })
 class TestHostComponent {
   menuRef = viewChild<TnMenuComponent>('menu');
-  items: TnMenuItem[] = [
+  items = signal<TnMenuItem[]>([
     { id: 'edit', label: 'Edit', action: jest.fn() },
     { id: 'delete', label: 'Delete', action: jest.fn() },
     { id: 'disabled-item', label: 'Locked', disabled: true, action: jest.fn() },
-  ];
+  ]);
 }
 
 describe('TnMenuHarness', () => {
@@ -74,14 +74,14 @@ describe('TnMenuHarness', () => {
     openMenu();
     const menu = await rootLoader.getHarness(TnMenuHarness);
     await menu.clickItem({ label: 'Edit' });
-    expect(hostComponent.items[0].action).toHaveBeenCalled();
+    expect(hostComponent.items()[0].action).toHaveBeenCalled();
   });
 
   it('should click a menu item by regex', async () => {
     openMenu();
     const menu = await rootLoader.getHarness(TnMenuHarness);
     await menu.clickItem({ label: /del/i });
-    expect(hostComponent.items[1].action).toHaveBeenCalled();
+    expect(hostComponent.items()[1].action).toHaveBeenCalled();
   });
 
   it('should throw when clicking non-existent item', async () => {
@@ -100,10 +100,10 @@ describe('TnMenuHarness', () => {
   });
 
   it('reports isItemSelected for items marked selected', async () => {
-    hostComponent.items = [
+    hostComponent.items.set([
       { id: 'csv', label: 'CSV' },
       { id: 'json', label: 'JSON', selected: true },
-    ];
+    ]);
     fixture.detectChanges();
     openMenu();
 
@@ -113,10 +113,10 @@ describe('TnMenuHarness', () => {
   });
 
   it('returns the label of the currently-selected item', async () => {
-    hostComponent.items = [
+    hostComponent.items.set([
       { id: 'csv', label: 'CSV' },
       { id: 'json', label: 'JSON', selected: true },
-    ];
+    ]);
     fixture.detectChanges();
     openMenu();
 

--- a/projects/truenas-ui/src/lib/select/select.component.ts
+++ b/projects/truenas-ui/src/lib/select/select.component.ts
@@ -838,8 +838,20 @@ export class TnSelectComponent<T = unknown> implements ControlValueAccessor, OnD
     // wrong option if two tn-select instances with the same testId are open
     // simultaneously, and couples the component to a global).
     queueMicrotask(() => {
-      const el = overlayEl.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
-      el?.scrollIntoView({ block: 'nearest' });
+      // Found by comparing the attribute rather than by building a `#id`
+      // selector, for the reason `a11y/accessible-name-testing.ts` already
+      // records: `CSS.escape` is the only safe way to compose one and `CSS` is
+      // not defined under jsdom, so the call throws `ReferenceError`. Zone
+      // swallowed that throw — it happened in a patched microtask — and #304
+      // took the zone away, which is how a latent break in every select spec
+      // that arrows through the options became visible.
+      const el = Array.from(overlayEl.querySelectorAll<HTMLElement>('[id]'))
+        .find((candidate) => candidate.id === id);
+      // jsdom implements no `scrollIntoView` either; same guard as
+      // `tn-autocomplete` and `tn-chip-input`.
+      if (el?.scrollIntoView) {
+        el.scrollIntoView({ block: 'nearest' });
+      }
     });
   }
 }

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -269,7 +269,8 @@ describe('tn-side-panel focus capture (#227)', () => {
    * the three entries come from `scheduleCallbackWithRafRace`.)
    *
    * So the frames are run as a set and the verdict is read from `attempts` and
-   * `document.activeElement` — which is what these tests were always about.
+   * `document.activeElement` — which is what these tests were always about —
+   * and the length of the list is not asserted at all, in either direction.
    * Swallowing Angular's half of the race is harmless: its `setTimeout` half
    * still fires. That the retry runs AT ALL is held by 'tries again after a
    * first focus that is silently dropped' above, which uses the real frame.
@@ -294,9 +295,12 @@ describe('tn-side-panel focus capture (#227)', () => {
     trigger().focus();
     await openByClick();
 
-    // The component asked once, was declined, and has a retry waiting.
+    // The component asked once and was declined. That a retry is WAITING is not
+    // asserted here: Angular's scheduler puts its own callbacks in `held`, so a
+    // non-empty list says nothing about this component and an assertion on it
+    // could not fail. 'tries again after a first focus that is silently
+    // dropped' above is what holds the retry's existence.
     expect(attempts).toBe(1);
-    expect(held.length).toBeGreaterThan(0);
 
     (overlay().querySelector('.tn-icon-button') as HTMLElement).focus();
     const landed = document.activeElement;
@@ -339,7 +343,6 @@ describe('tn-side-panel focus capture (#227)', () => {
     trigger().focus();
     await openByClick();
     expect(attempts).toBe(1);
-    expect(held.length).toBeGreaterThan(0);
 
     const elsewhere = fixture.nativeElement.querySelector('#elsewhere') as HTMLElement;
     elsewhere.focus();

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-focus-capture.spec.ts
@@ -257,6 +257,22 @@ describe('tn-side-panel focus capture (#227)', () => {
    * stubbed to hand the callback back rather than schedule it, so the frame
    * lands after the close button has taken focus rather than racing it —
    * jsdom is otherwise free to serve a frame inside `whenStable`, and does.
+   *
+   * WHAT THAT STUB CATCHES SINCE #304, AND WHY THE COUNT IS NOT ASSERTED
+   * -------------------------------------------------------------------
+   * Under Zone this list held exactly one callback — the capture's retry — and
+   * both tests below read `toHaveLength(1)` to say so. Zoneless change
+   * detection schedules its own work through `scheduleCallbackWithRafRace`,
+   * which races a `requestAnimationFrame` against a `setTimeout`, so Angular's
+   * scheduler now puts callbacks in here too and nothing at this seam can tell
+   * them from the capture's. (Named by reading the stacks, not guessed: two of
+   * the three entries come from `scheduleCallbackWithRafRace`.)
+   *
+   * So the frames are run as a set and the verdict is read from `attempts` and
+   * `document.activeElement` — which is what these tests were always about.
+   * Swallowing Angular's half of the race is harmless: its `setTimeout` half
+   * still fires. That the retry runs AT ALL is held by 'tries again after a
+   * first focus that is silently dropped' above, which uses the real frame.
    */
   it('leaves focus alone when it is already inside the panel', async () => {
     const target = panel();
@@ -269,10 +285,10 @@ describe('tn-side-panel focus capture (#227)', () => {
       }
     });
 
-    const pending: FrameRequestCallback[] = [];
+    const held: FrameRequestCallback[] = [];
     jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
-      pending.push(callback);
-      return pending.length;
+      held.push(callback);
+      return held.length;
     });
 
     trigger().focus();
@@ -280,14 +296,14 @@ describe('tn-side-panel focus capture (#227)', () => {
 
     // The component asked once, was declined, and has a retry waiting.
     expect(attempts).toBe(1);
-    expect(pending).toHaveLength(1);
+    expect(held.length).toBeGreaterThan(0);
 
     (overlay().querySelector('.tn-icon-button') as HTMLElement).focus();
     const landed = document.activeElement;
     expect(target.contains(landed)).toBe(true);
     expect(landed).not.toBe(target);
 
-    pending.shift()?.(0);
+    held.splice(0, held.length).forEach((frame) => frame(0));
 
     // The retry saw focus already inside and did not spend its call. Reading
     // that AFTER focusing, or comparing with `===` instead of `contains`,
@@ -308,26 +324,37 @@ describe('tn-side-panel focus capture (#227)', () => {
    */
   it('gives up when focus has moved somewhere it has no claim on', async () => {
     const target = panel();
-    jest.spyOn(target, 'focus').mockImplementation(() => undefined);
+    let attempts = 0;
+    jest.spyOn(target, 'focus').mockImplementation(() => {
+      attempts++;
+    });
 
-    const pending: FrameRequestCallback[] = [];
+    // Angular's scheduler shares this list; see the note above.
+    const held: FrameRequestCallback[] = [];
     jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
-      pending.push(callback);
-      return pending.length;
+      held.push(callback);
+      return held.length;
     });
 
     trigger().focus();
     await openByClick();
-    expect(pending).toHaveLength(1);
+    expect(attempts).toBe(1);
+    expect(held.length).toBeGreaterThan(0);
 
     const elsewhere = fixture.nativeElement.querySelector('#elsewhere') as HTMLElement;
     elsewhere.focus();
 
-    pending.shift()?.(0);
+    held.splice(0, held.length).forEach((frame) => frame(0));
 
     expect(document.activeElement).toBe(elsewhere);
-    // And it stopped: no further frame was asked for.
-    expect(pending).toHaveLength(0);
+    // And it stopped. Read as "the capture made no further attempt" rather than
+    // as "no further frame was asked for": Angular's own scheduler asks for
+    // frames on this list too, so an empty list is no longer the component's
+    // statement. A second round proves the give-up is permanent rather than
+    // one frame late.
+    held.splice(0, held.length).forEach((frame) => frame(0));
+    expect(attempts).toBe(1);
+    expect(document.activeElement).toBe(elsewhere);
   });
 
   /**

--- a/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel-lifecycle.spec.ts
@@ -1,8 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { NgZone } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TnSidePanelComponent } from './side-panel.component';
 import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
 
@@ -22,22 +21,24 @@ import { TN_TRANSITION_FALLBACK_MS } from '../utils/transition-lifecycle';
  *
  * WHY THE FIXTURE IS BUILT INSIDE EACH TEST, AND WHY THIS IS ITS OWN FILE
  * ----------------------------------------------------------------------
- * The fallback is a timer, so these tests need `fakeAsync` to see it — and a
- * timer is only reachable by `tick()` if it was scheduled inside that
- * `fakeAsync` zone. This one is armed with `runOutsideAngular`, so it lands in
- * the zone `NgZone` was CONSTRUCTED in — and `TestBed` constructs that once,
- * lazily, at the FIRST `TestBed.createComponent` of the suite. A `beforeEach`
- * that creates a fixture
- * therefore fixes the zone for every test after it, and the fallback then fires
- * on the real clock a third of a second after the test has already finished.
- *
- * That is why this is a separate file rather than another `describe` in
- * `side-panel.component.spec.ts`: sharing a suite means sharing that first
- * `createComponent`, and the fix is not local to the block that needs it.
- * Measured while writing these: with the shared fixture, three of the six below
+ * The fallback is a timer, so these tests have to advance a clock to see it,
+ * and the fixture has to exist before the clock they advance is the one the
+ * timer lands on. Under Zone that was sharper than it sounds: `runOutsideAngular`
+ * put the timer in the zone `NgZone` was CONSTRUCTED in, which `TestBed` did
+ * lazily at the suite's FIRST `TestBed.createComponent`, so a `beforeEach` that
+ * built a fixture fixed the zone for every test after it and the fallback then
+ * fired on the real clock a third of a second after the test had finished.
+ * Measured while writing these: with a shared fixture, three of the six below
  * failed and the other three passed on the `transitionend` path alone — which
  * is the failure mode worth naming, because a suite that half-passes reads as a
  * suite that works.
+ *
+ * Zone is gone (#304) and the fallback is now a plain `setTimeout` on Jest's
+ * fake clock, with no such lazily-fixed identity. The per-test fixture stays
+ * anyway, because it is also what keeps one test's armed fallback from
+ * reporting into the next one's spies — and this stays a separate file from
+ * `side-panel.component.spec.ts` so a suite-wide `useFakeTimers` is not imposed
+ * on specs that want a real clock.
  */
 describe('TnSidePanelComponent lifecycle outputs', () => {
   let panel: ComponentFixture<TnSidePanelComponent>;
@@ -48,11 +49,13 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TnSidePanelComponent],
-      // The panel's icon registry fetches the sprite config over HTTP, and
-      // `fakeAsync` refuses a real XHR outright — "Cannot make XHRs from within
-      // a fake async test". The testing backend answers nothing and is never
-      // flushed here, which is the whole intent: no icon in this suite is
-      // asserted on, and the request must simply not reach the network.
+      // The panel's icon registry fetches the sprite config over HTTP. The
+      // testing backend answers nothing and is never flushed here, which is the
+      // whole intent: no icon in this suite is asserted on, and the request
+      // must simply not reach the network. `fakeAsync` used to enforce that on
+      // its own by refusing a real XHR outright ("Cannot make XHRs from within
+      // a fake async test"); Jest's fake timers do not, so the testing backend
+      // is now the only thing standing between this suite and the network.
       providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
@@ -60,15 +63,20 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
     // panel warn in dev mode — which Jest is. Silenced so this suite's output
     // stays readable; the warning itself is asserted in `side-panel-a11y.spec.ts`.
     warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // After `compileComponents`, so the fake clock is never the thing an
+    // awaited compile is waiting on.
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     // Destroys the portaled overlay this suite appended to `document.body`.
     panel.destroy();
     warn.mockRestore();
+    jest.useRealTimers();
   });
 
-  /** Build the fixture under test. Call first, from inside the `fakeAsync` body. */
+  /** Build the fixture under test. Call first. */
   function createPanel(open = false): void {
     panel = TestBed.createComponent(TnSidePanelComponent);
     panel.componentRef.setInput('open', open);
@@ -98,103 +106,106 @@ describe('TnSidePanelComponent lifecycle outputs', () => {
       .dispatchEvent(event);
   }
 
-  it('emits opened when no transitionend arrives', fakeAsync(() => {
+  it('emits opened when no transitionend arrives', () => {
     createPanel();
     setOpen(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).toHaveBeenCalledTimes(1);
     expect(closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('emits closed when no transitionend arrives', fakeAsync(() => {
+  it('emits closed when no transitionend arrives', () => {
     createPanel();
     setOpen(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     setOpen(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).toHaveBeenCalledTimes(1);
     expect(closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits once, not twice, when the transition does complete', fakeAsync(() => {
+  it('emits once, not twice, when the transition does complete', () => {
     createPanel();
     setOpen(true);
     finishTransition();
 
     expect(opened).toHaveBeenCalledTimes(1);
 
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     expect(opened).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('ignores a transitionend that arrives after the fallback already fired', fakeAsync(() => {
+  it('ignores a transitionend that arrives after the fallback already fired', () => {
     createPanel();
     setOpen(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
     finishTransition();
 
     expect(opened).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits nothing while the panel stays closed', fakeAsync(() => {
+  it('emits nothing while the panel stays closed', () => {
     createPanel();
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('emits nothing for a panel that RENDERS open, which never opened', fakeAsync(() => {
+  it('emits nothing for a panel that RENDERS open, which never opened', () => {
     createPanel(true);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('still emits closed for a panel that rendered open and is then closed', fakeAsync(() => {
+  it('still emits closed for a panel that rendered open and is then closed', () => {
     createPanel(true);
     setOpen(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('emits only the final state when a close interrupts an open', fakeAsync(() => {
+  it('emits only the final state when a close interrupts an open', () => {
     createPanel();
     setOpen(true);
     setOpen(false);
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).not.toHaveBeenCalled();
     expect(closed).toHaveBeenCalledTimes(1);
-  }));
+  });
 
-  it('does not hold NgZone unstable while the fallback is armed', fakeAsync(() => {
-    createPanel();
-    setOpen(true);
+  /*
+   * WHERE 'does not hold NgZone unstable while the fallback is armed' WENT
+   * ---------------------------------------------------------------------
+   * This file used to assert
+   * `expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false)` right
+   * after an open, guarding the `runOutsideAngular` in
+   * `../utils/transition-lifecycle.ts`. #304 made the test suite zoneless, and
+   * with no Zone `NgZone` resolves to `NoopNgZone`, whose `hasPendingMacrotasks`
+   * is a hard-coded `false`. The assertion would have kept passing — including
+   * with the `runOutsideAngular` deleted — which is worse than not having it.
+   *
+   * It is DELETED HERE AND REPLACED, not dropped: `../utils/transition-lifecycle.spec.ts`
+   * covers the same guard by asserting that the fallback timer is scheduled
+   * inside a `runOutsideAngular` callback and that the report goes back through
+   * `zone.run`, both of which fail if the calls are removed. That test is on
+   * the shared helper rather than on each of its two callers, which is where
+   * the behaviour lives.
+   */
 
-    // The timer is armed from an `effect`, which runs inside
-    // `ApplicationRef.tick()` inside `NgZone.run(...)`, so scheduling it
-    // without `runOutsideAngular` makes it an Angular-zone macrotask — and
-    // `fixture.whenStable()` and CDK's `forceStabilize()` would then block for
-    // the whole fallback window after every open and every close, in every
-    // downstream suite that toggles one of these components.
-    expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false);
-
-    tick(TN_TRANSITION_FALLBACK_MS);
-    expect(opened).toHaveBeenCalledTimes(1);
-  }));
-
-  it('emits nothing after the panel is destroyed mid-transition', fakeAsync(() => {
+  it('emits nothing after the panel is destroyed mid-transition', () => {
     createPanel();
     setOpen(true);
     panel.destroy();
-    tick(TN_TRANSITION_FALLBACK_MS);
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(opened).not.toHaveBeenCalled();
-  }));
+  });
 });

--- a/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.spec.ts
+++ b/projects/truenas-ui/src/lib/slide-toggle/slide-toggle.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TestBed } from '@angular/core/testing';
 import { TnSlideToggleComponent } from './slide-toggle.component';
@@ -8,12 +8,12 @@ import { TnSlideToggleComponent } from './slide-toggle.component';
   standalone: true,
   imports: [TnSlideToggleComponent],
   template: `
-    <tn-slide-toggle label="Enable" [fullWidth]="fullWidth" (change)="changeCount = changeCount + 1" />
+    <tn-slide-toggle label="Enable" [fullWidth]="fullWidth()" (change)="changeCount = changeCount + 1" />
   `,
 })
 class TestHostComponent {
   changeCount = 0;
-  fullWidth = false;
+  fullWidth = signal(false);
 }
 
 describe('TnSlideToggleComponent', () => {
@@ -53,7 +53,7 @@ describe('TnSlideToggleComponent', () => {
     });
 
     it('stretches both the host and the inner row when set', () => {
-      host.fullWidth = true;
+      host.fullWidth.set(true);
       fixture.detectChanges();
 
       const toggle = fixture.nativeElement.querySelector('tn-slide-toggle') as HTMLElement;

--- a/projects/truenas-ui/src/lib/table/table-card.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table-card.harness.spec.ts
@@ -1,6 +1,6 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TnTableTesting } from './table-testing';
@@ -47,20 +47,20 @@ const SERVERS: Server[] = [
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-table
-      [mobileLayout]="mobileLayout"
-      [dataSource]="tableData"
-      [displayedColumns]="displayedColumns"
-      [selectable]="selectable"
-      [clickable]="clickable"
-      [expandable]="expandable"
-      [expandOnRowClick]="expandOnRowClick"
-      [cardPrimaryCount]="cardPrimaryCount"
-      [fixedLayout]="fixedLayout"
-      [minColumnWidth]="minColumnWidth"
-      [minWidth]="minWidth"
-      [activeRow]="activeRow"
-      [loading]="loading"
-      [trackBy]="trackByFn"
+      [mobileLayout]="mobileLayout()"
+      [dataSource]="tableData()"
+      [displayedColumns]="displayedColumns()"
+      [selectable]="selectable()"
+      [clickable]="clickable()"
+      [expandable]="expandable()"
+      [expandOnRowClick]="expandOnRowClick()"
+      [cardPrimaryCount]="cardPrimaryCount()"
+      [fixedLayout]="fixedLayout()"
+      [minColumnWidth]="minColumnWidth()"
+      [minWidth]="minWidth()"
+      [activeRow]="activeRow()"
+      [loading]="loading()"
+      [trackBy]="trackByFn()"
       (sortChange)="sortEvents.push($event)"
       (rowClick)="rowClicks.push($event)"
       (rowDoubleClick)="rowDoubleClicks.push($event)">
@@ -74,7 +74,7 @@ const SERVERS: Server[] = [
         <ng-template let-row tnCellDef>{{ row.id }}</ng-template>
       </ng-container>
 
-      <ng-container tnColumnDef="name" label="Name" [cardTitle]="titleOnName" [sortable]="true">
+      <ng-container tnColumnDef="name" label="Name" [cardTitle]="titleOnName()" [sortable]="true">
         <ng-template tnHeaderCellDef>Name</ng-template>
         <ng-template let-row tnCellDef>{{ row.name }}</ng-template>
       </ng-container>
@@ -110,7 +110,7 @@ const SERVERS: Server[] = [
         <ng-template let-row tnCellDef>{{ row.email }}</ng-template>
       </ng-container>
 
-      @if (expandable) {
+      @if (expandable()) {
         <ng-template let-row tnDetailRowDef>
           <div class="detail-body">
             <button
@@ -124,7 +124,7 @@ const SERVERS: Server[] = [
         </ng-template>
       }
 
-      @if (withActions) {
+      @if (withActions()) {
         <ng-template let-row tnRowActionsDef>
           <button type="button" class="row-action" (click)="actionClicks.push(row)">Edit</button>
         </ng-template>
@@ -133,22 +133,22 @@ const SERVERS: Server[] = [
   `,
 })
 class TableCardTestComponent {
-  tableData: Server[] = [...SERVERS];
-  displayedColumns = ['id', 'name', 'status', 'role', 'email'];
-  mobileLayout: 'cards' | 'scroll' = 'cards';
-  selectable = false;
-  clickable = false;
-  expandable = false;
-  expandOnRowClick = false;
-  withActions = false;
-  fixedLayout = false;
-  minColumnWidth = '';
-  minWidth = '';
-  activeRow: Server | null = null;
-  loading = false;
-  trackByFn: ((index: number, row: Server) => unknown) | undefined = undefined;
-  titleOnName = true;
-  cardPrimaryCount = 3;
+  tableData = signal<Server[]>([...SERVERS]);
+  displayedColumns = signal(['id', 'name', 'status', 'role', 'email']);
+  mobileLayout = signal<'cards' | 'scroll'>('cards');
+  selectable = signal(false);
+  clickable = signal(false);
+  expandable = signal(false);
+  expandOnRowClick = signal(false);
+  withActions = signal(false);
+  fixedLayout = signal(false);
+  minColumnWidth = signal('');
+  minWidth = signal('');
+  activeRow = signal<Server | null>(null);
+  loading = signal(false);
+  trackByFn = signal<((index: number, row: Server) => unknown) | undefined>(undefined);
+  titleOnName = signal(true);
+  cardPrimaryCount = signal(3);
   sortEvents: TnSortEvent[] = [];
   rowClicks: Server[] = [];
   rowDoubleClicks: Server[] = [];
@@ -254,7 +254,7 @@ describe('TnTable card layout', () => {
     it('skips a cardHidden column when falling back to a title', async () => {
       // No column claims cardTitle, so the fallback runs. `id` is first in
       // displayedColumns but cardHidden, so `name` should win.
-      component.titleOnName = false;
+      component.titleOnName.set(false);
       fixture.detectChanges();
       await goNarrow();
 
@@ -281,7 +281,7 @@ describe('TnTable card layout', () => {
     });
 
     it('folds fields past cardPrimaryCount behind the disclosure', async () => {
-      component.cardPrimaryCount = 2;
+      component.cardPrimaryCount.set(2);
       fixture.detectChanges();
       await goNarrow();
 
@@ -290,7 +290,7 @@ describe('TnTable card layout', () => {
     });
 
     it('prefers cardLabel over the shared label for a field', async () => {
-      component.cardPrimaryCount = 5;
+      component.cardPrimaryCount.set(5);
       fixture.detectChanges();
       await goNarrow();
 
@@ -545,8 +545,8 @@ describe('TnTable card layout', () => {
 
   describe('card detail section', () => {
     beforeEach(() => {
-      component.expandable = true;
-      component.clickable = true;
+      component.expandable.set(true);
+      component.clickable.set(true);
       fixture.detectChanges();
     });
 
@@ -563,7 +563,7 @@ describe('TnTable card layout', () => {
     // click on projected content used to bubble into card activation — emitting
     // rowClick and, with expandOnRowClick, collapsing the panel being used.
     it('does not activate the card when projected detail content is clicked', async () => {
-      component.expandOnRowClick = true;
+      component.expandOnRowClick.set(true);
       fixture.detectChanges();
       await goNarrow();
       await harness.toggleCardDetail(0);
@@ -591,7 +591,7 @@ describe('TnTable card layout', () => {
     });
 
     it('marks the card aria-expanded when the card itself is the expand trigger', async () => {
-      component.expandOnRowClick = true;
+      component.expandOnRowClick.set(true);
       fixture.detectChanges();
       await goNarrow();
 
@@ -608,7 +608,7 @@ describe('TnTable card layout', () => {
     // reports the state unconditionally — including when the card is also a trigger and
     // carries the same state. Redundant beats muting the real control.
     it('reports expanded state on the Details button even when the card is a trigger', async () => {
-      component.expandOnRowClick = true;
+      component.expandOnRowClick.set(true);
       fixture.detectChanges();
       await goNarrow();
 
@@ -648,8 +648,8 @@ describe('TnTable card layout', () => {
 
   describe('card activation', () => {
     beforeEach(() => {
-      component.clickable = true;
-      component.withActions = true;
+      component.clickable.set(true);
+      component.withActions.set(true);
       fixture.detectChanges();
     });
 
@@ -690,7 +690,7 @@ describe('TnTable card layout', () => {
       await goNarrow();
       expect(await harness.isCardFocusable(0)).toBe(true);
 
-      component.clickable = false;
+      component.clickable.set(false);
       fixture.detectChanges();
 
       expect(await harness.isCardFocusable(0)).toBe(false);
@@ -716,7 +716,7 @@ describe('TnTable card layout', () => {
     });
 
     it('activates the card from a field value folded under More fields', async () => {
-      component.cardPrimaryCount = 1;
+      component.cardPrimaryCount.set(1);
       fixture.detectChanges();
       await goNarrow();
       await harness.expandCardMoreFields(0);
@@ -741,9 +741,9 @@ describe('TnTable card layout', () => {
     }
 
     beforeEach(() => {
-      component.fixedLayout = true;
+      component.fixedLayout.set(true);
       // The derived floor is opt-in: `minColumnWidth` defaults to '' and applies none.
-      component.minColumnWidth = '120px';
+      component.minColumnWidth.set('120px');
       fixture.detectChanges();
     });
 
@@ -754,17 +754,17 @@ describe('TnTable card layout', () => {
     // The floor is opt-in (#168). The actions column contributes only to a floor that exists — it
     // must not conjure one on its own, or every actions table would silently get a floor back.
     it('applies no floor at all when minColumnWidth is unset, even with an actions column', () => {
-      component.minColumnWidth = '';
-      component.withActions = true;
+      component.minColumnWidth.set('');
+      component.withActions.set(true);
       fixture.detectChanges();
 
       expect(tableMinWidth()).toBe('');
     });
 
     it('still honours an explicit minWidth over the derivation', () => {
-      component.minColumnWidth = '';
-      component.minWidth = '900px';
-      component.withActions = true;
+      component.minColumnWidth.set('');
+      component.minWidth.set('900px');
+      component.withActions.set(true);
       fixture.detectChanges();
 
       expect(tableMinWidth()).toBe('900px');
@@ -774,16 +774,16 @@ describe('TnTable card layout', () => {
     // `minColumnWidth` share each — reserving full shares overstates the floor, and the slack
     // hides shortfalls elsewhere in it.
     it('adds the actions column width to the floor', () => {
-      component.withActions = true;
+      component.withActions.set(true);
       fixture.detectChanges();
 
       expect(tableMinWidth()).toBe('calc(120px * 5 + var(--tn-table-actions-width))');
     });
 
     it('counts the select and expand columns as shares, and adds the actions width', () => {
-      component.selectable = true;
-      component.expandable = true;
-      component.withActions = true;
+      component.selectable.set(true);
+      component.expandable.set(true);
+      component.withActions.set(true);
       fixture.detectChanges();
 
       // 5 displayed + __select + __expand as shares, plus the actions column's own width.
@@ -797,8 +797,8 @@ describe('TnTable card layout', () => {
   // and `rowClick` fired for the row instead. Card mode had guarded this from the start.
   describe('projected controls under the keyboard (table mode)', () => {
     beforeEach(() => {
-      component.clickable = true;
-      component.withActions = true;
+      component.clickable.set(true);
+      component.withActions.set(true);
       fixture.detectChanges();
     });
 
@@ -823,7 +823,7 @@ describe('TnTable card layout', () => {
     });
 
     it('leaves Space on the row checkbox alone', () => {
-      component.selectable = true;
+      component.selectable.set(true);
       fixture.detectChanges();
       const input = fixture.nativeElement.querySelector(
         '.tn-table__row .tn-table__select-cell input[type="checkbox"]'
@@ -888,8 +888,8 @@ describe('TnTable card layout', () => {
   // while card mode never did — same consumer template, behaviour keyed to container width.
   describe('projected controls under the mouse (table mode)', () => {
     beforeEach(() => {
-      component.clickable = true;
-      component.withActions = true;
+      component.clickable.set(true);
+      component.withActions.set(true);
       fixture.detectChanges();
     });
 
@@ -981,7 +981,7 @@ describe('TnTable card layout', () => {
 
   describe('loading blocks interaction in both layouts', () => {
     it('marks every rendered surface inert while loading', async () => {
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
 
       const table = fixture.nativeElement.querySelector('.tn-table__table') as HTMLElement;
@@ -1001,13 +1001,13 @@ describe('TnTable card layout', () => {
       header.focus();
       expect(document.activeElement).toBe(header);
 
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
       // jsdom does not implement inert's blur, so stand in for it.
       (document.activeElement as HTMLElement).blur();
       expect(document.activeElement).toBe(document.body);
 
-      component.loading = false;
+      component.loading.set(false);
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -1021,17 +1021,17 @@ describe('TnTable card layout', () => {
       const header = fixture.nativeElement.querySelector('th[data-column="name"]') as HTMLElement;
       header.focus();
 
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
       (document.activeElement as HTMLElement).blur();
 
       // Second load begins while focus is still parked on <body>.
-      component.loading = false;
-      component.loading = true;
+      component.loading.set(false);
+      component.loading.set(true);
       fixture.detectChanges();
       expect(document.activeElement).toBe(document.body);
 
-      component.loading = false;
+      component.loading.set(false);
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -1039,25 +1039,25 @@ describe('TnTable card layout', () => {
     });
 
     it('falls back to the host when the remembered element is gone', async () => {
-      component.trackByFn = (_index: number, row: Server) => row.id;
+      component.trackByFn.set((_index: number, row: Server) => row.id);
       fixture.detectChanges();
       const firstRow = fixture.nativeElement.querySelector('.tn-table__row') as HTMLElement;
       const cell = firstRow.querySelector('.tn-table__cell') as HTMLElement;
       cell.setAttribute('tabindex', '0');
       cell.focus();
 
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
       (document.activeElement as HTMLElement).blur();
       // The scenario the fallback exists for: an id-based `trackBy` plus a reload that drops
       // the focused row, so Angular destroys that element rather than reusing it. (Under the
       // default index `trackBy` the row element is reused and nothing detaches — which is why
       // an earlier version of this test proved nothing.)
-      component.tableData = [SERVERS[1]];
+      component.tableData.set([SERVERS[1]]);
       fixture.detectChanges();
       expect(cell.isConnected).toBe(false);
 
-      component.loading = false;
+      component.loading.set(false);
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -1071,11 +1071,11 @@ describe('TnTable card layout', () => {
       document.body.appendChild(elsewhere);
       header.focus();
 
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
       elsewhere.focus();
 
-      component.loading = false;
+      component.loading.set(false);
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -1084,9 +1084,9 @@ describe('TnTable card layout', () => {
     });
 
     it('drops inert again once loading finishes', () => {
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
-      component.loading = false;
+      component.loading.set(false);
       fixture.detectChanges();
 
       const table = fixture.nativeElement.querySelector('.tn-table__table') as HTMLElement;
@@ -1122,7 +1122,7 @@ describe('TnTable card layout', () => {
     });
 
     it('expandCardMoreFields is idempotent', async () => {
-      component.cardPrimaryCount = 1;
+      component.cardPrimaryCount.set(1);
       fixture.detectChanges();
       await goNarrow();
 
@@ -1143,7 +1143,7 @@ describe('TnTable card layout', () => {
     });
 
     it('counts expanded card details from getExpandedRowCount', async () => {
-      component.expandable = true;
+      component.expandable.set(true);
       fixture.detectChanges();
       await goNarrow();
       expect(await harness.getExpandedRowCount()).toBe(0);
@@ -1157,7 +1157,7 @@ describe('TnTable card layout', () => {
     // started counting cards: it cleared the bounds guard, then found no
     // `.tn-table__expand-button` over a card that renders a "Details" button.
     it('throws from hasExpandControl instead of answering a silent false', async () => {
-      component.expandable = true;
+      component.expandable.set(true);
       fixture.detectChanges();
       await goNarrow();
 
@@ -1215,7 +1215,7 @@ describe('TnTable card layout', () => {
     // `getActiveRowIndex()` used to answer null in card mode — "nothing is active" — over a
     // visibly active card, which greens a test rather than failing it.
     it('reports the active card index through the harness', async () => {
-      component.activeRow = SERVERS[1];
+      component.activeRow.set(SERVERS[1]);
       fixture.detectChanges();
       await goNarrow();
 
@@ -1237,8 +1237,8 @@ describe('TnTable card layout', () => {
   // ScrollModePinnedColumns play function.
   describe('scroll mode', () => {
     beforeEach(() => {
-      component.mobileLayout = 'scroll';
-      component.selectable = true;
+      component.mobileLayout.set('scroll');
+      component.selectable.set(true);
       fixture.detectChanges();
     });
 
@@ -1286,7 +1286,7 @@ describe('TnTable card layout', () => {
 
   describe('selection across the breakpoint', () => {
     beforeEach(() => {
-      component.selectable = true;
+      component.selectable.set(true);
       fixture.detectChanges();
     });
 

--- a/projects/truenas-ui/src/lib/table/table.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.harness.spec.ts
@@ -1,6 +1,6 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -40,15 +40,15 @@ const TEST_USERS: User[] = [
   // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
   template: `
     <tn-table
-      [dataSource]="tableData"
+      [dataSource]="tableData()"
       [displayedColumns]="['name', 'email']"
-      [selectable]="selectable"
-      [expandable]="expandable"
-      [isRowExpandable]="isRowExpandable"
-      [activeRow]="activeRow"
-      [loading]="loading"
-      [clickable]="clickable"
-      [mobileLayout]="mobileLayout"
+      [selectable]="selectable()"
+      [expandable]="expandable()"
+      [isRowExpandable]="isRowExpandable()"
+      [activeRow]="activeRow()"
+      [loading]="loading()"
+      [clickable]="clickable()"
+      [mobileLayout]="mobileLayout()"
       (sortChange)="onSort($event)"
       (selectionChange)="selectedUsers = $event"
       (rowClick)="lastClickedRow = $event"
@@ -63,7 +63,7 @@ const TEST_USERS: User[] = [
         <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
       </ng-container>
 
-      @if (expandable) {
+      @if (expandable()) {
         <ng-template let-user tnDetailRowDef>
           Details for {{ user.name }} ({{ user.email }})
         </ng-template>
@@ -72,14 +72,14 @@ const TEST_USERS: User[] = [
   `,
 })
 class TableHarnessTestComponent {
-  tableData: User[] = [...TEST_USERS];
-  selectable = false;
-  expandable = false;
-  mobileLayout: 'cards' | 'scroll' = 'scroll';
-  isRowExpandable: ((row: User) => boolean) | undefined = undefined;
-  activeRow: User | null = null;
-  loading = false;
-  clickable = false;
+  tableData = signal<User[]>([...TEST_USERS]);
+  selectable = signal(false);
+  expandable = signal(false);
+  mobileLayout = signal<'cards' | 'scroll'>('scroll');
+  isRowExpandable = signal<((row: User) => boolean) | undefined>(undefined);
+  activeRow = signal<User | null>(null);
+  loading = signal(false);
+  clickable = signal(false);
   lastClickedRow: User | null = null;
   lastDoubleClickedRow: User | null = null;
   lastSort: TnSortEvent | null = null;
@@ -88,14 +88,14 @@ class TableHarnessTestComponent {
   onSort(event: TnSortEvent): void {
     this.lastSort = event;
     if (!event.direction) {
-      this.tableData = [...TEST_USERS];
+      this.tableData.set([...TEST_USERS]);
       return;
     }
     const key = event.column as keyof User;
-    this.tableData = [...this.tableData].sort((a, b) => {
+    this.tableData.set([...this.tableData()].sort((a, b) => {
       const cmp = String(a[key]).localeCompare(String(b[key]));
       return event.direction === 'asc' ? cmp : -cmp;
-    });
+    }));
   }
 }
 
@@ -211,7 +211,7 @@ describe('TnTableHarness', () => {
 
   describe('selection', () => {
     beforeEach(() => {
-      component.selectable = true;
+      component.selectable.set(true);
       fixture.detectChanges();
     });
 
@@ -245,7 +245,7 @@ describe('TnTableHarness', () => {
 
   describe('expandable rows', () => {
     beforeEach(() => {
-      component.expandable = true;
+      component.expandable.set(true);
       fixture.detectChanges();
     });
 
@@ -285,7 +285,7 @@ describe('TnTableHarness', () => {
     });
 
     it('should not render an expand control on rows the predicate disallows', async () => {
-      component.isRowExpandable = (user) => user.id === 1;
+      component.isRowExpandable.set((user) => user.id === 1);
       fixture.detectChanges();
 
       const table = await loader.getHarness(TnTableHarness);
@@ -297,7 +297,7 @@ describe('TnTableHarness', () => {
 
   describe('clickable rows', () => {
     beforeEach(() => {
-      component.clickable = true;
+      component.clickable.set(true);
       fixture.detectChanges();
     });
 
@@ -340,7 +340,7 @@ describe('TnTableHarness', () => {
     });
 
     it('should report loading when enabled', async () => {
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
 
       const table = await loader.getHarness(TnTableHarness);
@@ -348,7 +348,7 @@ describe('TnTableHarness', () => {
     });
 
     it('should keep existing rows visible while loading', async () => {
-      component.loading = true;
+      component.loading.set(true);
       fixture.detectChanges();
 
       const table = await loader.getHarness(TnTableHarness);
@@ -364,7 +364,7 @@ describe('TnTableHarness', () => {
     });
 
     it('should mark the matching row as active', async () => {
-      component.activeRow = component.tableData[1];
+      component.activeRow.set(component.tableData()[1]);
       fixture.detectChanges();
 
       const table = await loader.getHarness(TnTableHarness);
@@ -375,13 +375,13 @@ describe('TnTableHarness', () => {
     });
 
     it('should clear active state when set to null', async () => {
-      component.activeRow = component.tableData[0];
+      component.activeRow.set(component.tableData()[0]);
       fixture.detectChanges();
 
       const table = await loader.getHarness(TnTableHarness);
       expect(await table.isRowActive(0)).toBe(true);
 
-      component.activeRow = null;
+      component.activeRow.set(null);
       fixture.detectChanges();
       expect(await table.isRowActive(0)).toBe(false);
       expect(await table.getActiveRowIndex()).toBeNull();
@@ -390,8 +390,8 @@ describe('TnTableHarness', () => {
 
   describe('combined features', () => {
     beforeEach(() => {
-      component.selectable = true;
-      component.expandable = true;
+      component.selectable.set(true);
+      component.expandable.set(true);
       fixture.detectChanges();
     });
 
@@ -435,8 +435,8 @@ describe('TnTableHarness', () => {
     }
 
     beforeEach(() => {
-      component.selectable = true;
-      component.mobileLayout = 'cards';
+      component.selectable.set(true);
+      component.mobileLayout.set('cards');
       fixture.detectChanges();
     });
 
@@ -477,7 +477,7 @@ describe('TnTableHarness', () => {
       }
 
       it('marks the active card with aria-current', () => {
-        component.activeRow = TEST_USERS[1];
+        component.activeRow.set(TEST_USERS[1]);
         forceCardMode();
 
         expect(card(1).getAttribute('aria-current')).toBe('true');
@@ -499,8 +499,8 @@ describe('TnTableHarness', () => {
       // the abstract `section` role, so the card does carry it when it is the expand trigger;
       // see the template comment above the card list.
       it('does not put aria-selected or role=button on the card', () => {
-        component.activeRow = TEST_USERS[0];
-        component.clickable = true;
+        component.activeRow.set(TEST_USERS[0]);
+        component.clickable.set(true);
         forceCardMode();
 
         expect(card(0).getAttribute('aria-selected')).toBeNull();

--- a/projects/truenas-ui/src/lib/test-id/test-id.directive.spec.ts
+++ b/projects/truenas-ui/src/lib/test-id/test-id.directive.spec.ts
@@ -1,18 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TN_TEST_ATTR } from './test-attr.token';
 import { TnTestIdDirective } from './test-id.directive';
 
+/**
+ * The hosts below hold their bound value in a `signal` rather than a plain
+ * field, and that is load-bearing rather than stylistic since #304 made this
+ * project's tests zoneless. Assigning a plain property marks no view dirty, so
+ * `fixture.detectChanges()` — which is `ApplicationRef.tick()` with nothing to
+ * do — refreshes nothing and the attribute under test keeps its old value. Dev
+ * mode then reports it as `NG0100` from the `checkNoChanges` pass, which reads
+ * as a component bug rather than as a spec that never re-rendered.
+ */
 @Component({
   standalone: true,
   imports: [TnTestIdDirective],
   template: `
     <!-- eslint-disable-next-line tn-local/require-tn-testid-type -- exercises verbatim (no tnTestIdType) directive behavior -->
-    <button [tnTestId]="value">click</button>
+    <button [tnTestId]="value()">click</button>
   `,
 })
 class HostComponent {
-  value: string | null | undefined = 'my-id';
+  value = signal<string | null | undefined>('my-id');
 }
 
 function createHost(providers: unknown[] = []) {
@@ -48,7 +57,7 @@ describe('TnTestIdDirective', () => {
 
     expect(button.getAttribute('data-testid')).toBe('my-id');
 
-    fixture.componentInstance.value = 'updated-id';
+    fixture.componentInstance.value.set('updated-id');
     fixture.detectChanges();
 
     expect(button.getAttribute('data-testid')).toBe('updated-id');
@@ -60,15 +69,15 @@ describe('TnTestIdDirective', () => {
 
     expect(button.getAttribute('data-testid')).toBe('my-id');
 
-    fixture.componentInstance.value = null;
+    fixture.componentInstance.value.set(null);
     fixture.detectChanges();
     expect(button.getAttribute('data-testid')).toBeNull();
 
-    fixture.componentInstance.value = '';
+    fixture.componentInstance.value.set('');
     fixture.detectChanges();
     expect(button.getAttribute('data-testid')).toBeNull();
 
-    fixture.componentInstance.value = undefined;
+    fixture.componentInstance.value.set(undefined);
     fixture.detectChanges();
     expect(button.getAttribute('data-testid')).toBeNull();
   });
@@ -77,10 +86,10 @@ describe('TnTestIdDirective', () => {
     @Component({
       standalone: true,
       imports: [TnTestIdDirective],
-      template: `<button tnTestIdType="button" [tnTestId]="value">click</button>`,
+      template: `<button tnTestIdType="button" [tnTestId]="value()">click</button>`,
     })
     class TypedHostComponent {
-      value: string | (string | number)[] = 'save';
+      value = signal<string | (string | number)[]>('save');
     }
 
     TestBed.configureTestingModule({ imports: [TypedHostComponent] });
@@ -90,7 +99,7 @@ describe('TnTestIdDirective', () => {
 
     expect(button.getAttribute('data-testid')).toBe('button-save');
 
-    fixture.componentInstance.value = ['username', 'Jane Doe'];
+    fixture.componentInstance.value.set(['username', 'Jane Doe']);
     fixture.detectChanges();
     expect(button.getAttribute('data-testid')).toBe('button-username-jane-doe');
   });
@@ -101,11 +110,11 @@ describe('TnTestIdDirective', () => {
       imports: [TnTestIdDirective],
   template: `
     <!-- eslint-disable-next-line tn-local/require-tn-testid-type -- exercises verbatim (no tnTestIdType) directive behavior -->
-    <button [tnTestId]="value">click</button>
+    <button [tnTestId]="value()">click</button>
   `,
     })
     class EmptyHostComponent {
-      value: string | undefined = undefined;
+      value = signal<string | undefined>(undefined);
     }
 
     TestBed.configureTestingModule({ imports: [EmptyHostComponent] });

--- a/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast-a11y.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import type { ComponentFixture } from '@angular/core/testing';
 import { TnToastComponent } from './toast.component';
 import { TN_TOAST_ANNOUNCE_DELAY_MS, TnToastService } from './toast.service';
@@ -187,10 +187,14 @@ describe('tn-toast live-region timing (#195)', () => {
       providers: [TnIconTesting.jest.providers()],
     });
     service = TestBed.inject(TnToastService);
+    // The announce delay this whole suite is about is a `setTimeout`, stepped
+    // over with Jest's clock since #304 made the suite zoneless.
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     document.querySelectorAll('tn-toast').forEach((el) => el.remove());
+    jest.useRealTimers();
   });
 
   /**
@@ -230,17 +234,20 @@ describe('tn-toast live-region timing (#195)', () => {
    * Reach the step the service defers the message to, then render it.
    *
    * The explicit `ApplicationRef.tick()` is because setting a signal only marks
-   * the view dirty — nothing in a TestBed zone test renders it on its own.
+   * the view dirty — nothing here renders it on its own. That was true under
+   * Zone and is more so without one (#304): zoneless change detection runs
+   * only what has been marked, and this suite drives the service rather than a
+   * fixture, so there is no `fixture.detectChanges()` to stand in for it.
    */
   function announceStep(): void {
-    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
+    jest.advanceTimersByTime(TN_TOAST_ANNOUNCE_DELAY_MS);
     TestBed.inject(ApplicationRef).tick();
   }
 
   describe('the region is inserted empty and populated afterwards', () => {
     it.each([TnToastType.Info, TnToastType.Success])(
       'gives a polite %s toast a content change to announce',
-      fakeAsync((type: TnToastType) => {
+      (type: TnToastType) => {
         service.open('Changes saved', { type, duration: 0 });
 
         const el = renderedRegion();
@@ -254,7 +261,7 @@ describe('tn-toast live-region timing (#195)', () => {
 
         expect(renderedRegion()).toBe(el);
         expect(messageOf(el)).toBe('Changes saved');
-      })
+      }
     );
 
     // Alert toasts were never the broken case, and the deferral does not cost
@@ -263,7 +270,7 @@ describe('tn-toast live-region timing (#195)', () => {
     // — and re-run for `warning`, which #194 moved onto this role.
     it.each([TnToastType.Error, TnToastType.Warning])(
       'keeps a %s toast announcing, on the role that interrupts',
-      fakeAsync((type: TnToastType) => {
+      (type: TnToastType) => {
         service.open('Save failed', { type, duration: 0 });
 
         const el = renderedRegion();
@@ -274,13 +281,13 @@ describe('tn-toast live-region timing (#195)', () => {
 
         expect(renderedRegion()).toBe(el);
         expect(messageOf(el)).toBe('Save failed');
-      })
+      }
     );
 
     // An action label is set before the host is attached, so this region is
     // NOT empty at insertion — and it does not need to be. What a reader
     // reports is the mutation, and the message still arrives as one.
-    it('announces a toast whose region already carries an action label', fakeAsync(() => {
+    it('announces a toast whose region already carries an action label', () => {
       service.open('Item deleted', 'Undo', { duration: 0 });
 
       const el = renderedRegion();
@@ -291,11 +298,11 @@ describe('tn-toast live-region timing (#195)', () => {
 
       expect(renderedRegion()).toBe(el);
       expect(messageOf(el)).toBe('Item deleted');
-    }));
+    });
   });
 
   describe('a toast dismissed before its frame never announces', () => {
-    it('leaves a superseded toast silent, and announces the one that replaced it', fakeAsync(() => {
+    it('leaves a superseded toast silent, and announces the one that replaced it', () => {
       service.open('First', { duration: 0 });
       const first = renderedRegion();
 
@@ -312,12 +319,12 @@ describe('tn-toast live-region timing (#195)', () => {
       expect(messageOf(first)).toBe('');
       expect(messageOf(renderedRegion(1))).toBe('Second');
 
-      tick(200);
-    }));
+      jest.advanceTimersByTime(200);
+    });
   });
 
   describe('the visible behaviour is unchanged', () => {
-    it('never shows the empty region, and still runs the enter transition', fakeAsync(() => {
+    it('never shows the empty region, and still runs the enter transition', () => {
       service.open('Changes saved', { duration: 0 });
 
       const el = renderedRegion();
@@ -332,6 +339,6 @@ describe('tn-toast live-region timing (#195)', () => {
       // render that gives it something to say, so there is no empty flash.
       expect(messageOf(el)).toBe('Changes saved');
       expect(el.classList.contains('tn-toast--visible')).toBe(true);
-    }));
+    });
   });
 });

--- a/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
+++ b/projects/truenas-ui/src/lib/toast/toast.service.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TN_TOAST_ANNOUNCE_DELAY_MS, TnToastService } from './toast.service';
 import { TnToastPosition, TnToastType } from './toast.types';
 import { TnIconTesting } from '../icon/icon-testing';
@@ -12,10 +12,16 @@ describe('TnToastService', () => {
       providers: [TnIconTesting.jest.providers()],
     });
     service = TestBed.inject(TnToastService);
+    // The announce delay and the auto-dismiss window are both `setTimeout`, and
+    // #304 replaced `fakeAsync`/`tick` with Jest's own clock. Nothing in this
+    // suite waits on a promise, so `advanceTimersByTime` is a straight swap for
+    // `tick` — see `../../setup-jest.ts` for where the two differ.
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     document.querySelectorAll('tn-toast').forEach(el => el.remove());
+    jest.useRealTimers();
   });
 
   function detectChanges() {
@@ -34,13 +40,13 @@ describe('TnToastService', () => {
   // The message lands after insertion, so that the live region changes rather
   // than arriving already populated (#195). `toast-a11y.spec.ts` holds that
   // contract; this only needs to reach the same step before reading.
-  it('should render the message text', fakeAsync(() => {
+  it('should render the message text', () => {
     service.open('Hello world', { duration: 0 });
-    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
+    jest.advanceTimersByTime(TN_TOAST_ANNOUNCE_DELAY_MS);
     detectChanges();
     const message = document.querySelector('.tn-toast__message');
     expect(message?.textContent?.trim()).toBe('Hello world');
-  }));
+  });
 
   it('should return a TnToastRef', () => {
     const ref = service.open('Test');
@@ -51,7 +57,7 @@ describe('TnToastService', () => {
     ref.dismiss();
   });
 
-  it('should dismiss the toast programmatically', fakeAsync(() => {
+  it('should dismiss the toast programmatically', () => {
     const ref = service.open('Test', { duration: 0 });
     let dismissed = false;
     ref.afterDismissed().subscribe(() => { dismissed = true; });
@@ -59,42 +65,42 @@ describe('TnToastService', () => {
     ref.dismiss();
     expect(dismissed).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 
   // `duration` is time on screen, so it is counted from the announcement and
   // not from the call (#195).
-  it('should auto-dismiss after duration', fakeAsync(() => {
+  it('should auto-dismiss after duration', () => {
     const ref = service.open('Test', { duration: 1000 });
     let dismissed = false;
     ref.afterDismissed().subscribe(() => { dismissed = true; });
 
-    tick(TN_TOAST_ANNOUNCE_DELAY_MS + 999);
+    jest.advanceTimersByTime(TN_TOAST_ANNOUNCE_DELAY_MS + 999);
     expect(dismissed).toBe(false);
 
-    tick(1);
+    jest.advanceTimersByTime(1);
     expect(dismissed).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 
   // Counted from the call, this duration would elapse before the toast was
   // ever shown — and dismissal cancels the pending announcement, so it would
   // appear and announce nothing at all.
-  it('should still show a toast whose duration is shorter than the announce delay', fakeAsync(() => {
+  it('should still show a toast whose duration is shorter than the announce delay', () => {
     service.open('Brief', { duration: 50 });
 
-    tick(TN_TOAST_ANNOUNCE_DELAY_MS);
+    jest.advanceTimersByTime(TN_TOAST_ANNOUNCE_DELAY_MS);
     detectChanges();
     const message = document.querySelector('.tn-toast__message');
     expect(message?.textContent?.trim()).toBe('Brief');
     expect(document.querySelector('.tn-toast')?.classList.contains('tn-toast--visible')).toBe(true);
 
-    tick(50);
-    tick(200);
-  }));
+    jest.advanceTimersByTime(50);
+    jest.advanceTimersByTime(200);
+  });
 
-  it('should dismiss previous toast when opening a new one', fakeAsync(() => {
+  it('should dismiss previous toast when opening a new one', () => {
     const ref1 = service.open('First', { duration: 0 });
     let dismissed1 = false;
     ref1.afterDismissed().subscribe(() => { dismissed1 = true; });
@@ -102,8 +108,8 @@ describe('TnToastService', () => {
     service.open('Second', { duration: 0 });
     expect(dismissed1).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 
   it('should render action button when action is provided', () => {
     service.open('Error', 'Retry');
@@ -135,7 +141,7 @@ describe('TnToastService', () => {
     expect(button?.textContent?.trim()).toBe('Retry');
   });
 
-  it('should emit onAction when action button is clicked', fakeAsync(() => {
+  it('should emit onAction when action button is clicked', () => {
     const ref = service.open('Error', 'Retry', { duration: 0 });
     detectChanges();
     let actionFired = false;
@@ -145,10 +151,10 @@ describe('TnToastService', () => {
     button?.click();
     expect(actionFired).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 
-  it('should dismiss after action button is clicked', fakeAsync(() => {
+  it('should dismiss after action button is clicked', () => {
     const ref = service.open('Error', 'Retry', { duration: 0 });
     detectChanges();
     let dismissed = false;
@@ -158,8 +164,8 @@ describe('TnToastService', () => {
     button?.click();
     expect(dismissed).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 
   it('should default to info type', () => {
     service.open('Info message');
@@ -182,17 +188,17 @@ describe('TnToastService', () => {
     expect(host?.classList.contains('tn-toast--top')).toBe(true);
   });
 
-  it('should default to 4000ms duration', fakeAsync(() => {
+  it('should default to 4000ms duration', () => {
     const ref = service.open('Test');
     let dismissed = false;
     ref.afterDismissed().subscribe(() => { dismissed = true; });
 
-    tick(TN_TOAST_ANNOUNCE_DELAY_MS + 3999);
+    jest.advanceTimersByTime(TN_TOAST_ANNOUNCE_DELAY_MS + 3999);
     expect(dismissed).toBe(false);
 
-    tick(1);
+    jest.advanceTimersByTime(1);
     expect(dismissed).toBe(true);
 
-    tick(200);
-  }));
+    jest.advanceTimersByTime(200);
+  });
 });

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
@@ -1,6 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { hasInteractiveContent, plainTextMessage } from './interactive-content';
 import { TnTooltipComponent } from './tooltip.component';
@@ -282,12 +282,12 @@ class DescriptionHostComponent {}
 @Component({
   standalone: true,
   imports: [TnTooltipDirective],
-  template: `<button class="null-host" [tnTooltip]="message">Null message</button>`,
+  template: `<button class="null-host" [tnTooltip]="message()">Null message()</button>`,
 })
 class NullMessageHostComponent {
   // Real consumers bind expressions like `reason ?? null` — the input accepts them
   // by contract (via its transform) and the runtime must treat them as "no tooltip".
-  message: string | null | undefined = null;
+  message = signal<string | null | undefined>(null);
 }
 
 describe('TnTooltipDirective nullish message tolerance', () => {
@@ -307,7 +307,7 @@ describe('TnTooltipDirective nullish message tolerance', () => {
 
   it('treats an undefined message the same as no tooltip', () => {
     const fixture = createNullHost();
-    fixture.componentInstance.message = undefined;
+    fixture.componentInstance.message.set(undefined);
 
     expect(() => fixture.detectChanges()).not.toThrow();
 
@@ -317,13 +317,13 @@ describe('TnTooltipDirective nullish message tolerance', () => {
 
   it('removes an existing description when the message becomes null', () => {
     const fixture = createNullHost();
-    fixture.componentInstance.message = 'Reason';
+    fixture.componentInstance.message.set('Reason');
     fixture.detectChanges();
 
     const button = (fixture.nativeElement as HTMLElement).querySelector('.null-host');
     expect(button?.getAttribute('aria-describedby')).toBeTruthy();
 
-    fixture.componentInstance.message = null;
+    fixture.componentInstance.message.set(null);
     fixture.detectChanges();
 
     expect(button?.getAttribute('aria-describedby')).toBeNull();

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.component.spec.ts
@@ -282,7 +282,7 @@ class DescriptionHostComponent {}
 @Component({
   standalone: true,
   imports: [TnTooltipDirective],
-  template: `<button class="null-host" [tnTooltip]="message()">Null message()</button>`,
+  template: `<button class="null-host" [tnTooltip]="message()">Null message</button>`,
 })
 class NullMessageHostComponent {
   // Real consumers bind expressions like `reason ?? null` — the input accepts them

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
@@ -4,7 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component, signal } from '@angular/core';
 import type { ComponentFixture } from '@angular/core/testing';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TnTooltipDirective } from './tooltip.directive';
 import { TnButtonComponent } from '../button/button.component';
 
@@ -91,71 +91,95 @@ describe('TnTooltipDirective sticky mode', () => {
     plainHost = fixture.nativeElement.querySelector('#plain') as HTMLButtonElement;
     ownerHost = fixture.nativeElement.querySelector('#owns-expanded') as HTMLButtonElement;
     sideHost = fixture.nativeElement.querySelector('#side') as HTMLButtonElement;
+
+    // The directive's show/hide are `setTimeout`s, and #304 replaced
+    // `fakeAsync`/`tick` with Jest's clock. `settleObserver()` below is where
+    // the two differ and it is the whole cost of the swap in this file.
+    jest.useFakeTimers();
   });
 
-  afterEach(fakeAsync(() => {
+  afterEach(() => {
     fixture.destroy();
-    tick();
-  }));
+    jest.advanceTimersByTime(0);
+    jest.useRealTimers();
+  });
+
+  /**
+   * Let the directive's 0ms show/hide timers run AND the `MutationObserver`
+   * deliver, then sync the view.
+   *
+   * `tick()` used to do both halves: Zone patched `MutationObserver`'s delivery
+   * onto its own microtask queue, so draining the clock drained that too.
+   * Jest's `advanceTimersByTime` moves only the timer queue — the observer's
+   * callback is an ordinary microtask and needs a real `await` to land. Which
+   * is why the tests that depend on it are `async`, as they already were for
+   * the same reason under Zone (its queue did not cover jsdom's observer
+   * either; see the comments they carry).
+   */
+  async function settleObserver(): Promise<void> {
+    jest.advanceTimersByTime(0);
+    await Promise.resolve();
+    fixture.detectChanges();
+  }
 
   function hover(target: HTMLElement = host): void {
     target.dispatchEvent(new MouseEvent('mouseenter'));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
   }
 
   function leave(target: HTMLElement = host): void {
     target.dispatchEvent(new MouseEvent('mouseleave'));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
   }
 
   function click(detail = 1): void {
     host.dispatchEvent(new MouseEvent('click', { bubbles: true, detail }));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
   }
 
-  it('shows plain help text on hover and hides it on mouseleave', fakeAsync(() => {
+  it('shows plain help text on hover and hides it on mouseleave', () => {
     hover(plainHost);
     expect(tooltipPanel()).not.toBeNull();
     expect(closeButton()).toBeNull();
 
     leave(plainHost);
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('does not open a pinnable tooltip on hover - the click is the only way in', fakeAsync(() => {
+  it('does not open a pinnable tooltip on hover - the click is the only way in', () => {
     hover();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('does not open a pinnable tooltip on keyboard focus either', fakeAsync(() => {
+  it('does not open a pinnable tooltip on keyboard focus either', () => {
     TestBed.inject(FocusMonitor).focusVia(host, 'keyboard');
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('never pins plain help text, so it does not hijack the host click', fakeAsync(() => {
+  it('never pins plain help text, so it does not hijack the host click', () => {
     plainHost.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('opens the tooltip already pinned on click, with a dismiss button', fakeAsync(() => {
+  it('opens the tooltip already pinned on click, with a dismiss button', () => {
     click();
 
     expect(tooltipPanel()).not.toBeNull();
     expect(closeButton()).not.toBeNull();
     expect(closeButton()?.getAttribute('aria-label')).toBe('Close tooltip');
-  }));
+  });
 
-  it('keeps a pinned tooltip open on mouseleave and blur', fakeAsync(() => {
+  it('keeps a pinned tooltip open on mouseleave and blur', () => {
     click();
 
     leave();
@@ -164,37 +188,37 @@ describe('TnTooltipDirective sticky mode', () => {
     // Focus moving into the overlay leaves the host, so without the sticky guard this blur
     // would hide the tooltip the moment the user reached its content.
     host.blur();
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
     expect(tooltipPanel()).not.toBeNull();
-  }));
+  });
 
-  it('makes a pinned tooltip interactive rather than click-through', fakeAsync(() => {
+  it('makes a pinned tooltip interactive rather than click-through', () => {
     click();
 
     const tooltipHost = document.querySelector('tn-tooltip') as HTMLElement;
     expect(tooltipHost.classList).toContain('tn-tooltip-component--sticky');
-  }));
+  });
 
-  it('dismisses on a second click of the host', fakeAsync(() => {
+  it('dismisses on a second click of the host', () => {
     click();
     expect(tooltipPanel()).not.toBeNull();
 
     click();
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('dismisses when the tooltip dismiss button is clicked', fakeAsync(() => {
+  it('dismisses when the tooltip dismiss button is clicked', () => {
     click();
 
     closeButton()?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('moves focus onto the tooltip panel when pinned from the keyboard', fakeAsync(() => {
+  it('moves focus onto the tooltip panel when pinned from the keyboard', () => {
     host.focus();
     // A click with detail 0 is what Enter/Space on a button produces.
     click(0);
@@ -202,46 +226,46 @@ describe('TnTooltipDirective sticky mode', () => {
     expect(document.activeElement).toBe(tooltipPanel());
     // Focused ahead of the message, so Tab reaches the tooltip's own links first.
     expect(tooltipPanel()?.getAttribute('tabindex')).toBe('-1');
-  }));
+  });
 
-  it('dismisses on Escape and restores focus to the host', fakeAsync(() => {
+  it('dismisses on Escape and restores focus to the host', () => {
     host.focus();
     click(0);
 
     document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
 
     expect(tooltipPanel()).toBeNull();
     expect(document.activeElement).toBe(host);
-  }));
+  });
 
-  it('does not intercept Escape while it is only a hover tooltip', fakeAsync(() => {
+  it('does not intercept Escape while it is only a hover tooltip', () => {
     // A permanent keydownEvents() subscription would make the tooltip's overlay the top-most
     // Escape handler, stealing the key from whatever dialog the host sits in.
     hover(plainHost);
 
     const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
     document.body.dispatchEvent(escape);
-    tick();
+    jest.advanceTimersByTime(0);
 
     expect(escape.defaultPrevented).toBe(false);
-  }));
+  });
 
-  it('dismisses on an outside click', fakeAsync(() => {
+  it('dismisses on an outside click', () => {
     click();
 
     const outside = document.createElement('div');
     document.body.appendChild(outside);
     outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    tick();
+    jest.advanceTimersByTime(0);
     fixture.detectChanges();
 
     expect(tooltipPanel()).toBeNull();
     outside.remove();
-  }));
+  });
 
-  it('falls back to hover when sticky mode is turned off, even with a link in the message', fakeAsync(() => {
+  it('falls back to hover when sticky mode is turned off, even with a link in the message', () => {
     fixture.componentInstance.sticky.set(false);
     fixture.detectChanges();
 
@@ -253,27 +277,27 @@ describe('TnTooltipDirective sticky mode', () => {
 
     leave();
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('does not pin a disabled tooltip', fakeAsync(() => {
+  it('does not pin a disabled tooltip', () => {
     fixture.componentInstance.disabled.set(true);
     fixture.detectChanges();
 
     click();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('does not pin when there is no message', fakeAsync(() => {
+  it('does not pin when there is no message', () => {
     fixture.componentInstance.message.set('');
     fixture.detectChanges();
 
     click();
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('re-opens after being dismissed', fakeAsync(() => {
+  it('re-opens after being dismissed', () => {
     click();
     click();
     expect(tooltipPanel()).toBeNull();
@@ -281,7 +305,7 @@ describe('TnTooltipDirective sticky mode', () => {
     click();
     expect(tooltipPanel()).not.toBeNull();
     expect(closeButton()).not.toBeNull();
-  }));
+  });
 
   // stick() ignores both `tnTooltipSticky` and the interactive-content rule by design. What it
   // must not do is produce a pinned tooltip that behaves unlike a pinned tooltip.
@@ -289,39 +313,39 @@ describe('TnTooltipDirective sticky mode', () => {
   // unobservable. A pinned panel stays until the user dismisses it, and `aria-describedby`
   // follows the input immediately - so a panel left on the old message would have the announced
   // text and the link on screen disagreeing for as long as it stayed up.
-  it('re-renders a pinned panel when the message changes underneath it', fakeAsync(() => {
+  it('re-renders a pinned panel when the message changes underneath it', () => {
     click();
     expect(tooltipPanel()?.textContent).toContain('Read the');
 
     fixture.componentInstance.message.set('Now says <a href="#other">something else</a>');
     fixture.detectChanges();
-    tick();
+    jest.advanceTimersByTime(0);
 
     expect(tooltipPanel()?.textContent).toContain('Now says');
     expect(tooltipPanel()?.querySelector('a')?.getAttribute('href')).toBe('#other');
     expect(host.getAttribute('aria-describedby')).not.toBeNull();
-  }));
+  });
 
-  it('takes a pinned panel down when its message is switched off', fakeAsync(() => {
+  it('takes a pinned panel down when its message is switched off', () => {
     click();
     expect(tooltipPanel()).not.toBeNull();
 
     fixture.componentInstance.message.set(null as unknown as string);
     fixture.detectChanges();
-    tick();
+    jest.advanceTimersByTime(0);
 
     expect(tooltipPanel()).toBeNull();
-  }));
+  });
 
-  it('re-renders a pinned panel when the dismiss label changes underneath it', fakeAsync(() => {
+  it('re-renders a pinned panel when the dismiss label changes underneath it', () => {
     click();
 
     fixture.componentInstance.closeLabel.set('Cerrar');
     fixture.detectChanges();
-    tick();
+    jest.advanceTimersByTime(0);
 
     expect(closeButton()?.getAttribute('aria-label')).toBe('Cerrar');
-  }));
+  });
 
   // Pinning made the click the only way in. A disabled control never delivers one - the native
   // button fires none, and tn-button swallows the retargeted one in a capture-phase listener - so
@@ -331,7 +355,7 @@ describe('TnTooltipDirective sticky mode', () => {
     const disabledHost = () => fixture.nativeElement.querySelector('#native-disabled') as HTMLButtonElement;
     const disabledWrapper = () => fixture.nativeElement.querySelector('#wrapper-disabled') as HTMLElement;
 
-    it('falls back to hover on a disabled host', fakeAsync(() => {
+    it('falls back to hover on a disabled host', () => {
       hover(disabledHost());
 
       expect(tooltipPanel()).not.toBeNull();
@@ -339,28 +363,28 @@ describe('TnTooltipDirective sticky mode', () => {
 
       leave(disabledHost());
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('falls back to hover when the disabled control is inside a wrapper host', fakeAsync(() => {
+    it('falls back to hover when the disabled control is inside a wrapper host', () => {
       hover(disabledWrapper());
 
       expect(tooltipPanel()).not.toBeNull();
-    }));
+    });
 
     // The reported case: tn-button registers a capture-phase click listener that
     // stopImmediatePropagation()s while disabled, so the directive's own host binding never runs.
-    it('falls back to hover on a disabled tn-button, whose click never reaches the directive', fakeAsync(() => {
+    it('falls back to hover on a disabled tn-button, whose click never reaches the directive', () => {
       const button = fixture.nativeElement.querySelector('#tn-button-disabled') as HTMLElement;
 
       button.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
       expect(tooltipPanel()).toBeNull();
 
       hover(button);
       expect(tooltipPanel()).not.toBeNull();
       expect(tooltipPanel()?.textContent).toContain('Read the');
-    }));
+    });
 
     it('advertises no disclosure state, since there is nothing to disclose by clicking', () => {
       expect(disabledHost().hasAttribute('aria-expanded')).toBe(false);
@@ -368,20 +392,20 @@ describe('TnTooltipDirective sticky mode', () => {
     });
 
     // Read live from the event handler, so this needs no re-sync to be correct.
-    it('goes back to click-only once the host is enabled again', fakeAsync(() => {
+    it('goes back to click-only once the host is enabled again', () => {
       disabledHost().removeAttribute('disabled');
 
       hover(disabledHost());
       expect(tooltipPanel()).toBeNull();
 
       disabledHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
       expect(closeButton()).not.toBeNull();
-    }));
+    });
 
-    // The disclosure attributes are written, not read, so they do need the re-sync. Real
-    // microtasks rather than fakeAsync: MutationObserver's queue is not part of the fake clock.
+    // The disclosure attributes are written, not read, so they do need the re-sync. A real
+    // microtask rather than the fake clock: MutationObserver's queue is not part of it.
     it('picks the disclosure state back up when disabled is toggled off', async () => {
       expect(disabledHost().hasAttribute('aria-haspopup')).toBe(false);
 
@@ -392,27 +416,27 @@ describe('TnTooltipDirective sticky mode', () => {
       expect(disabledHost().getAttribute('aria-expanded')).toBe('false');
     });
 
-    it('treats aria-disabled the same way', fakeAsync(() => {
+    it('treats aria-disabled the same way', () => {
       const ariaDisabled = disabledHost();
       ariaDisabled.removeAttribute('disabled');
       ariaDisabled.setAttribute('aria-disabled', 'true');
 
       hover(ariaDisabled);
       expect(tooltipPanel()).not.toBeNull();
-    }));
+    });
 
     // aria-disabled is advisory, so unlike `:disabled` the element still dispatches clicks. The
     // hover fallback above puts the panel on screen; without the same check in `_onClick` that
     // click would then pin it, which is the two-stage "hover, then click what is already on
     // screen" flow the fallback exists to avoid.
-    it('does not pin an aria-disabled host, whose click does still arrive', fakeAsync(() => {
+    it('does not pin an aria-disabled host, whose click does still arrive', () => {
       const ariaDisabled = disabledHost();
       ariaDisabled.removeAttribute('disabled');
       ariaDisabled.setAttribute('aria-disabled', 'true');
 
       hover(ariaDisabled);
       ariaDisabled.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(closeButton()).toBeNull();
@@ -420,21 +444,21 @@ describe('TnTooltipDirective sticky mode', () => {
       // ...and it stays a hover panel, rather than one that outlives the pointer.
       leave(ariaDisabled);
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('leaves an aria-disabled host advertising no disclosure state after a click', fakeAsync(() => {
+    it('leaves an aria-disabled host advertising no disclosure state after a click', () => {
       const ariaDisabled = disabledHost();
       ariaDisabled.removeAttribute('disabled');
       ariaDisabled.setAttribute('aria-disabled', 'true');
 
       hover(ariaDisabled);
       ariaDisabled.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(ariaDisabled.getAttribute('aria-expanded')).toBeNull();
       expect(ariaDisabled.getAttribute('aria-controls')).toBeNull();
-    }));
+    });
   });
 
   // A host that is not a control cannot be focused or activated from the keyboard, and the click
@@ -444,9 +468,9 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('a host that cannot be operated from the keyboard', () => {
     const spanHost = () => fixture.nativeElement.querySelector('#span-host') as HTMLElement;
 
-    it('falls back to hover rather than pinning on click', fakeAsync(() => {
+    it('falls back to hover rather than pinning on click', () => {
       spanHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
       expect(tooltipPanel()).toBeNull();
 
@@ -456,19 +480,19 @@ describe('TnTooltipDirective sticky mode', () => {
 
       leave(spanHost());
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
     // The panel does open on hover here, so the click that follows must not pin what is already
     // on screen — the same two-stage flow the aria-disabled fallback guards against.
-    it('does not pin the hover panel when the click arrives', fakeAsync(() => {
+    it('does not pin the hover panel when the click arrives', () => {
       hover(spanHost());
       spanHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(closeButton()).toBeNull();
       expect(spanHost().hasAttribute('aria-expanded')).toBe(false);
-    }));
+    });
 
     it('advertises no disclosure state, which is not valid on a non-control anyway', () => {
       expect(spanHost().hasAttribute('aria-expanded')).toBe(false);
@@ -478,39 +502,39 @@ describe('TnTooltipDirective sticky mode', () => {
     // `tabindex="-1"` makes an element a focus target without putting it in the tab order, so it
     // is no more keyboard-operable than the bare span - and `_restoreFocusTarget` leaves exactly
     // that behind on hosts it had to focus by hand.
-    it('does not count tabindex="-1" as being operable', fakeAsync(() => {
+    it('does not count tabindex="-1" as being operable', () => {
       spanHost().setAttribute('tabindex', '-1');
 
       hover(spanHost());
       expect(tooltipPanel()).not.toBeNull();
       expect(closeButton()).toBeNull();
-    }));
+    });
 
     // A text control is focusable, which is what made it look operable, but Enter submits the
     // form and Space types a space - neither produces the click a pinned panel is opened by.
     describe('a text control host, which is focusable but not activatable', () => {
       const inputHost = () => fixture.nativeElement.querySelector('#input-host') as HTMLInputElement;
 
-      it('shows the message on keyboard focus instead of waiting for a click', fakeAsync(() => {
+      it('shows the message on keyboard focus instead of waiting for a click', () => {
         TestBed.inject(FocusMonitor).focusVia(inputHost(), 'keyboard');
-        tick();
+        jest.advanceTimersByTime(0);
         fixture.detectChanges();
 
         expect(tooltipPanel()).not.toBeNull();
         expect(closeButton()).toBeNull();
-      }));
+      });
 
       // Every click into a text field places the caret, so pinning here would toggle the panel
       // each time the user repositioned the cursor.
-      it('does not pin when a click lands in the field', fakeAsync(() => {
+      it('does not pin when a click lands in the field', () => {
         hover(inputHost());
         inputHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-        tick();
+        jest.advanceTimersByTime(0);
         fixture.detectChanges();
 
         expect(tooltipPanel()).not.toBeNull();
         expect(closeButton()).toBeNull();
-      }));
+      });
 
       // `aria-expanded` is not supported on `role="textbox"`, and there is no disclosure to
       // describe in the first place.
@@ -527,25 +551,25 @@ describe('TnTooltipDirective sticky mode', () => {
     describe('a host wearing role="button", which the browser still sends no click for', () => {
       const roleHost = () => fixture.nativeElement.querySelector('#role-host') as HTMLElement;
 
-      it('shows the message on keyboard focus rather than waiting for a click', fakeAsync(() => {
+      it('shows the message on keyboard focus rather than waiting for a click', () => {
         TestBed.inject(FocusMonitor).focusVia(roleHost(), 'keyboard');
-        tick();
+        jest.advanceTimersByTime(0);
         fixture.detectChanges();
 
         expect(tooltipPanel()).not.toBeNull();
         expect(closeButton()).toBeNull();
-      }));
+      });
 
-      it('falls back to hover, and pins on neither route', fakeAsync(() => {
+      it('falls back to hover, and pins on neither route', () => {
         hover(roleHost());
         expect(tooltipPanel()).not.toBeNull();
 
         roleHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-        tick();
+        jest.advanceTimersByTime(0);
         fixture.detectChanges();
 
         expect(closeButton()).toBeNull();
-      }));
+      });
 
       it('advertises no disclosure it cannot deliver', () => {
         expect(roleHost().hasAttribute('aria-expanded')).toBe(false);
@@ -561,12 +585,7 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('a control host that leaves the tab order after view init', () => {
     const collapsibleHost = () => fixture.nativeElement.querySelector('#collapsible') as HTMLElement;
 
-    /** The observer's callback is a microtask outside Zone's queue, so `tick()` never reaches it. */
-    async function settleObserver(): Promise<void> {
-      await new Promise((resolve) => setTimeout(resolve));
-      fixture.detectChanges();
-    }
-
+    /** The observer's callback is a microtask outside Zone's queue, so `jest.advanceTimersByTime(0)` never reaches it. */
     function clickHost(): void {
       collapsibleHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
     }
@@ -620,12 +639,7 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('an anchor host that stops being a link after view init', () => {
     const linkHost = () => fixture.nativeElement.querySelector('#conditional-link') as HTMLElement;
 
-    /** The observer's callback is a microtask outside Zone's queue, so `tick()` never reaches it. */
-    async function settleObserver(): Promise<void> {
-      await new Promise((resolve) => setTimeout(resolve));
-      fixture.detectChanges();
-    }
-
+    /** The observer's callback is a microtask outside Zone's queue, so `jest.advanceTimersByTime(0)` never reaches it. */
     function clickLinkHost(): void {
       linkHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
     }
@@ -681,36 +695,36 @@ describe('TnTooltipDirective sticky mode', () => {
         .query((node) => node.nativeElement === spanHost())
         .injector.get(TnTooltipDirective)
         .stick({ focusTooltip: true });
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
     }
 
-    it('makes the host focusable rather than dropping focus to the body', fakeAsync(() => {
+    it('makes the host focusable rather than dropping focus to the body', () => {
       document.body.appendChild(fixture.nativeElement);
       stickSpanHost();
       expect(tooltipPanel()).not.toBeNull();
 
       closeButton()?.focus();
       closeButton()?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(spanHost().getAttribute('tabindex')).toBe('-1');
       expect(document.activeElement).toBe(spanHost());
       fixture.nativeElement.remove();
-    }));
+    });
 
     // Pinning it does not make the markup valid: none of the three attributes is allowed on a
     // `<span>`'s implicit `generic` role, so a panel pinned this way stays unadvertised rather
     // than reintroducing through `stick()` the axe violation the click path declines to produce.
-    it('still writes no disclosure state onto a host that cannot carry it', fakeAsync(() => {
+    it('still writes no disclosure state onto a host that cannot carry it', () => {
       stickSpanHost();
       expect(tooltipPanel()).not.toBeNull();
 
       expect(spanHost().hasAttribute('aria-expanded')).toBe(false);
       expect(spanHost().hasAttribute('aria-haspopup')).toBe(false);
       expect(spanHost().hasAttribute('aria-controls')).toBe(false);
-    }));
+    });
   });
 
   // The three entry points have to agree: `toggle()` routing to `show()` would put up an
@@ -722,32 +736,32 @@ describe('TnTooltipDirective sticky mode', () => {
         .query((node) => node.nativeElement === target)
         .injector.get(TnTooltipDirective)
         .toggle();
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
     }
 
-    it('opens a pinnable message pinned, as the host click would', fakeAsync(() => {
+    it('opens a pinnable message pinned, as the host click would', () => {
       toggleOn(host);
 
       expect(tooltipPanel()).not.toBeNull();
       expect(closeButton()).not.toBeNull();
-    }));
+    });
 
-    it('closes it again on a second call', fakeAsync(() => {
+    it('closes it again on a second call', () => {
       toggleOn(host);
       toggleOn(host);
 
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('still just shows and hides plain help text', fakeAsync(() => {
+    it('still just shows and hides plain help text', () => {
       toggleOn(plainHost);
       expect(tooltipPanel()).not.toBeNull();
       expect(closeButton()).toBeNull();
 
       toggleOn(plainHost);
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
   });
 
   describe('isSticky()', () => {
@@ -757,18 +771,18 @@ describe('TnTooltipDirective sticky mode', () => {
         .injector.get(TnTooltipDirective);
     }
 
-    it('reports the pin as soon as the host click makes it', fakeAsync(() => {
+    it('reports the pin as soon as the host click makes it', () => {
       expect(directiveOn(host).isSticky()).toBe(false);
 
       click();
 
       expect(directiveOn(host).isSticky()).toBe(true);
-    }));
+    });
 
     // `unstick` ends in `hide(0)`, which only *schedules* the teardown. Reading the flag out of
     // that timeout would leave a public "is it pinned right now" answering `true` for a macrotask
     // after the call that unpinned it - a caller cannot see the timeout to wait for it.
-    it('reports the unpin as soon as unstick() returns, not a macrotask later', fakeAsync(() => {
+    it('reports the unpin as soon as unstick() returns, not a macrotask later', () => {
       click();
       const directive = directiveOn(host);
 
@@ -780,11 +794,11 @@ describe('TnTooltipDirective sticky mode', () => {
       expect(host.getAttribute('aria-expanded')).toBe('false');
       expect(host.hasAttribute('aria-controls')).toBe(false);
 
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
       expect(tooltipPanel()).toBeNull();
       expect(directive.isSticky()).toBe(false);
-    }));
+    });
   });
 
   describe('a tooltip pinned imperatively through stick()', () => {
@@ -793,40 +807,40 @@ describe('TnTooltipDirective sticky mode', () => {
         .query((node) => node.nativeElement === plainHost)
         .injector.get(TnTooltipDirective);
       directive.stick();
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
     }
 
-    it('dismisses on a host click, like every other pinned tooltip', fakeAsync(() => {
+    it('dismisses on a host click, like every other pinned tooltip', () => {
       stickPlainHost();
       expect(closeButton()).not.toBeNull();
 
       plainHost.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('advertises itself on the host while it is up', fakeAsync(() => {
+    it('advertises itself on the host while it is up', () => {
       stickPlainHost();
 
       expect(plainHost.getAttribute('aria-expanded')).toBe('true');
       expect(plainHost.getAttribute('aria-controls')).toBe(tooltipPanel()?.id);
 
       plainHost.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       // Back to a plain hover tooltip, which advertises nothing.
       expect(plainHost.hasAttribute('aria-expanded')).toBe(false);
-    }));
+    });
   });
 
   describe('the host disclosure state', () => {
     // Nothing else on a plain button says "clicking me opens something", so the pinnable host has
     // to carry the state that does.
-    it('marks a pinnable host as a control that reveals a dialog, and tracks whether it is open', fakeAsync(() => {
+    it('marks a pinnable host as a control that reveals a dialog, and tracks whether it is open', () => {
       expect(host.getAttribute('aria-expanded')).toBe('false');
       expect(host.getAttribute('aria-haspopup')).toBe('dialog');
       expect(host.hasAttribute('aria-controls')).toBe(false);
@@ -838,7 +852,7 @@ describe('TnTooltipDirective sticky mode', () => {
       click();
       expect(host.getAttribute('aria-expanded')).toBe('false');
       expect(host.hasAttribute('aria-controls')).toBe(false);
-    }));
+    });
 
     it('leaves it off a hover tooltip, which reveals nothing on activation', () => {
       expect(plainHost.hasAttribute('aria-expanded')).toBe(false);
@@ -877,7 +891,7 @@ describe('TnTooltipDirective sticky mode', () => {
     // The three describe one popup between them, so they are yielded as a set: writing the two
     // the host does not own would announce "expanded dialog controlling tn-tooltip-xxx", mixing
     // the host's own expanded region with a tooltip panel that may well be closed.
-    it('yields the whole set, not just the attribute the host owns', fakeAsync(() => {
+    it('yields the whole set, not just the attribute the host owns', () => {
       fixture.componentInstance.ownerMessage.set('Read the <a href="#docs">docs</a>');
       fixture.detectChanges();
 
@@ -885,7 +899,7 @@ describe('TnTooltipDirective sticky mode', () => {
       expect(ownerHost.hasAttribute('aria-haspopup')).toBe(false);
 
       ownerHost.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       // Still pins - only the advertising is dropped, and the panel is reached by the same click.
@@ -893,28 +907,28 @@ describe('TnTooltipDirective sticky mode', () => {
       expect(ownerHost.getAttribute('aria-expanded')).toBe('true');
       expect(ownerHost.hasAttribute('aria-haspopup')).toBe(false);
       expect(ownerHost.hasAttribute('aria-controls')).toBe(false);
-    }));
+    });
 
     // Ownership is decided over the whole set, not over the attributes a given sync is about to
     // write. `aria-controls` is only written while pinned, so a host owning that one alone would
     // slip past an unpinned check - leaving the tooltip's collapsed dialog advertised next to the
     // host's own `aria-controls`, and dropped again the moment the pin brought `aria-controls`
     // into the set.
-    it('yields the set to a host that owns only the attribute the unpinned state never writes', fakeAsync(() => {
+    it('yields the set to a host that owns only the attribute the unpinned state never writes', () => {
       const controlsHost = fixture.nativeElement.querySelector('#owns-controls') as HTMLElement;
 
       expect(controlsHost.hasAttribute('aria-expanded')).toBe(false);
       expect(controlsHost.hasAttribute('aria-haspopup')).toBe(false);
 
       controlsHost.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       // Still pins, and the host's own target is left pointing where it pointed.
       expect(tooltipPanel()).not.toBeNull();
       expect(controlsHost.getAttribute('aria-controls')).toBe('panel-1');
       expect(controlsHost.hasAttribute('aria-expanded')).toBe(false);
-    }));
+    });
   });
 
   // The ledger that tells this directive's own writes apart from the host's is spent by the
@@ -924,11 +938,6 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('a wrapper whose inner control is swapped out', () => {
     const innerControl = () => fixture.nativeElement
       .querySelector('#swap-host a, #swap-host button') as HTMLElement;
-
-    async function settleObserver(): Promise<void> {
-      await new Promise((resolve) => setTimeout(resolve));
-      fixture.detectChanges();
-    }
 
     it('still notices the replacement taking a disclosure attribute over', async () => {
       expect(innerControl().tagName).toBe('A');
@@ -988,15 +997,8 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('a host that starts with no aria-expanded and takes it over later', () => {
     const lateHost = () => fixture.nativeElement.querySelector('#late-expanded') as HTMLElement;
 
-    /**
-     * The observer's callback is a microtask jsdom schedules outside Zone's queue, so `tick()`
-     * never reaches it - these have to run as real async tests rather than in `fakeAsync`.
-     */
-    async function settleObserver(): Promise<void> {
-      await new Promise((resolve) => setTimeout(resolve));
-      fixture.detectChanges();
-    }
-
+    // The observer's callback is a microtask, which no clock reaches - so the tests below that
+    // depend on it are `async` and go through `settleObserver()`, which awaits one.
     it('claims the attributes while the host has none of its own', () => {
       expect(lateHost().getAttribute('aria-expanded')).toBe('false');
       expect(lateHost().getAttribute('aria-haspopup')).toBe('dialog');
@@ -1030,12 +1032,12 @@ describe('TnTooltipDirective sticky mode', () => {
     });
   });
 
-  it('leaves no overlay pane behind once hidden', fakeAsync(() => {
+  it('leaves no overlay pane behind once hidden', () => {
     hover(plainHost);
     leave(plainHost);
 
     expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
-  }));
+  });
 
   // The arrow is measured against the pane, so it has to be measured after CDK has moved the
   // pane, not before. Both this directive and `RepositionScrollStrategy` reach `scrolled()`
@@ -1048,7 +1050,7 @@ describe('TnTooltipDirective sticky mode', () => {
 
     afterEach(() => jest.restoreAllMocks());
 
-    it('measures the panel after the scroll has re-placed it', fakeAsync(() => {
+    it('measures the panel after the scroll has re-placed it', () => {
       hover(sideHost);
 
       // A side-placed panel, where the offset runs down the panel: the host sits at y 170-186
@@ -1067,13 +1069,13 @@ describe('TnTooltipDirective sticky mode', () => {
 
       // A page scroll, which reaches the directive through CDK's ScrollDispatcher.
       document.dispatchEvent(new Event('scroll'));
-      tick(100);
+      jest.advanceTimersByTime(100);
       fixture.detectChanges();
 
       // 178 - 70. Reading 78px would mean the arrow was measured against the panel's pre-scroll
       // top of 100, i.e. before CDK had moved it.
       expect(arrowOffset()).toBe('108px');
-    }));
+    });
   });
 
   describe('a null message', () => {
@@ -1091,15 +1093,15 @@ describe('TnTooltipDirective sticky mode', () => {
       expect(() => fixture.detectChanges()).not.toThrow();
     });
 
-    it('shows nothing on hover', fakeAsync(() => {
+    it('shows nothing on hover', () => {
       expect(() => hover()).not.toThrow();
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('shows nothing on click', fakeAsync(() => {
+    it('shows nothing on click', () => {
       expect(() => click()).not.toThrow();
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
     it('describes nothing to assistive tech', () => {
       expect(host.getAttribute('aria-describedby')).toBeNull();
@@ -1110,38 +1112,38 @@ describe('TnTooltipDirective sticky mode', () => {
   // flips is a state neither entry point could produce - and a pinned one has no mouseleave or
   // blur left to close it.
   describe('disabling a tooltip that is already pinned', () => {
-    it('takes the panel down', fakeAsync(() => {
+    it('takes the panel down', () => {
       click();
       expect(closeButton()).not.toBeNull();
 
       fixture.componentInstance.disabled.set(true);
       fixture.detectChanges();
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
 
-    it('stops advertising the host as expanded', fakeAsync(() => {
+    it('stops advertising the host as expanded', () => {
       click();
       expect(host.getAttribute('aria-expanded')).toBe('true');
 
       fixture.componentInstance.disabled.set(true);
       fixture.detectChanges();
-      tick();
+      jest.advanceTimersByTime(0);
       fixture.detectChanges();
 
       expect(host.getAttribute('aria-expanded')).not.toBe('true');
-    }));
+    });
 
-    it('leaves a plain hover tooltip unaffected while it is not showing', fakeAsync(() => {
+    it('leaves a plain hover tooltip unaffected while it is not showing', () => {
       fixture.componentInstance.disabled.set(true);
       fixture.detectChanges();
-      tick();
+      jest.advanceTimersByTime(0);
 
       expect(() => hover()).not.toThrow();
       expect(tooltipPanel()).toBeNull();
-    }));
+    });
   });
 
   describe('arrow placement', () => {
@@ -1200,11 +1202,11 @@ describe('TnTooltipDirective sticky mode', () => {
 
     function reposition(): void {
       window.dispatchEvent(new Event('resize'));
-      tick(100);
+      jest.advanceTimersByTime(100);
       fixture.detectChanges();
     }
 
-    it('points the arrow at the host rather than at the panel centre', fakeAsync(() => {
+    it('points the arrow at the host rather than at the panel centre', () => {
       hover(plainHost);
       stubGeometry(plainHost, 40, 200);
 
@@ -1212,9 +1214,9 @@ describe('TnTooltipDirective sticky mode', () => {
 
       // Host centre 108 sits 68px into a panel starting at 40 - not the 100px panel centre.
       expect(arrowOffset()).toBe('68px');
-    }));
+    });
 
-    it('keeps the arrow clear of the panel corners when the host is far to one side', fakeAsync(() => {
+    it('keeps the arrow clear of the panel corners when the host is far to one side', () => {
       hover(plainHost);
       // A panel pushed right of the host by viewport clamping: the host centre lands outside it.
       stubGeometry(plainHost, 300, 200);
@@ -1223,9 +1225,9 @@ describe('TnTooltipDirective sticky mode', () => {
 
       // The stylesheet's inset, not the directive's fallback - see STUBBED_INSET.
       expect(arrowOffset()).toBe(`${STUBBED_INSET}px`);
-    }));
+    });
 
-    it('clamps against the far corner too', fakeAsync(() => {
+    it('clamps against the far corner too', () => {
       hover(plainHost);
       // A panel pushed left of the host: the host centre lands past its right edge.
       stubGeometry(plainHost, -160, 200);
@@ -1233,11 +1235,11 @@ describe('TnTooltipDirective sticky mode', () => {
       reposition();
 
       expect(arrowOffset()).toBe(`${200 - STUBBED_INSET}px`);
-    }));
+    });
 
     // A side-placed panel runs the other branch of the offset maths: a different axis, with its
     // own dimension and its own sign.
-    it('points the arrow down the panel when the tooltip sits beside its host', fakeAsync(() => {
+    it('points the arrow down the panel when the tooltip sits beside its host', () => {
       hover(sideHost);
       stubVerticalGeometry(sideHost, 100, 200);
 
@@ -1245,9 +1247,9 @@ describe('TnTooltipDirective sticky mode', () => {
 
       // Host centre 208 sits 108px down a panel starting at 100 - not the 100px panel centre.
       expect(arrowOffset()).toBe('108px');
-    }));
+    });
 
-    it('clamps a side-placed arrow clear of the corners as well', fakeAsync(() => {
+    it('clamps a side-placed arrow clear of the corners as well', () => {
       hover(sideHost);
       // A panel pushed below the host by viewport clamping: the host centre lands above it.
       stubVerticalGeometry(sideHost, 300, 200);
@@ -1255,9 +1257,9 @@ describe('TnTooltipDirective sticky mode', () => {
       reposition();
 
       expect(arrowOffset()).toBe(`${STUBBED_INSET}px`);
-    }));
+    });
 
-    it('re-places the panel when pinning resizes it, so the arrow stays on the host', fakeAsync(() => {
+    it('re-places the panel when pinning resizes it, so the arrow stays on the host', () => {
       // The resize happens inside the single click that opens a pinnable tooltip: the panel is
       // attached at hover width and only then switched into the wider sticky layout. Stubbed on
       // the prototype so the pane is covered from the moment it comes into existence.
@@ -1281,7 +1283,7 @@ describe('TnTooltipDirective sticky mode', () => {
       // Host centre 108, sticky panel starting at 20. Reading 68px would mean the offset was
       // computed against the hover-sized panel and never refreshed - the reported bug.
       expect(arrowOffset()).toBe('88px');
-    }));
+    });
   });
 });
 

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.directive.spec.ts
@@ -585,7 +585,6 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('a control host that leaves the tab order after view init', () => {
     const collapsibleHost = () => fixture.nativeElement.querySelector('#collapsible') as HTMLElement;
 
-    /** The observer's callback is a microtask outside Zone's queue, so `jest.advanceTimersByTime(0)` never reaches it. */
     function clickHost(): void {
       collapsibleHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
     }
@@ -639,7 +638,6 @@ describe('TnTooltipDirective sticky mode', () => {
   describe('an anchor host that stops being a link after view init', () => {
     const linkHost = () => fixture.nativeElement.querySelector('#conditional-link') as HTMLElement;
 
-    /** The observer's callback is a microtask outside Zone's queue, so `jest.advanceTimersByTime(0)` never reaches it. */
     function clickLinkHost(): void {
       linkHost().dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
     }

--- a/projects/truenas-ui/src/lib/tooltip/tooltip.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/tooltip/tooltip.harness.spec.ts
@@ -44,8 +44,26 @@ describe('TnTooltipHarness', () => {
     plainHost = fixture.nativeElement.querySelector('#plain') as HTMLButtonElement;
   });
 
+  /**
+   * Let the directive's show/hide timeout run.
+   *
+   * `tnTooltip` opens and closes from a `setTimeout`, and until #304 the
+   * harness environment's own stabilisation covered it: `forceStabilize()`
+   * waits on `fixture.whenStable()`, which under Zone meant "no pending
+   * macrotasks". Zoneless, `whenStable()` resolves once Angular's
+   * `PendingTasks` set is empty, and a bare `setTimeout` is not one of those —
+   * so `getHarness` ran before the panel existed and read an empty document.
+   *
+   * A real macrotask rather than Jest's fake clock, because the harness
+   * environment awaits promises of its own between here and the query.
+   */
+  function settle(): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve));
+  }
+
   it('finds a hover tooltip and reads its text', async () => {
     plainHost.dispatchEvent(new MouseEvent('mouseenter'));
+    await settle();
 
     const tooltip = await rootLoader.getHarness(TnTooltipHarness);
 
@@ -62,12 +80,14 @@ describe('TnTooltipHarness', () => {
     expect(await tooltip.getDismissLabel()).toBe('Close tooltip');
 
     await tooltip.dismiss();
+    await settle();
 
     expect(await rootLoader.getHarnessOrNull(TnTooltipHarness)).toBeNull();
   });
 
   it('refuses to dismiss a tooltip that is not sticky', async () => {
     plainHost.dispatchEvent(new MouseEvent('mouseenter'));
+    await settle();
 
     const tooltip = await rootLoader.getHarness(TnTooltipHarness);
 

--- a/projects/truenas-ui/src/lib/tree/nested-tree-node.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tree/nested-tree-node.component.spec.ts
@@ -1,7 +1,7 @@
 import type { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { CdkTreeModule } from '@angular/cdk/tree';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { TnNestedTreeDataSource } from './nested-tree-datasource';
 import { TnNestedTreeNodeComponent } from './nested-tree-node.component';
@@ -38,10 +38,10 @@ const dataset: ExampleNode[] = [
 
       <tn-nested-tree-node
         *cdkTreeNodeDef="let node; when: hasChild"
-        [testId]="withNodeTestIds ? node.name : undefined"
+        [testId]="withNodeTestIds() ? node.name : undefined"
         [toggleAriaLabel]="'Toggle ' + node.name"
-        [toggleTestId]="withExplicitToggleTestIds ? ['custom-toggle', node.name] : undefined"
-        [hideToggle]="hideToggle"
+        [toggleTestId]="withExplicitToggleTestIds() ? ['custom-toggle', node.name] : undefined"
+        [hideToggle]="hideToggle()"
       >
         {{ node.name }}
         <ng-container slot="children" tnTreeNodeOutlet />
@@ -50,9 +50,9 @@ const dataset: ExampleNode[] = [
   `,
 })
 class HostComponent {
-  hideToggle = false;
-  withNodeTestIds = true;
-  withExplicitToggleTestIds = false;
+  hideToggle = signal(false);
+  withNodeTestIds = signal(true);
+  withExplicitToggleTestIds = signal(false);
 
   readonly treeControl = createNestedTreeControl<ExampleNode>((node) => node.children);
   readonly dataSource = new TnNestedTreeDataSource<ExampleNode>(dataset);
@@ -109,7 +109,7 @@ describe('TnNestedTreeNodeComponent', () => {
   });
 
   it('prefers an explicit toggleTestId over the derived one', () => {
-    host.withExplicitToggleTestIds = true;
+    host.withExplicitToggleTestIds.set(true);
     fixture.detectChanges();
 
     expect(toggleButton('pool')).toBeNull();
@@ -117,7 +117,7 @@ describe('TnNestedTreeNodeComponent', () => {
   });
 
   it('renders no toggle test id when the node has no testId either', () => {
-    host.withNodeTestIds = false;
+    host.withNodeTestIds.set(false);
     fixture.detectChanges();
 
     const toggle = fixture.nativeElement.querySelector('.tn-nested-tree-node__toggle');
@@ -153,7 +153,7 @@ describe('TnNestedTreeNodeComponent', () => {
   });
 
   it('suppresses the built-in toggle and spacer when hideToggle is set', () => {
-    host.hideToggle = true;
+    host.hideToggle.set(true);
     fixture.detectChanges();
 
     expect(toggleButton('pool')).toBeNull();

--- a/projects/truenas-ui/src/lib/tree/tree-datasource.spec.ts
+++ b/projects/truenas-ui/src/lib/tree/tree-datasource.spec.ts
@@ -1,10 +1,21 @@
 import type { CollectionViewer } from '@angular/cdk/collections';
-import { fakeAsync, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { TnNestedTreeDataSource } from './nested-tree-datasource';
 import { createFlatTreeControl } from './tree-control.factory';
 import type { TnTreeExpansion } from './tree-expansion.interface';
 import { TnTreeFlatDataSource, TnTreeFlattener } from './tree.component';
+
+/**
+ * The debounce these suites step over is `debounceTime(200)` in the data
+ * sources, which is RxJS's `asyncScheduler` and so an ordinary `setInterval` —
+ * nothing Angular. Jest's own fake timers reach it directly, which is why the
+ * #304 port of this file is a rename (`tick` → `advanceTimersByTime`) rather
+ * than a rewrite: there is no microtask in the path, so the one behaviour
+ * `fakeAsync` had that Jest's timers do not — draining promises alongside the
+ * clock — is not in use here.
+ */
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
 
 interface ExampleNode {
   name: string;
@@ -49,29 +60,29 @@ describe('TnNestedTreeDataSource', () => {
     expect(data[1].children?.map((node) => node.name)).toEqual(['alpha', 'zeta']);
   });
 
-  it('filters through filterPredicate with a debounce and clears when query is emptied', fakeAsync(() => {
+  it('filters through filterPredicate with a debounce and clears when query is emptied', () => {
     const dataSource = new TnNestedTreeDataSource(makeData());
     dataSource.filterPredicate = (data, query) => data.filter((node) => node.name.includes(query));
 
     dataSource.filter('app');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['apple']);
 
     dataSource.filter('');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['banana', 'apple']);
-  }));
+  });
 
-  it('keeps filtering functional after a disconnect/reconnect cycle', fakeAsync(() => {
+  it('keeps filtering functional after a disconnect/reconnect cycle', () => {
     const dataSource = new TnNestedTreeDataSource(makeData());
     dataSource.filterPredicate = (data, query) => data.filter((node) => node.name.includes(query));
 
     dataSource.disconnect();
 
     dataSource.filter('app');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['apple']);
-  }));
+  });
 });
 
 describe('TnTreeFlatDataSource', () => {
@@ -117,21 +128,21 @@ describe('TnTreeFlatDataSource', () => {
     expect(latest(dataSource).map((node) => node.name)).toEqual(['apple', 'banana']);
   });
 
-  it('filters through filterPredicate with a debounce', fakeAsync(() => {
+  it('filters through filterPredicate with a debounce', () => {
     const { dataSource } = makeDataSource();
     dataSource.data = makeData();
     dataSource.filterPredicate = (data, query) => data.filter((node) => node.name.includes(query));
 
     dataSource.filter('app');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['apple']);
 
     dataSource.filter('');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['banana', 'apple']);
-  }));
+  });
 
-  it('keeps filtering functional after a disconnect/reconnect cycle', fakeAsync(() => {
+  it('keeps filtering functional after a disconnect/reconnect cycle', () => {
     const { dataSource } = makeDataSource();
     dataSource.data = makeData();
     dataSource.filterPredicate = (data, query) => data.filter((node) => node.name.includes(query));
@@ -139,9 +150,9 @@ describe('TnTreeFlatDataSource', () => {
     dataSource.disconnect();
 
     dataSource.filter('app');
-    tick(200);
+    jest.advanceTimersByTime(200);
     expect(latest(dataSource).map((node) => node.name)).toEqual(['apple']);
-  }));
+  });
 
   it('accepts a tree control with a custom trackBy key type', () => {
     const treeControl = createFlatTreeControl<ExampleFlatNode, string>(

--- a/projects/truenas-ui/src/lib/tree/tree-virtual-scroll-view.component.spec.ts
+++ b/projects/truenas-ui/src/lib/tree/tree-virtual-scroll-view.component.spec.ts
@@ -87,10 +87,19 @@ describe('TnTreeVirtualScrollViewComponent', () => {
    * Drive several change-detection passes to let the node stream (async `auditTime`)
    * emit and the DOM settle. The viewport's recycling repeater can reshuffle rows, so
    * the outlet's self-healing `ngDoCheck` reconciles aria attributes over the next
-   * pass or two — mirroring how zone-driven CD settles in the browser.
+   * pass or two.
+   *
+   * THE `flushFrame()` IS LOAD-BEARING, and was not needed before #304. The node
+   * stream is `auditTime(0, animationFrameScheduler)`, so it emits from a
+   * `requestAnimationFrame`. Zone patched rAF and counted it as a pending
+   * macrotask, so `whenStable()` alone waited for it. Zoneless `whenStable()`
+   * resolves when Angular's `PendingTasks` set is empty, and a bare rAF is not
+   * one of those — it resolved immediately, the stream never emitted, and every
+   * assertion here read a viewport with zero materialised rows.
    */
   async function settle(passes = 3): Promise<void> {
     for (let i = 0; i < passes; i++) {
+      await flushFrame();
       await fixture.whenStable();
       fixture.detectChanges();
     }

--- a/projects/truenas-ui/src/lib/tree/tree-virtual-scroll-view.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/tree/tree-virtual-scroll-view.harness.spec.ts
@@ -67,9 +67,14 @@ describe('TnTreeVirtualScrollViewHarness', () => {
   let fixture: ComponentFixture<HostComponent>;
   let loader: HarnessLoader;
 
-  /** Flush the node stream (async `auditTime`) and let the DOM settle, as in the component spec. */
+  /**
+   * Flush the node stream (async `auditTime`) and let the DOM settle, as in the
+   * component spec — including the animation frame the stream emits from, which
+   * zoneless `whenStable()` does not wait for. See the fuller note there.
+   */
   async function settle(passes = 3): Promise<void> {
     for (let i = 0; i < passes; i++) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
       await fixture.whenStable();
       fixture.detectChanges();
     }

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
@@ -69,8 +69,9 @@ describe('tnTransitionLifecycle zone discipline', () => {
     }).compileComponents();
 
     jest.useFakeTimers();
-    // Injected before the fixture exists, so the spies are in place for the
-    // very first `effect` run.
+    // The instance both tests spy on. Resolved here rather than inside them so
+    // that it is the SAME `NoopNgZone` the helper will inject — each test then
+    // installs its own spy on it, after `createHost()`.
     zone = TestBed.inject(NgZone);
   });
 

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
@@ -1,0 +1,159 @@
+import { Component, NgZone, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { TN_TRANSITION_FALLBACK_MS, tnTransitionLifecycle } from './transition-lifecycle';
+import type { TnTransitionLifecycle } from './transition-lifecycle';
+
+/**
+ * The narrowest possible caller of `tnTransitionLifecycle`: a state signal, a
+ * spy for `settled`, and nothing else that could arm a timer or call into
+ * `NgZone`. That exclusivity is the point — the assertions below count calls on
+ * the injected `NgZone`, and `tn-drawer` / `tn-side-panel` both pull in focus
+ * management, an overlay and an icon registry, any of which could contribute a
+ * call of its own and make a count meaningless.
+ */
+@Component({
+  standalone: true,
+  template: '',
+})
+class LifecycleHostComponent {
+  open = signal(false);
+  settled = jest.fn<void, [boolean]>();
+  lifecycle: TnTransitionLifecycle = tnTransitionLifecycle(this.open, this.settled);
+}
+
+/**
+ * THE `runOutsideAngular` GUARD IN `transition-lifecycle.ts`, AND WHY IT IS
+ * TESTED HERE RATHER THAN WHERE IT USED TO BE
+ * ------------------------------------------------------------------------
+ * `drawer-lifecycle.spec.ts` and `side-panel-lifecycle.spec.ts` each used to
+ * assert `TestBed.inject(NgZone).hasPendingMacrotasks === false` after an open,
+ * which is what the `runOutsideAngular` in `tnTransitionLifecycle` exists to
+ * keep true: the fallback is armed from an `effect`, effects run inside
+ * `ApplicationRef.tick()`, and under zone change detection `tick()` runs inside
+ * `NgZone.run(...)` — so a plain `setTimeout` there would be an Angular-zone
+ * macrotask holding the zone unstable for the whole 400ms window after every
+ * open and close, in every downstream suite that toggles one of these
+ * components.
+ *
+ * #304 made this project's test suite zoneless. `NgZone` then resolves to
+ * `NoopNgZone`, whose `hasPendingMacrotasks` is a hard-coded `false` — so the
+ * old assertion would have passed with the `runOutsideAngular` deleted. A test
+ * that cannot fail is worse than no test, because it reads as coverage.
+ *
+ * These two assert the same guard WITHOUT needing a real Zone, by checking that
+ * the calls are made and that the timer is the one they made:
+ *
+ *  - the fallback timer is the handle `runOutsideAngular` RETURNED, proven by
+ *    clearing that handle and watching the fallback not fire. Moving the
+ *    `setTimeout` out from inside the callback breaks that, because the call
+ *    then returns something else (or is not made at all).
+ *  - the report goes back through `zone.run`, which is what makes a consumer's
+ *    `(closed)` handler visible to change detection under a zone-based app.
+ *
+ * `NoopNgZone` runs both callbacks synchronously, so the spies observe the real
+ * control flow rather than a stub's.
+ */
+describe('tnTransitionLifecycle zone discipline', () => {
+  let fixture: ComponentFixture<LifecycleHostComponent>;
+  let host: LifecycleHostComponent;
+  let zone: NgZone;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LifecycleHostComponent],
+    }).compileComponents();
+
+    jest.useFakeTimers();
+    // Injected before the fixture exists, so the spies are in place for the
+    // very first `effect` run.
+    zone = TestBed.inject(NgZone);
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  function createHost(): void {
+    fixture = TestBed.createComponent(LifecycleHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('arms the fallback timer inside runOutsideAngular, not in Angular time', () => {
+    createHost();
+
+    /**
+     * How deep inside a `runOutsideAngular` callback we currently are.
+     *
+     * Counting CALLS would not do: `ComponentFixture`'s own constructor and
+     * Angular's render hooks each call `runOutsideAngular` too, so the number
+     * varies with framework internals rather than with this file's subject.
+     * What is being asserted is narrower and stable — that the ONE timer armed
+     * at the fallback delay was scheduled while inside such a callback.
+     */
+    let depth = 0;
+    jest.spyOn(zone, 'runOutsideAngular').mockImplementation(<T, >(fn: () => T): T => {
+      depth += 1;
+      try {
+        return fn();
+      } finally {
+        depth -= 1;
+      }
+    });
+
+    let armedOutside: boolean | null = null;
+    const scheduleTimer = globalThis.setTimeout;
+    jest.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (timeout === TN_TRANSITION_FALLBACK_MS) {
+        armedOutside = depth > 0;
+      }
+      return scheduleTimer(handler, timeout, ...args);
+    }) as unknown as typeof setTimeout);
+
+    host.open.set(true);
+    fixture.detectChanges();
+
+    // `null` here would mean no timer was armed at the fallback delay at all,
+    // which is a different failure from arming one in the wrong place.
+    expect(armedOutside).toBe(true);
+
+    // ...and it is a working timer, not merely a well-placed one.
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
+    expect(host.settled).toHaveBeenCalledWith(true);
+  });
+
+  it('reports back inside the Angular zone, so a consumer handler is seen', () => {
+    createHost();
+    const run = jest.spyOn(zone, 'run');
+
+    host.open.set(true);
+    fixture.detectChanges();
+    expect(host.settled).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
+
+    expect(host.settled).toHaveBeenCalledWith(true);
+    expect(run).toHaveBeenCalled();
+  });
+
+  // The early report takes the same route out, so it needs no zone of its own —
+  // it is called from a DOM event handler the caller already owns.
+  it('reports through transitionEnded without arming anything further', () => {
+    createHost();
+    host.open.set(true);
+    fixture.detectChanges();
+
+    host.lifecycle.transitionEnded();
+    expect(host.settled).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
+    expect(host.settled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.spec.ts
@@ -41,15 +41,19 @@ class LifecycleHostComponent {
  * old assertion would have passed with the `runOutsideAngular` deleted. A test
  * that cannot fail is worse than no test, because it reads as coverage.
  *
- * These two assert the same guard WITHOUT needing a real Zone, by checking that
- * the calls are made and that the timer is the one they made:
+ * These assert the same guard WITHOUT needing a real Zone, by watching WHERE
+ * the calls happen rather than what a no-op zone reports afterwards:
  *
- *  - the fallback timer is the handle `runOutsideAngular` RETURNED, proven by
- *    clearing that handle and watching the fallback not fire. Moving the
- *    `setTimeout` out from inside the callback breaks that, because the call
- *    then returns something else (or is not made at all).
- *  - the report goes back through `zone.run`, which is what makes a consumer's
- *    `(closed)` handler visible to change detection under a zone-based app.
+ *  - the fallback timer is scheduled while inside a `runOutsideAngular`
+ *    callback, read from a depth counter the spy maintains. Moving the
+ *    `setTimeout` out from inside the callback drops the depth to zero.
+ *  - the report runs while inside a `zone.run` callback, read the same way.
+ *    That is what makes a consumer's `(closed)` handler visible to change
+ *    detection under a zone-based application.
+ *
+ * Neither counts CALLS: `ComponentFixture`'s constructor and Angular's own
+ * render hooks use both methods, so a count measures framework internals. Depth
+ * at the moment of the thing under test does not.
  *
  * `NoopNgZone` runs both callbacks synchronously, so the spies observe the real
  * control flow rather than a stub's.
@@ -72,8 +76,12 @@ describe('tnTransitionLifecycle zone discipline', () => {
 
   afterEach(() => {
     fixture?.destroy();
-    jest.useRealTimers();
+    // Mocks first. One of the tests below spies on `globalThis.setTimeout`
+    // while the fake clock is installed, so what `restoreAllMocks` puts back is
+    // the FAKE function — running it after `useRealTimers` would write the fake
+    // timer onto `globalThis` again and leave it there for the next test.
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   function createHost(): void {
@@ -131,7 +139,24 @@ describe('tnTransitionLifecycle zone discipline', () => {
 
   it('reports back inside the Angular zone, so a consumer handler is seen', () => {
     createHost();
-    const run = jest.spyOn(zone, 'run');
+
+    // Depth again, not a call count, and for the same reason. `zone.run` in
+    // particular is called all over Angular's own testing infrastructure, so
+    // `toHaveBeenCalled()` here would be true no matter what this function did.
+    let depth = 0;
+    jest.spyOn(zone, 'run').mockImplementation(<T, >(fn: () => T): T => {
+      depth += 1;
+      try {
+        return fn();
+      } finally {
+        depth -= 1;
+      }
+    });
+
+    let reportedInside: boolean | null = null;
+    host.settled.mockImplementation(() => {
+      reportedInside = depth > 0;
+    });
 
     host.open.set(true);
     fixture.detectChanges();
@@ -140,7 +165,10 @@ describe('tnTransitionLifecycle zone discipline', () => {
     jest.advanceTimersByTime(TN_TRANSITION_FALLBACK_MS);
 
     expect(host.settled).toHaveBeenCalledWith(true);
-    expect(run).toHaveBeenCalled();
+    // `null` would mean `settled` never ran; `false` that it ran outside the
+    // zone, which is the shape that leaves a consumer's `(closed)` handler
+    // invisible to zone-based change detection.
+    expect(reportedInside).toBe(true);
   });
 
   // The early report takes the same route out, so it needs no zone of its own —

--- a/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
+++ b/projects/truenas-ui/src/lib/utils/transition-lifecycle.ts
@@ -161,6 +161,14 @@ export function tnTransitionLifecycle(
     // component-harness interaction) waits the full window. The emit itself
     // must be back inside, since `settled` is what fires the component's
     // outputs and a consumer's handler has to be seen by change detection.
+    //
+    // BOTH CALLS STILL MATTER THOUGH THIS PROJECT'S OWN TESTS ARE NOW ZONELESS
+    // (#304). Consumers choose their own change detection, and under a
+    // zone-based application both of the costs above are live. Zoneless, they
+    // resolve to `NoopNgZone` and run the callback straight through — which is
+    // why `transition-lifecycle.spec.ts` asserts that the calls are MADE rather
+    // than asserting `NgZone.hasPendingMacrotasks`, which `NoopNgZone` answers
+    // `false` to whatever this function does.
     timer = zone.runOutsideAngular(() =>
       setTimeout(() => zone.run(report), TN_TRANSITION_FALLBACK_MS)
     );

--- a/projects/truenas-ui/src/setup-jest.ts
+++ b/projects/truenas-ui/src/setup-jest.ts
@@ -1,8 +1,29 @@
-import 'zone.js';
-import 'zone.js/testing';
-import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+import { setupZonelessTestEnv } from 'jest-preset-angular/setup-env/zoneless';
 
-setupZoneTestEnv();
+/**
+ * The test environment for every spec in this project, zoneless (#304).
+ *
+ * WHY THERE IS NO `import 'zone.js'` HERE
+ * ---------------------------------------
+ * Nothing this library ships needs Zone. `@angular/core` 21 marks `zone.js`
+ * `optional: true`, the published manifest declares no peer for it, and no file
+ * under `src/lib/` touches the `Zone` global — so `bootstrapApplication` in a
+ * consumer and `@storybook/angular`'s preview are both already zoneless. The
+ * test suite was the last environment still patching `setTimeout`, `Promise`
+ * and `addEventListener`, which meant every spec exercised a runtime no
+ * consumer runs.
+ *
+ * WHAT THAT COSTS A SPEC, since it is not free
+ * --------------------------------------------
+ * `fakeAsync`/`tick` are Zone APIs and are gone with it. Timer-driven specs use
+ * Jest's own fake timers instead — `jest.useFakeTimers()` and
+ * `jest.advanceTimersByTime(ms)`. The one behavioural difference that matters:
+ * `tick()` drained the microtask queue as well as the timer queue, and
+ * `advanceTimersByTime()` does not. A spec waiting on a promise (a
+ * `MutationObserver` callback, a `whenStable()`) has to `await` it explicitly.
+ * The seven specs converted in #304 each carry a note where that applied.
+ */
+setupZonelessTestEnv();
 
 // Suppress expected console errors in test environment
 const originalConsoleError = console.error;

--- a/projects/truenas-ui/src/test-setup.ts
+++ b/projects/truenas-ui/src/test-setup.ts
@@ -1,4 +1,0 @@
-import '@testing-library/jest-dom';
-import 'zone.js'; // Required for Angular
-import 'jest-preset-angular/setup-jest';
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -21562,10 +21562,8 @@ __metadata:
     typescript: "npm:~5.9.3"
     vinyl: "npm:~3.0.0"
     wait-on: "npm:^9.1.0"
-    zone.js: "npm:^0.15.1"
   peerDependencies:
     rxjs: ^7.5.0
-    zone.js: ^0.15.0
   bin:
     truenas-icons: ./dist/truenas-ui/scripts/icon-sprite/cli.js
   languageName: unknown
@@ -23339,12 +23337,5 @@ __metadata:
   version: 4.3.5
   resolution: "zod@npm:4.3.5"
   checksum: 10c0/5a2db7e59177a3d7e202543f5136cb87b97b047b77c8a3d824098d3fa8b80d3aa40a0a5f296965c3b82dfdccdd05dbbfacce91347f16a39c675680fd7b1ab109
-  languageName: node
-  linkType: hard
-
-"zone.js@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "zone.js@npm:0.15.1"
-  checksum: 10c0/4eca000f90dbea1c34f62e88ce56910dace8cdecbe14747b214f2af37aa511264c7bd50faf3e9b00612e95dc4567da156a9690fef1983bfcf74604a630d190ef
   languageName: node
   linkType: hard


### PR DESCRIPTION
Fixes #304.

`setup-jest.ts` now calls `setupZonelessTestEnv()`, and `zone.js` is gone from
`package.json` (both the `devDependencies` entry and the `peerDependencies`
block), from `yarn.lock` and `package-lock.json` as a direct entry, from the
Storybook preview, and from the polyfills on the karma `test` target. The dead
`src/test-setup.ts` goes with it.

## Acceptance criteria

- [x] **`zone.js` appears in no manifest, and no file we own imports it.** Also
      removed from `README.md`'s documented peer list, which is not a manifest
      but is read as one. The remaining `zone.js` strings in `yarn.lock` are
      other packages' own peer declarations (`@angular/core`,
      `@storybook/angular`), which are theirs and not ours.
- [x] **The full Jest suite passes — all 150 spec files.** 4267 tests, 150
      suites, green. 25 suites failed on the first zoneless run; see *The blast
      radius* below for what each class of failure was.
- [x] **Every behaviour the current `fakeAsync` specs assert is still asserted.**
      One assertion was deleted rather than ported, twice — see the next item —
      and nothing else was dropped.
- [x] **The `runOutsideAngular` fallback timer is still covered by a test that
      can fail.** New file, `lib/utils/transition-lifecycle.spec.ts`.
- [x] **Storybook's preview loads with no `NG0914`.** See *Storybook* below.
- [x] **`ng build truenas-ui` succeeds and the published manifest is unchanged.**
      `projects/truenas-ui/package.json` is not touched by this branch, and never
      declared a `zone.js` peer — so `dist/truenas-ui/package.json` is
      byte-identical. Downstream sees no change.
- [x] **`src/test-setup.ts` and the karma `zone.js` polyfills are gone.**

## The assertion that had to go, and what replaced it

`drawer-lifecycle.spec.ts` and `side-panel-lifecycle.spec.ts` each asserted:

```ts
expect(TestBed.inject(NgZone).hasPendingMacrotasks).toBe(false);
```

guarding the `runOutsideAngular` in `lib/utils/transition-lifecycle.ts`. Without
a Zone, `NgZone` resolves to `NoopNgZone`, whose `hasPendingMacrotasks` is a
hard-coded `false` — so that line would have kept passing **with the
`runOutsideAngular` deleted**. A test that cannot fail is worse than no test.

Both are deleted, and each spec carries a comment at the spot saying so and
pointing at what took over. What took over is `lib/utils/transition-lifecycle.spec.ts`,
which asserts the two things the guard is actually for, needing no Zone:

- the fallback timer is scheduled **while inside** a `runOutsideAngular`
  callback, and
- the report runs **while inside** a `zone.run` callback.

Both read a depth counter the spy maintains rather than a call count, because
`ComponentFixture`'s constructor and Angular's render hooks call both methods
for their own reasons — a count would measure framework internals.

**Verified by mutation rather than asserted to work.** Removing the
`runOutsideAngular` from the source fails the first test and only that one;
removing the `zone.run` fails the second and only that one. Both were run in
that state and then restored.

## Two latent defects Zone was hiding

Both threw inside a patched microtask, where Zone swallowed the error. Without
Zone, jsdom reports them as uncaught and they fail the test.

- **`tn-select`** built an id selector with `CSS.escape`, which jsdom does not
  define — so `scrollFocusedIntoView` threw on every keyboard navigation in the
  suite (26 occurrences). Fixed by comparing the attribute instead of composing
  a selector, which is the rule `lib/a11y/accessible-name-testing.ts` already
  records, in those words, for exactly this reason.
- **`tn-chip-input`** called `scrollIntoView` unguarded; jsdom implements none.
  Guarded the way `tn-autocomplete` next door already does it.

Neither changes anything in a browser.

## The blast radius, since it is most of the diff

The ticket predicted the whole suite rather than the 7 `fakeAsync` files, and
that was right. Three distinct causes:

**1. `fakeAsync`/`tick`/`flush` are Zone APIs** (7 files). Replaced with
`jest.useFakeTimers()` / `advanceTimersByTime`. The one behavioural difference —
`tick()` drained the microtask queue as well as the timer queue — mattered in
`tooltip.directive.spec.ts`, whose `MutationObserver` waits now `await` a real
microtask through one shared `settleObserver()` (it had four copies).

**2. Zoneless change detection refreshes what has been marked dirty** (~17
files, 194 of the 206 initial failures). A test host assigning a plain property
marks nothing, so `fixture.detectChanges()` — `ApplicationRef.tick()` with
nothing to do — refreshed no view, and dev mode reported the stale binding as
`NG0100`, which reads as a component bug rather than as a spec that never
re-rendered. The affected hosts hold their bound state in signals now. Only the
fields a template READS were changed; a field an output binding writes into is
left plain.

**3. `whenStable()` waits on `PendingTasks`, not on every macrotask** (3 files).
A bare `setTimeout` or `requestAnimationFrame` is not one of those, so:

- `tree-virtual-scroll-view` (component + harness): the node stream is
  `auditTime(0, animationFrameScheduler)`, so `settle()` now awaits a frame.
  Every assertion there had been reading a viewport with zero materialised rows.
- `tooltip.harness.spec.ts`: the directive's show/hide is a `setTimeout` the
  harness environment no longer waits for, so the spec awaits it.
- `side-panel-focus-capture.spec.ts`: two tests stub `requestAnimationFrame` to
  hold the capture's retry. Angular's zoneless scheduler uses
  `scheduleCallbackWithRafRace`, so it now puts callbacks in the same list and
  nothing at that seam can tell them apart — named by reading the stacks, not
  guessed. The `toHaveLength(1)` assertions are gone; the verdict is read from
  the attempt counter and `document.activeElement`, which is what those tests
  were always about.

## Documentation

`docs/component_testing.md` gains a section on all three, because a spec author
who does not know them gets `zone-testing.js is needed` or an `NG0100` naming
their own host component, and neither error says what to do. Two entries added
to its *Common Issues* list pointing at it.

## What I did not change, and why

Findings from the local review that are real but out of this ticket's scope, or
that I disagree with:

- **`tn-select`'s lookup is now a linear scan of `[id]` descendants** rather than
  a direct `querySelector('#id')`. The review twice suggested a `typeof CSS`
  guard to keep the direct path in a browser. That is reasonable, and I went the
  other way on purpose: `lib/a11y/accessible-name-testing.ts` already made this
  exact call and wrote down why ("comparing the attribute keeps the question in
  the DOM, where there is no selector syntax to get wrong in the first place"),
  and a second, different answer to the same question in the same library is the
  thing that convention exists to prevent. The list is one dropdown's options.
- **The karma `test` target in `angular.json` is now dead config** — a `tsConfig`
  and nothing else, invoked by no script. Deleting it is very likely right, and
  the ticket asked only for the `zone.js` polyfills on it. Worth its own ticket.
- **`menu.component.spec.ts` installs fake timers for two whole `describe`
  blocks** to serve a few overlay-teardown tests. Deliberate: no test in either
  block awaits anything, so the fake clock costs the others nothing, and one
  `beforeEach` is easier to find than a per-test install. Noted in the file.

## Locally

`yarn lint`, `yarn test` (150 suites / 4267 tests), `yarn test:scripts` (5
suites / 57 tests), `yarn build` and `yarn build-storybook` all pass.

### Storybook

`yarn build-storybook` completes, and `__zone_symbol__` appears nowhere in
`storybook-static/` — zone.js is not in the preview bundle. `NG0914` is emitted
by `provideZonelessChangeDetection()` only under `typeof Zone !== 'undefined'`
(read from `@angular/core`'s source), so with nothing defining `Zone` it cannot
fire.

**I could not run `yarn test-sb` — Storybook Interaction Tests — on this
machine**, which has no browser and a read-only root, so "stories still render
and respond to interaction" is the one acceptance criterion I am arguing rather
than demonstrating. The argument: the preview was already running zoneless
(`@storybook/angular` 10.1.11 defaults `experimentalZoneless` for Angular ≥ 21
and calls `provideZonelessChangeDetection()` itself), so removing the
hand-written `import 'zone.js'` takes away a polyfill nothing was consuming
rather than changing which change detection the preview uses. CI runs that check
and it is the one to watch.

### Review

Two rounds of the project's own reviewer ran locally, both returning nothing at
or above MEDIUM. The LOWs each round raised are either fixed above or listed
under *What I did not change*.
