### PR TITLE
NAS-142376 / 27.0.0-BETA.1 / fix(radio)!: emit `radio-button-` for an option, not `radio-`

### DIFF
--- a/docs/test_ids.md
+++ b/docs/test_ids.md
@@ -173,7 +173,7 @@ Every interactive component listed below supports `testId`:
 | `tn-icon-button` | `testId` input | inner `<button>` |
 | `tn-input` | `testId` input | inner `<input>` / `<textarea>` |
 | `tn-menu` | `TnMenuItem.testId` per item | each item's `<button>` |
-| `tn-radio` | `testId` input | inner `<input>` |
+| `tn-radio` | `testId` input | visible `<label>` (the native `<input>` is hidden, so the label is the hit target) |
 | `tn-select` | `testId` input | `.tn-select-container` |
 | `tn-selection-list` | `hostDirectives` | host element |
 | `tn-side-panel` | `testId` input + `closeButtonTestId` input | panel root + close `<button>` |

--- a/docs/test_ids.md
+++ b/docs/test_ids.md
@@ -139,15 +139,20 @@ This keeps the harness API stable regardless of which attribute the consumer con
 
 ## Value-string conventions
 
-The library is **unopinionated** about value content. `testId` is a raw string the library renders verbatim — no automatic prefixing, no kebab-casing.
-
-That means consumers using a convention like `button-foo-bar` (e.g. webui's `[ixTest]`-style auto-prefix) should include the prefix themselves when they set a library `testId`:
+**The library owns the element-type prefix; the consumer supplies only the semantic base.** Each component declares its own type through `tnTestIdType`, and `composeTestId` assembles `<type>-<base>`, kebab-casing every segment:
 
 ```html
-<tn-button testId="button-save-changes" />
+<tn-button testId="save-changes" />   <!-- button-save-changes -->
 ```
 
-This deliberately puts the value-shape decision in the consumer's hands so different applications can keep their existing automation conventions.
+Pass the bare base — `"save-changes"`, not `"button-save-changes"`. A base may be a single token or an ordered array (`[testId]="['username', option.value]"`), and falsy segments drop out.
+
+Two behaviours are worth knowing:
+
+- **Idempotent guard.** A base that already starts with the component's own prefix is not prefixed twice (`composeTestId('button', 'button-save')` → `button-save`). This exists so a migration can land prefix-by-prefix, not as a way to hand-write ids. It only absorbs the component's *current* prefix, so a base carrying a stale one is compounded rather than absorbed — after the `radio` → `radio-button` change, `<tn-radio testId="radio-email" />` yields `radio-button-radio-email`.
+- **Kebab-casing is not identical to lodash.** camelCase and separators split (`sshPort` → `ssh-port`, `addr_trtype` → `addr-trtype`), but a letter↔digit boundary does not (`nvme0n1` stays `nvme0n1` where lodash would give `nvme-0n1`). Normalize dynamic values consumer-side if an existing convention depends on that split.
+
+Element types follow the control they name, and a grouped control pairs the container with the thing inside it: `radio-group`/`radio-button`, `button-toggle-group`/`button-toggle`, `select`/`option`. The declared type lives in each component's template — grep `tnTestIdType` for the full list.
 
 ## Coverage
 

--- a/projects/truenas-ui/src/lib/radio/radio-group.component.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-group.component.spec.ts
@@ -288,26 +288,22 @@ describe('TnRadioGroupComponent', () => {
   });
 
   describe('test ids', () => {
-    it('scopes each option id with the group base', () => {
-      expect(fixture.nativeElement.querySelector('[data-testid="radio-button-letter-alpha"]')).toBeTruthy();
-      expect(fixture.nativeElement.querySelector('[data-testid="radio-button-letter-beta"]')).toBeTruthy();
-    });
-
-    it('puts the base on the group root too', () => {
-      expect(fixture.nativeElement.querySelector('[data-testid="radio-group-letter"]')).toBeTruthy();
-    });
-
-    // The group/option pair is what automation selects on, and a `radio-group-x` whose members were
-    // `radio-x-*` read as a different control. `radio-button` also keeps the pair aligned with
-    // `button-toggle-group`/`button-toggle`, and with the `mat-radio-group`/`mat-radio-button` ids
-    // consumers migrate off — so a migrated group needs no per-option compensation.
-    it('names an option after the group it belongs to, not after the element', () => {
+    // Options are named after the group they belong to, not after the element: a `radio-group-x`
+    // whose members were `radio-x-*` reads as a different control. `radio-button` also keeps the
+    // pair aligned with `button-toggle-group`/`button-toggle`, and with the
+    // `mat-radio-group`/`mat-radio-button` ids consumers migrate off — so a migrated group needs no
+    // per-option compensation.
+    it('scopes each option id with the group base, under the radio-button prefix', () => {
       const optionIds = Array.from(
         fixture.nativeElement.querySelectorAll('[data-testid^="radio-button-letter-"]') as NodeListOf<HTMLElement>,
       ).map((element) => element.getAttribute('data-testid'));
 
       expect(optionIds).toEqual(['radio-button-letter-alpha', 'radio-button-letter-beta']);
       expect(fixture.nativeElement.querySelector('[data-testid="radio-letter-alpha"]')).toBeNull();
+    });
+
+    it('puts the base on the group root too', () => {
+      expect(fixture.nativeElement.querySelector('[data-testid="radio-group-letter"]')).toBeTruthy();
     });
   });
 

--- a/projects/truenas-ui/src/lib/radio/radio-group.component.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-group.component.spec.ts
@@ -289,12 +289,25 @@ describe('TnRadioGroupComponent', () => {
 
   describe('test ids', () => {
     it('scopes each option id with the group base', () => {
-      expect(fixture.nativeElement.querySelector('[data-testid="radio-letter-alpha"]')).toBeTruthy();
-      expect(fixture.nativeElement.querySelector('[data-testid="radio-letter-beta"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="radio-button-letter-alpha"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="radio-button-letter-beta"]')).toBeTruthy();
     });
 
     it('puts the base on the group root too', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="radio-group-letter"]')).toBeTruthy();
+    });
+
+    // The group/option pair is what automation selects on, and a `radio-group-x` whose members were
+    // `radio-x-*` read as a different control. `radio-button` also keeps the pair aligned with
+    // `button-toggle-group`/`button-toggle`, and with the `mat-radio-group`/`mat-radio-button` ids
+    // consumers migrate off — so a migrated group needs no per-option compensation.
+    it('names an option after the group it belongs to, not after the element', () => {
+      const optionIds = Array.from(
+        fixture.nativeElement.querySelectorAll('[data-testid^="radio-button-letter-"]') as NodeListOf<HTMLElement>,
+      ).map((element) => element.getAttribute('data-testid'));
+
+      expect(optionIds).toEqual(['radio-button-letter-alpha', 'radio-button-letter-beta']);
+      expect(fixture.nativeElement.querySelector('[data-testid="radio-letter-alpha"]')).toBeNull();
     });
   });
 

--- a/projects/truenas-ui/src/lib/radio/radio-group.component.ts
+++ b/projects/truenas-ui/src/lib/radio/radio-group.component.ts
@@ -116,7 +116,7 @@ export class TnRadioGroupComponent<T = unknown> implements ControlValueAccessor,
   /**
    * Test-id base for the group and, scoped by the option label, for every option rendered from
    * `options`: base `encryption` yields `radio-group-encryption` on the group and
-   * `radio-encryption-passphrase` on its options. Falls back to the bound control name.
+   * `radio-button-encryption-passphrase` on its options. Falls back to the bound control name.
    *
    * Projected `<tn-radio>` children keep their own test-id resolution — the group does not reach
    * into content it did not render — so give each one a `testId` of its own.

--- a/projects/truenas-ui/src/lib/radio/radio.component.html
+++ b/projects/truenas-ui/src/lib/radio/radio.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="classes()">
-  <label class="tn-radio__label" tnTestIdType="radio" [for]="id" [tnTestId]="resolvedTestId()">
+  <label class="tn-radio__label" tnTestIdType="radio-button" [for]="id" [tnTestId]="resolvedTestId()">
     <input
       #radioEl
       type="radio"

--- a/projects/truenas-ui/src/lib/radio/radio.component.ts
+++ b/projects/truenas-ui/src/lib/radio/radio.component.ts
@@ -36,6 +36,12 @@ export class TnRadioComponent implements AfterViewInit, OnDestroy, ControlValueA
   name = input<string | undefined>(undefined);
   disabled = input<boolean>(false);
   required = input<boolean>(false);
+  /**
+   * Test-id base. The element type this composes with is `radio-button`, not `radio`: the id
+   * identifies one radio BUTTON within a `radio-group`, matching the `radio-group`/`radio-button`
+   * pair every other grouped control in this library uses (`button-toggle-group`/`button-toggle`).
+   * So `testId="email"` yields `radio-button-email`.
+   */
   testId = input<TnTestIdValue>(undefined);
   /** Test-id base, falling back to the bound control name when `testId` is unset. */
   protected resolvedTestId = controlTestId(this.testId);

--- a/projects/truenas-ui/src/lib/radio/radio.harness.spec.ts
+++ b/projects/truenas-ui/src/lib/radio/radio.harness.spec.ts
@@ -55,7 +55,7 @@ describe('TnRadioHarness', () => {
     });
 
     it('should find radio by testId', async () => {
-      const radio = await loader.getHarness(TnRadioHarness.with({ testId: 'radio-a' }));
+      const radio = await loader.getHarness(TnRadioHarness.with({ testId: 'radio-button-a' }));
       expect(await radio.getLabelText()).toBe('Option A');
     });
 
@@ -100,7 +100,7 @@ describe('TnRadioHarness', () => {
   describe('getTestId()', () => {
     it('should return the test ID', async () => {
       const radio = await loader.getHarness(TnRadioHarness.with({ label: 'Option A' }));
-      expect(await radio.getTestId()).toBe('radio-a');
+      expect(await radio.getTestId()).toBe('radio-button-a');
     });
 
     it('should return null when no test ID is set', async () => {

--- a/projects/truenas-ui/src/stories/radio-group.stories.ts
+++ b/projects/truenas-ui/src/stories/radio-group.stories.ts
@@ -197,7 +197,8 @@ export const KeyboardNavigation: Story = {
 /**
  * **Test IDs.** The base lands on the group root under the `radio-group-` prefix and is scoped by
  * each option's label for the options themselves: `testId="color"` → `radio-group-color` plus
- * `radio-color-red`, `radio-color-blue`, … With no `testId`, the bound control name is used.
+ * `radio-button-color-red`, `radio-button-color-blue`, … With no `testId`, the bound control name
+ * is used.
  */
 export const TestIds: Story = {
   args: { testId: 'color', options: colorOptions, ariaLabel: 'Favorite color' },

--- a/projects/truenas-ui/src/stories/radio.stories.ts
+++ b/projects/truenas-ui/src/stories/radio.stories.ts
@@ -148,10 +148,12 @@ export const ComponentHarness: Story = {
 };
 
 /**
- * **Test IDs (default).** `tn-radio` emits the `radio-` prefix on its visible
- * `<label>` — the native `<input type="radio">` is hidden, so the label is the
- * real hit target. `testId="email"` → `radio-email` (under `data-testid` by
- * default / `data-test`). With no `testId`, nothing is emitted. Table read live.
+ * **Test IDs (default).** `tn-radio` emits the `radio-button-` prefix on its
+ * visible `<label>` — the native `<input type="radio">` is hidden, so the label
+ * is the real hit target. `testId="email"` → `radio-button-email` (under
+ * `data-testid` by default / `data-test`). The prefix names one button within a
+ * `radio-group`, mirroring `button-toggle-group`/`button-toggle`. With no
+ * `testId`, nothing is emitted. Table read live.
  */
 export const TestIds: Story = {
   args: { testId: 'email' },
@@ -168,7 +170,7 @@ export const TestIds: Story = {
 
 /**
  * **Scoped test id.** An array base namespaces the id —
- * `[testId]="['contact','email']"` → `radio-contact-email`.
+ * `[testId]="['contact','email']"` → `radio-button-contact-email`.
  */
 export const ScopedTestIds: Story = {
   args: { testId: ['contact', 'email'] },


### PR DESCRIPTION
## The bug

`tn-radio` declares `tnTestIdType="radio"`, so an option resolves to `radio-<base>` while the group around it resolves to `radio-group-<base>`:

```html
<tn-radio-group formControlName="encryptionType">   <!-- radio-group-encryption-type -->
  <tn-radio [testId]="['encryption-type', 'Passphrase']" />   <!-- radio-encryption-type-passphrase -->
</tn-radio-group>
```

`radio-group-x` whose members are `radio-x-*` reads as two unrelated controls. Every other grouped control in this library names the container and the thing inside it as a pair — `button-toggle-group`/`button-toggle`, `select`/`option` — and so do the `mat-radio-group`/`mat-radio-button` ids consumers migrate off. `radio` is the only element type in the library that doesn't line up with its legacy counterpart; `radio-group` already does.

## Why it needs fixing here

Consumers can't fix it on their side without a hack. `TnTestIdDirective` matches any element, so for most components a consumer can pin a legacy prefix on the host — but `tn-radio` resolves its id through `controlTestId()`, which falls back to the bound control name, so the inner label **always** emits one. A host directive would just add a second `data-test`.

What's left is pushing the prefix into the base and letting `composeTestId`'s idempotent guard absorb the wrong one:

```html
<!-- webui, 9 call sites today -->
<tn-radio [testId]="['radio-button', 'schema-or-regex', option.label]" />
```

That works only for **projected** options. A group rendered from the `options` input scopes each child itself (`scopeTestId(resolvedTestId(), option.label)`) with no per-option override, and pushing `radio-button` into the *group's* base corrupts the group's own id (`radio-group-radio-button-…`). So today a migrated `[options]` group simply cannot keep its ids.

Declaring the right element type fixes both shapes and deletes the workaround.

## Change

One line in `radio.component.html`: `tnTestIdType="radio"` → `tnTestIdType="radio-button"`. Plus the specs, story docs and JSDoc that quoted the old value, and a regression test pinning the group/option pairing.

`tn-radio-group`'s own id is unchanged.

## Breaking

Selectors matching `radio-*` on a radio option need updating. Known consumer impact in **webui**:

- 9 call sites already pass `['radio-button', …]` — unaffected (the guard keeps absorbing it), but the token becomes redundant and should be dropped.
- 3 call sites pass a bare base and currently emit `radio-*`; they get `radio-button-*` back, which **restores** the id their pre-migration `<ix-radio-group>` produced.
- `edit-nfs-ace.component.spec.ts` selects on `radio-permission-type-*` / `radio-flags-type-*` (6 tests). Those values are themselves post-migration drift from `radio-button-permission-type-*`, so the spec goes back to the original ids.

I verified all of the above by building this branch and copying it over `node_modules/@truenas/ui-components` in webui.

## Verification

- `yarn test` — 156 suites / 4391 tests pass
- `yarn lint` — clean
- `yarn build` — clean
- webui `pages/data-protection/replication` against this build — 13 suites / 107 tests pass with the `['radio-button', …]` compensation **removed** from all 5 groups