### PR TITLE
NAS-142530 / 27.0.0-BETA.1 / fix(dialog): let a long title wrap instead of chopping the dialog

### DIFF
--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -946,18 +946,26 @@ tn-dialog-shell {
     down the same line. Tabbing to a control near the left edge scrolled it back
     and the dialog abruptly looked correct, which is how the bug was reported.
 
-    Both declarations are load-bearing, and neither fixes it alone — measured on
-    that dialog at 400px, `scrollWidth` / `scrollLeft` after focusing close:
-      neither          677 / 277   the reported bug
-      min-width only   629 /   0   heading shrinks, but its unbroken word still
-                                   spills out of the heading box and across the
-                                   close button
-      break-word only  677 / 277   nothing breaks: at 613px the word already
-                                   fits its own line, so there is nothing to wrap
-      both             400 /   0
+    `anywhere` and not `break-word`, which is the difference between one
+    declaration and two: `anywhere` contributes its break opportunities to
+    MIN-CONTENT sizing, so the `auto` floor lands at the widest character rather
+    than the widest word and the heading is free to shrink. `break-word` does
+    not, and leaves the floor at 613px — where the word already fits its own
+    line and there is nothing to wrap — so it needs an explicit `min-width: 0`
+    beside it to reach the same place. Neither touches max-content, so a dialog
+    opened without an explicit width still sizes itself to its title as before.
+
+    Measured on that dialog at 400px, `scrollWidth` / `scrollLeft` after
+    focusing close:
+      none                       677 / 277   the reported bug
+      break-word                 677 / 277   nothing breaks (see above)
+      min-width: 0               629 /   0   heading shrinks, but its unbroken
+                                             word still spills out of the
+                                             heading box and across the ✕
+      min-width: 0 + break-word  400 /   0
+      anywhere                   400 /   0   what ships
   */
-  min-width: 0;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* Close button */

--- a/projects/truenas-ui/.storybook/public/themes.css
+++ b/projects/truenas-ui/.storybook/public/themes.css
@@ -929,6 +929,35 @@ tn-dialog-shell {
   line-height: 1.5;
   color: var(--tn-fg1, #000000);
   flex: 1; /* Take up remaining space */
+  /*
+    A title as long as a ZFS path has to WRAP, and `flex: 1` alone does not let
+    it (NAS-142530). A flex item's `min-width` defaults to `auto`, which floors
+    it at the widest unbreakable run of text inside it — for webui's delete-zvol
+    dialog, `dozer/TEST_ANOTHER_ZVOL_WITH_A_LONG_NAME` measures 613px against
+    the 320px the 400px-wide dialog's header can give it. The heading kept its
+    613px, and the header and `.tn-dialog-panel` with it.
+
+    That overflow is not the harmless kind. `.tn-dialog-panel` sets
+    `overflow: hidden`, which clips but stays SCROLLABLE programmatically, and
+    the shell's close button — the first tabbable element in the dialog — is the
+    one CDK's `autoFocus` focuses on open. The browser scrolled it into view, so
+    every dialog with a long title opened at `scrollLeft: 277` with its whole
+    left edge cut off: heading, body copy, fields and footer buttons all sliced
+    down the same line. Tabbing to a control near the left edge scrolled it back
+    and the dialog abruptly looked correct, which is how the bug was reported.
+
+    Both declarations are load-bearing, and neither fixes it alone — measured on
+    that dialog at 400px, `scrollWidth` / `scrollLeft` after focusing close:
+      neither          677 / 277   the reported bug
+      min-width only   629 /   0   heading shrinks, but its unbroken word still
+                                   spills out of the heading box and across the
+                                   close button
+      break-word only  677 / 277   nothing breaks: at 613px the word already
+                                   fits its own line, so there is nothing to wrap
+      both             400 /   0
+  */
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 /* Close button */
@@ -988,6 +1017,19 @@ tn-dialog-shell {
   overflow-x: hidden;
   box-sizing: border-box;
   padding: var(--tn-content-padding, 16px);
+  /*
+    The body's half of NAS-142530, and a quieter failure than the heading's: the
+    same dataset paths appear in the copy under the title, and `overflow-x:
+    hidden` means a path too long for the dialog is simply CUT OFF mid-name with
+    nothing on screen to say so — no scrollbar, no ellipsis. Unlike the header
+    this never reached `.tn-dialog-panel` (a scroll container contains its own
+    overflow), so it cost no layout, only the end of the name the dialog is
+    asking the user to confirm.
+
+    `overflow-wrap` rather than `word-break: break-all`: it only breaks a word
+    that cannot fit a line on its own, so ordinary prose wraps exactly as before.
+  */
+  overflow-wrap: break-word;
 }
 
 /* Dialog actions */

--- a/projects/truenas-ui/src/lib/side-panel/side-panel.component.scss
+++ b/projects/truenas-ui/src/lib/side-panel/side-panel.component.scss
@@ -100,6 +100,13 @@
   overflow-x: hidden;
   padding: var(--tn-content-padding, 24px);
   -webkit-overflow-scrolling: touch;
+  // The same body area as `.tn-dialog__content`, and the same quiet failure
+  // (NAS-142530): `overflow-x: hidden` means a dataset path too long for the
+  // panel is simply CUT OFF mid-name — no scrollbar, no ellipsis. The heading
+  // above never had it (`.tn-side-panel__title` ellipsises), so only the copy
+  // needs this. `overflow-wrap` only breaks a word that cannot fit a line on
+  // its own, so ordinary prose wraps exactly as before.
+  overflow-wrap: break-word;
 }
 
 // Fixed footer actions

--- a/projects/truenas-ui/src/stories/dialog-6.stories.html
+++ b/projects/truenas-ui/src/stories/dialog-6.stories.html
@@ -1,0 +1,12 @@
+<tn-dialog-shell [title]="'Delete zvol ' + path">
+  <p>The {{ path }} zvol and all snapshots stored with it will be permanently deleted.</p>
+  <p>Enter {{ path }} below to confirm.</p>
+  <tn-form-field>
+    <tn-input name="confirmName" [(ngModel)]="confirmName" />
+  </tn-form-field>
+
+  <div tnDialogAction>
+    <tn-button type="button" variant="outline" label="Cancel" (click)="ref.close()" />
+    <tn-button type="button" color="warn" label="Delete Zvol" (click)="ref.close('deleted')" />
+  </div>
+</tn-dialog-shell>

--- a/projects/truenas-ui/src/stories/dialog-6.stories.html
+++ b/projects/truenas-ui/src/stories/dialog-6.stories.html
@@ -1,7 +1,7 @@
 <tn-dialog-shell [title]="'Delete zvol ' + path">
   <p>The {{ path }} zvol and all snapshots stored with it will be permanently deleted.</p>
   <p>Enter {{ path }} below to confirm.</p>
-  <tn-form-field>
+  <tn-form-field label="Confirm name">
     <tn-input name="confirmName" [(ngModel)]="confirmName" />
   </tn-form-field>
 

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -557,17 +557,11 @@ export const LongTitle: Story = {
       // the panel has no horizontal overflow to scroll: 400, against 677 before.
       await expect(panel.scrollWidth).toBeLessThanOrEqual(panel.clientWidth);
 
-      // A re-enactment of the reported symptom rather than a second guard: with
-      // no overflow left to scroll, the maximum `scrollLeft` is already 0 and
-      // the line above has thrown on any CSS where it is not. Kept for what it
-      // documents — the step that used to open the dialog at `scrollLeft: 277`
-      // was CDK's `autoFocus` landing on the close button. Hence the `blur()`:
-      // focusing an already-focused element scrolls nothing, so without it this
-      // would not re-enact anything.
-      close.blur();
-      panel.scrollLeft = 0;
-      close.focus();
-      await expect(panel.scrollLeft).toBe(0);
+      // What the user saw is one step further on and needs no assertion of its
+      // own: with no overflow the maximum `scrollLeft` is 0, so the line above
+      // has already thrown on any CSS where the next part could go wrong. It
+      // was CDK's `autoFocus` landing on the close button, and the browser
+      // scrolling it into view, that opened the dialog at `scrollLeft: 277`.
 
       // The body copy carries the same path, and is clipped by `overflow-x:
       // hidden` rather than scrollable — so it has to wrap on its own.

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -3,6 +3,7 @@ import { JsonPipe } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
 import { TnDialogShellComponent } from '../lib/dialog/dialog-shell.component';
@@ -476,4 +477,97 @@ export const ChromeInputs: Story = {
     moduleMetadata: { imports: [DialogJobDemoComponent] },
     template: '<tn-dialog-job-demo />',
   }),
+};
+/**
+ * The dataset path from NAS-142530, and the one measurement that matters about
+ * it: unbroken it is 613px wide, against the 320px a 400px-wide dialog's header
+ * can give its heading.
+ */
+const LONG_ZVOL_PATH = 'dozer/TEST_ANOTHER_ZVOL_WITH_A_LONG_NAME';
+
+/**
+ * webui's delete-zvol dialog, reduced to the parts NAS-142530 turned on: a
+ * heading the width of a ZFS path, the same path again in the body copy, and a
+ * text field after the header's close button in tab order.
+ */
+@Component({
+  selector: 'tn-dialog-long-title',
+  standalone: true,
+  imports: [TnDialogShellComponent, TnButtonComponent, TnFormFieldComponent, TnInputComponent, FormsModule],
+  // 400px is webui's delete-dataset dialog — the width the report was filed against.
+  styles: [':host { display: block; width: 400px; }'],
+  templateUrl: './dialog-6.stories.html',
+})
+class DialogLongTitleComponent {
+  readonly ref = inject(DialogRef<string>);
+  readonly path = LONG_ZVOL_PATH;
+  confirmName = '';
+}
+
+@Component({
+  selector: 'tn-dialog-long-title-demo',
+  standalone: true,
+  imports: [TnButtonComponent],
+  template: `<tn-button type="button" label="Delete zvol" (click)="open()" />`,
+})
+class DialogLongTitleDemoComponent {
+  private dialog = inject(TnDialog);
+  open(): void {
+    this.dialog.open(DialogLongTitleComponent);
+  }
+}
+
+/**
+ * **A title too long for the dialog.** Dialogs are named after the thing they
+ * act on, and in TrueNAS that is routinely a full ZFS path. The heading wraps
+ * onto as many lines as it needs and the dialog keeps its width; nothing about
+ * it moves when focus does.
+ *
+ * It did not always: see the `.tn-dialog__title` block in `themes.css` for what
+ * `min-width: auto` on a flex item cost here (NAS-142530), and why the fix is
+ * two declarations rather than either one.
+ */
+export const LongTitle: Story = {
+  render: () => ({
+    moduleMetadata: { imports: [DialogLongTitleDemoComponent] },
+    template: '<tn-dialog-long-title-demo />',
+  }),
+  // Wrapping is layout, which jsdom cannot do — the unit specs next door can say
+  // nothing about it, so the guard has to live in a browser.
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Delete zvol' }));
+
+    // The dialog is portaled to <body>, so it is out of `canvasElement`.
+    const panel = await waitFor(() => {
+      const found = document.querySelector('.tn-dialog-panel') as HTMLElement | null;
+      if (!found) {
+        throw new Error('dialog did not open');
+      }
+      return found;
+    });
+    const close = panel.querySelector('.tn-dialog__close') as HTMLElement;
+
+    try {
+      // The heading wrapped rather than widening the header: no horizontal
+      // overflow anywhere on the panel, at the width the bug was filed against.
+      await expect(Math.round(panel.getBoundingClientRect().width)).toBe(400);
+      await expect(panel.scrollWidth).toBeLessThanOrEqual(panel.clientWidth);
+
+      // And so nothing scrolls the panel sideways. `autoFocus` has already put
+      // focus on the close button once — the step that used to open the dialog
+      // at `scrollLeft: 277` — so blur first, or re-focusing a focused element
+      // scrolls nothing and this passes on the broken CSS too.
+      close.blur();
+      panel.scrollLeft = 0;
+      close.focus();
+      await expect(panel.scrollLeft).toBe(0);
+
+      // The body copy carries the same path, and is clipped by `overflow-x:
+      // hidden` rather than scrollable — so it has to wrap on its own.
+      const content = panel.querySelector('.tn-dialog__content') as HTMLElement;
+      await expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+    } finally {
+      close.click();
+    }
+  },
 };

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -557,10 +557,13 @@ export const LongTitle: Story = {
       // the panel has no horizontal overflow to scroll: 400, against 677 before.
       await expect(panel.scrollWidth).toBeLessThanOrEqual(panel.clientWidth);
 
-      // And so nothing scrolls the panel sideways. `autoFocus` has already put
-      // focus on the close button once — the step that used to open the dialog
-      // at `scrollLeft: 277` — so blur first, or re-focusing a focused element
-      // scrolls nothing and this passes on the broken CSS too.
+      // A re-enactment of the reported symptom rather than a second guard: with
+      // no overflow left to scroll, the maximum `scrollLeft` is already 0 and
+      // the line above has thrown on any CSS where it is not. Kept for what it
+      // documents — the step that used to open the dialog at `scrollLeft: 277`
+      // was CDK's `autoFocus` landing on the close button. Hence the `blur()`:
+      // focusing an already-focused element scrolls nothing, so without it this
+      // would not re-enact anything.
       close.blur();
       panel.scrollLeft = 0;
       close.focus();

--- a/projects/truenas-ui/src/stories/dialog.stories.ts
+++ b/projects/truenas-ui/src/stories/dialog.stories.ts
@@ -548,9 +548,13 @@ export const LongTitle: Story = {
     const close = panel.querySelector('.tn-dialog__close') as HTMLElement;
 
     try {
-      // The heading wrapped rather than widening the header: no horizontal
-      // overflow anywhere on the panel, at the width the bug was filed against.
+      // Precondition, not the guard: the dialog is at the width the bug was
+      // filed against. It held on the broken CSS too — the heading overflowed
+      // the panel rather than widening it.
       await expect(Math.round(panel.getBoundingClientRect().width)).toBe(400);
+
+      // The guard. The heading wrapped instead of pushing the header wider, so
+      // the panel has no horizontal overflow to scroll: 400, against 677 before.
       await expect(panel.scrollWidth).toBeLessThanOrEqual(panel.clientWidth);
 
       // And so nothing scrolls the panel sideways. `autoFocus` has already put

--- a/projects/truenas-ui/src/stories/side-panel.stories.ts
+++ b/projects/truenas-ui/src/stories/side-panel.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
+import { expect } from 'storybook/test';
 import { expectOpeningMovesFocusInside } from './focus-capture';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnButtonComponent } from '../lib/button/button.component';
@@ -22,6 +23,9 @@ const textareaStyle = 'width: 100%; padding: 10px 12px; border: 1px solid var(--
  * child of it. `focus-capture.ts` holds the assertion, shared with `tn-drawer`.
  */
 const SIDE_PANEL_DIALOG = '.tn-side-panel__overlay';
+
+/** A dataset path long enough to overflow a 400px panel unbroken (NAS-142530). */
+const LONG_DATASET_PATH = 'dozer/TEST_ANOTHER_DATASET_WITH_A_LONG_NAME';
 
 const meta: Meta<TnSidePanelComponent> = {
   title: 'Components/Side Panel',
@@ -814,4 +818,30 @@ export const TestIds: Story = {
     `,
     moduleMetadata: { imports: [TnSidePanelComponent] },
   }),
+};
+
+/**
+ * **A path too long for the panel.** The body's copy names datasets in full, and
+ * `.tn-side-panel__content` is `overflow-x: hidden` — so before NAS-142530 a path
+ * wider than the panel was simply cut off mid-name, with no scrollbar and no
+ * ellipsis to say anything was missing. It wraps now. The heading is the other
+ * half of the same question and answers it differently, on purpose: a panel
+ * header cannot grow, so `.tn-side-panel__title` ellipsises instead.
+ */
+export const LongPath: Story = {
+  render: () => ({
+    props: { path: LONG_DATASET_PATH },
+    template: `
+      <tn-side-panel [open]="true" width="400px" [title]="'Delete ' + path">
+        <p>The {{ path }} dataset and all snapshots stored with it will be permanently deleted.</p>
+      </tn-side-panel>
+    `,
+    moduleMetadata: { imports: [TnSidePanelComponent] },
+  }),
+  // Wrapping is layout, which jsdom cannot do — the guard has to be in a browser.
+  play: async () => {
+    // The panel is portaled to <body>, so it is out of `canvasElement`.
+    const content = document.querySelector('.tn-side-panel__content') as HTMLElement;
+    await expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+  },
 };

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -946,18 +946,26 @@ tn-dialog-shell {
     down the same line. Tabbing to a control near the left edge scrolled it back
     and the dialog abruptly looked correct, which is how the bug was reported.
 
-    Both declarations are load-bearing, and neither fixes it alone — measured on
-    that dialog at 400px, `scrollWidth` / `scrollLeft` after focusing close:
-      neither          677 / 277   the reported bug
-      min-width only   629 /   0   heading shrinks, but its unbroken word still
-                                   spills out of the heading box and across the
-                                   close button
-      break-word only  677 / 277   nothing breaks: at 613px the word already
-                                   fits its own line, so there is nothing to wrap
-      both             400 /   0
+    `anywhere` and not `break-word`, which is the difference between one
+    declaration and two: `anywhere` contributes its break opportunities to
+    MIN-CONTENT sizing, so the `auto` floor lands at the widest character rather
+    than the widest word and the heading is free to shrink. `break-word` does
+    not, and leaves the floor at 613px — where the word already fits its own
+    line and there is nothing to wrap — so it needs an explicit `min-width: 0`
+    beside it to reach the same place. Neither touches max-content, so a dialog
+    opened without an explicit width still sizes itself to its title as before.
+
+    Measured on that dialog at 400px, `scrollWidth` / `scrollLeft` after
+    focusing close:
+      none                       677 / 277   the reported bug
+      break-word                 677 / 277   nothing breaks (see above)
+      min-width: 0               629 /   0   heading shrinks, but its unbroken
+                                             word still spills out of the
+                                             heading box and across the ✕
+      min-width: 0 + break-word  400 /   0
+      anywhere                   400 /   0   what ships
   */
-  min-width: 0;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* Close button */

--- a/projects/truenas-ui/src/styles/themes.css
+++ b/projects/truenas-ui/src/styles/themes.css
@@ -929,6 +929,35 @@ tn-dialog-shell {
   line-height: 1.5;
   color: var(--tn-fg1, #000000);
   flex: 1; /* Take up remaining space */
+  /*
+    A title as long as a ZFS path has to WRAP, and `flex: 1` alone does not let
+    it (NAS-142530). A flex item's `min-width` defaults to `auto`, which floors
+    it at the widest unbreakable run of text inside it — for webui's delete-zvol
+    dialog, `dozer/TEST_ANOTHER_ZVOL_WITH_A_LONG_NAME` measures 613px against
+    the 320px the 400px-wide dialog's header can give it. The heading kept its
+    613px, and the header and `.tn-dialog-panel` with it.
+
+    That overflow is not the harmless kind. `.tn-dialog-panel` sets
+    `overflow: hidden`, which clips but stays SCROLLABLE programmatically, and
+    the shell's close button — the first tabbable element in the dialog — is the
+    one CDK's `autoFocus` focuses on open. The browser scrolled it into view, so
+    every dialog with a long title opened at `scrollLeft: 277` with its whole
+    left edge cut off: heading, body copy, fields and footer buttons all sliced
+    down the same line. Tabbing to a control near the left edge scrolled it back
+    and the dialog abruptly looked correct, which is how the bug was reported.
+
+    Both declarations are load-bearing, and neither fixes it alone — measured on
+    that dialog at 400px, `scrollWidth` / `scrollLeft` after focusing close:
+      neither          677 / 277   the reported bug
+      min-width only   629 /   0   heading shrinks, but its unbroken word still
+                                   spills out of the heading box and across the
+                                   close button
+      break-word only  677 / 277   nothing breaks: at 613px the word already
+                                   fits its own line, so there is nothing to wrap
+      both             400 /   0
+  */
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 /* Close button */
@@ -988,6 +1017,19 @@ tn-dialog-shell {
   overflow-x: hidden;
   box-sizing: border-box;
   padding: var(--tn-content-padding, 16px);
+  /*
+    The body's half of NAS-142530, and a quieter failure than the heading's: the
+    same dataset paths appear in the copy under the title, and `overflow-x:
+    hidden` means a path too long for the dialog is simply CUT OFF mid-name with
+    nothing on screen to say so — no scrollbar, no ellipsis. Unlike the header
+    this never reached `.tn-dialog-panel` (a scroll container contains its own
+    overflow), so it cost no layout, only the end of the name the dialog is
+    asking the user to confirm.
+
+    `overflow-wrap` rather than `word-break: break-all`: it only breaks a word
+    that cannot fit a line on its own, so ordinary prose wraps exactly as before.
+  */
+  overflow-wrap: break-word;
 }
 
 /* Dialog actions */


### PR DESCRIPTION
Result:
<img width="442" height="554" alt="Screenshot 2026-09-03 at 15 42 35" src="https://github.com/user-attachments/assets/7f8b41fb-b858-435e-b7c7-663de722039c" />


## What was reported

Deleting a zvol with a long name opens the confirmation dialog with its **whole left edge cut off** — heading, body copy, the confirm field and the footer buttons all sliced down the same vertical line. Tabbing to the Confirm checkbox makes it abruptly snap back into place.

Reported against `27.0.0-MASTER+20260824-075527` with `dozer/REPRO_NVMET_ENC_ZVOL`, and reproduced on a non-encrypted zvol too. The consumer is webui's `ix-delete-dataset-dialog`, a 400px-wide `tn-dialog-shell` titled `Delete zvol <path>`.

## What it actually is

`.tn-dialog__title` is `flex: 1`, and a flex item's `min-width` defaults to `auto` — which floors it at the widest **unbreakable** run of text inside it. `dozer/TEST_ANOTHER_ZVOL_WITH_A_LONG_NAME` measures 613px against the 320px a 400px dialog's header has to give it, so the heading kept its 613px and took the header, and `.tn-dialog-panel` with it, along for the ride.

That overflow is not the harmless kind. `.tn-dialog-panel` sets `overflow: hidden`, which clips but stays **scrollable programmatically**, and the shell's close (✕) button is the first tabbable element in the dialog — the one CDK's `autoFocus` focuses on open. The browser scrolled it into view, so the dialog opened at `scrollLeft: 277`. Tabbing to the confirm field, which sits at the left, scrolled it back to 0 — the "stuff did realign" in the report.

Measured on that dialog at 400px, `panel.scrollWidth / panel.scrollLeft` after focusing close:

| | scrollWidth | scrollLeft | |
|---|---|---|---|
| before | 677 | 277 | the reported bug |
| `min-width: 0` only | 629 | 0 | heading shrinks, but its unbroken word still spills out of the heading box and across the close button |
| `overflow-wrap` only | 677 | 277 | nothing breaks — at 613px the word already fits its own line |
| **both** | **400** | **0** | |

## The change

- `.tn-dialog__title` — `min-width: 0` + `overflow-wrap: break-word`. Both are load-bearing; the table above is in the stylesheet next to them.
- `.tn-dialog__content` — the same `overflow-wrap`, for the body's quieter half of the same bug: dialogs repeat the path in their copy, and `overflow-x: hidden` there means a path too long is simply **cut off mid-name** with no scrollbar and no ellipsis. It never reached the panel (a scroll container contains its own overflow), so it cost no layout — only the end of the name the dialog is asking the user to confirm.
- `.tn-side-panel__content` — the library's other `overflow-x: hidden` body area had that same quiet defect, for the same reason. Its heading did not: `.tn-side-panel__title` already ellipsises, which is the right answer for a header that cannot grow, and is why the two overlays deliberately differ on the title.

`overflow-wrap: break-word` rather than `word-break: break-all`: it only breaks a word that cannot fit a line on its own, so ordinary prose wraps exactly as before.

## Guards

Wrapping is layout, which jsdom cannot do — the unit specs next door can say nothing about this, so both guards are `play` functions measuring real geometry.

- `Components/Dialog` → **LongTitle**: webui's delete-zvol dialog reduced to the parts this turns on (400px host, a ZFS path in the heading and again in the copy, a field after close in tab order). Asserts no horizontal overflow on the panel or the content section.
- `Components/Side Panel` → **LongPath**: the same path in a 400px panel's body.

Each verified to fail with its declaration reverted: `expected 677 to be less than or equal to 400` for the title, `413` for the dialog body, `440` for the panel body.

## Consumer impact

None needed in webui — it is a stylesheet fix that arrives with the next release. Checked webui's two existing `.tn-dialog__title` / `.tn-dialog__header` overrides (`ix-truenas-connect-status-modal`, `ix-error-dialog` / `ix-info-dialog`); neither conflicts.

https://claude.ai/code/session_01Sj5dZWmCZdPTotcfySaYch