### PR TITLE
NAS-142382 / 27.0.0-BETA.1 / feat(checkbox): add tn-checkbox-group for array-valued multi-select

### DIFF
--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.html
@@ -1,0 +1,25 @@
+<div
+  class="tn-checkbox-group"
+  role="group"
+  tnTestIdType="checkbox-group"
+  [class.tn-checkbox-group--inline]="inline()"
+  [attr.aria-label]="ariaLabel() || null"
+  [attr.aria-labelledby]="fieldAria.labelledby()"
+  [attr.aria-describedby]="fieldAria.describedby()"
+  [attr.aria-invalid]="fieldAria.invalid()"
+  [attr.aria-disabled]="isDisabled() ? true : null"
+  [attr.aria-required]="ariaRequired() ? true : null"
+  [tnTestId]="resolvedTestId()"
+  (focusout)="onFocusOut()"
+>
+  @for (option of options(); track option.value) {
+    <tn-checkbox
+      class="tn-checkbox-group__option"
+      [label]="option.label"
+      [checked]="isSelected(option.value)"
+      [disabled]="isDisabled() || !!option.disabled"
+      [testId]="optionTestId(option)"
+      (change)="toggle(option.value, $event)"
+    />
+  }
+</div>

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.html
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.html
@@ -3,12 +3,11 @@
   role="group"
   tnTestIdType="checkbox-group"
   [class.tn-checkbox-group--inline]="inline()"
-  [attr.aria-label]="ariaLabel() || null"
-  [attr.aria-labelledby]="fieldAria.labelledby()"
+  [attr.aria-label]="resolvedAriaLabel()"
+  [attr.aria-labelledby]="labelledBy()"
   [attr.aria-describedby]="fieldAria.describedby()"
   [attr.aria-invalid]="fieldAria.invalid()"
   [attr.aria-disabled]="isDisabled() ? true : null"
-  [attr.aria-required]="ariaRequired() ? true : null"
   [tnTestId]="resolvedTestId()"
   (focusout)="onFocusOut()"
 >
@@ -23,3 +22,11 @@
     />
   }
 </div>
+
+<!-- The required-ness rides in the group's accessible NAME, because `role="group"` does not
+     support `aria-required` — see the `required` input's docblock. It sits OUTSIDE the group so
+     the text is not also read as group content on the way past the options; `aria-labelledby`
+     resolves ids document-wide, so it names the group from here just the same. -->
+@if (ariaRequired()) {
+  <span class="cdk-visually-hidden" [attr.id]="requiredTextId">required</span>
+}

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
@@ -1,0 +1,29 @@
+.tn-checkbox-group-host {
+  display: block;
+}
+
+.tn-checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tn-checkbox-group-gap, 8px);
+
+  &--inline {
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: var(--tn-checkbox-group-inline-gap, 16px);
+
+    // Equal columns rather than options hugging their labels: a multi-select list is read down a
+    // column, and ragged widths make an option easy to miss.
+    .tn-checkbox-group__option {
+      flex: 1 1 var(--tn-checkbox-group-inline-basis, 50%);
+      box-sizing: border-box;
+    }
+
+    // Columns of half a narrow viewport are too tight for a label of any length.
+    @media (max-width: 768px) {
+      .tn-checkbox-group__option {
+        flex-basis: 100%;
+      }
+    }
+  }
+}

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
@@ -36,3 +36,19 @@
     }
   }
 }
+
+// Screen-reader-only text. `.cdk-visually-hidden` comes from the CDK's global a11y stylesheet,
+// which this library does not ship; without a local definition the group's "required" name
+// fragment renders as visible text under the options. Same local copy the stepper, table and
+// calendar components keep.
+.cdk-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.scss
@@ -14,8 +14,17 @@
 
     // Equal columns rather than options hugging their labels: a multi-select list is read down a
     // column, and ragged widths make an option easy to miss.
+    //
+    // The gap has to come OUT of the basis. Gaps count toward the space a flex line needs, so a
+    // bare `flex-basis: 50%` makes two options plus the gap exceed the container and the second
+    // wraps — silently collapsing the whole thing to one column, which is the opposite of what
+    // asking for `inline` means. Subtracting a full gap per option leaves a line of two at
+    // `100% - 16px` and pushes a third onto the next line; `flex-grow: 1` then shares the
+    // remainder back out so the columns stay equal.
     .tn-checkbox-group__option {
-      flex: 1 1 var(--tn-checkbox-group-inline-basis, 50%);
+      flex: 1 1 calc(
+        var(--tn-checkbox-group-inline-basis, 50%) - var(--tn-checkbox-group-inline-gap, 16px)
+      );
       box-sizing: border-box;
     }
 

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.spec.ts
@@ -1,0 +1,294 @@
+import type { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, signal } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TnCheckboxGroupComponent } from './checkbox-group.component';
+import type { TnCheckboxOption } from './checkbox-group.component';
+import { TnCheckboxGroupHarness } from './checkbox-group.harness';
+import { TnCheckboxHarness } from './checkbox.harness';
+import { TnFormFieldComponent } from '../form-field/form-field.component';
+
+interface ObjectValue {
+  id: number;
+}
+
+@Component({
+  selector: 'tn-checkbox-group-test',
+  standalone: true,
+  imports: [ReactiveFormsModule, TnCheckboxGroupComponent, TnFormFieldComponent],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-checkbox-group
+      ariaLabel="Letters"
+      testId="letters"
+      [formControl]="control"
+      [options]="options"
+      [inline]="inline()"
+      [disabled]="disabled()"
+      (change)="changes.push($event)" />
+
+    <tn-checkbox-group
+      testId="objects"
+      ariaLabel="Objects"
+      [formControl]="objectControl"
+      [options]="objectOptions"
+      [compareWith]="compareById" />
+
+    <tn-form-field label="Required letters">
+      <tn-checkbox-group testId="required" [formControl]="requiredControl" [options]="options" />
+    </tn-form-field>
+  `,
+})
+class TestHostComponent {
+  readonly control = new FormControl<string[]>(['a']);
+  readonly objectControl = new FormControl<ObjectValue[]>([]);
+  readonly requiredControl = new FormControl<string[]>([], Validators.required);
+
+  readonly inline = signal(false);
+  readonly disabled = signal(false);
+  readonly changes: string[][] = [];
+
+  readonly options: TnCheckboxOption<string>[] = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+    { value: 'c', label: 'Gamma', disabled: true },
+  ];
+
+  readonly objectOptions: TnCheckboxOption<ObjectValue>[] = [
+    { value: { id: 1 }, label: 'First' },
+    { value: { id: 2 }, label: 'Second' },
+  ];
+
+  readonly compareById = (a: ObjectValue | null, b: ObjectValue | null): boolean => a?.id === b?.id;
+}
+
+@Component({
+  selector: 'tn-checkbox-group-fallback-test',
+  standalone: true,
+  imports: [ReactiveFormsModule, TnCheckboxGroupComponent],
+  template: `
+    <form [formGroup]="form">
+      <tn-checkbox-group formControlName="usbDevices" ariaLabel="USB" [options]="options" />
+    </form>
+  `,
+})
+class FallbackHostComponent {
+  readonly form = new FormGroup({ usbDevices: new FormControl<string[]>([]) });
+
+  readonly options: TnCheckboxOption<string>[] = [{ value: 'usb_1_1', label: 'Web Cam' }];
+}
+
+describe('TnCheckboxGroupComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  function letters(): Promise<TnCheckboxGroupHarness> {
+    return loader.getHarness(TnCheckboxGroupHarness.with({ ariaLabel: 'Letters' }));
+  }
+
+  it('renders one checkbox per option', async () => {
+    const group = await letters();
+    expect(await group.getOptionLabels()).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+
+  it('renders the bound array as the checked set', async () => {
+    const group = await letters();
+    expect(await group.getValue()).toEqual(['Alpha']);
+  });
+
+  it('adds a value to the control when an option is checked', async () => {
+    const group = await letters();
+    await group.toggle('Beta');
+
+    expect(host.control.value).toEqual(['a', 'b']);
+    expect(host.changes).toEqual([['a', 'b']]);
+  });
+
+  it('removes a value from the control when an option is unchecked', async () => {
+    const group = await letters();
+    await group.toggle('Alpha');
+
+    expect(host.control.value).toEqual([]);
+  });
+
+  // The value is rebuilt in `options` order, so the same checked set always produces the same
+  // array however the user got there — a payload diff (and a spec asserting one) stays stable.
+  it('emits values in option order, not in click order', async () => {
+    host.control.setValue([]);
+    fixture.detectChanges();
+
+    const group = await letters();
+    await group.toggle('Beta');
+    await group.toggle('Alpha');
+
+    expect(host.control.value).toEqual(['a', 'b']);
+  });
+
+  it('keeps written values that no longer match an option', async () => {
+    host.control.setValue(['a', 'gone']);
+    fixture.detectChanges();
+
+    const group = await letters();
+    await group.toggle('Beta');
+
+    expect(host.control.value).toEqual(['a', 'b', 'gone']);
+  });
+
+  it('replaces the checked set through the harness', async () => {
+    const group = await letters();
+    await group.setValue(['Beta']);
+
+    expect(host.control.value).toEqual(['b']);
+    expect(await group.getValue()).toEqual(['Beta']);
+  });
+
+  it('reflects a programmatic write without emitting a change', async () => {
+    host.control.setValue(['a', 'b']);
+    fixture.detectChanges();
+
+    const group = await letters();
+    expect(await group.getValue()).toEqual(['Alpha', 'Beta']);
+    expect(host.changes).toEqual([]);
+  });
+
+  it('disables a single option without disabling the group', async () => {
+    const group = await letters();
+    const options = await group.getOptions();
+
+    expect(await options[2].isDisabled()).toBe(true);
+    expect(await group.isDisabled()).toBe(false);
+  });
+
+  it('disables every option when the group is disabled', async () => {
+    host.disabled.set(true);
+    fixture.detectChanges();
+
+    const group = await letters();
+    expect(await group.isDisabled()).toBe(true);
+  });
+
+  it('disables every option when the bound control is disabled', async () => {
+    host.control.disable();
+    fixture.detectChanges();
+
+    const group = await letters();
+    expect(await group.isDisabled()).toBe(true);
+  });
+
+  it('marks the control touched when focus leaves the group', async () => {
+    expect(host.control.touched).toBe(false);
+
+    const group = await letters();
+    await group.toggle('Beta');
+
+    expect(host.control.touched).toBe(true);
+  });
+
+  it('matches object values through compareWith', async () => {
+    host.objectControl.setValue([{ id: 2 }]);
+    fixture.detectChanges();
+
+    const group = await loader.getHarness(TnCheckboxGroupHarness.with({ ariaLabel: 'Objects' }));
+    expect(await group.getValue()).toEqual(['Second']);
+
+    await group.toggle('First');
+    expect(host.objectControl.value).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('lays the options out in a wrapping row when inline', async () => {
+    host.inline.set(true);
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement.querySelector('.tn-checkbox-group') as HTMLElement;
+    expect(root.classList).toContain('tn-checkbox-group--inline');
+  });
+
+  describe('accessibility', () => {
+    it('groups the options under role="group"', async () => {
+      const root = fixture.nativeElement.querySelector('.tn-checkbox-group') as HTMLElement;
+      expect(root.getAttribute('role')).toBe('group');
+    });
+
+    it('names the group from its own ariaLabel when standalone', async () => {
+      const group = await letters();
+      expect(await group.getAriaLabel()).toBe('Letters');
+      expect(await group.getAriaLabelledBy()).toBeNull();
+    });
+
+    it('delegates the name to an enclosing tn-form-field label', async () => {
+      const group = await loader.getHarness(
+        TnCheckboxGroupHarness.with({ testId: 'checkbox-group-required' })
+      );
+      expect(await group.getAriaLabel()).toBeNull();
+      expect(await group.getAriaLabelledBy()).toBeTruthy();
+    });
+
+    it('announces the field-inferred required state', async () => {
+      const root = fixture.nativeElement.querySelector(
+        '[data-testid="checkbox-group-required"]'
+      ) as HTMLElement;
+      expect(root.getAttribute('aria-required')).toBe('true');
+    });
+
+    // Native `required` on a checkbox demands that checkbox, not one of the set — see the
+    // `required` input's docblock.
+    it('does not propagate required to the options themselves', async () => {
+      const checkboxes = await loader.getAllHarnesses(
+        TnCheckboxHarness.with({ testId: 'checkbox-required-alpha' })
+      );
+      expect(await checkboxes[0].isRequired()).toBe(false);
+    });
+
+    it('announces the disabled state on the group', async () => {
+      host.disabled.set(true);
+      fixture.detectChanges();
+
+      const root = fixture.nativeElement.querySelector('.tn-checkbox-group') as HTMLElement;
+      expect(root.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
+  describe('test ids', () => {
+    it('writes the group base under the checkbox-group prefix', async () => {
+      const group = await letters();
+      expect(await group.getTestId()).toBe('checkbox-group-letters');
+    });
+
+    it('scopes each option by its label under the checkbox prefix', async () => {
+      const group = await letters();
+      const options = await group.getOptions();
+
+      expect(await Promise.all(options.map((option) => option.getTestId()))).toEqual([
+        'checkbox-letters-alpha',
+        'checkbox-letters-beta',
+        'checkbox-letters-gamma',
+      ]);
+    });
+
+    it('falls back to the bound control name when testId is unset', async () => {
+      const fallback = TestBed.createComponent(FallbackHostComponent);
+      fallback.detectChanges();
+      const fallbackLoader = TestbedHarnessEnvironment.loader(fallback);
+
+      const group = await fallbackLoader.getHarness(TnCheckboxGroupHarness);
+      expect(await group.getTestId()).toBe('checkbox-group-usb-devices');
+
+      const options = await group.getOptions();
+      expect(await options[0].getTestId()).toBe('checkbox-usb-devices-web-cam');
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.spec.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.spec.ts
@@ -12,6 +12,7 @@ import { TnFormFieldComponent } from '../form-field/form-field.component';
 
 interface ObjectValue {
   id: number;
+  name?: string;
 }
 
 @Component({
@@ -39,6 +40,8 @@ interface ObjectValue {
     <tn-form-field label="Required letters">
       <tn-checkbox-group testId="required" [formControl]="requiredControl" [options]="options" />
     </tn-form-field>
+
+    <tn-checkbox-group testId="standalone-required" ariaLabel="Standalone" [required]="true" [options]="options" />
   `,
 })
 class TestHostComponent {
@@ -189,11 +192,22 @@ describe('TnCheckboxGroupComponent', () => {
     expect(await group.isDisabled()).toBe(true);
   });
 
-  it('marks the control touched when focus leaves the group', async () => {
+  it('marks the control touched on toggle', async () => {
     expect(host.control.touched).toBe(false);
 
     const group = await letters();
     await group.toggle('Beta');
+
+    expect(host.control.touched).toBe(true);
+  });
+
+  // Toggling touches the control on its own, so this has to blur the group for real to cover
+  // `onFocusOut` — a harness toggle dispatches mousedown/mouseup/click and moves no focus.
+  it('marks the control touched when focus leaves the group', () => {
+    expect(host.control.touched).toBe(false);
+
+    const root = fixture.nativeElement.querySelector('.tn-checkbox-group') as HTMLElement;
+    root.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
 
     expect(host.control.touched).toBe(true);
   });
@@ -207,6 +221,21 @@ describe('TnCheckboxGroupComponent', () => {
 
     await group.toggle('First');
     expect(host.objectControl.value).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  // Only newly checked options contribute the option's own value; an already-selected one is
+  // re-emitted as the object the consumer wrote, so properties outside `compareWith`'s reach
+  // survive an unrelated toggle.
+  it('keeps the selected value objects the consumer wrote', async () => {
+    const loaded: ObjectValue = { id: 2, name: 'usb-cam' };
+    host.objectControl.setValue([loaded]);
+    fixture.detectChanges();
+
+    const group = await loader.getHarness(TnCheckboxGroupHarness.with({ ariaLabel: 'Objects' }));
+    await group.toggle('First');
+
+    expect(host.objectControl.value).toEqual([{ id: 1 }, loaded]);
+    expect(host.objectControl.value?.[1]).toBe(loaded);
   });
 
   it('lays the options out in a wrapping row when inline', async () => {
@@ -237,11 +266,28 @@ describe('TnCheckboxGroupComponent', () => {
       expect(await group.getAriaLabelledBy()).toBeTruthy();
     });
 
-    it('announces the field-inferred required state', async () => {
+    // `role="group"` supports only the globals plus aria-activedescendant/aria-disabled, so an
+    // `aria-required` there would be dropped by assistive tech: the state rides in the name.
+    it('folds the field-inferred required state into the accessible name', () => {
       const root = fixture.nativeElement.querySelector(
         '[data-testid="checkbox-group-required"]'
       ) as HTMLElement;
-      expect(root.getAttribute('aria-required')).toBe('true');
+
+      expect(root.getAttribute('aria-required')).toBeNull();
+
+      const ids = root.getAttribute('aria-labelledby')?.split(' ') ?? [];
+      const name = ids.map((id) => document.getElementById(id)?.textContent?.trim()).join(' ');
+      expect(name).toBe('Required letters required');
+    });
+
+    it('folds the required state into an explicit ariaLabel when standalone', () => {
+      const root = fixture.nativeElement.querySelector(
+        '[data-testid="checkbox-group-standalone-required"]'
+      ) as HTMLElement;
+
+      expect(root.getAttribute('aria-required')).toBeNull();
+      expect(root.getAttribute('aria-labelledby')).toBeNull();
+      expect(root.getAttribute('aria-label')).toBe('Standalone required');
     });
 
     // Native `required` on a checkbox demands that checkbox, not one of the set — see the

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.ts
@@ -1,0 +1,225 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, forwardRef, input, output, signal } from '@angular/core';
+import type { ControlValueAccessor } from '@angular/forms';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { TnCheckboxComponent } from './checkbox.component';
+import { injectTnFormFieldAria } from '../form-field/form-field-context';
+import { TnTestIdDirective, controlTestId, scopeTestId } from '../test-id';
+import type { TnTestIdValue } from '../test-id';
+
+/** One option of a `tn-checkbox-group`, rendered as a single `tn-checkbox`. */
+export interface TnCheckboxOption<T = unknown> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+}
+
+/**
+ * A `role="group"` wrapper that owns the selection for a set of `tn-checkbox`es, as one control
+ * whose value is the ARRAY of checked option values.
+ *
+ * `tn-checkbox` is a boolean `ControlValueAccessor` — one control per box. A multi-select field
+ * ("which USB devices to pass through", "which catalog trains to offer") has a single
+ * array-valued control instead, and nothing in the library spoke that shape: consumers either
+ * exploded it into one boolean control per option and reassembled the array by hand on submit, or
+ * kept a bespoke component outside the library. This is that shape, with the same
+ * `options`/`compareWith`/`testId` surface as {@link TnRadioGroupComponent} so the single-select
+ * and multi-select forms of the same field read alike.
+ *
+ * ```html
+ * <tn-form-field label="USB Devices" tooltip="Devices to pass through to the container">
+ *   <tn-checkbox-group formControlName="usb_devices" [options]="usbOptions" />
+ * </tn-form-field>
+ * ```
+ *
+ * Inside a `tn-form-field` the group is a normal control: the field names it via
+ * `aria-labelledby`, infers the required indicator from its validators, and renders its validation
+ * message — none of which a loose pile of checkboxes gets.
+ *
+ * Options come from the `options` input only. Unlike `tn-radio`, `tn-checkbox` is not group-aware,
+ * so a projected child would render as an independent boolean control that silently ignores the
+ * group's value; the group therefore projects nothing rather than accepting content it cannot
+ * drive.
+ */
+@Component({
+  selector: 'tn-checkbox-group',
+  standalone: true,
+  imports: [TnCheckboxComponent, TnTestIdDirective],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TnCheckboxGroupComponent),
+      multi: true
+    }
+  ],
+  templateUrl: './checkbox-group.component.html',
+  styleUrl: './checkbox-group.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    'class': 'tn-checkbox-group-host'
+  }
+})
+export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccessor {
+  /**
+   * Options to render, one checkbox each.
+   *
+   * Options are tracked by `value`, so object values must be referentially stable — rebuilding
+   * them as fresh literals on every change detection pass re-creates the whole list. Same
+   * requirement the `compareWith` case implies; hold the objects in a field.
+   */
+  options = input<TnCheckboxOption<T>[]>([]);
+
+  /**
+   * Lays the options out in a wrapping row of equal columns instead of stacking them. Column width
+   * comes from `--tn-checkbox-group-inline-basis` (default `50%`), and collapses to one column on
+   * a narrow viewport.
+   */
+  inline = input<boolean>(false);
+
+  /**
+   * Explicit accessible name for the group. Inside a `tn-form-field` with a label this is
+   * unnecessary — the field names the group automatically — but a group with neither is announced
+   * as an unlabeled group.
+   */
+  ariaLabel = input<string | undefined>(undefined);
+
+  disabled = input<boolean>(false);
+
+  /**
+   * Whether the group announces itself as required.
+   *
+   * Deliberately NOT propagated to the options' native `required`, which is the opposite of the
+   * choice `tn-radio-group` makes — and the difference is in the HTML, not in taste. A required
+   * radio is satisfied by any one option in the `name` group; a required checkbox is satisfied
+   * only by ITSELF being checked, so propagating it here would have the browser demand every box.
+   * "At least one" is a validator's job, and the group reports it through `aria-required` alone.
+   */
+  required = input<boolean>(false);
+
+  /**
+   * Test-id base for the group and, scoped by the option label, for every option: base
+   * `usb_devices` yields `checkbox-group-usb-devices` on the group and
+   * `checkbox-usb-devices-web-cam` on its options. Falls back to the bound control name.
+   */
+  testId = input<TnTestIdValue>(undefined);
+
+  /**
+   * Custom comparator for matching option values against the selected ones. Provide it when option
+   * values are objects — the default is identity, so a structurally-equal-but-distinct object
+   * would leave the group rendering nothing as checked.
+   *
+   * Called with an option value on the right and a currently-selected value on the left, and must
+   * tolerate `null`/`undefined` on either side rather than dereferencing straight into a property.
+   *
+   * @example
+   * ```ts
+   * compareWith = (a, b) => a?.id === b?.id;
+   * ```
+   */
+  compareWith = input<(a: T | null, b: T | null) => boolean>();
+
+  /** Emits the new value array on every user toggle (not on programmatic writes). */
+  change = output<T[]>();
+
+  /**
+   * ARIA wiring from an enclosing `tn-form-field` (label, error/hint, invalid, required).
+   * All-null standalone, or when `ariaLabel` overrides the field's label.
+   */
+  protected readonly fieldAria = injectTnFormFieldAria(this.ariaLabel);
+
+  /** Test-id base, falling back to the bound control name when `testId` is unset. */
+  protected readonly resolvedTestId = controlTestId(this.testId);
+
+  private readonly selectedValues = signal<T[]>([]);
+
+  private readonly formDisabled = signal<boolean>(false);
+
+  /**
+   * Combined disabled state (own input plus a disabled bound control). The native `disabled` on
+   * each option is what blocks interaction; `aria-disabled` on the group is what tells a screen
+   * reader landing on the container about it, and gives styling a hook for the group as a whole.
+   */
+  readonly isDisabled = computed(() => this.disabled() || this.formDisabled());
+
+  /** Whether the group announces itself as required: its own input, or the field's inferred state. */
+  protected readonly ariaRequired = computed(() => this.required() || this.fieldAria.required() === true);
+
+  private onChange: (value: T[]) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  /** Whether `value` is among the currently selected values. */
+  isSelected(value: T): boolean {
+    const comparator = this.compareWith();
+    if (comparator) {
+      return this.selectedValues().some((selected) => comparator(selected, value));
+    }
+    return this.selectedValues().includes(value);
+  }
+
+  /**
+   * Adds or removes an option's value.
+   *
+   * The emitted array is rebuilt in `options` order rather than appended to in click order, so the
+   * value a given set of checked boxes produces is the same however the user got there — which is
+   * what makes a payload diff (and a spec asserting one) stable.
+   */
+  protected toggle(value: T, checked: boolean): void {
+    const isCurrentlySelected = this.isSelected(value);
+    if (checked === isCurrentlySelected) {
+      return;
+    }
+
+    const next = this.options()
+      .map((option) => option.value)
+      .filter((optionValue) => (this.matches(optionValue, value) ? checked : this.isSelected(optionValue)));
+
+    // Values written by the consumer that no longer correspond to an option are kept: a control
+    // loaded with a device that has since been unplugged would otherwise be silently pruned by an
+    // unrelated toggle.
+    const unknownValues = this.selectedValues().filter(
+      (selected) => !this.options().some((option) => this.matches(option.value, selected))
+    );
+
+    this.selectedValues.set([...next, ...unknownValues]);
+    this.onChange(this.selectedValues());
+    this.onTouched();
+    this.change.emit(this.selectedValues());
+  }
+
+  private matches(a: T, b: T): boolean {
+    const comparator = this.compareWith();
+    return comparator ? comparator(a, b) : a === b;
+  }
+
+  // ── ControlValueAccessor ──
+
+  writeValue(value: T[] | null | undefined): void {
+    this.selectedValues.set(value ?? []);
+  }
+
+  registerOnChange(fn: (value: T[]) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.formDisabled.set(isDisabled);
+  }
+
+  /**
+   * Marks the control touched when focus leaves the group. `focusout` also fires while moving
+   * between the group's own options, which is harmless — the user has interacted either way — and
+   * it is the only blur signal available, since a checkbox's blur does not bubble.
+   */
+  protected onFocusOut(): void {
+    this.onTouched();
+  }
+
+  /** Per-option test-id segments: the group's base scoped by the option label. */
+  protected optionTestId(option: TnCheckboxOption<T>): TnTestIdValue {
+    return scopeTestId(this.resolvedTestId(), option.label);
+  }
+}

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.component.ts
@@ -6,6 +6,8 @@ import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import { TnTestIdDirective, controlTestId, scopeTestId } from '../test-id';
 import type { TnTestIdValue } from '../test-id';
 
+let nextId = 0;
+
 /** One option of a `tn-checkbox-group`, rendered as a single `tn-checkbox`. */
 export interface TnCheckboxOption<T = unknown> {
   value: T;
@@ -80,6 +82,9 @@ export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccess
    * Explicit accessible name for the group. Inside a `tn-form-field` with a label this is
    * unnecessary — the field names the group automatically — but a group with neither is announced
    * as an unlabeled group.
+   *
+   * A required group appends "required" to whatever this says, since that is the only channel
+   * `role="group"` leaves open for it — see the `required` input.
    */
   ariaLabel = input<string | undefined>(undefined);
 
@@ -92,7 +97,13 @@ export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccess
    * choice `tn-radio-group` makes — and the difference is in the HTML, not in taste. A required
    * radio is satisfied by any one option in the `name` group; a required checkbox is satisfied
    * only by ITSELF being checked, so propagating it here would have the browser demand every box.
-   * "At least one" is a validator's job, and the group reports it through `aria-required` alone.
+   * "At least one" is a validator's job.
+   *
+   * Nor does it become `aria-required`, which is the OTHER place `tn-radio-group` cannot be
+   * copied: WAI-ARIA 1.2 supports only the globals plus `aria-activedescendant`/`aria-disabled`
+   * on `role="group"`, so an `aria-required` there is dropped by assistive tech and flagged by
+   * axe, whereas `role="radiogroup"` genuinely supports it. The state instead rides in the
+   * group's accessible NAME, as a "required" suffix — see {@link labelledBy}.
    */
   required = input<boolean>(false);
 
@@ -144,11 +155,42 @@ export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccess
   /** Whether the group announces itself as required: its own input, or the field's inferred state. */
   protected readonly ariaRequired = computed(() => this.required() || this.fieldAria.required() === true);
 
+  /** Id of the visually hidden "required" text this group contributes to its own name. */
+  protected readonly requiredTextId = `tn-checkbox-group-required-${nextId++}`;
+
+  /**
+   * `aria-label` for the group: the `ariaLabel` input with the required-ness folded in, since
+   * `role="group"` gives it nowhere else to go (see the `required` input).
+   */
+  protected readonly resolvedAriaLabel = computed(() => {
+    const label = this.ariaLabel();
+    if (!label) {
+      return null;
+    }
+    return this.ariaRequired() ? `${label} required` : label;
+  });
+
+  /**
+   * `aria-labelledby` for the group: the enclosing field's label, plus this group's own hidden
+   * "required" text when required. A multi-id `aria-labelledby` concatenates, so the field keeps
+   * naming the group and the required-ness reaches a screen reader as part of that name.
+   *
+   * Null when the name comes from `ariaLabel` instead — that path carries the suffix itself,
+   * because `aria-labelledby` would otherwise win over the very label it is meant to extend.
+   */
+  protected readonly labelledBy = computed(() => {
+    const fieldLabel = this.fieldAria.labelledby();
+    if (!fieldLabel) {
+      return null;
+    }
+    return this.ariaRequired() ? `${fieldLabel} ${this.requiredTextId}` : fieldLabel;
+  });
+
   private onChange: (value: T[]) => void = () => {};
   private onTouched: () => void = () => {};
 
   /** Whether `value` is among the currently selected values. */
-  isSelected(value: T): boolean {
+  protected isSelected(value: T): boolean {
     const comparator = this.compareWith();
     if (comparator) {
       return this.selectedValues().some((selected) => comparator(selected, value));
@@ -162,6 +204,11 @@ export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccess
    * The emitted array is rebuilt in `options` order rather than appended to in click order, so the
    * value a given set of checked boxes produces is the same however the user got there — which is
    * what makes a payload diff (and a spec asserting one) stable.
+   *
+   * Ordering is all the rebuild changes: an already-selected value is re-emitted as the object the
+   * consumer wrote, not as the equal-under-`compareWith` object the option holds. A control loaded
+   * with `{ id: 2, name: 'usb-cam' }` against an option of `{ id: 2 }` keeps its `name` when an
+   * unrelated box is toggled; only a newly checked option contributes the option's own value.
    */
   protected toggle(value: T, checked: boolean): void {
     const isCurrentlySelected = this.isSelected(value);
@@ -171,7 +218,8 @@ export class TnCheckboxGroupComponent<T = unknown> implements ControlValueAccess
 
     const next = this.options()
       .map((option) => option.value)
-      .filter((optionValue) => (this.matches(optionValue, value) ? checked : this.isSelected(optionValue)));
+      .filter((optionValue) => (this.matches(optionValue, value) ? checked : this.isSelected(optionValue)))
+      .map((optionValue) => this.selectedValues().find((selected) => this.matches(optionValue, selected)) ?? optionValue);
 
     // Values written by the consumer that no longer correspond to an option are kept: a control
     // loaded with a device that has since been unplugged would otherwise be silently pruned by an

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.harness.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.harness.ts
@@ -1,0 +1,192 @@
+import type { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { TnCheckboxHarness } from './checkbox.harness';
+
+/**
+ * Harness for interacting with `tn-checkbox-group` in tests.
+ * Drives the group as a whole — reading the checked set, replacing it wholesale, toggling one
+ * option by label — rather than reaching for each `tn-checkbox` individually.
+ *
+ * @example
+ * ```typescript
+ * const group = await loader.getHarness(TnCheckboxGroupHarness.with({ testId: 'checkbox-group-trains' }));
+ * await group.setValue(['stable', 'enterprise']);
+ * expect(await group.getValue()).toEqual(['stable', 'enterprise']);
+ * ```
+ */
+export class TnCheckboxGroupHarness extends ComponentHarness {
+  /** The selector for the host element of a `TnCheckboxGroupComponent` instance. */
+  static hostSelector = 'tn-checkbox-group';
+
+  private _root = this.locatorFor('.tn-checkbox-group');
+  private _checkboxes = this.locatorForAll(TnCheckboxHarness);
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a checkbox group with specific
+   * attributes.
+   *
+   * @param options Options for filtering which checkbox group instances are considered a match.
+   * @returns A `HarnessPredicate` configured with the given options.
+   *
+   * @example
+   * ```typescript
+   * // Find by accessible name
+   * const group = await loader.getHarness(TnCheckboxGroupHarness.with({ ariaLabel: 'USB Devices' }));
+   *
+   * // Find by testId
+   * const group = await loader.getHarness(TnCheckboxGroupHarness.with({ testId: 'checkbox-group-usb-devices' }));
+   * ```
+   */
+  static with(options: CheckboxGroupHarnessFilters = {}) {
+    return new HarnessPredicate(TnCheckboxGroupHarness, options)
+      .addOption('ariaLabel', options.ariaLabel, (harness, ariaLabel) =>
+        HarnessPredicate.stringMatches(harness.getAriaLabel(), ariaLabel)
+      )
+      .addOption('testId', options.testId, async (harness, testId) => {
+        return (await harness.getTestId()) === testId;
+      });
+  }
+
+  /**
+   * Gets the harnesses for the group's options, in DOM order.
+   *
+   * @example
+   * ```typescript
+   * const options = await group.getOptions();
+   * expect(options).toHaveLength(3);
+   * ```
+   */
+  async getOptions(): Promise<TnCheckboxHarness[]> {
+    return this._checkboxes();
+  }
+
+  /**
+   * Gets the label text of every option, in DOM order.
+   *
+   * @example
+   * ```typescript
+   * expect(await group.getOptionLabels()).toEqual(['Stable', 'Enterprise']);
+   * ```
+   */
+  async getOptionLabels(): Promise<string[]> {
+    const checkboxes = await this._checkboxes();
+    return Promise.all(checkboxes.map((checkbox) => checkbox.getLabelText()));
+  }
+
+  /**
+   * Gets the labels of the currently checked options, in DOM order.
+   *
+   * Labels rather than values, because the values live in the bound control and the DOM only ever
+   * carries what the user can read.
+   *
+   * @example
+   * ```typescript
+   * expect(await group.getValue()).toEqual(['Stable']);
+   * ```
+   */
+  async getValue(): Promise<string[]> {
+    const checkboxes = await this._checkboxes();
+    const checked: string[] = [];
+    for (const checkbox of checkboxes) {
+      if (await checkbox.isChecked()) {
+        checked.push(await checkbox.getLabelText());
+      }
+    }
+    return checked;
+  }
+
+  /**
+   * Makes the checked set exactly the options with the given labels — checking the ones listed and
+   * unchecking every other.
+   *
+   * @param labels Label text of the options that should end up checked.
+   *
+   * @example
+   * ```typescript
+   * await group.setValue(['Stable']);
+   * ```
+   */
+  async setValue(labels: string[]): Promise<void> {
+    const checkboxes = await this._checkboxes();
+    for (const checkbox of checkboxes) {
+      const label = await checkbox.getLabelText();
+      if (labels.includes(label)) {
+        await checkbox.check();
+      } else {
+        await checkbox.uncheck();
+      }
+    }
+  }
+
+  /**
+   * Toggles the option with the given label. Throws when the group has no such option, so a
+   * renamed or missing option fails loudly instead of silently leaving the selection unchanged.
+   *
+   * @param label Label text of the option to toggle.
+   *
+   * @example
+   * ```typescript
+   * await group.toggle('Enterprise');
+   * ```
+   */
+  async toggle(label: string): Promise<void> {
+    const checkbox = await this.locatorForOptional(TnCheckboxHarness.with({ label }))();
+    if (!checkbox) {
+      const available = (await this.getOptionLabels()).join(', ');
+      throw new Error(`No option labelled "${label}" in this tn-checkbox-group (available: ${available}).`);
+    }
+    await checkbox.toggle();
+  }
+
+  /**
+   * Checks whether every option is disabled — the state a disabled group or a disabled bound form
+   * control produces. Use {@link getOptions} to inspect a single per-option `disabled`.
+   *
+   * @example
+   * ```typescript
+   * expect(await group.isDisabled()).toBe(true);
+   * ```
+   */
+  async isDisabled(): Promise<boolean> {
+    const checkboxes = await this._checkboxes();
+    if (!checkboxes.length) {
+      return false;
+    }
+    const states = await Promise.all(checkboxes.map((checkbox) => checkbox.isDisabled()));
+    return states.every(Boolean);
+  }
+
+  /**
+   * Gets the group's accessible name as written by the `ariaLabel` input, or null when the name
+   * comes from an enclosing `tn-form-field` (see {@link getAriaLabelledBy}).
+   */
+  async getAriaLabel(): Promise<string | null> {
+    return (await this._root()).getAttribute('aria-label');
+  }
+
+  /** Gets the id the group's accessible name is delegated to, or null. */
+  async getAriaLabelledBy(): Promise<string | null> {
+    return (await this._root()).getAttribute('aria-labelledby');
+  }
+
+  /**
+   * Gets the test ID attribute value of the group root.
+   *
+   * @example
+   * ```typescript
+   * expect(await group.getTestId()).toBe('checkbox-group-trains');
+   * ```
+   */
+  async getTestId(): Promise<string | null> {
+    const root = await this._root();
+    return (await root.getAttribute('data-testid')) ?? (await root.getAttribute('data-test'));
+  }
+}
+
+/** A set of criteria that can be used to filter a list of `TnCheckboxGroupHarness` instances. */
+export interface CheckboxGroupHarnessFilters extends BaseHarnessFilters {
+  /** Filters by the group's `aria-label`. Supports string or regex matching. */
+  ariaLabel?: string | RegExp;
+  /** Filters by the resolved test-id attribute on the group root. */
+  testId?: string;
+}

--- a/projects/truenas-ui/src/lib/checkbox/checkbox-group.harness.ts
+++ b/projects/truenas-ui/src/lib/checkbox/checkbox-group.harness.ts
@@ -10,8 +10,9 @@ import { TnCheckboxHarness } from './checkbox.harness';
  * @example
  * ```typescript
  * const group = await loader.getHarness(TnCheckboxGroupHarness.with({ testId: 'checkbox-group-trains' }));
- * await group.setValue(['stable', 'enterprise']);
- * expect(await group.getValue()).toEqual(['stable', 'enterprise']);
+ * // Labels, not option values — the DOM only carries what the user can read.
+ * await group.setValue(['Stable', 'Enterprise']);
+ * expect(await group.getValue()).toEqual(['Stable', 'Enterprise']);
  * ```
  */
 export class TnCheckboxGroupHarness extends ComponentHarness {

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -31,6 +31,8 @@ export * from './lib/expansion-panel/expansion-panel.component';
 export * from './lib/expansion-panel/expansion-panel.harness';
 export * from './lib/checkbox/checkbox.component';
 export * from './lib/checkbox/checkbox.harness';
+export * from './lib/checkbox/checkbox-group.component';
+export * from './lib/checkbox/checkbox-group.harness';
 export * from './lib/radio/radio.component';
 export * from './lib/radio/radio.harness';
 export * from './lib/radio/radio-group.component';

--- a/projects/truenas-ui/src/stories/checkbox-group.stories.ts
+++ b/projects/truenas-ui/src/stories/checkbox-group.stories.ts
@@ -77,7 +77,8 @@ same checked set always produces the same array however the user got there.
     required: {
       control: 'boolean',
       description:
-        'Announced via `aria-required`. Deliberately NOT propagated to the options\' native '
+        'Announced as a "required" suffix on the group\'s accessible name — `role="group"` does '
+        + 'not support `aria-required`. Deliberately NOT propagated to the options\' native '
         + '`required`, which would have the browser demand every box rather than one of the set.',
     },
     ariaLabel: {

--- a/projects/truenas-ui/src/stories/checkbox-group.stories.ts
+++ b/projects/truenas-ui/src/stories/checkbox-group.stories.ts
@@ -1,0 +1,211 @@
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { TestIdInspectorComponent } from './testid-inspector.component';
+import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
+import { TnCheckboxGroupComponent } from '../lib/checkbox/checkbox-group.component';
+import { TnFormFieldComponent } from '../lib/form-field/form-field.component';
+
+const harnessDoc = loadHarnessDoc('checkbox-group');
+
+const trainOptions = [
+  { value: 'stable', label: 'Stable' },
+  { value: 'enterprise', label: 'Enterprise' },
+  { value: 'community', label: 'Community' },
+  { value: 'test', label: 'Test', disabled: true },
+];
+
+const meta: Meta<TnCheckboxGroupComponent> = {
+  title: 'Components/Checkbox Group',
+  component: TnCheckboxGroupComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [ReactiveFormsModule, TnFormFieldComponent],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+Groups a set of \`tn-checkbox\`es into one \`role="group"\` control whose value is the ARRAY of
+checked option values.
+
+## Why a group
+
+\`tn-checkbox\` is a boolean \`ControlValueAccessor\` — one control per box. A multi-select field
+("which USB devices to pass through", "which catalog trains to offer") has a single array-valued
+control instead, and nothing in the library spoke that shape: consumers either exploded it into one
+boolean control per option and reassembled the array by hand on submit, or kept a bespoke component
+outside the library.
+
+It also gives the set the things a loose pile of checkboxes can't have: one accessible name, one
+disabled state, and — inside a \`tn-form-field\` — an inferred required indicator and a rendered
+validation message.
+
+## Options
+
+Pass an \`options\` array. Unlike \`tn-radio\`, \`tn-checkbox\` is not group-aware, so a projected
+child would render as an independent boolean control silently ignoring the group's value; the group
+projects nothing rather than accepting content it cannot drive.
+
+## Value order
+
+The emitted array is rebuilt in \`options\` order rather than appended to in click order, so the
+same checked set always produces the same array however the user got there.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    options: {
+      control: 'object',
+      description: 'Options to render, one checkbox each',
+    },
+    inline: {
+      control: 'boolean',
+      description:
+        'Lays the options out in a wrapping row of equal columns instead of stacking them. '
+        + 'Column width comes from `--tn-checkbox-group-inline-basis` (default `50%`).',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables every option in the group',
+    },
+    required: {
+      control: 'boolean',
+      description:
+        'Announced via `aria-required`. Deliberately NOT propagated to the options\' native '
+        + '`required`, which would have the browser demand every box rather than one of the set.',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Accessible name — unnecessary inside a labelled `tn-form-field`',
+    },
+    testId: {
+      control: 'text',
+      description: 'Test-id base for the group and, scoped by option label, for each option',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<TnCheckboxGroupComponent>;
+
+export const Default: Story = {
+  args: {
+    options: trainOptions,
+    ariaLabel: 'Preferred trains',
+  },
+};
+
+/**
+ * `inline` lays the options out as equal columns rather than letting them hug their labels: a
+ * multi-select list is read down a column, and ragged widths make an option easy to miss.
+ */
+export const Inline: Story = {
+  args: {
+    options: trainOptions,
+    inline: true,
+    ariaLabel: 'Preferred trains',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: trainOptions,
+    disabled: true,
+    ariaLabel: 'Preferred trains',
+  },
+};
+
+/**
+ * Inside a `tn-form-field` the group is a normal control: the field names it via
+ * `aria-labelledby`, infers the required asterisk from `Validators.required`, and renders the
+ * validation message once the group is touched.
+ */
+export const InsideFormField: Story = {
+  render: () => ({
+    props: {
+      control: new FormControl<string[]>([], Validators.required),
+      options: trainOptions,
+    },
+    template: `
+      <tn-form-field label="Preferred trains" tooltip="Trains offered when installing an app">
+        <tn-checkbox-group [formControl]="control" [options]="options" />
+      </tn-form-field>
+      <p>Selected: {{ control.value?.join(', ') || 'none' }}</p>
+      <button type="button" (click)="control.markAsTouched(); control.updateValueAndValidity()">
+        Touch the group
+      </button>
+    `,
+  }),
+};
+
+/**
+ * **Value order.** The array is rebuilt in `options` order on every toggle, so checking Community
+ * before Stable still yields `['stable', 'community']`. That is what keeps a payload diff (and a
+ * spec asserting one) stable across click sequences.
+ */
+export const ValueOrder: Story = {
+  render: () => ({
+    props: {
+      control: new FormControl<string[]>([]),
+      options: trainOptions,
+    },
+    template: `
+      <tn-checkbox-group ariaLabel="Preferred trains" [formControl]="control" [options]="options" />
+      <p data-testid="selected">Selected: {{ control.value?.join(', ') }}</p>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const boxes = canvas.getAllByRole('checkbox') as HTMLInputElement[];
+    const selected = canvas.getByTestId('selected');
+
+    // Community (index 2) first, Stable (index 0) second.
+    await userEvent.click(boxes[2]);
+    await userEvent.click(boxes[0]);
+
+    await waitFor(() => expect(selected).toHaveTextContent('Selected: stable, community'));
+  },
+};
+
+/**
+ * **Test IDs.** The base lands on the group root under the `checkbox-group-` prefix and is scoped
+ * by each option's label for the options themselves: `testId="trains"` → `checkbox-group-trains`
+ * plus `checkbox-trains-stable`, `checkbox-trains-enterprise`, … With no `testId`, the bound
+ * control name is used.
+ */
+export const TestIds: Story = {
+  args: { testId: 'trains', options: trainOptions, ariaLabel: 'Preferred trains' },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tn-testid-inspector>
+        <tn-checkbox-group [options]="options" [testId]="testId" [ariaLabel]="ariaLabel" />
+      </tn-testid-inspector>
+    `,
+    moduleMetadata: { imports: [TnCheckboxGroupComponent, TestIdInspectorComponent] },
+  }),
+};
+
+export const ComponentHarness: Story = {
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      canvas: {
+        hidden: true,
+        sourceState: 'none'
+      },
+      description: {
+        story: harnessDoc || ''
+      }
+    },
+    controls: { disable: true },
+    layout: 'fullscreen'
+  },
+  render: () => ({ template: '' })
+};


### PR DESCRIPTION
Usage: <img width="480" height="232" alt="Screenshot 2026-09-01 at 14 47 45" src="https://github.com/user-attachments/assets/d1356c6f-14d7-4be2-b645-9397400b62b7" />

`tn-checkbox` is a boolean ControlValueAcc
essor — one control per box. A multi-select field ("which USB devices to pass through", "which catalog trains to offer") has a single array-valued control instead, and nothing in the library spoke that shape: consumers either exploded it into one boolean control per option and reassembled the array by hand on submit, or kept a bespoke component outside the library (webui's `ix-checkbox-list`, still on `mat-checkbox`).

`tn-checkbox-group` is that shape, with the same options / compareWith / testId surface as `tn-radio-group` so the single- and multi-select forms of the same field read alike, and the same `tn-form-field` integration (name, inferred required indicator, validation message, ARIA wiring).

Two deliberate divergences from `tn-radio-group`, both documented at the source:

- `required` is NOT propagated to the options' native `required`. A required radio is satisfied by any one option in the `name` group; a required checkbox is satisfied only by itself, so propagating would have the browser demand every box. "At least one" is a validator's job; the group reports it through `aria-required` alone.
- No content projection. `tn-checkbox` is not group-aware, so a projected child would render as an independent boolean control silently ignoring the group's value — better to accept no content than content the group cannot drive.

The emitted array is rebuilt in `options` order rather than appended to in click order, so the same checked set always produces the same array however the user got there; values written by the consumer that match no option are preserved across toggles.

Test ids: `checkbox-group-<base>` on the group root, `checkbox-<base>-<label>` per option, both falling back to the bound control name.
