### PR TITLE
NAS-142381 / 27.0.0-BETA.1 / feat(autocomplete,chip-input): drive options from an async [dataSource]

### DIFF
--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -252,6 +252,39 @@ describe('tn-autocomplete [dataSource]', () => {
       expect(requests).toEqual([{ query: 'ali', page: 0 }]);
     });
 
+    it('fetches without waiting for a reopen when the panel is already open', () => {
+      // The harder half of the same shape, and the one that sticks: `prime` is
+      // only called from open/focus, so a source that binds while the panel is
+      // UP had nothing left to ask. The panel sat on "No results found" — with
+      // the user looking straight at it — until they typed or closed and
+      // reopened the field.
+      host.source.set(undefined);
+      fixture.detectChanges();
+
+      focus();
+      expect(requests).toEqual([]);
+      expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeTruthy();
+
+      host.source.set(source);
+      fixture.detectChanges();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+
+    it('still issues nothing for a field nobody has opened', () => {
+      // The transition must not become a back door around "a form of pickers
+      // costs nothing until one is used": only a host that already asked and
+      // was turned away is owed a page.
+      host.source.set(undefined);
+      fixture.detectChanges();
+
+      host.source.set(source);
+      fixture.detectChanges();
+
+      expect(requests).toEqual([]);
+    });
+
     it('does not release the paging latch of a host that pages [options] itself', () => {
       // `onSettled` is what clears `loadMorePending`, and the empty "success"
       // fired it roughly one debounce after every keystroke — even with NO

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -42,6 +42,8 @@ function pageOf(query: string, page: number, count: number): Option[] {
       [dataSourceDebounce]="250"
       [pageSize]="pageSize()"
       [options]="staticOptions()"
+      [allowCustomValue]="allowCustomValue()"
+      [requireSelection]="requireSelection()"
       [actionOption]="actionOption()"
       (actionSelected)="actionCount = actionCount + 1"
       (loadMore)="loadMoreCount = loadMoreCount + 1"
@@ -53,6 +55,8 @@ class DataSourceHostComponent {
   control = new FormControl<string | null>(null);
   pageSize = signal(5);
   staticOptions = signal<Option[]>([]);
+  allowCustomValue = signal(false);
+  requireSelection = signal(false);
   actionOption = signal<Option | undefined>(undefined);
   source = signal<TnOptionsFetchFn<Option> | undefined>(undefined);
   actionCount = 0;
@@ -662,9 +666,90 @@ describe('tn-autocomplete [dataSource]', () => {
 
       expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
     });
+
+    it('commits the pinned value when its label is typed under allowCustomValue', () => {
+      // The paint/read asymmetry, from the custom-value side: the field is
+      // willing to render `g-7` as `admins`, so it has to accept `admins`
+      // back. Matching only the fetched pages committed the raw string over
+      // the id it names — a second, wrong value for the same record.
+      host.allowCustomValue.set(true);
+      host.staticOptions.set([{ label: 'admins', value: 'g-7' }]);
+      fixture.detectChanges();
+
+      focus();
+      type('admins');
+      expect(renderedOptions()).not.toContain('admins');
+
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe('g-7');
+      expect(input().value).toBe('admins');
+    });
+
+    it('resolves the pinned label instead of reverting under requireSelection', () => {
+      // The milder half of the same root: unrecognised text is reverted, so
+      // typing the exact name the field itself displays threw the term away.
+      host.requireSelection.set(true);
+      host.staticOptions.set([{ label: 'admins', value: 'g-7' }]);
+      fixture.detectChanges();
+
+      focus();
+      type('admins');
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe('g-7');
+      expect(input().value).toBe('admins');
+    });
+
+    it('still reverts text no listed or pinned row carries', () => {
+      // Widening the match list must not make `requireSelection` accept
+      // anything the field never offered.
+      host.requireSelection.set(true);
+      host.staticOptions.set([{ label: 'admins', value: 'g-7' }]);
+      fixture.detectChanges();
+
+      focus();
+      type('nobody');
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBeNull();
+      expect(input().value).toBe('');
+    });
   });
 
   describe('[keepSelectedOption]', () => {
+    it('reads back the kept row rather than committing its label as free text', () => {
+      // The kept row is listed and clickable, and its label may be one
+      // remembered from the option the value was picked from — so it has to be
+      // matchable too. Restricting the match to the label-resolution list (the
+      // one that rightly drops this row, since resolving a VALUE against its
+      // `String(value)` fallback always "succeeds") would turn "type the text
+      // you can see, then blur" into a free-text commit of that text over the
+      // id it stands for — the same bug from the other side.
+      host.allowCustomValue.set(true);
+      responder = () => of([{ label: 'archived-user', value: '4242' }]);
+      fixture.detectChanges();
+
+      focus();
+      (overlayEl.querySelector('.tn-autocomplete__option') as HTMLElement).click();
+      fixture.detectChanges();
+      expect(host.control.value).toBe('4242');
+
+      // Page the real row away, so only the synthetic one carries the label.
+      responder = () => of([]);
+      type('archived');
+      type('archived-user');
+      expect(renderedOptions()).toEqual(['archived-user']);
+
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe('4242');
+    });
+
     it('keeps the committed value listed when the page does not contain it', () => {
       // A preset value sorted past the first page, or one just created that the
       // query does not match yet. Without this the field renders blank for a

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -1,0 +1,695 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Subject, of, throwError } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { TnAutocompleteComponent } from './autocomplete.component';
+import type { TnAutocompleteOption } from './autocomplete.component';
+import type { TnOptionsFetchFn } from '../utils/options-data-source';
+
+/**
+ * `[dataSource]` — the async half of `tn-autocomplete`.
+ *
+ * Everything here was, until this input existed, hand-written in each consuming
+ * form: a subject fed from `(searchChange)`, a `debounceTime`, a
+ * `distinctUntilChanged`, a `switchMap`, a page cursor, an exhaustion flag, an
+ * error latch, and a "keep the selected option listed" pass. Several of those
+ * copies got one of the edge cases wrong, so each case below names the failure
+ * it prevents rather than just the behaviour it asserts.
+ */
+
+type Option = TnAutocompleteOption<string>;
+
+/** Options named so a page's contents identify the page that produced them. */
+function pageOf(query: string, page: number, count: number): Option[] {
+  return Array.from({ length: count }, (_, index) => ({
+    label: `${query || 'all'}-p${page}-${index}`,
+    value: `${query || 'all'}-p${page}-${index}`,
+  }));
+}
+
+@Component({
+  selector: 'tn-data-source-host',
+  standalone: true,
+  imports: [TnAutocompleteComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-autocomplete
+      [formControl]="control"
+      [dataSource]="source()"
+      [dataSourceDebounce]="250"
+      [pageSize]="pageSize()"
+      [options]="staticOptions()"
+      [actionOption]="actionOption()"
+      (actionSelected)="actionCount = actionCount + 1"
+      (dataSourceError)="errors.push($event)" />
+  `,
+})
+class DataSourceHostComponent {
+  control = new FormControl<string | null>(null);
+  pageSize = signal(5);
+  staticOptions = signal<Option[]>([]);
+  actionOption = signal<Option | undefined>(undefined);
+  source = signal<TnOptionsFetchFn<Option> | undefined>(undefined);
+  actionCount = 0;
+  errors: unknown[] = [];
+}
+
+describe('tn-autocomplete [dataSource]', () => {
+  let fixture: ComponentFixture<DataSourceHostComponent>;
+  let host: DataSourceHostComponent;
+  let overlayEl: HTMLElement;
+
+  /** Every `(query, page)` the component asked for, in order. */
+  let requests: { query: string; page: number }[];
+  /** Swappable per-spec response for a request. */
+  let responder: (query: string, page: number) => Observable<Option[]>;
+
+  const source: TnOptionsFetchFn<Option> = (query, page) => {
+    requests.push({ query, page });
+    return responder(query, page);
+  };
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('.tn-autocomplete__input') as HTMLInputElement;
+  }
+
+  function listbox(): HTMLElement {
+    return overlayEl.querySelector('.tn-autocomplete__listbox') as HTMLElement;
+  }
+
+  function renderedOptions(): string[] {
+    return Array.from(overlayEl.querySelectorAll('.tn-autocomplete__option'))
+      .map((option) => option.textContent?.trim() ?? '');
+  }
+
+  /** Focus the field, which is what triggers the first page. */
+  function focus(): void {
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+  }
+
+  /** Type `text`, then let the debounce elapse and the response render. */
+  function type(text: string): void {
+    input().value = text;
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+  }
+
+  /**
+   * Make every element report a scrollbar, so the panel never reads as
+   * underfilled.
+   *
+   * jsdom gives every element a zero height, which the auto-fill check
+   * correctly treats as "no scrollbar, ask for more" — so without this a source
+   * pages itself as far as the auto-fill cap allows the moment it opens, and no
+   * case below could isolate a single page. It has to be the prototype rather
+   * than `scrollingTo` on the listbox: the first auto-fill round runs during
+   * the same `detectChanges` that first renders the listbox, so there is no
+   * point at which a spec could reach that element in time.
+   */
+  function stubFilledPanel(): void {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => 350,
+    });
+  }
+
+  /** Put jsdom's zero-height geometry back, i.e. a panel that never fills. */
+  function restorePanelGeometry(): void {
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollHeight;
+    delete (HTMLElement.prototype as Partial<HTMLElement>).clientHeight;
+  }
+
+  /** Scroll the listbox to its end, the condition the paging handler reads. */
+  function scrollToEnd(): void {
+    const el = listbox();
+    Object.defineProperty(el, 'scrollTop', { value: 50, configurable: true });
+    el.dispatchEvent(new Event('scroll'));
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    requests = [];
+    responder = (query, page) => of(pageOf(query, page, page === 0 ? 2 : 0));
+    stubFilledPanel();
+
+    await TestBed.configureTestingModule({
+      imports: [DataSourceHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DataSourceHostComponent);
+    host = fixture.componentInstance;
+    overlayEl = TestBed.inject(OverlayContainer).getContainerElement();
+    host.source.set(source);
+    fixture.detectChanges();
+
+    // The library is zoneless, so `fakeAsync`/`tick` are unavailable — jest's
+    // own timers stand in to drive the debounce. Installed after the async
+    // setup above, which needs real ones to resolve.
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    restorePanelGeometry();
+    TestBed.inject(OverlayContainer).ngOnDestroy();
+  });
+
+  describe('fetching', () => {
+    it('does not query until the panel is first opened', () => {
+      // A form of pickers must cost nothing until one is used — the picker this
+      // replaced fetched from its own ngOnInit, so merely rendering a field the
+      // current user could not even see issued a query.
+      expect(requests).toEqual([]);
+
+      focus();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+    });
+
+    it('does not refetch the first page when the panel is reopened', () => {
+      focus();
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      focus();
+
+      expect(requests).toHaveLength(1);
+    });
+
+    it('debounces typing into a single request for the final term', () => {
+      focus();
+      requests = [];
+
+      input().value = 'a';
+      input().dispatchEvent(new Event('input'));
+      jest.advanceTimersByTime(100);
+      input().value = 'al';
+      input().dispatchEvent(new Event('input'));
+      jest.advanceTimersByTime(100);
+      input().value = 'ali';
+      input().dispatchEvent(new Event('input'));
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+
+      expect(requests).toEqual([{ query: 'ali', page: 0 }]);
+    });
+
+    it('renders the fetched page without filtering it again on the label', () => {
+      // The server already applied the query. Re-filtering on the label would
+      // drop rows it matched on some other field — a domain-prefixed username
+      // found by its bare name, say.
+      responder = () => of([{ label: 'ACME\\jsmith', value: 'jsmith' }]);
+      focus();
+      type('jsmith');
+
+      expect(renderedOptions()).toEqual(['ACME\\jsmith']);
+    });
+
+    it('ignores [options] while a data source is bound', () => {
+      host.staticOptions.set([{ label: 'static', value: 'static' }]);
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+  });
+
+  describe('paging', () => {
+    it('appends the next page when scrolled to the end', () => {
+      responder = (query, page) => of(pageOf(query, page, page < 2 ? 5 : 1));
+      focus();
+      expect(renderedOptions()).toEqual(pageOf('', 0, 5).map((o) => o.label));
+
+      scrollToEnd();
+
+      expect(requests).toEqual([{ query: '', page: 0 }, { query: '', page: 1 }]);
+      expect(renderedOptions()).toHaveLength(10);
+    });
+
+    it('stops paging once a short page proves the source is exhausted', () => {
+      // Without an exhaustion latch every further scroll issues another query
+      // at a growing offset that can only come back empty.
+      responder = (query, page) => of(pageOf(query, page, page === 0 ? 5 : 2));
+      focus();
+
+      scrollToEnd();
+      expect(requests).toHaveLength(2);
+
+      scrollToEnd();
+      scrollToEnd();
+
+      expect(requests).toHaveLength(2);
+    });
+
+    it('fills an underfilled panel without waiting for a scroll', () => {
+      // A page too short to overflow the panel produces no scroll event, so
+      // paging would dead-end with data still available.
+      restorePanelGeometry();
+      responder = (query, page) => of(pageOf(query, page, page < 2 ? 5 : 1));
+
+      focus();
+
+      expect(requests.map((request) => request.page)).toEqual([0, 1, 2]);
+      expect(renderedOptions()).toHaveLength(11);
+    });
+
+    it('stops auto-filling a source that never runs out', () => {
+      // A source answering synchronously re-arms the underfill check within the
+      // same change-detection pass, so without a cap this spins rather than
+      // yielding between rounds.
+      restorePanelGeometry();
+      responder = (query, page) => of(pageOf(query, page, 5));
+
+      focus();
+
+      expect(requests.length).toBeLessThanOrEqual(21);
+    });
+
+    it('restarts paging at page 0 for a new search term', () => {
+      responder = (query, page) => of(pageOf(query, page, 5));
+      focus();
+      scrollToEnd();
+      expect(requests).toContainEqual({ query: '', page: 1 });
+
+      type('bob');
+
+      expect(requests.at(-1)).toEqual({ query: 'bob', page: 0 });
+      expect(renderedOptions()).toEqual(pageOf('bob', 0, 5).map((o) => o.label));
+    });
+
+    it('does not advance the cursor over a page that failed', () => {
+      // Advancing it would silently skip the rows that page held — they would
+      // never appear, however far the user scrolled.
+      let failNextPage = true;
+      responder = (query, page) => {
+        if (page === 1 && failNextPage) {
+          failNextPage = false;
+          return throwError(() => new Error('nope'));
+        }
+        return of(pageOf(query, page, 5));
+      };
+      focus();
+
+      scrollToEnd();
+      expect(host.errors).toHaveLength(1);
+
+      scrollToEnd();
+
+      expect(requests.filter((request) => request.page === 1)).toHaveLength(2);
+      expect(renderedOptions()).toHaveLength(10);
+    });
+
+    it('discards a page that lands after a newer search started', () => {
+      const slowPage = new Subject<Option[]>();
+      responder = (query, page) => {
+        if (page === 1) {
+          return slowPage;
+        }
+        return of(pageOf(query, page, 5));
+      };
+      focus();
+      scrollToEnd();
+
+      type('bob');
+      // The stale page answers only now, after the new term's results are up.
+      slowPage.next(pageOf('', 1, 5));
+      slowPage.complete();
+      fixture.detectChanges();
+
+      expect(renderedOptions()).toEqual(pageOf('bob', 0, 5).map((o) => o.label));
+    });
+  });
+
+  describe('errors', () => {
+    it('reports a failure and keeps the field usable', () => {
+      // A `catchError` outside the `switchMap` would end the subscription here,
+      // freezing the picker for the life of the panel.
+      let failing = true;
+      responder = (query, page) => (failing
+        ? throwError(() => new Error('boom'))
+        : of(pageOf(query, page, 2)));
+
+      focus();
+      expect(host.errors).toHaveLength(1);
+
+      failing = false;
+      type('bob');
+
+      expect(renderedOptions()).toEqual(pageOf('bob', 0, 2).map((o) => o.label));
+    });
+
+    it('retries the same term after it failed', () => {
+      // `distinctUntilChanged` would otherwise suppress the repeat, and the
+      // field could never recover from a transient error without retyping.
+      let failing = true;
+      responder = (query, page) => (failing
+        ? throwError(() => new Error('boom'))
+        : of(pageOf(query, page, 2)));
+
+      focus();
+      type('bob');
+      expect(host.errors).toHaveLength(2);
+
+      failing = false;
+      type('bob');
+
+      expect(renderedOptions()).toEqual(pageOf('bob', 0, 2).map((o) => o.label));
+    });
+
+    it('re-requests the page that failed rather than stepping over it', () => {
+      // Two halves: a failed page must not read as an exhausted source (which
+      // would drop the request entirely), and the cursor must roll back to the
+      // page that failed. Page 0 is the case a "last page loaded" cursor gets
+      // wrong — it reads 0 both before anything has landed and after page 0
+      // succeeded, so the retry asked for page 1 and the first page of matches
+      // was silently skipped.
+      responder = () => throwError(() => new Error('boom'));
+      focus();
+      requests = [];
+
+      scrollToEnd();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+    });
+
+    it('retries the first page when the panel is reopened after it failed', () => {
+      // `prime` is a no-op once a query has run, so latching it on a request
+      // that *failed* left a click-to-open field permanently empty: reopening
+      // issued no request at all, and only typing could ever recover it.
+      let failing = true;
+      responder = (query, page) => (failing
+        ? throwError(() => new Error('boom'))
+        : of(pageOf(query, page, 2)));
+
+      focus();
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      failing = false;
+      focus();
+
+      expect(renderedOptions()).toEqual(pageOf('', 0, 2).map((option) => option.label));
+    });
+
+    it('re-primes with the term the field holds, not an empty one', () => {
+      // The retry path replays the current query: re-priming with '' would
+      // answer 'bob' with the whole directory, which is not what is typed.
+      let failing = true;
+      responder = (query, page) => (failing
+        ? throwError(() => new Error('boom'))
+        : of(pageOf(query, page, 2)));
+
+      focus();
+      type('bob');
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      failing = false;
+      requests = [];
+      focus();
+
+      expect(requests).toEqual([{ query: 'bob', page: 0 }]);
+    });
+  });
+
+  describe('[actionOption]', () => {
+    const addNew: Option = { label: 'Add New', value: '__add__' };
+
+    beforeEach(() => {
+      host.actionOption.set(addNew);
+      fixture.detectChanges();
+    });
+
+    it('pins the row above the results and keeps it while searching', () => {
+      focus();
+      expect(renderedOptions()[0]).toBe('Add New');
+
+      type('bob');
+
+      expect(renderedOptions()[0]).toBe('Add New');
+    });
+
+    it('emits actionSelected and commits nothing to the control', () => {
+      // The old picker committed a `NEW` sentinel, which satisfied
+      // `Validators.required` and could be submitted as if it were a username.
+      focus();
+      type('bo');
+
+      (overlayEl.querySelector('.tn-autocomplete__option') as HTMLElement).click();
+      fixture.detectChanges();
+
+      expect(host.actionCount).toBe(1);
+      expect(host.control.value).toBeNull();
+      // The partial term typed to reach the row must not survive as text.
+      expect(input().value).toBe('');
+    });
+
+    it('restores the committed value\'s label after the action row is chosen', () => {
+      focus();
+      (overlayEl.querySelectorAll('.tn-autocomplete__option')[1] as HTMLElement).click();
+      fixture.detectChanges();
+      expect(host.control.value).toBe('all-p0-0');
+
+      focus();
+      type('zz');
+      (overlayEl.querySelector('.tn-autocomplete__option') as HTMLElement).click();
+      fixture.detectChanges();
+
+      expect(host.control.value).toBe('all-p0-0');
+      expect(input().value).toBe('all-p0-0');
+    });
+
+    it('still reports no results when only the action row matched', () => {
+      responder = () => of([]);
+      focus();
+
+      expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeTruthy();
+      expect(renderedOptions()).toEqual(['Add New']);
+    });
+  });
+
+  describe('[options] alongside a source', () => {
+    it('names a written value before the first page is fetched', () => {
+      // The record holds an id and only the host can name it, while the
+      // source's first page does not exist until the field is focused.
+      // Ignoring `[options]` here left every id-valued edit form reading as a
+      // raw number until someone clicked into it — `tn-chip-input` already
+      // treated its own `options` as a label source for exactly this reason.
+      host.staticOptions.set([{ label: 'archived-user', value: '4242' }]);
+      host.control.setValue('4242');
+      fixture.detectChanges();
+
+      expect(input().value).toBe('archived-user');
+    });
+
+    it('keeps that value listed by name when the fetched page lacks it', () => {
+      host.staticOptions.set([{ label: 'archived-user', value: '4242' }]);
+      host.control.setValue('4242');
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toContain('archived-user');
+    });
+
+    it('leaves the dropdown to the source', () => {
+      // Pinned rows name values; they are not offered as results. Listing them
+      // would put rows the query never matched in front of the ones it did.
+      host.staticOptions.set([{ label: 'archived-user', value: '4242' }]);
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+
+    it('does not duplicate a row the page also carries', () => {
+      host.staticOptions.set([{ label: 'all-p0-0', value: 'all-p0-0' }]);
+      host.control.setValue('all-p0-0');
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+  });
+
+  describe('[keepSelectedOption]', () => {
+    it('keeps the committed value listed when the page does not contain it', () => {
+      // A preset value sorted past the first page, or one just created that the
+      // query does not match yet. Without this the field renders blank for a
+      // perfectly valid value.
+      host.control.setValue('bob');
+      fixture.detectChanges();
+      expect(input().value).toBe('bob');
+
+      focus();
+
+      expect(renderedOptions()).toContain('bob');
+      expect(input().value).toBe('bob');
+    });
+
+    it('still reports no results when only the kept row is listed', () => {
+      // The kept row is there for the committed value, not because the query
+      // matched it. Counting it as a match hid "No results found" for every
+      // search made with a value committed, and the panel then showed that
+      // value's label as though the server had returned it.
+      host.control.setValue('bob');
+      fixture.detectChanges();
+      focus();
+
+      responder = () => of([]);
+      type('zzz');
+
+      expect(renderedOptions()).toEqual(['bob']);
+      expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeTruthy();
+    });
+
+    it('drops the synthetic row once a page carries the real option', () => {
+      host.control.setValue('all-p0-0');
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+  });
+
+  describe('refreshOptions()', () => {
+    /**
+     * A `[dataSource]` is usually a fixed function reading live configuration —
+     * that is what keeps it from being swapped out from under a request in
+     * flight. Nothing in here observes that configuration, so this is how the
+     * caller says it moved.
+     */
+    function component(): TnAutocompleteComponent<string> {
+      return fixture.debugElement.children[0].componentInstance as TnAutocompleteComponent<string>;
+    }
+
+    it('re-queries the current term instead of being suppressed as a duplicate', () => {
+      focus();
+      type('ann');
+      requests = [];
+
+      component().refreshOptions();
+      fixture.detectChanges();
+
+      expect(requests).toEqual([{ query: 'ann', page: 0 }]);
+    });
+
+    it('replaces the rows on screen with the new configuration\'s', () => {
+      focus();
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+
+      responder = () => of([{ label: 'narrowed', value: 'narrowed' }]);
+      component().refreshOptions();
+      fixture.detectChanges();
+
+      expect(renderedOptions()).toEqual(['narrowed']);
+    });
+
+    it('restarts paging, so the next scroll asks for page 1 of the new results', () => {
+      focus();
+      responder = (query, page) => of(pageOf(query, page, 5));
+      component().refreshOptions();
+      fixture.detectChanges();
+      requests = [];
+
+      scrollToEnd();
+
+      expect(requests).toEqual([{ query: '', page: 1 }]);
+    });
+
+    it('primes with the term still inside the debounce window, not the last dispatched one', () => {
+      // `prime` emits immediately, which cancels whatever the debounce is
+      // holding. Priming with the last *dispatched* term therefore threw the
+      // pending keystroke away entirely: the panel listed the previous term's
+      // rows while the input read the newer one, and nothing re-queried until
+      // the next keystroke — so picking a row committed a value the typed term
+      // had never matched.
+      focus();
+      type('al');
+      requests = [];
+
+      input().value = 'ali';
+      input().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      component().refreshOptions();
+      fixture.detectChanges();
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+
+      expect(requests).toEqual([{ query: 'ali', page: 0 }]);
+      expect(renderedOptions()).toEqual(['ali-p0-0', 'ali-p0-1']);
+    });
+
+    it('does not query for a panel that has never been opened', () => {
+      // A field nobody has touched must not reach the server because some
+      // sibling input moved. The first open is what fetches, as it always was.
+      component().refreshOptions();
+      fixture.detectChanges();
+      expect(requests).toEqual([]);
+
+      focus();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+    });
+
+    it('drops a page that was already in flight when the configuration changed', () => {
+      // `refresh` issues no request of its own, so `switchMap` has nothing to
+      // cancel the outstanding one in favour of. Landing unguarded, that page
+      // re-latched `prime` and the field served the retired configuration's
+      // rows for good — only a keystroke recovered it.
+      const inFlight = new Subject<Option[]>();
+      responder = () => inFlight;
+      focus();
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      responder = () => of([{ label: 'narrowed', value: 'narrowed' }]);
+      component().refreshOptions();
+      fixture.detectChanges();
+
+      inFlight.next(pageOf('', 0, 2));
+      inFlight.complete();
+      fixture.detectChanges();
+      requests = [];
+
+      focus();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+      expect(renderedOptions()).toEqual(['narrowed']);
+    });
+
+    it('defers to the next open when the panel is closed, and is not suppressed there', () => {
+      focus();
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      responder = () => of([{ label: 'narrowed', value: 'narrowed' }]);
+      component().refreshOptions();
+      fixture.detectChanges();
+      expect(requests).toHaveLength(1);
+
+      focus();
+
+      // `prime` latches once a query succeeds, and the term has not changed —
+      // without the refresh clearing that latch AND arming the duplicate-term
+      // guard, reopening would re-list the previous configuration's rows and
+      // never ask again.
+      expect(requests).toHaveLength(2);
+      expect(renderedOptions()).toEqual(['narrowed']);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -44,6 +44,7 @@ function pageOf(query: string, page: number, count: number): Option[] {
       [options]="staticOptions()"
       [actionOption]="actionOption()"
       (actionSelected)="actionCount = actionCount + 1"
+      (loadMore)="loadMoreCount = loadMoreCount + 1"
       (dataSourceError)="errors.push($event)" />
   `,
 })
@@ -54,6 +55,7 @@ class DataSourceHostComponent {
   actionOption = signal<Option | undefined>(undefined);
   source = signal<TnOptionsFetchFn<Option> | undefined>(undefined);
   actionCount = 0;
+  loadMoreCount = 0;
   errors: unknown[] = [];
 }
 
@@ -215,13 +217,68 @@ describe('tn-autocomplete [dataSource]', () => {
       expect(renderedOptions()).toEqual(['ACME\\jsmith']);
     });
 
-    it('ignores [options] while a data source is bound', () => {
+    it('leaves [options] out of the dropdown while a data source is bound', () => {
       host.staticOptions.set([{ label: 'static', value: 'static' }]);
       fixture.detectChanges();
 
       focus();
 
       expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+  });
+
+  describe('no source bound', () => {
+    it('fetches a source that arrives after the user has already typed', () => {
+      // A request made with no source used to be answered with an empty
+      // SUCCESS, which latched `primed` off a fetch that never happened. Every
+      // later open then bailed on that latch and issued no request at all, so
+      // the panel read "No results found" for the life of the field. The
+      // `| undefined` input type invites exactly this shape — a source that
+      // depends on a sibling field, or on a resolver.
+      host.source.set(undefined);
+      fixture.detectChanges();
+
+      focus();
+      type('ali');
+      expect(requests).toEqual([]);
+
+      host.source.set(source);
+      fixture.detectChanges();
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      focus();
+
+      expect(requests).toEqual([{ query: 'ali', page: 0 }]);
+    });
+
+    it('does not release the paging latch of a host that pages [options] itself', () => {
+      // `onSettled` is what clears `loadMorePending`, and the empty "success"
+      // fired it roughly one debounce after every keystroke — even with NO
+      // source bound at all. Type, flick-scroll the open panel to the bottom
+      // inside that window, and the latch was dropped while the consumer's
+      // page was still in flight: the next scroll event of the same inertial
+      // scroll asked for it a second time.
+      host.source.set(undefined);
+      host.staticOptions.set(pageOf('', 0, 5));
+      fixture.detectChanges();
+
+      focus();
+
+      // A keystroke legitimately resets the latch — a new term is a new
+      // pagination context — so the scroll below is what arms it.
+      input().value = 'a';
+      input().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      scrollToEnd();
+      expect(host.loadMoreCount).toBe(1);
+
+      // The non-request used to land here.
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+      scrollToEnd();
+
+      expect(host.loadMoreCount).toBe(1);
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -45,6 +45,7 @@ function pageOf(query: string, page: number, count: number): Option[] {
       [actionOption]="actionOption()"
       (actionSelected)="actionCount = actionCount + 1"
       (loadMore)="loadMoreCount = loadMoreCount + 1"
+      (optionSelected)="selectedEvents.push($event)"
       (dataSourceError)="errors.push($event)" />
   `,
 })
@@ -56,6 +57,7 @@ class DataSourceHostComponent {
   source = signal<TnOptionsFetchFn<Option> | undefined>(undefined);
   actionCount = 0;
   loadMoreCount = 0;
+  selectedEvents: Option[] = [];
   errors: unknown[] = [];
 }
 
@@ -566,6 +568,53 @@ describe('tn-autocomplete [dataSource]', () => {
 
       expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeTruthy();
       expect(renderedOptions()).toEqual(['Add New']);
+    });
+
+    describe('setSelectedOption(), the other half of the handoff', () => {
+      /** The row the host creates and hands back after `(actionSelected)`. */
+      const created: Option = { label: 'freshly-made', value: 'made-42' };
+
+      function component(): TnAutocompleteComponent<string> {
+        return fixture.debugElement.children[0].componentInstance as TnAutocompleteComponent<string>;
+      }
+
+      it('commits the option to the bound control, not just to the display', () => {
+        // The advertised flow: the action row creates something, and the host
+        // hands the new row back because `writeValue` cannot carry a label.
+        // Updating only the display left the field showing the new name, that
+        // row marked selected, and the control still on its old value — which
+        // is the value a submit then sent.
+        focus();
+        (overlayEl.querySelector('.tn-autocomplete__option') as HTMLElement).click();
+        fixture.detectChanges();
+        expect(host.control.value).toBeNull();
+
+        component().setSelectedOption(created);
+        fixture.detectChanges();
+
+        expect(host.control.value).toBe('made-42');
+        expect(input().value).toBe('freshly-made');
+      });
+
+      it('shows the label rather than the raw value, with no search to resolve it', () => {
+        // The reason the method exists: nothing the source returns carries
+        // this row, so `writeValue` alone would render `String(value)`.
+        component().setSelectedOption(created);
+        fixture.detectChanges();
+
+        expect(input().value).toBe('freshly-made');
+        expect(requests).toEqual([]);
+      });
+
+      it('does not emit optionSelected — the host already knows', () => {
+        // That output means the USER picked a row. This is the host telling
+        // the component what the host decided, so echoing it back to the
+        // caller that made the call would be noise.
+        component().setSelectedOption(created);
+        fixture.detectChanges();
+
+        expect(host.selectedEvents).toEqual([]);
+      });
     });
   });
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -811,6 +811,84 @@ describe('tn-autocomplete [dataSource]', () => {
     });
   });
 
+  describe('abandoning a term', () => {
+    it('re-queries the reverted term, so reopening is not stuck on the abandoned one', () => {
+      // `asyncOptions.search()` is reached from `onInput` alone, so every path
+      // that rewrites the text WITHOUT the user typing left the engine holding
+      // the query, the rows and the `primed` latch of the term walked away
+      // from. `open()` only calls `prime()`, a no-op once primed — so the panel
+      // reopened on "No results found" against an empty field and issued
+      // nothing to correct it. Only a non-empty keystroke recovered it.
+      host.requireSelection.set(true);
+      fixture.detectChanges();
+
+      focus();
+      responder = () => of([]);
+      type('zzz');
+      expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeTruthy();
+
+      responder = (query, page) => of(pageOf(query, page, page === 0 ? 2 : 0));
+      input().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      expect(input().value).toBe('');
+
+      // The revert re-asked for the empty term, through the usual debounce.
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+      expect(overlayEl.querySelector('.tn-autocomplete__no-results')).toBeFalsy();
+    });
+
+    it('re-queries after Escape cancels a draft under allowCustomValue', () => {
+      host.allowCustomValue.set(true);
+      fixture.detectChanges();
+
+      focus();
+      responder = () => of([]);
+      type('zzz');
+
+      responder = (query, page) => of(pageOf(query, page, page === 0 ? 2 : 0));
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      fixture.detectChanges();
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+
+      focus();
+
+      expect(renderedOptions()).toEqual(['all-p0-0', 'all-p0-1']);
+    });
+
+    it('does not re-query when the reverted text is the term already loaded', () => {
+      // The common Escape — panel opened, nothing typed. The duplicate-term
+      // guard has to drop this, or every dismissal costs a round trip.
+      host.allowCustomValue.set(true);
+      fixture.detectChanges();
+
+      focus();
+      const before = requests.length;
+
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      fixture.detectChanges();
+      jest.advanceTimersByTime(250);
+      fixture.detectChanges();
+
+      expect(requests.length).toBe(before);
+    });
+
+    it('does not query for a value written before the field was ever opened', () => {
+      // The revert funnel must not swallow the rule that a field nobody has
+      // touched costs nothing: `writeValue` repaints through the same display
+      // helper, but deliberately not through the engine sync.
+      host.control.setValue('4242');
+      fixture.detectChanges();
+      jest.advanceTimersByTime(250);
+
+      expect(requests).toEqual([]);
+    });
+  });
+
   describe('refreshOptions()', () => {
     /**
      * A `[dataSource]` is usually a fixed function reading live configuration —

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete-data-source.spec.ts
@@ -42,6 +42,7 @@ function pageOf(query: string, page: number, count: number): Option[] {
       [dataSourceDebounce]="250"
       [pageSize]="pageSize()"
       [options]="staticOptions()"
+      [keepSelectedOption]="keepSelectedOption()"
       [allowCustomValue]="allowCustomValue()"
       [requireSelection]="requireSelection()"
       [actionOption]="actionOption()"
@@ -55,6 +56,7 @@ class DataSourceHostComponent {
   control = new FormControl<string | null>(null);
   pageSize = signal(5);
   staticOptions = signal<Option[]>([]);
+  keepSelectedOption = signal(true);
   allowCustomValue = signal(false);
   requireSelection = signal(false);
   actionOption = signal<Option | undefined>(undefined);
@@ -644,6 +646,25 @@ describe('tn-autocomplete [dataSource]', () => {
       focus();
 
       expect(renderedOptions()).toContain('archived-user');
+    });
+
+    it('upgrades the raw fallback when a late [options] names the value, with the keep opt-out off', () => {
+      // The display-upgrade effect has to TRACK the list it RESOLVES from.
+      // Tracking `resolvedOptions` instead read `keptSelectedOption`, which
+      // returns at its first guard when `keepSelectedOption` is false — before
+      // it ever touches the pinned rows. So `options` was not a dependency on
+      // that branch, and a host label that resolved after the write never
+      // reached the screen: the edit form kept showing the raw id until the
+      // panel was opened AND a fetched page happened to carry the row.
+      host.keepSelectedOption.set(false);
+      host.control.setValue('4242');
+      fixture.detectChanges();
+      expect(input().value).toBe('4242');
+
+      host.staticOptions.set([{ label: 'archived-user', value: '4242' }]);
+      fixture.detectChanges();
+
+      expect(input().value).toBe('archived-user');
     });
 
     it('leaves the dropdown to the source', () => {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.html
@@ -56,7 +56,7 @@
       class="tn-autocomplete__listbox"
       role="listbox"
       [attr.id]="uid + '-dropdown'"
-      [attr.aria-busy]="loading() ? true : null"
+      [attr.aria-busy]="resolvedLoading() ? true : null"
       (scroll)="onPanelScroll($event)">
       @if (hasResults()) {
         @for (option of filteredOptions(); track $index) {
@@ -68,6 +68,7 @@
             [tnTestId]="optionTestIdParts(option)"
             [class.highlighted]="highlightedIndex() === $index"
             [class.disabled]="option.disabled"
+            [class.tn-autocomplete__option--action]="option === actionOption()"
             [attr.id]="uid + '-option-' + $index"
             [attr.aria-selected]="isOptionSelected(option)"
             [attr.aria-disabled]="option.disabled ? true : null"
@@ -81,7 +82,7 @@
     </div>
 
     <div role="status">
-      @if (loading()) {
+      @if (resolvedLoading()) {
         <div
           class="tn-autocomplete__loading"
           tnTestIdType="autocomplete"
@@ -89,7 +90,7 @@
           <tn-spinner [diameter]="16" [strokeWidth]="2" [ariaLabel]="resolvedLoadingText()" />
           <span>{{ resolvedLoadingText() }}</span>
         </div>
-      } @else if (!hasResults()) {
+      } @else if (!hasMatches()) {
         <div
           class="tn-autocomplete__no-results"
           tnTestIdType="autocomplete"

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -100,6 +100,16 @@
     cursor: not-allowed;
     opacity: 0.6;
   }
+
+  // The pinned action row is not one of the results — separate it from them
+  // and carry the accent so it reads as a command, not a match. The accent is
+  // `--tn-primary-text`, not `--tn-primary`: this is text, and the panel is
+  // `--tn-bg2`, which is exactly the surface that token guarantees 4.5:1 on.
+  &--action {
+    border-bottom: 1px solid var(--tn-lines, #dee2e6);
+    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
+    font-weight: 500;
+  }
 }
 
 .tn-autocomplete__no-results {

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.scss
@@ -101,13 +101,20 @@
     opacity: 0.6;
   }
 
-  // The pinned action row is not one of the results — separate it from them
-  // and carry the accent so it reads as a command, not a match. The accent is
-  // `--tn-primary-text`, not `--tn-primary`: this is text, and the panel is
-  // `--tn-bg2`, which is exactly the surface that token guarantees 4.5:1 on.
+  // The pinned action row is not one of the results — the separator and the
+  // heavier weight are what say so.
+  //
+  // Deliberately NOT the accent colour. This row hovers and keyboard-highlights
+  // like any other, so it also paints on `--tn-alt-bg2` / `--tn-alt-bg1`, and
+  // `--tn-primary-text` is tuned for `--tn-bg1` / `--tn-bg2` only: on those two
+  // fills it measures 2.37:1 to 4.23:1 across the shipped palettes, under the
+  // 4.5:1 this repo holds normal text to. A keyboard user reaches that state
+  // with one ArrowDown, since `open()` highlights index 0 and this row is
+  // always index 0. Keeping `--tn-fg1` is what makes the row legible in every
+  // state it can be in — see the same hazard recorded for `tn-menu` in
+  // `primary-text-contrast.spec.ts`.
   &--action {
     border-bottom: 1px solid var(--tn-lines, #dee2e6);
-    color: var(--tn-primary-text, var(--tn-primary, #0074a7));
     font-weight: 500;
   }
 }

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -1064,6 +1064,36 @@ describe('TnAutocompleteComponent', () => {
       expect(getAsyncInput().value).toBe('beta');
     });
 
+    it('forgets the previous option label once a custom value is committed', () => {
+      // The remembered label belongs to the option that WAS selected. Left in
+      // place, every path that re-derives the text from the committed value
+      // preferred it over the custom value: Escape repainted `beta` over
+      // `zzz`, and the next blur read `beta` back and silently committed the
+      // option it names over the text the user actually typed.
+      getAsyncInput().dispatchEvent(new Event('focus'));
+      asyncFixture.detectChanges();
+      const overlay = TestBed.inject(OverlayContainer).getContainerElement();
+      (Array.from(overlay.querySelectorAll('.tn-autocomplete__option'))
+        .find((option) => option.textContent?.trim() === 'beta') as HTMLElement).click();
+      asyncFixture.detectChanges();
+      expect(asyncHost.control.value).toBe('beta');
+
+      typeAsync('zzz');
+      getAsyncInput().dispatchEvent(new Event('blur'));
+      asyncFixture.detectChanges();
+      expect(asyncHost.control.value).toBe('zzz');
+
+      getAsyncInput().dispatchEvent(new Event('focus'));
+      asyncFixture.detectChanges();
+      getAsyncInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      asyncFixture.detectChanges();
+      expect(getAsyncInput().value).toBe('zzz');
+
+      getAsyncInput().dispatchEvent(new Event('blur'));
+      asyncFixture.detectChanges();
+      expect(asyncHost.control.value).toBe('zzz');
+    });
+
     it('clears the value when the text is emptied', () => {
       asyncHost.control.setValue('beta');
       asyncFixture.detectChanges();

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -153,7 +153,13 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * page is fetched; see {@link options}.
    *
    * The first page is fetched when the panel first opens, not on init, so a
-   * form full of pickers issues no queries until one is actually used.
+   * form full of pickers issues no queries until one is actually used. Binding
+   * a source that is `undefined` at that moment is fine — the field fetches as
+   * soon as one arrives, open panel included.
+   *
+   * Swapping one source function for ANOTHER is not a signal to refetch, since
+   * a source is expected to be a stable function reading live configuration.
+   * Call {@link refreshOptions} when that configuration moves.
    *
    * @example
    * ```html

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -182,6 +182,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * `maxResults` cap, and choosing it emits {@link actionSelected} and closes
    * the panel **without** touching the form control, so no placeholder
    * sentinel is ever committed to the value.
+   *
+   * **Must be a stable reference.** The row is recognized by identity, so the
+   * obvious call site — `[actionOption]="{ label: 'Add ' + term, value: null }"`
+   * — builds a new object on every change-detection pass, re-firing the input,
+   * invalidating the filtered rows and marking the component dirty again. Hold
+   * it in a field, or derive it with `computed()`.
    */
   actionOption = input<TnAutocompleteOption<T> | undefined>(undefined);
 
@@ -303,9 +309,15 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /**
    * Emits when the open dropdown is scrolled near its bottom — append the
    * next page to `options` (and use `loading` while it fetches). Suppressed
-   * until the `options` COUNT changes so a slow consumer is not spammed —
-   * which also means replacing the array with a same-length page (e.g. a
-   * fixed-size window) does not re-arm the emitter; pagination must append.
+   * until the row COUNT changes so a slow consumer is not spammed — which also
+   * means replacing the array with a same-length page (e.g. a fixed-size
+   * window) does not re-arm the emitter; pagination must append.
+   *
+   * With a `[dataSource]` bound the count read is the resolved one (the
+   * fetched pages), and the latch is also released when a request settles, so
+   * a page that FAILED does not leave scrolling dead. The output still fires
+   * either way: it is for a host paging `options` itself, so do not wire both
+   * — the source already pages, and the two together fetch each page twice.
    */
   loadMore = output<void>();
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -25,6 +25,7 @@ import type { TnSelectOption } from '../select/select.component';
 import { TnSpinnerComponent } from '../spinner/spinner.component';
 import { TnTestIdDirective, controlTestId, optionTestId, scopeTestId, type TnTestIdValue } from '../test-id';
 import { injectTnLabels } from '../utils/inject-labels';
+import { createTnOptionsDataSource, type TnAsyncOptionsHost, type TnOptionsFetchFn } from '../utils/options-data-source';
 
 /**
  * Option shape for `tn-autocomplete` — the `label` is displayed, the `value`
@@ -85,7 +86,7 @@ export const TN_AUTOCOMPLETE_LABELS = new InjectionToken<TnAutocompleteLabels | 
   templateUrl: './autocomplete.component.html',
   styleUrl: './autocomplete.component.scss',
 })
-export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor, OnDestroy {
+export class TnAutocompleteComponent<T = unknown> implements ControlValueAccessor, TnAsyncOptionsHost, OnDestroy {
   private readonly elementRef = inject(ElementRef);
   private readonly overlay = inject(Overlay);
   private readonly viewContainerRef = inject(ViewContainerRef);
@@ -98,6 +99,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * to the form control. A written value is resolved back to its option's
    * label for display — falling back to `String(value)` until the matching
    * option is available, and upgraded once an async option load lands.
+   *
+   * With a `[dataSource]` bound these are not listed in the dropdown, which is
+   * the source's, but they still NAME a value: pass the options a host already
+   * holds labels for — the ids on the record being edited — and the field
+   * reads them as names from the moment it renders, rather than as raw numbers
+   * until someone opens it.
    */
   options = input<TnAutocompleteOption<T>[]>([]);
 
@@ -133,8 +140,63 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   allowCustomValue = input<boolean>(false);
 
   /**
+   * Server-driven options: a function of `(query, page)` returning one page of
+   * matches. Binding it hands the component the whole async lifecycle —
+   * debounced search, request cancellation, the paging cursor, exhaustion,
+   * error recovery and the loading state — so a consumer no longer writes a
+   * `searchChange` → subject → `switchMap` → `options` pipeline of its own.
+   *
+   * While set, the source is the only origin of DROPDOWN rows and the
+   * client-side filter is skipped, since the server already filtered — pass an
+   * explicit `[filterFn]` to filter the fetched page on top. `[options]` stays
+   * a source of LABELS, for values the host can already name before the first
+   * page is fetched; see {@link options}.
+   *
+   * The first page is fetched when the panel first opens, not on init, so a
+   * form full of pickers issues no queries until one is actually used.
+   *
+   * @example
+   * ```html
+   * <tn-autocomplete [dataSource]="userOptions" [pageSize]="50" />
+   * ```
+   * ```ts
+   * userOptions: TnOptionsFetchFn<string> =
+   *   (query, page) => this.api.searchUsers(query, page * 50);
+   * ```
+   */
+  dataSource = input<TnOptionsFetchFn<TnAutocompleteOption<T>> | undefined>(undefined);
+
+  /** Debounce applied to typing before `dataSource` is queried, in ms. */
+  dataSourceDebounce = input<number>(250);
+
+  /**
+   * Rows `dataSource` returns per page. Used to detect exhaustion — a short
+   * page is the last one — so scrolling past the end stops querying rather
+   * than issuing requests at a growing offset that can only return nothing.
+   */
+  pageSize = input<number>(50);
+
+  /**
+   * A row pinned above the results that performs an action instead of
+   * selecting a value — "Add New…" and friends. It survives filtering and the
+   * `maxResults` cap, and choosing it emits {@link actionSelected} and closes
+   * the panel **without** touching the form control, so no placeholder
+   * sentinel is ever committed to the value.
+   */
+  actionOption = input<TnAutocompleteOption<T> | undefined>(undefined);
+
+  /**
+   * Keep the committed value listed even when the page on screen does not
+   * contain it — a value sorted past the first page, or one just created that
+   * the query does not match yet. Without it such a field renders blank for a
+   * perfectly valid value. Only applies with `dataSource` bound.
+   */
+  keepSelectedOption = input<boolean>(true);
+
+  /**
    * Show a loading row in the dropdown panel while options are being fetched.
-   * Pair with `searchChange`/`loadMore` for server-driven options.
+   * Pair with `searchChange`/`loadMore` for server-driven options. Redundant
+   * with `dataSource`, which drives this state itself; the two are OR-ed.
    */
   loading = input<boolean>(false);
 
@@ -225,6 +287,20 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   searchChange = output<string>();
 
   /**
+   * Emits when {@link actionOption} is chosen. No value is committed and the
+   * panel closes; the consumer runs whatever the row promises (typically
+   * opening a create form) and can then write the new value to the control.
+   */
+  actionSelected = output<void>();
+
+  /**
+   * Emits once per failed `dataSource` request. The component recovers on its
+   * own — the stream stays alive and the failed term stays retryable — so this
+   * is purely for the app to report the failure the way it reports others.
+   */
+  dataSourceError = output<unknown>();
+
+  /**
    * Emits when the open dropdown is scrolled near its bottom — append the
    * next page to `options` (and use `loading` while it fetches). Suppressed
    * until the `options` COUNT changes so a slow consumer is not spammed —
@@ -264,33 +340,170 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** The currently committed value (an option's `value`, or a custom-typed one) */
   private selectedValue = signal<T | null>(null);
 
+  /**
+   * Label of the option the value was chosen from, remembered so
+   * `keepSelectedOption` can re-list it with its real text after a search
+   * replaced the page it came from. Null for a programmatic write, whose
+   * label is not known until an option carrying it arrives.
+   */
+  private selectedLabel = signal<string | null>(null);
+
   /** CVA disabled state from the form */
   private formDisabled = signal(false);
 
   /** Combined disabled state */
   isDisabled = computed(() => this.disabled() || this.formDisabled());
 
-  /** Filtered and capped options */
-  protected filteredOptions = computed(() => {
-    const term = this.searchTerm();
-    const all = this.options();
-    const customFilter = this.filterFn();
-    const max = this.maxResults();
-
-    if (!term) {
-      return all.slice(0, max);
-    }
-
-    const lowerTerm = term.toLowerCase();
-    const filtered = customFilter
-      ? all.filter((opt) => customFilter(opt, term))
-      : all.filter((opt) => opt.label.toLowerCase().includes(lowerTerm));
-
-    return filtered.slice(0, max);
+  /** Async engine backing `dataSource`; idle while no source is bound. */
+  private readonly asyncOptions = createTnOptionsDataSource<TnAutocompleteOption<T>>({
+    source: this.dataSource,
+    debounceMs: this.dataSourceDebounce,
+    pageSize: this.pageSize,
+    identity: (option) => option.value,
+    onError: (error) => this.dataSourceError.emit(error),
+    // Release the paging latch on every round trip. The count-change re-arm
+    // below cannot do it for a page that FAILED — no rows arrive, so the count
+    // never moves and every later scroll would be suppressed, leaving the
+    // field unable to retry the page it just lost.
+    onSettled: () => {
+      this.loadMorePending = false;
+    },
   });
 
-  /** Whether there are any results to show */
+  /**
+   * The synthetic row that keeps a committed value listed while the pages
+   * fetched so far do not contain it, or `undefined`.
+   *
+   * Held separately from {@link resolvedOptions} so {@link filteredOptions} can
+   * recognize it and pin it past the `maxResults` cap, the way the action row
+   * is pinned. Appended and then sliced with everything else, a full page
+   * filled the cap and cut off the one row this exists to guarantee.
+   */
+  private readonly keptSelectedOption = computed<TnAutocompleteOption<T> | undefined>(() => {
+    if (!this.dataSource() || !this.keepSelectedOption()) {
+      return undefined;
+    }
+
+    const value = this.selectedValue();
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (this.asyncOptions.options().some((option) => this.valueMatches(option.value, value))) {
+      return undefined;
+    }
+    // The committed value is not on the current page — keep it listed so the
+    // field shows its label rather than rendering blank. A host-pinned row can
+    // name it even before the first page lands, which is the whole point of
+    // `options` alongside a source.
+    const pinned = this.pinnedOptions().find((option) => this.valueMatches(option.value, value));
+    return { label: pinned?.label ?? this.selectedLabel() ?? String(value), value };
+  });
+
+  /**
+   * Rows the host named itself, honoured even while a `dataSource` is bound.
+   *
+   * With a source the dropdown is the server's to fill — but its first page is
+   * not fetched until the field is focused, so a value the host already holds
+   * the label for renders as its raw `String(value)` until someone opens the
+   * panel. An edit form bound to an id shows the number. `options` is how that
+   * label is supplied, so it stays part of the LOOKUP even where it is not
+   * part of the dropdown. `tn-chip-input` treats its own `options` the same
+   * way, and the asymmetry was a bug rather than a design.
+   */
+  private readonly pinnedOptions = computed<TnAutocompleteOption<T>[]>(
+    () => (this.dataSource() ? this.options() : []),
+  );
+
+  /**
+   * The rows to work from: the async engine's when `dataSource` is bound,
+   * the `options` input otherwise. Everything that resolves a value to a
+   * label, matches typed text, or counts rows reads this rather than
+   * `options` — the action row is deliberately absent, since it carries no
+   * selectable value.
+   */
+  private readonly resolvedOptions = computed<TnAutocompleteOption<T>[]>(() => {
+    if (!this.dataSource()) {
+      return this.options();
+    }
+
+    const fetched = this.asyncOptions.options();
+    const kept = this.keptSelectedOption();
+    return kept ? [...fetched, kept] : fetched;
+  });
+
+  /**
+   * The rows a value may be resolved to a label FROM — everything in
+   * {@link resolvedOptions} except the synthetic kept row.
+   *
+   * That row exists to keep a committed value listed, and its label is the
+   * display text itself: `String(value)` for a value nothing has named yet.
+   * Resolving against it therefore always "succeeds", which would report the
+   * raw fallback as a resolved label and leave it on screen for good.
+   */
+  private readonly resolvableOptions = computed<TnAutocompleteOption<T>[]>(() => {
+    if (!this.dataSource()) {
+      return this.options();
+    }
+    // Fetched rows first: every reader takes the FIRST match, so a value in
+    // both lists resolves to the server's row rather than the host's, which
+    // may be a stale name the record was saved with.
+    const pinned = this.pinnedOptions();
+    const fetched = this.asyncOptions.options();
+    return pinned.length ? [...fetched, ...pinned] : fetched;
+  });
+
+  /** Loading state: the `loading` input OR-ed with the async engine's. */
+  protected readonly resolvedLoading = computed(() => this.loading() || this.asyncOptions.loading());
+
+  /** Filtered and capped options, with {@link actionOption} pinned on top. */
+  protected filteredOptions = computed(() => {
+    const term = this.searchTerm();
+    const all = this.resolvedOptions();
+    const customFilter = this.filterFn();
+    const max = this.maxResults();
+    const action = this.actionOption();
+
+    // A server-driven source already applied the query; filtering again on the
+    // label would hide rows matched on some other field, and would drop the
+    // action row the moment the user typed.
+    const isPreFiltered = !!this.dataSource() && !customFilter;
+
+    let filtered: TnAutocompleteOption<T>[];
+    if (!term || isPreFiltered) {
+      filtered = all;
+    } else if (customFilter) {
+      filtered = all.filter((opt) => customFilter(opt, term));
+    } else {
+      const lowerTerm = term.toLowerCase();
+      filtered = all.filter((opt) => opt.label.toLowerCase().includes(lowerTerm));
+    }
+
+    // `maxResults` caps the rows the source returned, not the two rows that are
+    // there by construction: the action row is pinned on top after the slice,
+    // and the kept-selected row — always last, appended by `resolvedOptions` —
+    // is held back across it.
+    const kept = this.keptSelectedOption();
+    const capped = kept && filtered.at(-1) === kept
+      ? [...filtered.slice(0, -1).slice(0, max), kept]
+      : filtered.slice(0, max);
+    return action ? [action, ...capped] : capped;
+  });
+
+  /** Whether there are any rows to render (the action row counts). */
   protected hasResults = computed(() => this.filteredOptions().length > 0);
+
+  /**
+   * Whether the query matched anything selectable. Distinct from
+   * {@link hasResults} so a search that found nothing still says so, rather
+   * than being masked by a pinned action row — or by the kept-selected row,
+   * which is held on screen for the committed value regardless of the query.
+   */
+  protected hasMatches = computed(() => {
+    const kept = this.keptSelectedOption();
+    return this.filteredOptions().some(
+      (option) => !this.isActionOption(option) && option !== kept,
+    );
+  });
 
   private onChange = (_value: T | null) => {};
   private onTouched = () => {};
@@ -311,8 +524,35 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   /** Scroll distance (px) from the panel bottom that triggers `loadMore`. */
   private static readonly loadMoreThresholdPx = 48;
 
+  /**
+   * Cap on how many pages the underfill check may request without the user
+   * scrolling, per search. The check re-arms whenever the option count
+   * changes, which a `dataSource` answering synchronously does within the same
+   * change-detection pass — so an inexhaustible source would spin the tab
+   * rather than yield between rounds. Well beyond any real panel's capacity
+   * (20 × a 50-row page), so it only ever trips on a misbehaving source.
+   */
+  private static readonly maxAutoFillPages = 20;
+
+  /** Underfill-driven pages requested since the last search or panel open. */
+  private autoFillCount = 0;
+
   /** Guards the object-without-compareWith warning so it fires only once. */
   private warnedAboutObjectCompare = false;
+
+  /**
+   * Whether the text on screen is the raw `String(value)` fallback rather than
+   * an option's label — i.e. the value has never resolved and the user has not
+   * typed over it.
+   *
+   * The upgrade effect otherwise leaves an open panel alone, on the grounds
+   * that the text belongs to the user's search. With a `dataSource` that never
+   * holds: rows only ever arrive while the panel is open, so a written value
+   * would keep the fallback as its display text for good — and
+   * `allowCustomValue` would then commit that text back over the real value on
+   * blur. This says the text is nobody's draft, so upgrading it is safe.
+   */
+  private displayIsFallback = false;
 
   constructor() {
     // A value written before its option loaded displays as the raw fallback —
@@ -320,21 +560,27 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     // the text to the option's label. UPGRADE-ONLY: when no option matches
     // (e.g. a server-search picker replaced `options` after a selection), the
     // current text is left alone rather than downgraded back to the raw
-    // value. Skipped while the panel is open so active typing isn't clobbered.
+    // value. While the panel is open the text is the user's search and is left
+    // alone — unless it is still the untouched fallback, which is the only
+    // state a `dataSource` field's rows can ever reach it in.
+    // `isOpen` is a dependency rather than an `untracked` read so that closing
+    // the panel re-runs the resolution over whatever the search left behind.
     effect(() => {
-      this.options();
+      this.resolvedOptions();
       this.compareWith();
+      this.isOpen();
       untracked(() => {
-        if (this.isOpen()) {
+        if (this.isOpen() && !this.displayIsFallback) {
           return;
         }
         const value = this.selectedValue();
         if (value === null || value === undefined) {
           return;
         }
-        const match = this.options().find((opt) => this.valueMatches(opt.value, value));
+        const match = this.resolvableOptions().find((opt) => this.valueMatches(opt.value, value));
         if (match) {
           this.searchTerm.set(match.label);
+          this.displayIsFallback = false;
         }
       });
     });
@@ -351,9 +597,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     // underfill check would be skipped (checkUnderfill bails while loading)
     // and never re-run.
     effect(() => {
-      const count = this.options().length;
+      const count = this.resolvedOptions().length;
       this.isOpen();
-      this.loading();
+      this.resolvedLoading();
       untracked(() => {
         if (count !== this.lastOptionsCount) {
           this.lastOptionsCount = count;
@@ -367,7 +613,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     // event; nudge CDK so the anchored position tracks the new height.
     effect(() => {
       this.filteredOptions();
-      this.loading();
+      this.resolvedLoading();
       this.overlayRef?.updatePosition();
     });
 
@@ -392,11 +638,11 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
   writeValue(value: T | null): void {
     this.selectedValue.set(value);
-    if (value !== null && value !== undefined) {
-      this.searchTerm.set(this.displayValue(value));
-    } else {
-      this.searchTerm.set('');
-    }
+    // A programmatic write says nothing about the option's label — drop the
+    // remembered one so `keepSelectedOption` doesn't relabel the new value
+    // with the previous selection's text.
+    this.selectedLabel.set(null);
+    this.setDisplayFromValue(value);
   }
 
   registerOnChange(fn: (value: T | null) => void): void {
@@ -411,13 +657,56 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     this.formDisabled.set(isDisabled);
   }
 
+  // ── Async options ──
+
+  /**
+   * Discard the pages fetched from `dataSource` and re-query the current term.
+   *
+   * For a caller whose `[dataSource]` is a fixed function reading live
+   * configuration — the shape that keeps the source from being swapped out
+   * from under a search in flight — this is how a change to that configuration
+   * takes effect, rather than waiting for the next keystroke to notice.
+   */
+  refreshOptions(): void {
+    // Both latches belong to the result set being thrown away; left set, they
+    // would suppress the first `loadMore` of the one replacing it.
+    this.loadMorePending = false;
+    this.autoFillCount = 0;
+    this.asyncOptions.refresh();
+    if (this.isOpen()) {
+      // Rows are on screen and clickable right now, so they have to be
+      // replaced at once. A closed panel refetches when it next opens — the
+      // `prime` there is no longer answered from the invalidated pages.
+      this.asyncOptions.prime();
+    }
+  }
+
+  /**
+   * Commit an option programmatically, its label included.
+   *
+   * `writeValue` deliberately forgets the label — the forms layer hands over a
+   * value and nothing else — so a value the host picked itself would render as
+   * `String(value)` until a search happened to return the row carrying it.
+   * This is the path for a caller that already holds the option.
+   */
+  setSelectedOption(option: TnAutocompleteOption<T>): void {
+    this.selectedValue.set(option.value);
+    this.selectedLabel.set(option.label);
+    this.searchTerm.set(option.label);
+    this.displayIsFallback = false;
+  }
+
   // ── Event handlers ──
 
   onInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.searchTerm.set(value);
+    // The text is the user's now, whatever it was before this keystroke.
+    this.displayIsFallback = false;
     // A new term is a new pagination context — don't hold back its first page.
     this.loadMorePending = false;
+    this.autoFillCount = 0;
+    this.asyncOptions.search(value);
     this.searchChange.emit(value);
 
     if (!this.isOpen()) {
@@ -448,7 +737,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
     if (this.requireSelection()) {
       const term = this.searchTerm();
-      const match = this.options().find(
+      const match = this.resolvedOptions().find(
         (opt) => !opt.disabled && opt.label.toLowerCase() === term.toLowerCase()
       );
 
@@ -457,10 +746,8 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       } else {
         // Revert to last valid selection or clear
         const current = this.selectedValue();
-        if (current !== null && current !== undefined) {
-          this.searchTerm.set(this.displayValue(current));
-        } else {
-          this.searchTerm.set('');
+        this.setDisplayFromValue(current);
+        if (current === null || current === undefined) {
           this.onChange(null);
         }
       }
@@ -474,7 +761,28 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     if (option.disabled) {
       return;
     }
+    if (this.isActionOption(option)) {
+      this.runAction();
+      return;
+    }
     this.selectOption(option);
+  }
+
+  /** Whether `option` is the pinned {@link actionOption} row rather than a value. */
+  private isActionOption(option: TnAutocompleteOption<T>): boolean {
+    return option === this.actionOption();
+  }
+
+  /**
+   * The action row was chosen: close the panel and hand off, leaving the
+   * committed value and the text exactly as they were. Restoring the text
+   * matters because the user has usually typed a partial term to find the
+   * row — that draft must not survive as a value.
+   */
+  private runAction(): void {
+    this.setDisplayFromValue(this.selectedValue());
+    this.close();
+    this.actionSelected.emit();
   }
 
   onKeydown(event: KeyboardEvent): void {
@@ -509,7 +817,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
         event.preventDefault();
         const idx = this.highlightedIndex();
         if (this.isOpen() && idx >= 0 && idx < options.length && !options[idx].disabled) {
-          this.selectOption(options[idx]);
+          this.onOptionClick(options[idx]);
         } else if (this.allowCustomValue()) {
           this.commitCustomValue();
           this.close();
@@ -522,10 +830,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
         if (this.allowCustomValue()) {
           // Escape means "cancel the draft": revert to the committed value's
           // text so the upcoming blur doesn't commit the abandoned term.
-          const current = this.selectedValue();
-          this.searchTerm.set(
-            current !== null && current !== undefined ? this.displayValue(current) : ''
-          );
+          this.setDisplayFromValue(this.selectedValue());
         }
         this.close();
         break;
@@ -540,7 +845,10 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * opens), emit once more if the panel has no scrollbar.
    */
   private checkUnderfill(): void {
-    if (!this.isOpen() || this.loading() || this.loadMorePending) {
+    if (!this.isOpen() || this.resolvedLoading() || this.loadMorePending) {
+      return;
+    }
+    if (this.autoFillCount >= TnAutocompleteComponent.maxAutoFillPages) {
       return;
     }
     // No rows to measure, or rendering is capped by maxResults — more data
@@ -560,23 +868,33 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     const panel = this.overlayRef?.overlayElement
       ?.querySelector<HTMLElement>('.tn-autocomplete__listbox');
     if (panel && panel.scrollHeight <= panel.clientHeight) {
-      this.loadMorePending = true;
-      this.loadMore.emit();
+      this.autoFillCount++;
+      this.requestMore();
     }
+  }
+
+  /**
+   * Ask for another page: the internal engine when `dataSource` is bound, the
+   * consumer via `loadMore` otherwise. Both are notified — an app can page a
+   * `dataSource` and still observe the event.
+   */
+  private requestMore(): void {
+    this.loadMorePending = true;
+    this.asyncOptions.loadMore();
+    this.loadMore.emit();
   }
 
   onPanelScroll(event: Event): void {
     // While loading, the rendered rows belong to the previous page/term —
     // scrolling them must not request a page of data that hasn't landed yet.
-    if (this.loadMorePending || this.loading()) {
+    if (this.loadMorePending || this.resolvedLoading()) {
       return;
     }
     const el = event.target as HTMLElement;
     const nearBottom = el.scrollTop + el.clientHeight
       >= el.scrollHeight - TnAutocompleteComponent.loadMoreThresholdPx;
     if (nearBottom) {
-      this.loadMorePending = true;
-      this.loadMore.emit();
+      this.requestMore();
     }
   }
 
@@ -662,7 +980,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   private commitCustomValue(): void {
     const term = this.searchTerm();
     const lowerTerm = term.toLowerCase();
-    const match = this.options().find(
+    const match = this.resolvedOptions().find(
       (opt) => !opt.disabled && opt.label.toLowerCase() === lowerTerm
     );
     if (match) {
@@ -671,7 +989,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     }
     // Best-effort guard: silent when options haven't loaded yet (the common
     // async + allowCustomValue case), where the value type can't be known.
-    if (isDevMode() && term !== '' && this.options().some((opt) => typeof opt.value !== 'string')) {
+    if (isDevMode() && term !== '' && this.resolvedOptions().some((opt) => typeof opt.value !== 'string')) {
       console.warn(
         '[tn-autocomplete] allowCustomValue committed free text into a control whose option '
         + 'values are not strings — custom values are only sound for string-valued autocompletes.'
@@ -683,12 +1001,26 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   }
 
   /**
-   * Resolves a committed value back to its option's display label, falling
-   * back to the raw value's string until the matching option is available.
+   * Show `value`'s label and record whether that text is a real label or the
+   * raw `String(value)` fallback, so {@link displayIsFallback} — and with it
+   * the upgrade effect — can tell a resolved display from an unresolved one.
+   * Every path that re-derives the text from the committed value goes through
+   * here, so the two can never disagree.
+   *
+   * A label remembered from the option the value was picked from counts as
+   * resolved: it is the same text the option would give, and the row carrying
+   * it may well have been paged away since.
    */
-  private displayValue(value: T): string {
-    const match = this.options().find((opt) => this.valueMatches(opt.value, value));
-    return match ? match.label : String(value);
+  private setDisplayFromValue(value: T | null): void {
+    if (value === null || value === undefined) {
+      this.searchTerm.set('');
+      this.displayIsFallback = false;
+      return;
+    }
+    const match = this.resolvableOptions().find((opt) => this.valueMatches(opt.value, value));
+    const remembered = this.selectedLabel();
+    this.searchTerm.set(match?.label ?? remembered ?? String(value));
+    this.displayIsFallback = !match && remembered === null;
   }
 
   /**
@@ -723,7 +1055,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
   private selectOption(option: TnAutocompleteOption<T>): void {
     this.selectedValue.set(option.value);
+    this.selectedLabel.set(option.label);
     this.searchTerm.set(option.label);
+    this.displayIsFallback = false;
     this.onChange(option.value);
     this.optionSelected.emit(option);
     this.close();
@@ -734,6 +1068,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       return;
     }
     this.isOpen.set(true);
+    this.autoFillCount = 0;
+    // Fetch the first page the first time the panel is shown. Deferring to
+    // here (rather than init) means a form of pickers costs nothing until one
+    // is used; `prime` is a no-op on every later open, so reopening does not
+    // refetch what is already listed.
+    this.asyncOptions.prime();
     // Seed the keyboard cursor on the committed option so ArrowDown resumes
     // from the current value (and it scrolls into view). -1 when nothing is
     // committed or the value has no visible, enabled option — e.g. a custom

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -705,13 +705,29 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * `writeValue` deliberately forgets the label — the forms layer hands over a
    * value and nothing else — so a value the host picked itself would render as
    * `String(value)` until a search happened to return the row carrying it.
-   * This is the path for a caller that already holds the option.
+   * This is the path for a caller that already holds the option: the
+   * `actionOption` handoff, where `(actionSelected)` creates an entity and the
+   * host hands the new row straight back.
+   *
+   * It COMMITS, form control included. Updating only the display left the
+   * field showing the new label, marking that row selected, and the bound
+   * control still holding the previous value — which is what a submit then
+   * sent. (With `requireSelection` and `keepSelectedOption` together, blur
+   * happened to find the label on the synthetic kept row and reconcile it
+   * through `selectOption`; on the default path nothing ever did.)
+   *
+   * `optionSelected` deliberately does NOT fire: that output means the user
+   * picked a row, and this is the host telling the component what the host
+   * already decided — echoing it back to the caller that made the call would
+   * be noise. A host keeping a side model in sync updates it where it calls
+   * this, not from the output.
    */
   setSelectedOption(option: TnAutocompleteOption<T>): void {
     this.selectedValue.set(option.value);
     this.selectedLabel.set(option.label);
     this.searchTerm.set(option.label);
     this.displayIsFallback = false;
+    this.onChange(option.value);
   }
 
   // ── Event handlers ──

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -427,6 +427,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * label is supplied, so it stays part of the LOOKUP even where it is not
    * part of the dropdown. `tn-chip-input` treats its own `options` the same
    * way, and the asymmetry was a bug rather than a design.
+   *
+   * Reached through {@link resolvableOptions} for display and
+   * {@link matchableOptions} for matching, so `commitCustomValue` and the
+   * `requireSelection` branch of `onBlur` recognise a pinned label too.
+   * Painting from a list wider than the one it reads back is the bug this
+   * shape exists to avoid.
    */
   private readonly pinnedOptions = computed<TnAutocompleteOption<T>[]>(
     () => (this.dataSource() ? this.options() : []),
@@ -450,8 +456,9 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
   });
 
   /**
-   * The rows a value may be resolved to a label FROM — everything in
-   * {@link resolvedOptions} except the synthetic kept row.
+   * The rows a value may be resolved to a label FROM — the fetched pages plus
+   * the host-pinned {@link pinnedOptions}, and never the synthetic kept row.
+   * {@link matchableOptions} is the other direction.
    *
    * That row exists to keep a committed value listed, and its label is the
    * display text itself: `String(value)` for a value nothing has named yet.
@@ -468,6 +475,36 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     const pinned = this.pinnedOptions();
     const fetched = this.asyncOptions.options();
     return pinned.length ? [...fetched, ...pinned] : fetched;
+  });
+
+  /**
+   * The rows typed text may be matched BACK to a value by: every label this
+   * field puts in front of the user, so that anything it PAINTS it also READS.
+   *
+   * {@link resolvableOptions} for the labels a value can be resolved from,
+   * plus the synthetic kept row — which the two lists on either side each drop
+   * for a reason that does not apply here:
+   *
+   * - {@link resolvedOptions} omits the host-pinned rows, since the dropdown
+   *   under a source is the server's to fill. But a pinned row is exactly how a
+   *   host names a value the pages do not carry, so matching without it painted
+   *   `g-7` as `admins` and then committed the raw string `'admins'` over the
+   *   id it names. That is the asymmetry `tn-chip-input` closed by pointing
+   *   `commitText` at its `labelOptions`.
+   * - {@link resolvableOptions} omits the kept row, because resolving a VALUE
+   *   against it always "succeeds" and would report its `String(value)`
+   *   fallback as a real label. Matching a LABEL against it is the opposite
+   *   case: the row is listed, the user can click it, and its label may be one
+   *   remembered from the option the value was picked from. Dropping it would
+   *   turn "type the text you can see, then blur" into a free-text commit of
+   *   that text over the value it stands for.
+   *
+   * Order is the usual precedence — the server's rows, then the host's, then
+   * the synthetic one — and every reader takes the first match.
+   */
+  private readonly matchableOptions = computed<TnAutocompleteOption<T>[]>(() => {
+    const kept = this.keptSelectedOption();
+    return kept ? [...this.resolvableOptions(), kept] : this.resolvableOptions();
   });
 
   /** Loading state: the `loading` input OR-ed with the async engine's. */
@@ -771,7 +808,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
 
     if (this.requireSelection()) {
       const term = this.searchTerm();
-      const match = this.resolvedOptions().find(
+      // {@link matchableOptions}, not {@link resolvedOptions}: the labels the
+      // field is willing to PAINT are the ones it has to read back. Matching
+      // the narrower list left a host-pinned label unrecognised, so typing the
+      // exact name the field itself displays reverted the term instead of
+      // resolving it.
+      const match = this.matchableOptions().find(
         (opt) => !opt.disabled && opt.label.toLowerCase() === term.toLowerCase()
       );
 
@@ -1010,11 +1052,18 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * display match (case-insensitive, same as the requireSelection path)
    * commits the matching option instead, so picking an existing entry by
    * typing its full text behaves like clicking it.
+   *
+   * Matched against {@link matchableOptions} so the host-pinned rows count:
+   * with `[dataSource]` + `[options]` the field painted `g-7` as `admins` and
+   * then, on a page that did not carry that row, committed the raw string
+   * `'admins'` over the id it names — a label it would not read back. Same
+   * asymmetry `tn-chip-input` closed by pointing `commitText` at its
+   * `labelOptions`.
    */
   private commitCustomValue(): void {
     const term = this.searchTerm();
     const lowerTerm = term.toLowerCase();
-    const match = this.resolvedOptions().find(
+    const match = this.matchableOptions().find(
       (opt) => !opt.disabled && opt.label.toLowerCase() === lowerTerm
     );
     if (match) {
@@ -1023,7 +1072,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     }
     // Best-effort guard: silent when options haven't loaded yet (the common
     // async + allowCustomValue case), where the value type can't be known.
-    if (isDevMode() && term !== '' && this.resolvedOptions().some((opt) => typeof opt.value !== 'string')) {
+    if (isDevMode() && term !== '' && this.matchableOptions().some((opt) => typeof opt.value !== 'string')) {
       console.warn(
         '[tn-autocomplete] allowCustomValue committed free text into a control whose option '
         + 'values are not strings — custom values are only sound for string-valued autocompletes.'

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -621,7 +621,11 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     // `isOpen` is a dependency rather than an `untracked` read so that closing
     // the panel re-runs the resolution over whatever the search left behind.
     effect(() => {
-      this.resolvedOptions();
+      // Track the list this resolves FROM. `resolvedOptions` is not the same
+      // list: with `[keepSelectedOption]="false"` its kept-row branch returns
+      // before reading `pinnedOptions`, so `options` would not be a dependency
+      // and a late-arriving host label would never upgrade the raw fallback.
+      this.resolvableOptions();
       this.compareWith();
       this.isOpen();
       untracked(() => {
@@ -1080,6 +1084,12 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     }
     const value = term === '' ? null : (term as unknown as T);
     this.selectedValue.set(value);
+    // The remembered label belongs to the option that WAS selected; a custom
+    // value came from no option, so keeping it would let `setDisplayFromValue`
+    // repaint the old name over the user's text — and the next blur would read
+    // that name back and commit the option it belongs to. `writeValue` clears
+    // it for the same reason.
+    this.selectedLabel.set(null);
     this.onChange(value);
   }
 

--- a/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/truenas-ui/src/lib/autocomplete/autocomplete.component.ts
@@ -826,7 +826,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
       } else {
         // Revert to last valid selection or clear
         const current = this.selectedValue();
-        this.setDisplayFromValue(current);
+        this.revertDisplayToValue(current);
         if (current === null || current === undefined) {
           this.onChange(null);
         }
@@ -860,7 +860,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
    * row — that draft must not survive as a value.
    */
   private runAction(): void {
-    this.setDisplayFromValue(this.selectedValue());
+    this.revertDisplayToValue(this.selectedValue());
     this.close();
     this.actionSelected.emit();
   }
@@ -910,7 +910,7 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
         if (this.allowCustomValue()) {
           // Escape means "cancel the draft": revert to the committed value's
           // text so the upcoming blur doesn't commit the abandoned term.
-          this.setDisplayFromValue(this.selectedValue());
+          this.revertDisplayToValue(this.selectedValue());
         }
         this.close();
         break;
@@ -1114,6 +1114,33 @@ export class TnAutocompleteComponent<T = unknown> implements ControlValueAccesso
     const remembered = this.selectedLabel();
     this.searchTerm.set(match?.label ?? remembered ?? String(value));
     this.displayIsFallback = !match && remembered === null;
+  }
+
+  /**
+   * Abandon the draft term: repaint `value`'s label AND tell the async engine
+   * the term is gone.
+   *
+   * `asyncOptions.search()` is otherwise only reached from `onInput`, so every
+   * path that rewrites the text WITHOUT the user typing — the `requireSelection`
+   * revert on blur, the `allowCustomValue` Escape branch, and `runAction` —
+   * moved the display while the engine kept the query, the rows and the
+   * `primed` latch of the term walked away from. Reopening then showed that
+   * term's results (or "No results found") against a field displaying something
+   * else, and issued nothing to correct it: `open()` only calls `prime()`,
+   * which is a documented no-op once primed.
+   *
+   * `tn-chip-input.clearInput()` closes the same gap the same way. The request
+   * goes through the usual debounce, and the duplicate-term guard drops it
+   * entirely when the reverted text is the term already loaded — which is the
+   * common case of an Escape with no draft typed.
+   *
+   * `writeValue` deliberately does NOT come through here: a programmatic write
+   * is not a user abandoning a search, and querying there would break the rule
+   * that a field nobody has opened issues no request.
+   */
+  private revertDisplayToValue(value: T | null): void {
+    this.setDisplayFromValue(value);
+    this.asyncOptions.search(this.searchTerm());
   }
 
   /**

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -41,6 +41,34 @@ class ChipDataSourceHostComponent {
   errors: unknown[] = [];
 }
 
+/**
+ * `[options]` bound ALONGSIDE `[dataSource]`: how a host names the values it
+ * already holds, so a form loaded with ids paints names before anything has
+ * been fetched. `allowCustomValue` is false because that is what the docs tell
+ * value-mode callers to use — and the setting under which failing to match a
+ * pinned label loses the text outright.
+ */
+@Component({
+  selector: 'tn-chip-pinned-labels-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-chip-input
+      [formControl]="control"
+      [dataSource]="source"
+      [dataSourceDebounce]="250"
+      [options]="pinned"
+      [allowCustomValue]="false" />
+  `,
+})
+class ChipPinnedLabelsHostComponent {
+  control = new FormControl<string[]>(['g-7']);
+  readonly pinned: Option[] = [{ label: 'admins', value: 'g-7' }];
+  responder: () => Observable<Option[]> = () => of([]);
+  readonly source: TnOptionsFetchFn<Option> = () => this.responder();
+}
+
 describe('tn-chip-input [dataSource]', () => {
   let fixture: ComponentFixture<ChipDataSourceHostComponent>;
   let host: ChipDataSourceHostComponent;
@@ -363,6 +391,62 @@ describe('tn-chip-input [dataSource]', () => {
     expect(renderedSuggestions()).toEqual(['admins', 'analysts']);
   });
 
+  it('shows the loading row on the cold first fetch, with no rows behind it', () => {
+    // The first fetch is the one most likely to be slow, and it was the one
+    // with no cue at all: `onFocus` primes and then syncs against a suggestion
+    // list that is still empty, so the panel closed and stayed detached for
+    // the whole round trip — no spinner, no `aria-busy`, nothing.
+    const pending = new Subject<Option[]>();
+    responder = () => pending;
+
+    focus();
+
+    expect(renderedSuggestions()).toEqual([]);
+    expect(loadingRow()?.textContent).toContain('Loading...');
+    expect(listbox()?.getAttribute('aria-busy')).toBe('true');
+
+    pending.next([{ label: 'admins', value: 'admins' }]);
+    pending.complete();
+    fixture.detectChanges();
+
+    expect(renderedSuggestions()).toEqual(['admins']);
+    expect(loadingRow()).toBeNull();
+  });
+
+  it('retracts the loading-only panel when the cold fetch lands empty', () => {
+    // Holding the panel open for the round trip must not resurrect the empty
+    // bordered box: once the request settles with nothing, it closes as it
+    // does for any other empty result.
+    const pending = new Subject<Option[]>();
+    responder = () => pending;
+    focus();
+    expect(loadingRow()).not.toBeNull();
+
+    pending.next([]);
+    pending.complete();
+    fixture.detectChanges();
+
+    expect(listbox()).toBeNull();
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('shows the loading row for a term typed after one that matched nothing', () => {
+    // The panel is shut when the keystroke lands, so `onInput`'s sync cannot
+    // open it; the request only goes out a debounce later. Without the
+    // re-open effect tracking `loading`, that second search ran uncued too.
+    focus();
+    responder = () => of([]);
+    type('zzz');
+    expect(listbox()).toBeNull();
+
+    const pending = new Subject<Option[]>();
+    responder = () => pending;
+    type('zzzz');
+
+    expect(renderedSuggestions()).toEqual([]);
+    expect(loadingRow()?.textContent).toContain('Loading...');
+  });
+
   it('reports a failure and keeps the field usable', () => {
     let failing = true;
     responder = (query) => (failing
@@ -376,5 +460,77 @@ describe('tn-chip-input [dataSource]', () => {
     type('ops');
 
     expect(renderedSuggestions()).toEqual(['ops']);
+  });
+});
+
+describe('tn-chip-input [dataSource] with pinned [options]', () => {
+  let fixture: ComponentFixture<ChipPinnedLabelsHostComponent>;
+  let overlayEl: HTMLElement;
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  }
+
+  function chipLabels(): string[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.tn-chip__label'))
+      .map((label) => (label as HTMLElement).textContent?.trim() ?? '');
+  }
+
+  function commit(text: string): void {
+    input().value = text;
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChipPinnedLabelsHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipPinnedLabelsHostComponent);
+    overlayEl = TestBed.inject(OverlayContainer).getContainerElement();
+    fixture.detectChanges();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    TestBed.inject(OverlayContainer).ngOnDestroy();
+  });
+
+  it('paints a pinned label before anything has been fetched', () => {
+    expect(chipLabels()).toEqual(['admins']);
+  });
+
+  it('reads back a label it painted, even with no page holding that row', () => {
+    // The asymmetry this closes: the field rendered `g-7` as `admins`, then
+    // refused to recognise `admins` when it was typed. Under
+    // `allowCustomValue="false"` the text was dropped on the floor; under the
+    // default `true` it was committed raw, next to the chip it duplicates.
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    fixture.componentInstance.control.setValue([]);
+    fixture.detectChanges();
+
+    commit('admins');
+
+    expect(fixture.componentInstance.control.value).toEqual(['g-7']);
+    expect(chipLabels()).toEqual(['admins']);
+  });
+
+  it('keeps the pinned rows out of the dropdown', () => {
+    // They are labels for values the host already holds, not results: the
+    // server ordered and filtered what the panel shows, and splicing these in
+    // would append the same entries to every term.
+    fixture.componentInstance.responder = () => of([{ label: 'builders', value: 'g-9' }]);
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+
+    expect(Array.from(overlayEl.querySelectorAll('.tn-chip-input__option'))
+      .map((option) => option.textContent?.trim())).toEqual(['builders']);
   });
 });

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -297,6 +297,35 @@ describe('tn-chip-input [dataSource]', () => {
     expect(input().getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('fetches a source that binds while the panel is already open', () => {
+    // `prime` is only called on focus, so a source arriving late — a resolver,
+    // a sibling field's signal — left an open field with nothing to ask. The
+    // chip input reaches a worse state than the autocomplete here: it renders
+    // no no-results row, so the empty bordered `role="listbox"` just stays
+    // attached under `aria-expanded="true"`.
+    host.source.set(undefined);
+    fixture.detectChanges();
+
+    focus();
+    expect(queries).toEqual([]);
+
+    host.source.set(source);
+    fixture.detectChanges();
+
+    expect(queries).toEqual(['']);
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts', 'builders']);
+  });
+
+  it('still issues nothing for a field nobody has focused', () => {
+    host.source.set(undefined);
+    fixture.detectChanges();
+
+    host.source.set(source);
+    fixture.detectChanges();
+
+    expect(queries).toEqual([]);
+  });
+
   it('reports a failure and keeps the field usable', () => {
     let failing = true;
     responder = (query) => (failing

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -1,0 +1,271 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Subject, of, throwError } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { TnChipInputComponent } from './chip-input.component';
+import type { TnChipInputOption } from './chip-input.component';
+import type { TnOptionsFetchFn } from '../utils/options-data-source';
+
+/**
+ * `[dataSource]` — server-driven suggestions for `tn-chip-input`.
+ *
+ * The same engine `tn-autocomplete` uses, minus paging: the chip dropdown shows
+ * one page. What it removes from consumers is the `(searchChange)` → subject →
+ * `debounceTime` → `switchMap` → `catchError` → `shareReplay` pipeline that
+ * every user/group chip field in the app had written out by hand.
+ */
+
+type Option = TnChipInputOption<string>;
+
+@Component({
+  selector: 'tn-chip-data-source-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-chip-input
+      [formControl]="control"
+      [dataSource]="source()"
+      [dataSourceDebounce]="250"
+      [suggestions]="staticSuggestions()"
+      (dataSourceError)="errors.push($event)" />
+  `,
+})
+class ChipDataSourceHostComponent {
+  control = new FormControl<string[]>([]);
+  staticSuggestions = signal<string[]>([]);
+  source = signal<TnOptionsFetchFn<Option> | undefined>(undefined);
+  errors: unknown[] = [];
+}
+
+describe('tn-chip-input [dataSource]', () => {
+  let fixture: ComponentFixture<ChipDataSourceHostComponent>;
+  let host: ChipDataSourceHostComponent;
+  let overlayEl: HTMLElement;
+
+  let queries: string[];
+  let responder: (query: string) => Observable<Option[]>;
+
+  const source: TnOptionsFetchFn<Option> = (query) => {
+    queries.push(query);
+    return responder(query);
+  };
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  }
+
+  function renderedSuggestions(): string[] {
+    return Array.from(overlayEl.querySelectorAll('.tn-chip-input__option'))
+      .map((option) => option.textContent?.trim() ?? '');
+  }
+
+  function listbox(): HTMLElement | null {
+    return overlayEl.querySelector('.tn-chip-input__listbox');
+  }
+
+  function loadingRow(): HTMLElement | null {
+    return overlayEl.querySelector('.tn-chip-input__loading');
+  }
+
+  function focus(): void {
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+  }
+
+  function type(text: string): void {
+    input().value = text;
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    queries = [];
+    responder = (query) => of(
+      ['admins', 'analysts', 'builders']
+        .filter((name) => name.startsWith(query))
+        .map((name) => ({ label: name, value: name })),
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [ChipDataSourceHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipDataSourceHostComponent);
+    host = fixture.componentInstance;
+    overlayEl = TestBed.inject(OverlayContainer).getContainerElement();
+    host.source.set(source);
+    fixture.detectChanges();
+
+    // The library is zoneless, so `fakeAsync`/`tick` are unavailable.
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    TestBed.inject(OverlayContainer).ngOnDestroy();
+  });
+
+  it('does not query until the field is first focused', () => {
+    expect(queries).toEqual([]);
+
+    focus();
+
+    expect(queries).toEqual(['']);
+  });
+
+  it('opens the panel on the first page fetched at focus', () => {
+    // A static suggestion list drops the panel open on focus; an async one has
+    // nothing to show at that instant, so it has to open when the page lands.
+    focus();
+
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts', 'builders']);
+  });
+
+  it('debounces typing into a single query for the final term', () => {
+    focus();
+    queries = [];
+
+    input().value = 'a';
+    input().dispatchEvent(new Event('input'));
+    jest.advanceTimersByTime(100);
+    input().value = 'an';
+    input().dispatchEvent(new Event('input'));
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    expect(queries).toEqual(['an']);
+  });
+
+  it('renders the fetched page without filtering it again on the label', () => {
+    // The server already applied the query; a second client-side pass would
+    // drop rows it matched on some other field.
+    responder = () => of([{ label: 'ACME\\ops', value: 'ops' }]);
+    focus();
+    type('ops');
+
+    expect(renderedSuggestions()).toEqual(['ACME\\ops']);
+  });
+
+  it('supersedes [suggestions] while bound', () => {
+    host.staticSuggestions.set(['static']);
+    fixture.detectChanges();
+
+    focus();
+
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts', 'builders']);
+  });
+
+  it('still hides an option already committed as a chip', () => {
+    host.control.setValue(['admins']);
+    fixture.detectChanges();
+
+    focus();
+
+    expect(renderedSuggestions()).toEqual(['analysts', 'builders']);
+  });
+
+  it('marks the dropdown busy while a request is in flight', () => {
+    // With a `dataSource` the rows are NOT re-filtered on the label, so between
+    // the keystroke and the response the panel is showing the PREVIOUS term's
+    // matches — clickable, and indistinguishable from a result set. The
+    // autocomplete has said so with a spinner and `aria-busy` since it grew a
+    // `dataSource`; this had no equivalent.
+    const pending = new Subject<Option[]>();
+    focus();
+    expect(loadingRow()).toBeNull();
+
+    responder = () => pending;
+    type('ana');
+
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts', 'builders']);
+    expect(listbox()?.getAttribute('aria-busy')).toBe('true');
+    expect(loadingRow()?.textContent).toContain('Loading...');
+
+    pending.next([{ label: 'analysts', value: 'analysts' }]);
+    pending.complete();
+    fixture.detectChanges();
+
+    expect(renderedSuggestions()).toEqual(['analysts']);
+    expect(listbox()?.getAttribute('aria-busy')).toBeNull();
+    expect(loadingRow()).toBeNull();
+  });
+
+  it('leaves the panel closed after a chip is committed', () => {
+    // Committing changes the suggestion list — the chosen row drops out — which
+    // re-runs the effect that re-opens the panel when results arrive. With a
+    // `dataSource` bound the field counts as "actively searching" even on an
+    // empty input, so the panel sprang straight back open against a blank
+    // field, still listing the rows of the term just committed. The static
+    // path never did this: there, the empty input ends the search.
+    focus();
+    type('a');
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts']);
+
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    expect(host.control.value).toEqual(['a']);
+    expect(renderedSuggestions()).toEqual([]);
+  });
+
+  it('re-opens on the next keystroke after a commit', () => {
+    focus();
+    type('a');
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    type('b');
+
+    expect(renderedSuggestions()).toEqual(['builders']);
+  });
+
+  describe('refreshOptions()', () => {
+    function component(): TnChipInputComponent<string> {
+      return fixture.debugElement.children[0].componentInstance as TnChipInputComponent<string>;
+    }
+
+    it('re-queries the current term instead of being suppressed as a duplicate', () => {
+      focus();
+      type('a');
+      queries = [];
+      responder = () => of([{ label: 'narrowed', value: 'narrowed' }]);
+
+      component().refreshOptions();
+      fixture.detectChanges();
+
+      expect(queries).toEqual(['a']);
+      expect(renderedSuggestions()).toEqual(['narrowed']);
+    });
+
+    it('does not query for a field that has never been focused', () => {
+      component().refreshOptions();
+      fixture.detectChanges();
+      expect(queries).toEqual([]);
+
+      focus();
+
+      expect(queries).toEqual(['']);
+    });
+  });
+
+  it('reports a failure and keeps the field usable', () => {
+    let failing = true;
+    responder = (query) => (failing
+      ? throwError(() => new Error('boom'))
+      : of([{ label: query, value: query }]));
+
+    focus();
+    expect(host.errors).toHaveLength(1);
+
+    failing = false;
+    type('ops');
+
+    expect(renderedSuggestions()).toEqual(['ops']);
+  });
+});

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -214,6 +214,30 @@ describe('tn-chip-input [dataSource]', () => {
     expect(renderedSuggestions()).toEqual([]);
   });
 
+  it('re-queries with an empty term once a chip is committed', () => {
+    // Committing cleared the text but not the ENGINE's term, so the rows on
+    // hand stayed the committed term's. Blur and refocus and the panel opened
+    // on those rows against an empty field — where the static path shows
+    // everything. One request per commit, not one per keystroke: it goes
+    // through the same debounce as typing.
+    focus();
+    type('a');
+    queries = [];
+
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    expect(queries).toEqual(['']);
+
+    input().dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    focus();
+
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts', 'builders']);
+  });
+
   it('re-opens on the next keystroke after a commit', () => {
     focus();
     type('a');

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -278,6 +278,25 @@ describe('tn-chip-input [dataSource]', () => {
     });
   });
 
+  it('closes the panel when a search comes back with nothing', () => {
+    // With a source bound the rows are NOT re-filtered on the label, so
+    // `onInput` runs its sync against the previous term's rows — still there,
+    // still matching — and leaves the panel open. Nothing then retracted it
+    // when the response landed empty: a bordered box with an empty
+    // `role="listbox"` stayed attached under `aria-expanded="true"` until the
+    // next keystroke or blur. `tn-autocomplete` renders a no-results row
+    // instead; this has no equivalent, so it has to close.
+    focus();
+    type('a');
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts']);
+
+    responder = () => of([]);
+    type('zzz');
+
+    expect(listbox()).toBeNull();
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('reports a failure and keeps the field usable', () => {
     let failing = true;
     responder = (query) => (failing

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -326,6 +326,43 @@ describe('tn-chip-input [dataSource]', () => {
     expect(queries).toEqual([]);
   });
 
+  it('leaves the panel dismissed when Escape lands mid-request', () => {
+    // Escape is a third deliberate close, alongside blur and the post-commit
+    // one, and it was the only one nothing guarded: the response landing after
+    // it reached `syncDropdownAfterFetch`, which OPENS. Focus stays in the
+    // field, so this put the panel back under the user and defeated Escape for
+    // the whole in-flight window. The ARIA combobox pattern is that Escape
+    // dismisses the popup and it stays dismissed.
+    const pending = new Subject<Option[]>();
+    focus();
+    responder = () => pending;
+
+    input().value = 'an';
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+    expect(listbox()).toBeNull();
+
+    jest.advanceTimersByTime(250);
+    pending.next([{ label: 'analysts', value: 'analysts' }]);
+    pending.complete();
+    fixture.detectChanges();
+
+    expect(listbox()).toBeNull();
+  });
+
+  it('re-arms the panel on the next keystroke after Escape', () => {
+    // The dismissal is until the term next changes, not for good.
+    focus();
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+
+    type('a');
+
+    expect(renderedSuggestions()).toEqual(['admins', 'analysts']);
+  });
+
   it('reports a failure and keeps the field usable', () => {
     let failing = true;
     responder = (query) => (failing

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-data-source.spec.ts
@@ -69,6 +69,28 @@ class ChipPinnedLabelsHostComponent {
   readonly source: TnOptionsFetchFn<Option> = () => this.responder();
 }
 
+/**
+ * A `[dataSource]` with NO pinned `[options]`: the fetched page is the only
+ * list a chip's label can come from, and it is replaced on the next search.
+ */
+@Component({
+  selector: 'tn-chip-remembered-label-host',
+  standalone: true,
+  imports: [TnChipInputComponent, ReactiveFormsModule],
+  // eslint-disable-next-line @angular-eslint/component-max-inline-declarations
+  template: `
+    <tn-chip-input
+      [formControl]="control"
+      [dataSource]="source"
+      [dataSourceDebounce]="250" />
+  `,
+})
+class ChipRememberedLabelHostComponent {
+  control = new FormControl<string[]>([]);
+  responder: (query: string) => Observable<Option[]> = () => of([]);
+  readonly source: TnOptionsFetchFn<Option> = (query) => this.responder(query);
+}
+
 describe('tn-chip-input [dataSource]', () => {
   let fixture: ComponentFixture<ChipDataSourceHostComponent>;
   let host: ChipDataSourceHostComponent;
@@ -532,5 +554,132 @@ describe('tn-chip-input [dataSource] with pinned [options]', () => {
 
     expect(Array.from(overlayEl.querySelectorAll('.tn-chip-input__option'))
       .map((option) => option.textContent?.trim())).toEqual(['builders']);
+  });
+});
+
+
+describe('tn-chip-input [dataSource] label memory', () => {
+  let fixture: ComponentFixture<ChipRememberedLabelHostComponent>;
+  let host: ChipRememberedLabelHostComponent;
+  let overlayEl: HTMLElement;
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  }
+
+  function chipLabels(): string[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('.tn-chip__label'))
+      .map((label) => (label as HTMLElement).textContent?.trim() ?? '');
+  }
+
+  function focus(): void {
+    input().dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+  }
+
+  function type(text: string): void {
+    input().value = text;
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+  }
+
+  function pressEnter(): void {
+    input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChipRememberedLabelHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipRememberedLabelHostComponent);
+    host = fixture.componentInstance;
+    overlayEl = TestBed.inject(OverlayContainer).getContainerElement();
+    host.responder = (query) => of(
+      [{ label: 'admins', value: 'g-7' }, { label: 'developers', value: 'g-9' }]
+        .filter((option) => option.label.startsWith(query)),
+    );
+    fixture.detectChanges();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    TestBed.inject(OverlayContainer).ngOnDestroy();
+  });
+
+  /** Click the fetched row carrying `label`. */
+  function pickSuggestion(label: string): void {
+    const row = Array.from(overlayEl.querySelectorAll('.tn-chip-input__option'))
+      .find((option) => option.textContent?.trim() === label) as HTMLElement;
+    row.click();
+    fixture.detectChanges();
+  }
+
+  it('keeps a picked chip named after the page carrying its row is replaced', () => {
+    // The page is the ONLY list this chip's label can be resolved from, and the
+    // next query replaces it. Without remembering the label the value was
+    // committed from, a chip the user picked a keystroke ago reverted to its
+    // raw id — the exact failure `[options]` fixes for values the HOST already
+    // knows, but for one the FIELD itself painted, where no host binding can
+    // help.
+    focus();
+    pickSuggestion('admins');
+    expect(host.control.value).toEqual(['g-7']);
+    expect(chipLabels()).toEqual(['admins']);
+
+    type('dev');
+
+    expect(chipLabels()).toEqual(['admins']);
+  });
+
+  it('reads that remembered label back rather than duplicating it as free text', () => {
+    // Paint/read symmetry: a label the field is still willing to SHOW is one it
+    // has to RECOGNISE. With the row paged away and nothing remembering it,
+    // typing the name on the chip resolved to no option and was committed as
+    // the raw string `admins`, beside the `g-7` chip it already names.
+    focus();
+    pickSuggestion('admins');
+
+    host.responder = () => of([]);
+    type('admins');
+    expect(chipLabels()).toEqual(['admins']);
+    pressEnter();
+
+    // Recognised as the chip already committed, so the duplicate guard drops it.
+    expect(host.control.value).toEqual(['g-7']);
+  });
+
+  it('forgets the label once its chip is gone', () => {
+    // The memory is bounded by the chips on screen. A label no longer painted
+    // must not keep being read back, or removing a chip and retyping its name
+    // would resurrect a value the field no longer offers.
+    focus();
+    pickSuggestion('admins');
+    (fixture.nativeElement.querySelector('.tn-chip__close') as HTMLElement).click();
+    fixture.detectChanges();
+    expect(host.control.value).toEqual([]);
+
+    host.responder = () => of([]);
+    type('admins');
+    pressEnter();
+
+    expect(host.control.value).toEqual(['admins']);
+  });
+
+  it('lets a fetched row win over the remembered name', () => {
+    // Remembered labels are consulted LAST: a name the server has since changed
+    // must not be pinned to the screen by the fact that it was once picked.
+    focus();
+    pickSuggestion('admins');
+    expect(chipLabels()).toEqual(['admins']);
+
+    host.responder = () => of([{ label: 'administrators', value: 'g-7' }]);
+    type('admin');
+
+    expect(chipLabels()).toEqual(['administrators']);
   });
 });

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-labels.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-labels.spec.ts
@@ -15,8 +15,8 @@ import type { TnOptionsFetchFn } from '../utils/options-data-source';
  * a signal-valued token re-renders when the app switches language.
  *
  * `loading` is the only label the chip input has, and it is on screen only
- * while a `dataSource` request is in flight — so every case here opens the
- * panel on a page that lands, then leaves a second request hanging.
+ * while a `dataSource` request is in flight — so every case here leaves a
+ * request hanging rather than answering it.
  */
 
 type Option = TnChipInputOption<string>;
@@ -54,7 +54,8 @@ describe('TnChipInputComponent labels', () => {
 
   /**
    * Open the panel on a page that lands, then type into a request that never
-   * answers — which is the only state the loading row is rendered in.
+   * answers — one of the states the loading row is rendered in, and the one
+   * that exercises the label against rows already on screen.
    */
   function loadingText(): string {
     const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;

--- a/projects/truenas-ui/src/lib/chip-input/chip-input-labels.spec.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input-labels.spec.ts
@@ -1,0 +1,113 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { TnChipInputComponent, TN_CHIP_INPUT_LABELS, type TnChipInputLabels } from './chip-input.component';
+import type { TnChipInputOption } from './chip-input.component';
+import type { TnOptionsFetchFn } from '../utils/options-data-source';
+
+/**
+ * The app-wide label default for `tn-chip-input` — the twin of
+ * `autocomplete-labels.spec.ts`. No binding renders whatever
+ * `TN_CHIP_INPUT_LABELS` supplies, an explicit `[loadingText]` still wins, and
+ * a signal-valued token re-renders when the app switches language.
+ *
+ * `loading` is the only label the chip input has, and it is on screen only
+ * while a `dataSource` request is in flight — so every case here opens the
+ * panel on a page that lands, then leaves a second request hanging.
+ */
+
+type Option = TnChipInputOption<string>;
+
+@Component({
+  selector: 'tn-chip-input-labels-host',
+  standalone: true,
+  imports: [TnChipInputComponent],
+  template: `
+    <tn-chip-input [dataSource]="source" [dataSourceDebounce]="250" [loadingText]="loadingText()" />
+  `,
+})
+class LabelsHostComponent {
+  loadingText = signal<string | undefined>(undefined);
+  responder: () => Observable<Option[]> = () => of([{ label: 'admins', value: 'admins' }]);
+  readonly source: TnOptionsFetchFn<Option> = () => this.responder();
+}
+
+describe('TnChipInputComponent labels', () => {
+  const french: TnChipInputLabels = { loading: 'Chargement…' };
+
+  let fixture: ComponentFixture<LabelsHostComponent>;
+
+  function setup(
+    labels?: TnChipInputLabels | ReturnType<typeof signal<TnChipInputLabels>>,
+  ): void {
+    TestBed.configureTestingModule({
+      imports: [LabelsHostComponent],
+      providers: labels ? [{ provide: TN_CHIP_INPUT_LABELS, useValue: labels }] : [],
+    });
+    fixture = TestBed.createComponent(LabelsHostComponent);
+    fixture.detectChanges();
+    jest.useFakeTimers();
+  }
+
+  /**
+   * Open the panel on a page that lands, then type into a request that never
+   * answers — which is the only state the loading row is rendered in.
+   */
+  function loadingText(): string {
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    input.dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+
+    fixture.componentInstance.responder = () => new Subject<Option[]>();
+    input.value = 'a';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    jest.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    const row = TestBed.inject(OverlayContainer).getContainerElement()
+      .querySelector('.tn-chip-input__loading');
+    return row?.textContent?.trim() ?? '';
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+    TestBed.inject(OverlayContainer).ngOnDestroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('falls back to the English default when no token is provided', () => {
+    setup();
+
+    expect(loadingText()).toContain('Loading...');
+  });
+
+  it('renders the app-wide text from a plain-object token', () => {
+    setup(french);
+
+    expect(loadingText()).toContain('Chargement…');
+  });
+
+  it('lets an explicit [loadingText] win over the token', () => {
+    setup(french);
+    fixture.componentInstance.loadingText.set('Searching the directory…');
+    fixture.detectChanges();
+
+    expect(loadingText()).toContain('Searching the directory…');
+  });
+
+  it('re-renders when a signal-valued token changes, so a language switch propagates', () => {
+    const labels = signal<TnChipInputLabels>({ loading: 'Loading...' });
+    setup(labels);
+    expect(loadingText()).toContain('Loading...');
+
+    labels.set(french);
+    fixture.detectChanges();
+
+    expect(TestBed.inject(OverlayContainer).getContainerElement()
+      .querySelector('.tn-chip-input__loading')?.textContent).toContain('Chargement…');
+  });
+});

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.html
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.html
@@ -48,31 +48,51 @@
 <!-- Suggestion dropdown — portaled via CDK overlay so it escapes ancestor
      overflow/clipping. Attach/detach is driven by open()/close(). -->
 <ng-template #dropdownTemplate>
-  <div
-    class="tn-chip-input__dropdown"
-    role="listbox"
-    [attr.id]="uid + '-listbox'"
-  >
-    @for (suggestion of filteredSuggestions(); track $index) {
-      <!-- Options are tabindex="-1" and never focused: keyboard selection goes
-           through the input's aria-activedescendant + the Enter branch in
-           onKeydown, so a key handler here would be dead code. Click is a
-           pointer-only affordance. -->
-      <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
-      <div
-        class="tn-chip-input__option"
-        role="option"
-        tabindex="-1"
-        tnTestIdType="option"
-        [tnTestId]="suggestionTestId(suggestion)"
-        [class.highlighted]="highlightedIndex() === $index"
-        [attr.id]="uid + '-option-' + $index"
-        [attr.aria-selected]="highlightedIndex() === $index"
-        (mousedown)="onSuggestionMousedown($event)"
-        (click)="onSuggestionClick(suggestion)"
-      >
-        {{ suggestion.label }}
-      </div>
-    }
+  <div class="tn-chip-input__dropdown">
+    <!-- Per ARIA a listbox may only contain option children, so the loading row
+         lives OUTSIDE it as a live-region sibling. The listbox is also the
+         scrollport, which keeps that row pinned below the rows it describes
+         rather than scrolling away with them. -->
+    <div
+      class="tn-chip-input__listbox"
+      role="listbox"
+      [attr.id]="uid + '-listbox'"
+      [attr.aria-busy]="loading() ? true : null"
+    >
+      @for (suggestion of filteredSuggestions(); track $index) {
+        <!-- Options are tabindex="-1" and never focused: keyboard selection goes
+             through the input's aria-activedescendant + the Enter branch in
+             onKeydown, so a key handler here would be dead code. Click is a
+             pointer-only affordance. -->
+        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+        <div
+          class="tn-chip-input__option"
+          role="option"
+          tabindex="-1"
+          tnTestIdType="option"
+          [tnTestId]="suggestionTestId(suggestion)"
+          [class.highlighted]="highlightedIndex() === $index"
+          [attr.id]="uid + '-option-' + $index"
+          [attr.aria-selected]="highlightedIndex() === $index"
+          (mousedown)="onSuggestionMousedown($event)"
+          (click)="onSuggestionClick(suggestion)"
+        >
+          {{ suggestion.label }}
+        </div>
+      }
+    </div>
+
+    <div role="status">
+      @if (loading()) {
+        <div
+          class="tn-chip-input__loading"
+          tnTestIdType="chip-input"
+          [tnTestId]="statusTestIdParts('loading')"
+        >
+          <tn-spinner [diameter]="16" [strokeWidth]="2" [ariaLabel]="resolvedLoadingText()" />
+          <span>{{ resolvedLoadingText() }}</span>
+        </div>
+      }
+    </div>
   </div>
 </ng-template>

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.scss
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.scss
@@ -52,13 +52,40 @@
 }
 
 .tn-chip-input__dropdown {
+  // The max-height is declared here and inherits, so it bounds the panel as a
+  // whole AND the listbox inside it — the listbox scrolls, and the status row
+  // below it stays outside the scrolling area.
+  //
+  // The column is what makes both of those true at once: the loading row is a
+  // SIBLING of the listbox, so a cap on the listbox alone lets the two of them
+  // together push past the panel's own max-height and paint below its border.
+  // Mirrors tn-autocomplete, where the same split lives.
+  display: flex;
+  flex-direction: column;
   max-height: var(--tn-chip-input-panel-max-height, 320px);
-  overflow-y: auto;
   background-color: var(--tn-bg1, #ffffff);
   border: 1px solid var(--tn-lines, #d1d5db);
   border-radius: 0.375rem;
   // Matches the tn-autocomplete dropdown shadow for visual consistency.
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.tn-chip-input__listbox {
+  max-height: inherit;
+  overflow-y: auto;
+  // A flex item floors at its content height. Without this the listbox refuses
+  // to shrink for the loading row and pushes it past the panel's max-height,
+  // outside the bordered box.
+  min-height: 0;
+}
+
+.tn-chip-input__loading {
+  align-items: center;
+  color: var(--tn-fg2, #6c757d);
+  display: flex;
+  font-size: 0.875rem;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .tn-chip-input__option {

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -376,8 +376,14 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * names values it already knows the labels for, so it stays part of the
    * lookup even where it is not part of the dropdown.
    *
-   * Deliberately not deduplicated: fetched rows come first, and both readers
-   * take the first match, so a value in both lists resolves to the server's row.
+   * Deliberately not deduplicated: fetched rows come first, and every reader
+   * takes the first match, so a value in both lists resolves to the server's row.
+   *
+   * Read by {@link commitText} as well, so the labels the field paints and the
+   * labels it accepts back are one set. Deliberately NOT read by
+   * {@link filteredSuggestions}: with a source bound the rows are shown as the
+   * server ordered and filtered them, and splicing the pinned rows in would
+   * append the same entries to every term's results, matching or not.
    */
   private readonly labelOptions = computed<TnChipInputOption<T>[]>(() => {
     const list = this.optionList();
@@ -439,6 +445,12 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     // close, which would otherwise re-open on the next option-set change.
     effect(() => {
       const hasMatches = this.filteredSuggestions().length > 0;
+      // A debounced search reaches the wire a quarter-second after the
+      // keystroke that called `syncDropdown`, so on a term whose predecessor
+      // matched nothing the panel is shut by the time the request goes out.
+      // Tracking `loading` here is what puts the in-flight cue on screen in
+      // that case; like everything else in this effect it only ever opens.
+      const busy = this.loading();
       untracked(() => {
         // With a `dataSource`, the first page is fetched on focus with an
         // empty term — so an empty field is still "searching" and its results
@@ -450,7 +462,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
           && (searchingEmpty || this.inputValue().trim() !== '')
           && this.canAddMore()
           && !this.isDisabled();
-        if (hasMatches && activelySearching && !this.closedByUser) {
+        if ((hasMatches || busy) && activelySearching && !this.closedByUser) {
           this.open();
         }
       });
@@ -708,13 +720,23 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     return event.key === 'Enter' || this.separatorKeys().includes(event.key);
   }
 
-  /** Commits typed text: resolve it to an option's value, else accept as custom. */
+  /**
+   * Commits typed text: resolve it to an option's value, else accept as custom.
+   *
+   * Matched against {@link labelOptions}, not the dropdown rows, so that every
+   * label the field is willing to PAINT it is also willing to READ back. With a
+   * `dataSource` bound, `options` names values the host already knows the
+   * labels for; a chip rendered as `admins` that this method did not recognise
+   * when `admins` was typed was silently dropped under
+   * `allowCustomValue="false"` and committed as the raw string under the
+   * default `true` — a second chip beside the one it duplicates.
+   */
   private commitText(raw: string): void {
     const text = (raw ?? '').trim();
     if (!text) {
       return;
     }
-    const match = this.optionList().find((option) => option.label.toLowerCase() === text.toLowerCase());
+    const match = this.labelOptions().find((option) => option.label.toLowerCase() === text.toLowerCase());
     if (match) {
       this.commitValue(match.value);
       return;
@@ -827,9 +849,17 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * Opens the dropdown when there is something to show, closes it otherwise.
    * Stays closed once the chip cap is reached — suggesting rows that
    * `commitValue()` would reject is misleading.
+   *
+   * A request in flight counts as something to show even with no rows behind
+   * it: the loading row is the only in-flight cue this field has, and the
+   * fetch most likely to be slow is the COLD one on first focus, where there
+   * is nothing to keep the panel open on its own. Without this the panel was
+   * detached for that whole round trip — no spinner, no `aria-busy` — and the
+   * empty listbox that carries the loading row cost no height.
    */
   private syncDropdown(): void {
-    if (this.filteredSuggestions().length > 0 && this.canAddMore() && !this.isDisabled()) {
+    const hasSomethingToShow = this.filteredSuggestions().length > 0 || this.loading();
+    if (hasSomethingToShow && this.canAddMore() && !this.isDisabled()) {
       this.open();
     } else {
       this.close();

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -760,6 +760,14 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   private clearInput(): void {
     this.inputValue.set('');
     this.inputEl().nativeElement.value = '';
+    // The engine has to be told the term is gone too, or it keeps the
+    // committed term's query and rows. `closedByCommit` hides that for the
+    // immediate re-open, but not for the next focus: blur, refocus, and the
+    // panel opens on the PREVIOUS term's matches against an empty field. An
+    // empty input means "show everything" on the static path, and this is what
+    // makes the async path agree. One request, not one per chip — it goes
+    // through the same debounce as typing.
+    this.asyncOptions.search('');
     this.closedByCommit = true;
     this.close();
   }

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -194,7 +194,14 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * The chip dropdown is not paged, so `page` is always 0 — the parameter is
    * there only so one source function can feed both this and `tn-autocomplete`.
    *
-   * The first query runs when the field is first focused, not on init.
+   * The first query runs when the field is first focused, not on init. Binding
+   * a source that is `undefined` at that moment is fine — the field fetches as
+   * soon as one arrives, open panel included.
+   *
+   * Swapping one source function for ANOTHER is not a signal to refetch: a
+   * source is expected to be a stable function reading live configuration,
+   * which is what keeps it from being replaced out from under a request in
+   * flight. Call `refreshOptions()` when that configuration moves.
    *
    * @example
    * ```html
@@ -335,6 +342,11 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * panel keeps showing the *previous* term's matches, clickable and looking
    * current, for the debounce plus the round trip. Without a cue that is
    * indistinguishable from "these are your results".
+   *
+   * It covers the ROUND TRIP only. The debounce window before it is
+   * deliberately left uncued: a spinner appearing and vanishing on every
+   * keystroke of a term that is still being typed is noise, and the request it
+   * would announce may never be sent.
    */
   protected readonly loading = computed(() => this.asyncOptions.loading());
 

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -406,25 +406,37 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   private overlaySubs: Subscription[] = [];
 
   /**
-   * Set when the panel was closed by a commit rather than by the user, and read
-   * by the re-open effect below.
+   * Set when the panel was closed deliberately — by committing a chip, or by
+   * Escape — and read by everything that would otherwise re-open it.
    *
-   * Committing a chip changes the suggestion list — the chosen row is now
-   * excluded — which re-runs that effect. On the static path the empty input
-   * makes `activelySearching` false and the close stands; with a `dataSource`
-   * bound, `searchingEmpty` holds regardless, so the panel sprang back open
-   * against an empty field, still listing the rows of the term just committed.
-   * Cleared by the next thing that is genuinely a search.
+   * Committing changes the suggestion list, since the chosen row is now
+   * excluded, which re-runs the effect below. On the static path the empty
+   * input makes `activelySearching` false and the close stands; with a
+   * `dataSource` bound, `searchingEmpty` holds regardless, so the panel sprang
+   * back open against an empty field, still listing the rows of the term just
+   * committed.
+   *
+   * Escape is here for the same reason and one more: a response landing after
+   * it reaches `syncDropdownAfterFetch`, which OPENS. Typing `an`, pressing
+   * Escape inside the 250 ms debounce, and waiting put the panel straight back
+   * with focus still in the field — Escape defeated for the whole in-flight
+   * window. The ARIA combobox pattern is that Escape dismisses the popup and it
+   * stays dismissed, so that was a keyboard and AT regression, not a cosmetic
+   * one.
+   *
+   * Cleared by the next thing that is genuinely a search, so typing re-arms the
+   * panel immediately.
    */
-  private closedByCommit = false;
+  private closedByUser = false;
 
   constructor() {
     // Async suggestions: when the user types, onInput runs syncDropdown()
     // against the still-stale list and leaves the panel closed; results land a
     // tick later via [suggestions]/[options]. Re-open the panel once fresh
     // matches arrive while the field is focused and actively searching. This
-    // only ever opens (never closes), so it doesn't fight Escape, blur, or the
-    // post-commit close — those stay shut until the option set next changes.
+    // only ever opens (never closes), so it doesn't fight blur — and the
+    // `closedByUser` latch is what keeps it off Escape and the post-commit
+    // close, which would otherwise re-open on the next option-set change.
     effect(() => {
       const hasMatches = this.filteredSuggestions().length > 0;
       untracked(() => {
@@ -438,7 +450,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
           && (searchingEmpty || this.inputValue().trim() !== '')
           && this.canAddMore()
           && !this.isDisabled();
-        if (hasMatches && activelySearching && !this.closedByCommit) {
+        if (hasMatches && activelySearching && !this.closedByUser) {
           this.open();
         }
       });
@@ -505,7 +517,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   protected onInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.inputValue.set(value);
-    this.closedByCommit = false;
+    this.closedByUser = false;
     this.asyncOptions.search(value);
     this.searchChange.emit(value);
     this.highlightedIndex.set(-1);
@@ -514,7 +526,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
 
   protected onFocus(): void {
     this.focused.set(true);
-    this.closedByCommit = false;
+    this.closedByUser = false;
     // Fetch the first page the first time the field is used, so a form of
     // chip inputs costs nothing until one is focused. A no-op thereafter.
     this.asyncOptions.prime();
@@ -563,6 +575,9 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     if (event.key === 'Escape') {
       if (this.isOpen()) {
         event.preventDefault();
+        // Latched, so neither the re-open effect nor a `dataSource` response
+        // still in flight can undo the dismissal. See {@link closedByUser}.
+        this.closedByUser = true;
         this.close();
       }
       return;
@@ -774,14 +789,14 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     this.inputValue.set('');
     this.inputEl().nativeElement.value = '';
     // The engine has to be told the term is gone too, or it keeps the
-    // committed term's query and rows. `closedByCommit` hides that for the
+    // committed term's query and rows. `closedByUser` hides that for the
     // immediate re-open, but not for the next focus: blur, refocus, and the
     // panel opens on the PREVIOUS term's matches against an empty field. An
     // empty input means "show everything" on the static path, and this is what
     // makes the async path agree. One request, not one per chip — it goes
     // through the same debounce as typing.
     this.asyncOptions.search('');
-    this.closedByCommit = true;
+    this.closedByUser = true;
     this.close();
   }
 
@@ -797,11 +812,12 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * static path never reaches that state, because there the label filter has
    * already emptied the list by the time `syncDropdown()` reads it.
    *
-   * Both guards are the post-commit and blur closes: this must not reopen a
-   * panel either of them just shut.
+   * The guards are every deliberate close: {@link closedByUser} covers the
+   * post-commit close and Escape, `focused()` covers blur. This must not reopen
+   * a panel any of them just shut.
    */
   private syncDropdownAfterFetch(): void {
-    if (this.closedByCommit || !this.focused()) {
+    if (this.closedByUser || !this.focused()) {
       return;
     }
     this.syncDropdown();

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -1,8 +1,9 @@
 import { Overlay, type OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import type { ElementRef, OnDestroy, TemplateRef } from '@angular/core';
+import type { ElementRef, OnDestroy, Signal, TemplateRef } from '@angular/core';
 import {
   Component,
+  InjectionToken,
   ViewContainerRef,
   computed,
   effect,
@@ -20,9 +21,12 @@ import type { Subscription } from 'rxjs';
 import { TnChipComponent } from '../chip/chip.component';
 import { injectTnFormFieldAria } from '../form-field/form-field-context';
 import type { TnSelectOption } from '../select/select.component';
+import { TnSpinnerComponent } from '../spinner/spinner.component';
 import {
   TnTestIdDirective, composeTestId, controlTestId, optionTestId, scopeTestId, type TnTestIdValue,
 } from '../test-id';
+import { injectTnLabels } from '../utils/inject-labels';
+import { createTnOptionsDataSource, type TnAsyncOptionsHost, type TnOptionsFetchFn } from '../utils/options-data-source';
 
 /**
  * Option shape for `tn-chip-input`'s value mode — the `label` is displayed on
@@ -31,6 +35,34 @@ import {
  * feed all three.
  */
 export type TnChipInputOption<T = unknown> = TnSelectOption<T>;
+
+/**
+ * Copy rendered inside `tn-chip-input` that is the same for every instance in
+ * an app. Provide {@link TN_CHIP_INPUT_LABELS} at the app root rather than
+ * repeating the identical string on each call site; the matching input on
+ * `<tn-chip-input>` still wins where one instance needs its own wording.
+ */
+export interface TnChipInputLabels {
+  /** Text shown next to the spinner while a `dataSource` request is in flight. */
+  loading: string;
+}
+
+/** English defaults used when no {@link TN_CHIP_INPUT_LABELS} provider is registered. */
+export const TN_CHIP_INPUT_DEFAULT_LABELS: TnChipInputLabels = {
+  loading: 'Loading...',
+};
+
+/**
+ * DI token for app-wide default labels. Provide either a static object or a
+ * `Signal<TnChipInputLabels>` — the latter lets every chip input react to
+ * language changes when the consumer wires it up to an i18n service.
+ *
+ * Explicit input bindings on `<tn-chip-input>` still win over these defaults.
+ */
+export const TN_CHIP_INPUT_LABELS = new InjectionToken<TnChipInputLabels | Signal<TnChipInputLabels>>(
+  'TN_CHIP_INPUT_LABELS',
+  { providedIn: 'root', factory: () => TN_CHIP_INPUT_DEFAULT_LABELS },
+);
 
 let nextId = 0;
 
@@ -77,7 +109,7 @@ let nextId = 0;
 @Component({
   selector: 'tn-chip-input',
   standalone: true,
-  imports: [TnChipComponent, TnTestIdDirective],
+  imports: [TnChipComponent, TnSpinnerComponent, TnTestIdDirective],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -88,7 +120,7 @@ let nextId = 0;
   templateUrl: './chip-input.component.html',
   styleUrl: './chip-input.component.scss',
 })
-export class TnChipInputComponent<T = string> implements ControlValueAccessor, OnDestroy {
+export class TnChipInputComponent<T = string> implements ControlValueAccessor, TnAsyncOptionsHost, OnDestroy {
   private readonly overlay = inject(Overlay);
   private readonly viewContainerRef = inject(ViewContainerRef);
 
@@ -144,8 +176,41 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
    * Value-mode option list (`{ label, value }`). When non-empty, chips display
    * the resolved `label` while the form model holds `value`s. Takes precedence
    * over `suggestions`. For async sources, update in response to `(searchChange)`.
+   *
+   * A bound `dataSource` supersedes these as the *suggestions*, but they are
+   * still read when labelling a chip — see {@link labelOptions}.
    */
   options = input<TnChipInputOption<T>[]>([]);
+
+  /**
+   * Server-driven suggestions: a function of `(query, page)` returning the
+   * matches for `query`. Binding it hands the component the debounce,
+   * request cancellation, loading state and error recovery that a consumer
+   * otherwise writes by hand around `(searchChange)`, and it supersedes both
+   * `suggestions` and `options` as the source of the dropdown's rows —
+   * `options` is still consulted when labelling a chip, so a host can name a
+   * value the fetched pages have not produced.
+   *
+   * The chip dropdown is not paged, so `page` is always 0 — the parameter is
+   * there only so one source function can feed both this and `tn-autocomplete`.
+   *
+   * The first query runs when the field is first focused, not on init.
+   *
+   * @example
+   * ```html
+   * <tn-chip-input [dataSource]="groupOptions" />
+   * ```
+   */
+  dataSource = input<TnOptionsFetchFn<TnChipInputOption<T>> | undefined>(undefined);
+
+  /** Debounce applied to typing before `dataSource` is queried, in ms. */
+  dataSourceDebounce = input<number>(250);
+
+  /**
+   * Text shown next to the spinner while a `dataSource` request is in flight.
+   * Falls back to {@link TN_CHIP_INPUT_LABELS}.
+   */
+  loadingText = input<string | undefined>(undefined);
 
   /**
    * Comparator for value equality — used for de-duplication, display resolution
@@ -206,6 +271,19 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
    */
   searchChange = output<string>();
 
+  /**
+   * Emits once per failed `dataSource` request. The component recovers on its
+   * own — the stream stays alive and the failed term stays retryable — so this
+   * is purely for the app to report the failure the way it reports others.
+   */
+  dataSourceError = output<unknown>();
+
+  private readonly defaultLabels = injectTnLabels(TN_CHIP_INPUT_LABELS);
+
+  protected readonly resolvedLoadingText = computed(
+    () => this.loadingText() ?? this.defaultLabels().loading,
+  );
+
   private readonly container = viewChild.required<ElementRef<HTMLElement>>('container');
   private readonly inputEl = viewChild.required<ElementRef<HTMLInputElement>>('inputEl');
   private readonly dropdownTemplate = viewChild.required<TemplateRef<unknown>>('dropdownTemplate');
@@ -237,11 +315,36 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     return max === undefined || this.values().length < max;
   });
 
+  /** Async engine backing `dataSource`; idle while no source is bound. */
+  private readonly asyncOptions = createTnOptionsDataSource<TnChipInputOption<T>>({
+    source: this.dataSource,
+    debounceMs: this.dataSourceDebounce,
+    // The dropdown is not paged, so nothing ever asks for page 1 and this
+    // only decides an `exhausted` flag no one reads.
+    pageSize: computed(() => Number.POSITIVE_INFINITY),
+    identity: (option) => option.value,
+    onError: (error) => this.dataSourceError.emit(error),
+  });
+
   /**
-   * Unified option list. Value-mode `options` win; otherwise string-mode
-   * `suggestions` are lifted into `{ label: s, value: s }`.
+   * Whether a `dataSource` request is in flight.
+   *
+   * Surfaced in the dropdown because with a `dataSource` bound the rows are NOT
+   * re-filtered on the label — the server already applied the query — so the
+   * panel keeps showing the *previous* term's matches, clickable and looking
+   * current, for the debounce plus the round trip. Without a cue that is
+   * indistinguishable from "these are your results".
+   */
+  protected readonly loading = computed(() => this.asyncOptions.loading());
+
+  /**
+   * Unified option list. A bound `dataSource` wins; then value-mode `options`;
+   * otherwise string-mode `suggestions` lifted into `{ label: s, value: s }`.
    */
   protected optionList = computed<TnChipInputOption<T>[]>(() => {
+    if (this.dataSource()) {
+      return this.asyncOptions.options();
+    }
     const opts = this.options();
     if (opts.length) {
       return opts;
@@ -249,14 +352,37 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     return this.suggestions().map((suggestion) => ({ label: suggestion, value: suggestion as unknown as T }));
   });
 
+  /**
+   * The rows a chip's label and test id may be resolved from: the suggestions,
+   * plus — with a `dataSource` bound — the `options` input.
+   *
+   * Those two lists are the same thing without a `dataSource`. With one, the
+   * fetched pages are the only source of labels, and the first of them does not
+   * exist until the field is focused: a form loaded with ids would render every
+   * chip as its raw id until someone clicked into it. `options` is how a host
+   * names values it already knows the labels for, so it stays part of the
+   * lookup even where it is not part of the dropdown.
+   *
+   * Deliberately not deduplicated: fetched rows come first, and both readers
+   * take the first match, so a value in both lists resolves to the server's row.
+   */
+  private readonly labelOptions = computed<TnChipInputOption<T>[]>(() => {
+    const list = this.optionList();
+    const pinned = this.dataSource() ? this.options() : [];
+    return pinned.length ? [...list, ...pinned] : list;
+  });
+
   /** Options matching the typed text and not already selected. */
   protected filteredSuggestions = computed<TnChipInputOption<T>[]>(() => {
     const term = this.inputValue().trim().toLowerCase();
+    // A `dataSource` already applied the query server-side; filtering again on
+    // the label would hide rows it matched on some other field.
+    const isPreFiltered = !!this.dataSource();
     return this.optionList().filter((option) => {
       if (this.valuesIncludes(option.value)) {
         return false;
       }
-      return term === '' || option.label.toLowerCase().includes(term);
+      return isPreFiltered || term === '' || option.label.toLowerCase().includes(term);
     });
   });
 
@@ -265,6 +391,19 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
 
   private overlayRef?: OverlayRef;
   private overlaySubs: Subscription[] = [];
+
+  /**
+   * Set when the panel was closed by a commit rather than by the user, and read
+   * by the re-open effect below.
+   *
+   * Committing a chip changes the suggestion list — the chosen row is now
+   * excluded — which re-runs that effect. On the static path the empty input
+   * makes `activelySearching` false and the close stands; with a `dataSource`
+   * bound, `searchingEmpty` holds regardless, so the panel sprang back open
+   * against an empty field, still listing the rows of the term just committed.
+   * Cleared by the next thing that is genuinely a search.
+   */
+  private closedByCommit = false;
 
   constructor() {
     // Async suggestions: when the user types, onInput runs syncDropdown()
@@ -276,11 +415,17 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     effect(() => {
       const hasMatches = this.filteredSuggestions().length > 0;
       untracked(() => {
+        // With a `dataSource`, the first page is fetched on focus with an
+        // empty term — so an empty field is still "searching" and its results
+        // should drop the panel open, the way a static suggestion list does
+        // on focus. Typed-term-only would leave that first page invisible
+        // until the user typed something.
+        const searchingEmpty = !!this.dataSource();
         const activelySearching = this.focused()
-          && this.inputValue().trim() !== ''
+          && (searchingEmpty || this.inputValue().trim() !== '')
           && this.canAddMore()
           && !this.isDisabled();
-        if (hasMatches && activelySearching) {
+        if (hasMatches && activelySearching && !this.closedByCommit) {
           this.open();
         }
       });
@@ -289,6 +434,26 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
 
   ngOnDestroy(): void {
     this.detachOverlay();
+  }
+
+  // ── Async options ──
+
+  /**
+   * Discard the pages fetched from `dataSource` and re-query the current term.
+   *
+   * For a caller whose `[dataSource]` is a fixed function reading live
+   * configuration — the shape that keeps the source from being swapped out
+   * from under a search in flight — this is how a change to that configuration
+   * takes effect, rather than waiting for the next keystroke to notice.
+   */
+  refreshOptions(): void {
+    this.asyncOptions.refresh();
+    if (this.focused()) {
+      // Suggestions are on screen (or one keystroke from it), so they have to
+      // be replaced at once. An unfocused field refetches on its next focus —
+      // the `prime` there is no longer answered from the invalidated pages.
+      this.asyncOptions.prime();
+    }
   }
 
   // ── ControlValueAccessor ──
@@ -327,6 +492,8 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   protected onInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     this.inputValue.set(value);
+    this.closedByCommit = false;
+    this.asyncOptions.search(value);
     this.searchChange.emit(value);
     this.highlightedIndex.set(-1);
     this.syncDropdown();
@@ -334,6 +501,10 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
 
   protected onFocus(): void {
     this.focused.set(true);
+    this.closedByCommit = false;
+    // Fetch the first page the first time the field is used, so a form of
+    // chip inputs costs nothing until one is focused. A no-op thereafter.
+    this.asyncOptions.prime();
     this.syncDropdown();
   }
 
@@ -479,6 +650,11 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
     return this.discriminatedTestId(optionTestId(this.resolvedTestId(), option, this.optionTestIdKey()));
   }
 
+  /** Test-id parts for the dropdown's status row. Mirrors `tn-autocomplete`. */
+  protected statusTestIdParts(status: 'loading'): (string | number | null | undefined)[] {
+    return scopeTestId(this.resolvedTestId(), status);
+  }
+
   /**
    * Keeps a scoped id only when both halves of it survive normalization.
    *
@@ -551,7 +727,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   private optionFor(value: T): TnChipInputOption<T> | undefined {
     const comparator = this.compareWith();
     if (comparator) {
-      return this.optionList().find((option) => comparator(option.value, value));
+      return this.labelOptions().find((option) => comparator(option.value, value));
     }
     return this.optionIndex().get(value);
   }
@@ -564,7 +740,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
    */
   private optionIndex = computed<Map<T, TnChipInputOption<T>>>(() => {
     const index = new Map<T, TnChipInputOption<T>>();
-    for (const option of this.optionList()) {
+    for (const option of this.labelOptions()) {
       if (!index.has(option.value)) {
         index.set(option.value, option);
       }
@@ -584,6 +760,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, O
   private clearInput(): void {
     this.inputValue.set('');
     this.inputEl().nativeElement.value = '';
+    this.closedByCommit = true;
     this.close();
   }
 

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -324,6 +324,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     pageSize: computed(() => Number.POSITIVE_INFINITY),
     identity: (option) => option.value,
     onError: (error) => this.dataSourceError.emit(error),
+    onSettled: () => this.syncDropdownAfterFetch(),
   });
 
   /**
@@ -770,6 +771,28 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     this.asyncOptions.search('');
     this.closedByCommit = true;
     this.close();
+  }
+
+  /**
+   * Re-decide the panel once a `dataSource` response lands.
+   *
+   * The constructor effect only ever OPENS — it must not fight Escape, blur or
+   * the post-commit close — and with a source bound `onInput` runs
+   * `syncDropdown()` against the PREVIOUS term's rows, which are still there,
+   * so it leaves the panel open too. Nothing was left to retract it: a search
+   * that matched nothing kept a bordered, empty `role="listbox"` attached,
+   * `aria-expanded="true"` over it, until the next keystroke or blur. The
+   * static path never reaches that state, because there the label filter has
+   * already emptied the list by the time `syncDropdown()` reads it.
+   *
+   * Both guards are the post-commit and blur closes: this must not reopen a
+   * panel either of them just shut.
+   */
+  private syncDropdownAfterFetch(): void {
+    if (this.closedByCommit || !this.focused()) {
+      return;
+    }
+    this.syncDropdown();
   }
 
   /**

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -298,6 +298,24 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   /** Committed chip values — the form model. */
   protected values = signal<T[]>([]);
 
+  /**
+   * The label each committed value was picked FROM, for values whose row is no
+   * longer in {@link optionList} or {@link options}.
+   *
+   * With a `dataSource` the fetched page is the only list a chip's label can be
+   * resolved from, and it is replaced on the next search: pick `admins`, type
+   * `dev`, and the row carrying `g-7` is gone, so the chip the user just made
+   * reverts to `g-7` and stays that way. The pinned `[options]` escape hatch
+   * does not cover it — the host would have to append every freshly picked row
+   * to that input, which is the bookkeeping `dataSource` exists to remove.
+   *
+   * `tn-autocomplete` remembers the same thing in its `selectedLabel`; this is
+   * the multi-value form of it. Consulted LAST (see {@link labelOptions}), so a
+   * live row or a host pin always wins over a name that may since have changed,
+   * and pruned to the committed values so it cannot grow without bound.
+   */
+  private readonly rememberedLabels = signal<TnChipInputOption<T>[]>([]);
+
   /** Current text in the field. */
   protected inputValue = signal('');
 
@@ -376,8 +394,10 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
    * names values it already knows the labels for, so it stays part of the
    * lookup even where it is not part of the dropdown.
    *
-   * Deliberately not deduplicated: fetched rows come first, and every reader
-   * takes the first match, so a value in both lists resolves to the server's row.
+   * Deliberately not deduplicated: the order is the precedence — the server's
+   * fetched rows, then the host's pinned ones, then the labels this field
+   * remembered committing ({@link rememberedLabels}) — and every reader takes
+   * the first match, so the freshest name for a value wins.
    *
    * Read by {@link commitText} as well, so the labels the field paints and the
    * labels it accepts back are one set. Deliberately NOT read by
@@ -388,7 +408,11 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   private readonly labelOptions = computed<TnChipInputOption<T>[]>(() => {
     const list = this.optionList();
     const pinned = this.dataSource() ? this.options() : [];
-    return pinned.length ? [...list, ...pinned] : list;
+    const remembered = this.rememberedLabels();
+    if (!pinned.length && !remembered.length) {
+      return list;
+    }
+    return [...list, ...pinned, ...remembered];
   });
 
   /** Options matching the typed text and not already selected. */
@@ -500,6 +524,9 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     // may legitimately seed more values than the cap; silently dropping them
     // would lose data. The cap only blocks further user-driven additions.
     this.values.set(Array.isArray(value) ? [...value] : []);
+    // A value the model dropped takes its remembered label with it — otherwise
+    // a form reset would leave the field naming chips it no longer holds.
+    this.pruneRememberedLabels();
   }
 
   registerOnChange(fn: (value: T[]) => void): void {
@@ -599,7 +626,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
       event.preventDefault();
       const idx = this.highlightedIndex();
       if (this.isOpen() && idx >= 0 && idx < suggestions.length) {
-        this.commitValue(suggestions[idx].value);
+        this.commitValue(suggestions[idx].value, suggestions[idx].label);
       } else {
         this.commitText(this.inputValue());
       }
@@ -615,7 +642,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   }
 
   protected onSuggestionClick(option: TnChipInputOption<T>): void {
-    this.commitValue(option.value);
+    this.commitValue(option.value, option.label);
     this.inputEl().nativeElement.focus();
   }
 
@@ -633,6 +660,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
       return;
     }
     this.values.update((values) => values.filter((_, i) => i !== index));
+    this.pruneRememberedLabels();
     this.onChange(this.values());
     this.onTouched();
     this.chipRemoved.emit(removed);
@@ -738,7 +766,7 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     }
     const match = this.labelOptions().find((option) => option.label.toLowerCase() === text.toLowerCase());
     if (match) {
-      this.commitValue(match.value);
+      this.commitValue(match.value, match.label);
       return;
     }
     if (this.allowCustomValue()) {
@@ -748,8 +776,15 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
     this.clearInput();
   }
 
-  /** Commits a resolved value, honouring duplicate and cap rules. */
-  private commitValue(value: T): void {
+  /**
+   * Commits a resolved value, honouring duplicate and cap rules.
+   *
+   * `label` is the text of the option the value came from, when there was one —
+   * remembered so the chip keeps that name after the page carrying its row is
+   * replaced. See {@link rememberedLabels}. Free text passes none: such a chip
+   * is its own label, and `String(value)` already renders it.
+   */
+  private commitValue(value: T, label?: string): void {
     if (this.isDisabled() || !this.canAddMore()) {
       return;
     }
@@ -758,10 +793,26 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
       return;
     }
     this.values.update((values) => [...values, value]);
+    if (label !== undefined) {
+      this.rememberedLabels.update((remembered) => [...remembered, { label, value }]);
+    }
     this.onChange(this.values());
     this.onTouched();
     this.chipAdded.emit(value);
     this.clearInput();
+  }
+
+  /**
+   * Drop remembered labels for values no longer committed, so the memory stays
+   * bounded by the chips on screen rather than by everything ever picked.
+   */
+  private pruneRememberedLabels(): void {
+    if (!this.rememberedLabels().length) {
+      return;
+    }
+    this.rememberedLabels.update((remembered) => remembered.filter(
+      (option) => this.values().some((value) => this.valueMatches(option.value, value)),
+    ));
   }
 
   /**

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.component.ts
@@ -344,9 +344,12 @@ export class TnChipInputComponent<T = string> implements ControlValueAccessor, T
   private readonly asyncOptions = createTnOptionsDataSource<TnChipInputOption<T>>({
     source: this.dataSource,
     debounceMs: this.dataSourceDebounce,
-    // The dropdown is not paged, so nothing ever asks for page 1 and this
-    // only decides an `exhausted` flag no one reads.
-    pageSize: computed(() => Number.POSITIVE_INFINITY),
+    // The dropdown is not paged, so nothing ever asks for page 1 and this only
+    // decides an `exhausted` flag no one reads yet. `0` leaves that flag false;
+    // `Infinity` would latch it TRUE for every page (`rows.length < Infinity`),
+    // and `loadMore()` bails on `exhausted()` before anything else — so paging
+    // would silently no-op for whoever wires it into this dropdown later.
+    pageSize: signal(0),
     identity: (option) => option.value,
     onError: (error) => this.dataSourceError.emit(error),
     onSettled: () => this.syncDropdownAfterFetch(),

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.ts
@@ -111,6 +111,23 @@ export class TnChipInputHarness extends ComponentHarness {
     return texts;
   }
 
+  /**
+   * Whether the dropdown is showing its loading row, i.e. a `[dataSource]`
+   * request is in flight. The rows on screen while this is true belong to the
+   * previous term — a `dataSource` is trusted to have applied the query, so
+   * they are not re-filtered as the user types.
+   *
+   * @example
+   * ```typescript
+   * const chips = await loader.getHarness(TnChipInputHarness);
+   * await chips.focus();
+   * expect(await chips.isLoading()).toBe(true);
+   * ```
+   */
+  async isLoading(): Promise<boolean> {
+    return (await this.documentRoot.locatorForOptional('.tn-chip-input__loading')()) !== null;
+  }
+
   async isDisabled(): Promise<boolean> {
     const input = await this._input();
     return (await input.getProperty('disabled')) === true;

--- a/projects/truenas-ui/src/lib/chip-input/chip-input.harness.ts
+++ b/projects/truenas-ui/src/lib/chip-input/chip-input.harness.ts
@@ -113,9 +113,10 @@ export class TnChipInputHarness extends ComponentHarness {
 
   /**
    * Whether the dropdown is showing its loading row, i.e. a `[dataSource]`
-   * request is in flight. The rows on screen while this is true belong to the
+   * request is in flight. Any rows on screen while this is true belong to the
    * previous term — a `dataSource` is trusted to have applied the query, so
-   * they are not re-filtered as the user types.
+   * they are not re-filtered as the user types. On the first focus there are
+   * no rows yet and the panel holds the loading row alone.
    *
    * @example
    * ```typescript

--- a/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
+++ b/projects/truenas-ui/src/lib/theme/text-token-surface-contrast.spec.ts
@@ -347,9 +347,9 @@ const PAINTS_UNTUNED: Readonly<Record<string, { fills: number; text: number; why
   },
   'chip-input/chip-input.component.scss': {
     fills: 2,
-    text: 3,
+    text: 4,
     why: 'the highlighted option fills --tn-bg3 under --tn-fg1; the disabled field fill is under '
-      + 'an opacity',
+      + 'an opacity; the dropdown loading row is --tn-fg2 on the panel\'s own --tn-bg1',
   },
   'chip/chip.component.scss': {
     fills: 3,

--- a/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
@@ -105,6 +105,38 @@ describe('createTnOptionsDataSource', () => {
       expect(engine.loading()).toBe(false);
     });
 
+    it('leaves the flag to a newer loadMore that genuinely owns it', () => {
+      // `searchInFlight` tracks only the SEARCH pipeline, so a page retired by
+      // an older generation could clear a flag a later page had set: issue A,
+      // type (its search settles and clears the flag), scroll for B, then let
+      // A finally land — the spinner vanished for the rest of B's round trip.
+      loadFirstPage();
+      const pageA = new Subject<Row[]>();
+      responder = () => pageA;
+      engine.loadMore();
+
+      // A search retires A's generation, and settles.
+      responder = () => of(page(pageSize));
+      engine.search('zzz');
+      jest.advanceTimersByTime(250);
+      expect(engine.loading()).toBe(false);
+
+      const pageB = new Subject<Row[]>();
+      responder = () => pageB;
+      engine.loadMore();
+      expect(engine.loading()).toBe(true);
+
+      pageA.next(page(pageSize));
+      pageA.complete();
+
+      expect(engine.loading()).toBe(true);
+
+      pageB.next(page(1));
+      pageB.complete();
+
+      expect(engine.loading()).toBe(false);
+    });
+
     it('releases the flag when a retired page fails rather than answers', () => {
       loadFirstPage();
       const inFlight = new Subject<Row[]>();

--- a/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
@@ -1,0 +1,120 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Subject, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { createTnOptionsDataSource } from './options-data-source';
+import type { TnOptionsDataSource, TnOptionsFetchFn } from './options-data-source';
+
+/**
+ * The engine on its own, for the parts of its contract no component surfaces.
+ *
+ * `tn-autocomplete` and `tn-chip-input` cover it end to end through their own
+ * `*-data-source.spec.ts`; what belongs here is behaviour of the exported
+ * signals that a component either hides or self-heals, so a spec driven through
+ * one cannot see it fail.
+ */
+
+interface Row { id: number }
+
+describe('createTnOptionsDataSource', () => {
+  const pageSize = 2;
+
+  let source: ReturnType<typeof signal<TnOptionsFetchFn<Row> | undefined>>;
+  let engine: TnOptionsDataSource<Row>;
+  /** Every `(query, page)` asked for, in order. */
+  let requests: { query: string; page: number }[];
+  let responder: (query: string, page: number) => Observable<Row[]>;
+
+  function page(count: number): Row[] {
+    return Array.from({ length: count }, (_, index) => ({ id: index }));
+  }
+
+  beforeEach(() => {
+    requests = [];
+    responder = () => of(page(pageSize));
+    source = signal<TnOptionsFetchFn<Row> | undefined>((query, pageIndex) => {
+      requests.push({ query, page: pageIndex });
+      return responder(query, pageIndex);
+    });
+
+    TestBed.configureTestingModule({});
+    engine = TestBed.runInInjectionContext(() => createTnOptionsDataSource<Row>({
+      source,
+      debounceMs: signal(250),
+      pageSize: signal(pageSize),
+      identity: (row) => row.id,
+      onError: () => {},
+    }));
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  /** A full first page, so paging is open and `loadMore` will issue. */
+  function loadFirstPage(): void {
+    engine.prime();
+  }
+
+  describe('loading', () => {
+    it('releases the flag when refresh() retires a page still in flight', () => {
+      // `refresh` bumps the generation without issuing anything, so the page it
+      // retires is the only thing that can release the flag it set. Returning
+      // on the premise that "a newer request owns loading" left it stuck true —
+      // and `loadMore` is a no-op behind it, so the engine paged no further
+      // until something happened to prime it again.
+      loadFirstPage();
+      const inFlight = new Subject<Row[]>();
+      responder = () => inFlight;
+
+      engine.loadMore();
+      expect(engine.loading()).toBe(true);
+
+      engine.refresh();
+      inFlight.next(page(pageSize));
+      inFlight.complete();
+
+      expect(engine.loading()).toBe(false);
+    });
+
+    it('leaves the flag to the newer search that genuinely owns it', () => {
+      // The other half of the same branch: here the generation moved because a
+      // SEARCH started, and that request set `loading` itself. Clearing it on
+      // the retired page's behalf would report the field as settled while its
+      // replacement rows are still on the way.
+      loadFirstPage();
+      const stalePage = new Subject<Row[]>();
+      responder = () => stalePage;
+      engine.loadMore();
+
+      const freshSearch = new Subject<Row[]>();
+      responder = () => freshSearch;
+      engine.search('zzz');
+      jest.advanceTimersByTime(250);
+
+      stalePage.next(page(pageSize));
+      stalePage.complete();
+
+      expect(engine.loading()).toBe(true);
+
+      freshSearch.next(page(1));
+      freshSearch.complete();
+
+      expect(engine.loading()).toBe(false);
+    });
+
+    it('releases the flag when a retired page fails rather than answers', () => {
+      loadFirstPage();
+      const inFlight = new Subject<Row[]>();
+      responder = () => inFlight;
+      engine.loadMore();
+
+      engine.refresh();
+      inFlight.error(new Error('gone'));
+
+      expect(engine.loading()).toBe(false);
+    });
+  });
+});

--- a/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.spec.ts
@@ -1,6 +1,6 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Subject, of } from 'rxjs';
+import { EMPTY, Subject, of } from 'rxjs';
 import type { Observable } from 'rxjs';
 import { createTnOptionsDataSource } from './options-data-source';
 import type { TnOptionsDataSource, TnOptionsFetchFn } from './options-data-source';
@@ -147,6 +147,78 @@ describe('createTnOptionsDataSource', () => {
       inFlight.error(new Error('gone'));
 
       expect(engine.loading()).toBe(false);
+    });
+
+    it('releases the flag when a search completes without emitting', () => {
+      // `(q) => q ? this.api.search(q) : EMPTY` is a shape the signature invites
+      // and the engine used to hang on: every latch is released from `next`, so
+      // an empty completion released none of them. Both hosts prime with `''`,
+      // which is exactly the branch that returns EMPTY — so the first open hung
+      // a spinner over an empty panel for the life of the field, and `loadMore`
+      // bails on `loading()`, so paging died with it.
+      responder = () => EMPTY;
+
+      engine.prime();
+
+      expect(engine.loading()).toBe(false);
+      expect(engine.options()).toEqual([]);
+    });
+
+    it('releases the flag when a page completes without emitting', () => {
+      loadFirstPage();
+      responder = () => EMPTY;
+
+      engine.loadMore();
+
+      expect(engine.loading()).toBe(false);
+    });
+  });
+
+  describe('a source that does not emit exactly once', () => {
+    it('reads only the first page a source emits', () => {
+      // Without `take(1)` a multicasting source appends the same rows twice and
+      // drives `loadMoreInFlight` below zero, which then releases `loading` for
+      // a page still genuinely in flight.
+      loadFirstPage();
+      const twice = new Subject<Row[]>();
+      responder = () => twice;
+
+      engine.loadMore();
+      twice.next([{ id: 10 }]);
+      twice.next([{ id: 11 }]);
+      twice.complete();
+
+      expect(engine.options()).toEqual([{ id: 0 }, { id: 1 }, { id: 10 }]);
+      expect(engine.loading()).toBe(false);
+    });
+  });
+
+  describe('a source that binds late', () => {
+    it('primes once when the source arrives, not on every identity change', () => {
+      // The effect re-runs on any identity change of `source`, and
+      // `[dataSource]="(q, p) => this.search(q, p)"` — the call site the docs
+      // warn against, but one that type-checks — hands it a new reference on
+      // every change detection. Priming on every run then wrote `loading`,
+      // which schedules another one: a cancel-storm of requests for the whole
+      // first round trip.
+      source.set(undefined);
+      TestBed.tick();
+      engine.prime();
+      expect(requests).toEqual([]);
+
+      const fetch: TnOptionsFetchFn<Row> = (query, pageIndex) => {
+        requests.push({ query, page: pageIndex });
+        return responder(query, pageIndex);
+      };
+      source.set(fetch);
+      TestBed.tick();
+      expect(requests).toEqual([{ query: '', page: 0 }]);
+
+      // A new reference for the same bound source is not a re-binding.
+      source.set((query, pageIndex) => fetch(query, pageIndex));
+      TestBed.tick();
+
+      expect(requests).toEqual([{ query: '', page: 0 }]);
     });
   });
 });

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -2,7 +2,7 @@ import { DestroyRef, inject, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, of, timer } from 'rxjs';
 import type { Observable } from 'rxjs';
-import { catchError, debounce, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounce, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
 
 /**
  * Fetches one page of options for a server-driven dropdown.
@@ -180,6 +180,19 @@ export function createTnOptionsDataSource<O>(
 
   requests$
     .pipe(
+      // A request made with no source bound is not a request. Every latch
+      // below — `primed`, the cursor, `onSettled` — describes a round trip,
+      // and answering this with an empty success made all three fire for one
+      // that never happened: a `[dataSource]` that arrives after the user has
+      // typed once found `primed` already latched and never fetched at all,
+      // and a host with no source at all had its paging latch released on a
+      // timer, which is enough to page the same rows twice from one scroll.
+      //
+      // Dropped ahead of the duplicate-term guard on purpose: that operator
+      // remembers whatever passes THROUGH it, so a term filtered out later
+      // would still become the "previous" one and suppress the identical term
+      // once a source finally is bound.
+      filter(() => !!config.source()),
       // `prime` must not sit behind the typing debounce — an empty first page
       // should be on screen as the panel opens, not a quarter-second later.
       debounce((request) => (request.immediate ? of(0) : timer(config.debounceMs()))),
@@ -204,23 +217,41 @@ export function createTnOptionsDataSource<O>(
         const requestedGeneration = generation;
         const fetch = config.source();
         if (!fetch) {
-          return of({ rows: [] as O[], failed: false, requestedGeneration });
+          // The source went away inside the debounce window, past the filter
+          // above. Tagged rather than answered: `failed` would make the term
+          // look retryable-because-broken, and a plain success would latch the
+          // state of a fetch that never ran.
+          return of({
+            rows: [] as O[], failed: false, skipped: true, requestedGeneration,
+          });
         }
         return fetch(request.query, 0).pipe(
-          map((rows) => ({ rows, failed: false, requestedGeneration })),
+          map((rows) => ({
+            rows, failed: false, skipped: false, requestedGeneration,
+          })),
           catchError((error: unknown) => {
             config.onError(error);
-            return of({ rows: [] as O[], failed: true, requestedGeneration });
+            return of({
+              rows: [] as O[], failed: true, skipped: false, requestedGeneration,
+            });
           }),
         );
       }),
       takeUntilDestroyed(destroyRef),
     )
-    .subscribe(({ rows, failed, requestedGeneration }) => {
+    .subscribe(({
+      rows, failed, skipped, requestedGeneration,
+    }) => {
       // No other request can be outstanding — a newer one through this subject
       // would have unsubscribed this response — so the flag is released either
       // way, stale or not.
       loading.set(false);
+      if (skipped) {
+        // Nothing was asked, so nothing may be latched. `onSettled` in
+        // particular is the host's paging latch: releasing it here hands a
+        // consumer a second `loadMore` for a page still in flight.
+        return;
+      }
       if (requestedGeneration !== generation) {
         // Fetched under a configuration `refresh` has since retired. Latching
         // `primed` on it would answer the next `prime` from the invalidated

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -194,6 +194,16 @@ export function createTnOptionsDataSource<O>(
    * it — until the next open happened to prime.
    */
   let searchInFlight = false;
+  /**
+   * How many `loadMore` pages are outstanding.
+   *
+   * The companion to {@link searchInFlight}: that one tracks only the search
+   * pipeline, so a page retired by an OLDER generation could release `loading`
+   * out from under a newer `loadMore` that had genuinely set it — issue page A,
+   * type (its search settles and clears the flag), scroll for page B, then let
+   * A finally arrive, and the spinner vanished for the rest of B's round trip.
+   */
+  let loadMoreInFlight = 0;
 
   const requests$ = new Subject<{ query: string; immediate: boolean }>();
 
@@ -339,10 +349,10 @@ export function createTnOptionsDataSource<O>(
 
   /**
    * Release {@link loading} for a page whose result set has been retired,
-   * unless a search is genuinely in flight and owns the flag.
+   * unless a search or a later `loadMore` is in flight and owns the flag.
    */
   function releaseStaleLoading(): void {
-    if (!searchInFlight) {
+    if (!searchInFlight && loadMoreInFlight === 0) {
       loading.set(false);
     }
   }
@@ -374,11 +384,13 @@ export function createTnOptionsDataSource<O>(
       const requestedPage = nextPage;
       const requestedGeneration = generation;
       loading.set(true);
+      loadMoreInFlight++;
 
       fetch(query, requestedPage)
         .pipe(takeUntilDestroyed(destroyRef))
         .subscribe({
           next: (rows) => {
+            loadMoreInFlight--;
             if (requestedGeneration !== generation) {
               // This page belongs to a result set that has been retired. A
               // fresh SEARCH owns `loading` and will release it; a `refresh`
@@ -398,6 +410,7 @@ export function createTnOptionsDataSource<O>(
             config.onSettled?.();
           },
           error: (error: unknown) => {
+            loadMoreInFlight--;
             if (requestedGeneration !== generation) {
               releaseStaleLoading();
               return;

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -175,6 +175,19 @@ export function createTnOptionsDataSource<O>(
    * comparator exists to suppress.
    */
   let refreshRequested = false;
+  /**
+   * Whether a page-0 request is outstanding — i.e. whether the search pipeline
+   * owns {@link loading} right now.
+   *
+   * Read by {@link TnOptionsDataSource.loadMore}'s stale-generation branches.
+   * Those bail without touching the flag on the premise that a newer request
+   * owns it, which is true when the generation was bumped by the `tap` below
+   * (it sets `loading` in the same block) and false when `refresh` bumped it
+   * without issuing anything: blur a panel with a page in flight, refresh it,
+   * and `loading` would stay `true` for good — with `loadMore` a no-op behind
+   * it — until the next open happened to prime.
+   */
+  let searchInFlight = false;
 
   const requests$ = new Subject<{ query: string; immediate: boolean }>();
 
@@ -207,6 +220,7 @@ export function createTnOptionsDataSource<O>(
         lastRequestFailed = false;
         refreshRequested = false;
         generation++;
+        searchInFlight = true;
         loading.set(true);
       }),
       switchMap((request) => {
@@ -245,6 +259,7 @@ export function createTnOptionsDataSource<O>(
       // No other request can be outstanding — a newer one through this subject
       // would have unsubscribed this response — so the flag is released either
       // way, stale or not.
+      searchInFlight = false;
       loading.set(false);
       if (skipped) {
         // Nothing was asked, so nothing may be latched. `onSettled` in
@@ -271,6 +286,16 @@ export function createTnOptionsDataSource<O>(
       options.set(rows);
       config.onSettled?.();
     });
+
+  /**
+   * Release {@link loading} for a page whose result set has been retired,
+   * unless a search is genuinely in flight and owns the flag.
+   */
+  function releaseStaleLoading(): void {
+    if (!searchInFlight) {
+      loading.set(false);
+    }
+  }
 
   return {
     options: options.asReadonly(),
@@ -312,8 +337,10 @@ export function createTnOptionsDataSource<O>(
         .subscribe({
           next: (rows) => {
             if (requestedGeneration !== generation) {
-              // A fresh search started while this page was in flight; its
-              // result set is already on screen and owns `loading`.
+              // This page belongs to a result set that has been retired. A
+              // fresh SEARCH owns `loading` and will release it; a `refresh`
+              // issued nothing, so this is the only thing that can.
+              releaseStaleLoading();
               return;
             }
             loading.set(false);
@@ -329,6 +356,7 @@ export function createTnOptionsDataSource<O>(
           },
           error: (error: unknown) => {
             if (requestedGeneration !== generation) {
+              releaseStaleLoading();
               return;
             }
             loading.set(false);

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -1,0 +1,330 @@
+import { DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subject, of, timer } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { catchError, debounce, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+
+/**
+ * Fetches one page of options for a server-driven dropdown.
+ *
+ * Stateless on purpose: the page number is passed in rather than held by the
+ * caller, so a source is a plain function of `(query, page)` and never has to
+ * track — or roll back — a cursor of its own. {@link createTnOptionsDataSource}
+ * owns the cursor, and rolls it back for you when a page fails.
+ *
+ * `page` is zero-based; page 0 is the first page of a fresh search.
+ */
+export type TnOptionsFetchFn<O> = (query: string, page: number) => Observable<O[]>;
+
+/** Inputs {@link createTnOptionsDataSource} reads. All are signals so they stay live. */
+export interface TnOptionsDataSourceConfig<O> {
+  /** The fetch function, or `undefined` when the host has no async source bound. */
+  source: Signal<TnOptionsFetchFn<O> | undefined>;
+  /** Debounce applied to typing before a request goes out, in ms. */
+  debounceMs: Signal<number>;
+  /**
+   * Rows per page. Only used to detect exhaustion: a page shorter than this is
+   * the last one, after which further {@link TnOptionsDataSource.loadMore}
+   * calls are dropped instead of issuing queries that can only return `[]`.
+   */
+  pageSize: Signal<number>;
+  /** Identity of an option, used to drop duplicates when appending a page. */
+  identity: (option: O) => unknown;
+  /** Called once per failed request, so the host can surface it its own way. */
+  onError: (error: unknown) => void;
+  /**
+   * Called after every request settles, successfully or not. Hosts use this to
+   * release their own "a page is in flight" latches: a synchronous source
+   * flips {@link TnOptionsDataSource.loading} true and back within one block,
+   * so watching that signal misses the round trip entirely.
+   */
+  onSettled?: () => void;
+}
+
+/** The live state of a {@link createTnOptionsDataSource}. */
+export interface TnOptionsDataSource<O> {
+  /** Options fetched so far for the current query, in server order. */
+  readonly options: Signal<O[]>;
+  /** Whether a request is in flight. */
+  readonly loading: Signal<boolean>;
+  /** Whether the last page came back short, i.e. there is nothing more to page in. */
+  readonly exhausted: Signal<boolean>;
+  /** Run a fresh (debounced) search, resetting paging to page 0. */
+  search(query: string): void;
+  /**
+   * Fetch page 0 for the current term immediately if nothing has been fetched
+   * yet. For click-to-open pickers, where `search` never fires until the user
+   * types. A no-op once a query has run *successfully*, so reopening the panel
+   * does not refetch — but a request that failed is retried, as it is on the
+   * `search` path.
+   */
+  prime(): void;
+  /** Append the next page. No-op while loading, when exhausted, or with no source. */
+  loadMore(): void;
+  /**
+   * Declare everything fetched so far out of date, without fetching anything.
+   *
+   * The other half of the stable-source contract. A host whose `[dataSource]`
+   * is a fixed function reading live configuration — the shape that keeps a
+   * source from being swapped out from under a search in flight — has nothing
+   * here observing that configuration, so a change to it would otherwise take
+   * effect only on the next keystroke. This is how the host says it changed.
+   *
+   * Clears {@link TnOptionsDataSource.prime}'s latch and rolls paging back to
+   * page 0, so the next `prime` refetches instead of being answered from the
+   * previous configuration's rows — and is not suppressed for repeating the
+   * term already on screen. Deliberately does NOT issue a request itself: only
+   * the host knows whether its panel is open, and a field nobody has touched
+   * should not query the server because a sibling input moved. A host with rows
+   * on screen calls `prime` straight after this.
+   */
+  refresh(): void;
+}
+
+/**
+ * The part of a host component (`tn-autocomplete`, `tn-chip-input`) that an
+ * outer component wrapping it drives directly.
+ *
+ * The engine is private to the host, so a composite field — one that builds the
+ * `[dataSource]` itself and binds it once — needs this to invalidate what the
+ * host has fetched when its own inputs move.
+ */
+export interface TnAsyncOptionsHost {
+  /** See {@link TnOptionsDataSource.refresh}. */
+  refreshOptions(): void;
+}
+
+/**
+ * The stateful half of a server-driven dropdown: debounce, cancellation,
+ * paging, exhaustion, and error recovery, so a host component only has to
+ * render {@link TnOptionsDataSource.options} and forward its own events.
+ *
+ * Must be called in an injection context — it ties its subscription to the
+ * caller's {@link DestroyRef}.
+ *
+ * Notable behaviours, each of which was a bug in a hand-rolled copy of this:
+ *
+ * - **Errors never kill the stream.** `catchError` sits inside the `switchMap`,
+ *   so a failed request reports and yields an empty page while the outer
+ *   subscription survives; without that, one transient failure freezes the
+ *   field for the life of the panel.
+ * - **A failed term is retryable.** `distinctUntilChanged` treats a repeat of a
+ *   failed query as a change, so reopening a picker after an error refetches
+ *   instead of being suppressed as a duplicate.
+ * - **A failed page does not advance the cursor**, so the next scroll re-requests
+ *   the page that errored rather than stepping over those rows. The cursor
+ *   tracks the *next* page to ask for rather than the last one loaded, so page 0
+ *   rolls back like every other page instead of being silently skipped.
+ * - **A late page cannot contaminate a newer search.** Every response carries
+ *   the generation it was requested in and is dropped if a search — or a
+ *   {@link TnOptionsDataSource.refresh} — has since started. Cancellation is
+ *   not enough on its own: `refresh` invalidates without issuing a request, so
+ *   there is nothing for `switchMap` to unsubscribe the old one in favour of.
+ */
+export function createTnOptionsDataSource<O>(
+  config: TnOptionsDataSourceConfig<O>,
+): TnOptionsDataSource<O> {
+  const destroyRef = inject(DestroyRef);
+
+  const options = signal<O[]>([]);
+  const loading = signal(false);
+  const exhausted = signal(false);
+
+  /** Current query, replayed by `loadMore` so a page matches what is on screen. */
+  let query = '';
+  /**
+   * Latest term handed to {@link search}, whether or not its request has been
+   * dispatched yet — what {@link prime} re-asks with.
+   *
+   * `query` is only assigned once a request survives the debounce, so it lags
+   * the field by up to `debounceMs`. That gap matters because `prime` emits
+   * `immediate: true`: a prime landing inside a pending search's debounce
+   * window cancels that search outright, and priming with `query` would then
+   * fetch the *previous* term while the input holds the newer one — rows that
+   * do not match what is typed, with nothing left to re-query them. Priming
+   * with the pending term promotes the cancelled search instead of losing it.
+   */
+  let pendingQuery = '';
+  /**
+   * Index of the next page to request for `query`.
+   *
+   * Deliberately "next to request" rather than "last loaded": those two only
+   * differ on page 0, which is exactly where the difference bites. A fresh
+   * search resets the cursor *before* anything has landed, so a "last loaded"
+   * counter reads 0 both for "page 0 is on screen" and for "page 0 failed" —
+   * and the next `loadMore` would step over the first page of matches instead
+   * of retrying it.
+   */
+  let nextPage = 0;
+  /** Whether a query has run successfully — gates {@link prime}. */
+  let primed = false;
+  /**
+   * Set when a request fails, cleared when the next one starts. Read by the
+   * `distinctUntilChanged` comparator so the same term can be retried.
+   */
+  let lastRequestFailed = false;
+  /**
+   * Bumped by every fresh search. A `loadMore` response from an older
+   * generation is discarded rather than appended to a different result set.
+   */
+  let generation = 0;
+  /**
+   * Set by `refresh`, cleared when the request it queued starts. Read by the
+   * `distinctUntilChanged` comparator, the same way `lastRequestFailed` is: a
+   * refresh re-asks the term already on screen, which is exactly the shape that
+   * comparator exists to suppress.
+   */
+  let refreshRequested = false;
+
+  const requests$ = new Subject<{ query: string; immediate: boolean }>();
+
+  requests$
+    .pipe(
+      // `prime` must not sit behind the typing debounce — an empty first page
+      // should be on screen as the panel opens, not a quarter-second later.
+      debounce((request) => (request.immediate ? of(0) : timer(config.debounceMs()))),
+      distinctUntilChanged(
+        (previous, current) => previous.query === current.query
+          && !lastRequestFailed
+          && !refreshRequested,
+      ),
+      tap((request) => {
+        query = request.query;
+        nextPage = 0;
+        lastRequestFailed = false;
+        refreshRequested = false;
+        generation++;
+        loading.set(true);
+      }),
+      switchMap((request) => {
+        // Stamped with the generation it was asked for in, the way `loadMore`
+        // stamps its pages: `refresh` retires a request in flight without
+        // pushing anything through this subject, so `switchMap` alone never
+        // cancels it and its rows would otherwise land as if still current.
+        const requestedGeneration = generation;
+        const fetch = config.source();
+        if (!fetch) {
+          return of({ rows: [] as O[], failed: false, requestedGeneration });
+        }
+        return fetch(request.query, 0).pipe(
+          map((rows) => ({ rows, failed: false, requestedGeneration })),
+          catchError((error: unknown) => {
+            config.onError(error);
+            return of({ rows: [] as O[], failed: true, requestedGeneration });
+          }),
+        );
+      }),
+      takeUntilDestroyed(destroyRef),
+    )
+    .subscribe(({ rows, failed, requestedGeneration }) => {
+      // No other request can be outstanding — a newer one through this subject
+      // would have unsubscribed this response — so the flag is released either
+      // way, stale or not.
+      loading.set(false);
+      if (requestedGeneration !== generation) {
+        // Fetched under a configuration `refresh` has since retired. Latching
+        // `primed` on it would answer the next `prime` from the invalidated
+        // pages for good, which is the exact failure `refresh` exists to
+        // prevent; `lastRequestFailed` is left alone for the same reason.
+        config.onSettled?.();
+        return;
+      }
+      lastRequestFailed = failed;
+      // An empty page from a failure is not evidence that the source is
+      // exhausted — leave paging open so a retry can still reach page 1.
+      exhausted.set(failed ? false : rows.length < config.pageSize());
+      // A failed page 0 leaves the cursor on 0, so the next `loadMore` retries
+      // it; `primed` likewise only latches on a request that arrived.
+      nextPage = failed ? 0 : 1;
+      primed = primed || !failed;
+      options.set(rows);
+      config.onSettled?.();
+    });
+
+  return {
+    options: options.asReadonly(),
+    loading: loading.asReadonly(),
+    exhausted: exhausted.asReadonly(),
+
+    search(next: string): void {
+      pendingQuery = next;
+      requests$.next({ query: next, immediate: false });
+    },
+
+    prime(): void {
+      // `lastRequestFailed` is what makes a failed term retryable on the
+      // `search` path; without it here, one transient failure would empty a
+      // click-to-open picker for the life of the field — reopening the panel
+      // would issue no request at all.
+      if ((primed && !lastRequestFailed) || !config.source()) {
+        return;
+      }
+      // The latest term the field asked for, not `''` and not the last one
+      // dispatched: on the retry path the field may already hold the text whose
+      // lookup failed, and a term still inside the debounce window is cancelled
+      // by this emission — see `pendingQuery`.
+      requests$.next({ query: pendingQuery, immediate: true });
+    },
+
+    loadMore(): void {
+      const fetch = config.source();
+      if (!fetch || loading() || exhausted()) {
+        return;
+      }
+
+      const requestedPage = nextPage;
+      const requestedGeneration = generation;
+      loading.set(true);
+
+      fetch(query, requestedPage)
+        .pipe(takeUntilDestroyed(destroyRef))
+        .subscribe({
+          next: (rows) => {
+            if (requestedGeneration !== generation) {
+              // A fresh search started while this page was in flight; its
+              // result set is already on screen and owns `loading`.
+              return;
+            }
+            loading.set(false);
+            // Only a page that arrived counts as read — see the error branch.
+            nextPage = requestedPage + 1;
+            primed = true;
+            exhausted.set(rows.length < config.pageSize());
+            options.update((current) => {
+              const seen = new Set(current.map(config.identity));
+              return [...current, ...rows.filter((row) => !seen.has(config.identity(row)))];
+            });
+            config.onSettled?.();
+          },
+          error: (error: unknown) => {
+            if (requestedGeneration !== generation) {
+              return;
+            }
+            loading.set(false);
+            // `nextPage` deliberately not advanced: the next scroll re-requests
+            // this page instead of skipping the rows it would have held.
+            config.onError(error);
+            config.onSettled?.();
+          },
+        });
+    },
+
+    refresh(): void {
+      primed = false;
+      nextPage = 0;
+      exhausted.set(false);
+      // Any page still in flight was asked for under the old configuration —
+      // bump the generation so it is dropped rather than appended to whatever
+      // the next request produces.
+      generation++;
+      // The refetch re-asks the term already on screen, which is exactly what
+      // the duplicate-term guard suppresses. Left armed until a request
+      // actually starts, so a host that refreshes while closed is still not
+      // suppressed when it primes on its next open.
+      refreshRequested = true;
+      // `options` is deliberately left alone: a panel that is open keeps
+      // showing the previous rows until the replacements land, rather than
+      // blinking empty for a round trip.
+    },
+  };
+}

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { DestroyRef, effect, inject, signal, untracked, type Signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, of, timer } from 'rxjs';
 import type { Observable } from 'rxjs';
@@ -159,6 +159,12 @@ export function createTnOptionsDataSource<O>(
   /** Whether a query has run successfully — gates {@link prime}. */
   let primed = false;
   /**
+   * Whether the host has ever asked for a first page, i.e. whether its panel
+   * has been opened. Set by `prime` even on the calls it declines to issue,
+   * which is what tells the late-source effect below that a page is owed.
+   */
+  let primeRequested = false;
+  /**
    * Set when a request fails, cleared when the next one starts. Read by the
    * `distinctUntilChanged` comparator so the same term can be retried.
    */
@@ -288,6 +294,50 @@ export function createTnOptionsDataSource<O>(
     });
 
   /**
+   * Issue page 0 for the current term, unless one has already been fetched
+   * successfully or there is no source to fetch from.
+   *
+   * `lastRequestFailed` is what makes a failed term retryable on the `search`
+   * path; without it here, one transient failure would empty a click-to-open
+   * picker for the life of the field — reopening the panel would issue no
+   * request at all.
+   */
+  function primeNow(): void {
+    if ((primed && !lastRequestFailed) || !config.source()) {
+      return;
+    }
+    // The latest term the field asked for, not `''` and not the last one
+    // dispatched: on the retry path the field may already hold the text whose
+    // lookup failed, and a term still inside the debounce window is cancelled
+    // by this emission — see `pendingQuery`.
+    requests$.next({ query: pendingQuery, immediate: true });
+  }
+
+  // A source that binds LATE — a resolver, or a sibling field's signal, both
+  // shapes the `| undefined` input type invites — issues nothing by itself:
+  // `source` is only read from inside the request pipeline, and the filter
+  // above dropped whatever was asked while it was undefined. A closed panel
+  // recovers on its next open, which primes. An OPEN one had nothing left to
+  // ask, and sat on "No results found" (or, for the chip input, an empty
+  // attached listbox) until the user typed or closed and reopened it.
+  //
+  // Gated on `primeRequested` so this cannot break the rule that a field
+  // nobody has opened issues no query: the transition only fetches for a host
+  // that already asked and was turned away.
+  //
+  // `untracked` because emitting runs the pipeline synchronously, which reads
+  // `source` and `debounceMs` — tracked here, those would re-run this effect
+  // on every debounce change and on its own writes.
+  effect(() => {
+    const hasSource = !!config.source();
+    untracked(() => {
+      if (hasSource && primeRequested) {
+        primeNow();
+      }
+    });
+  });
+
+  /**
    * Release {@link loading} for a page whose result set has been retired,
    * unless a search is genuinely in flight and owns the flag.
    */
@@ -308,18 +358,11 @@ export function createTnOptionsDataSource<O>(
     },
 
     prime(): void {
-      // `lastRequestFailed` is what makes a failed term retryable on the
-      // `search` path; without it here, one transient failure would empty a
-      // click-to-open picker for the life of the field — reopening the panel
-      // would issue no request at all.
-      if ((primed && !lastRequestFailed) || !config.source()) {
-        return;
-      }
-      // The latest term the field asked for, not `''` and not the last one
-      // dispatched: on the retry path the field may already hold the text whose
-      // lookup failed, and a term still inside the debounce window is cancelled
-      // by this emission — see `pendingQuery`.
-      requests$.next({ query: pendingQuery, immediate: true });
+      // Recorded before the guards: a prime declined for want of a source is
+      // still the host saying it wants a first page, and the effect above is
+      // what honours it once one arrives.
+      primeRequested = true;
+      primeNow();
     },
 
     loadMore(): void {

--- a/projects/truenas-ui/src/lib/utils/options-data-source.ts
+++ b/projects/truenas-ui/src/lib/utils/options-data-source.ts
@@ -2,7 +2,9 @@ import { DestroyRef, effect, inject, signal, untracked, type Signal } from '@ang
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, of, timer } from 'rxjs';
 import type { Observable } from 'rxjs';
-import { catchError, debounce, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import {
+  catchError, debounce, defaultIfEmpty, distinctUntilChanged, filter, map, switchMap, take, tap,
+} from 'rxjs/operators';
 
 /**
  * Fetches one page of options for a server-driven dropdown.
@@ -13,6 +15,14 @@ import { catchError, debounce, distinctUntilChanged, filter, map, switchMap, tap
  * owns the cursor, and rolls it back for you when a page fails.
  *
  * `page` is zero-based; page 0 is the first page of a fresh search.
+ *
+ * Only the FIRST emission is read, and an observable that completes without
+ * emitting is treated as an empty page — both normalized by
+ * {@link createTnOptionsDataSource} rather than required of the caller, since
+ * the signature promises neither. `(q) => q ? this.api.search(q) : EMPTY` is a
+ * shape consumers reach for, and left unnormalized it wedged the `loading`
+ * latch for the life of the field: both hosts prime with `''`, so the very
+ * first open would hang a spinner over an empty panel and kill paging with it.
  */
 export type TnOptionsFetchFn<O> = (query: string, page: number) => Observable<O[]>;
 
@@ -207,6 +217,22 @@ export function createTnOptionsDataSource<O>(
 
   const requests$ = new Subject<{ query: string; immediate: boolean }>();
 
+  /**
+   * One page from `fetch`, normalized to exactly one emission.
+   *
+   * Every latch in here — `loading`, `searchInFlight`, `loadMoreInFlight`,
+   * `onSettled` — is released from the `next` handler, so a source that
+   * completes without emitting released none of them: `loading` stuck true, and
+   * `loadMore` bails on `loading()`, so paging was dead for the rest of the
+   * session. `defaultIfEmpty` makes an empty completion an empty page, which is
+   * what it means. `take(1)` is the other half: a source that emits more than
+   * once would otherwise append the same page twice through `loadMore` and
+   * decrement `loadMoreInFlight` below zero.
+   */
+  function fetchPage(fetch: TnOptionsFetchFn<O>, term: string, page: number): Observable<O[]> {
+    return fetch(term, page).pipe(take(1), defaultIfEmpty([] as O[]));
+  }
+
   requests$
     .pipe(
       // A request made with no source bound is not a request. Every latch
@@ -255,7 +281,7 @@ export function createTnOptionsDataSource<O>(
             rows: [] as O[], failed: false, skipped: true, requestedGeneration,
           });
         }
-        return fetch(request.query, 0).pipe(
+        return fetchPage(fetch, request.query, 0).pipe(
           map((rows) => ({
             rows, failed: false, skipped: false, requestedGeneration,
           })),
@@ -338,10 +364,21 @@ export function createTnOptionsDataSource<O>(
   // `untracked` because emitting runs the pipeline synchronously, which reads
   // `source` and `debounceMs` — tracked here, those would re-run this effect
   // on every debounce change and on its own writes.
+  //
+  // Latched on the false->true EDGE rather than on every run: this effect
+  // re-runs on any identity change of `source`, and `[dataSource]="(q, p) =>
+  // this.search(q, p)"` — the call site the docs warn against, but one that
+  // type-checks — hands it a new reference on every change detection. Priming
+  // unconditionally then wrote `loading`, which schedules another change
+  // detection, which changes the input again: a cancel-storm of requests for
+  // the whole first round trip, and indefinitely if the endpoint keeps failing.
+  let hadSource = !!untracked(() => config.source());
   effect(() => {
     const hasSource = !!config.source();
     untracked(() => {
-      if (hasSource && primeRequested) {
+      const bound = hasSource && !hadSource;
+      hadSource = hasSource;
+      if (bound && primeRequested) {
         primeNow();
       }
     });
@@ -386,7 +423,7 @@ export function createTnOptionsDataSource<O>(
       loading.set(true);
       loadMoreInFlight++;
 
-      fetch(query, requestedPage)
+      fetchPage(fetch, query, requestedPage)
         .pipe(takeUntilDestroyed(destroyRef))
         .subscribe({
           next: (rows) => {

--- a/projects/truenas-ui/src/public-api.ts
+++ b/projects/truenas-ui/src/public-api.ts
@@ -115,6 +115,7 @@ export * from './lib/enums/modifier-keys.enum';
 export * from './lib/enums/common-shortcuts.enum';
 export * from './lib/utils/shortcut-builder';
 export * from './lib/utils/inject-labels';
+export * from './lib/utils/options-data-source';
 export * from './lib/pipes/file-size/file-size.pipe';
 export * from './lib/pipes/label-markup/label-markup.pipe';
 export * from './lib/pipes/label-markup/label-text.pipe';

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -492,6 +492,11 @@ export const AsyncOptions: Story = {
  * filtering, and choosing it emits `actionSelected` **without** committing
  * anything to the control, so no placeholder value can be submitted.
  *
+ * `setSelectedOption()` is the other half of that handoff: the host creates the
+ * entity and hands the row straight back, which commits the value AND carries
+ * the label. `control.setValue()` alone would not — a programmatic write has no
+ * label attached, and no search will ever return this row to supply one.
+ *
  * Same simulated backend: 600 ms, 100 entries, pages of 20. Every fifth search
  * fails, to show that an error reports once and leaves the field usable.
  */
@@ -533,10 +538,10 @@ export const DataSource: Story = {
           return () => clearTimeout(timer);
         }),
         onError: (error: unknown) => lastError.set((error as Error).message),
-        onAddNew: () => {
+        onAddNew: (field: TnAutocompleteComponent<string>) => {
           const name = `device-custom-${added().length + 1}`;
           added.update((current) => [...current, name]);
-          control.setValue(name);
+          field.setSelectedOption({ label: name, value: name });
         },
       };
     })(),
@@ -545,13 +550,14 @@ export const DataSource: Story = {
         label="Device"
         hint="Scroll the open list to page in more; every fifth lookup fails on purpose">
         <tn-autocomplete
+          #deviceField
           [formControl]="control"
           [dataSource]="devices"
           [pageSize]="pageSize"
           [actionOption]="addNew"
           [requireSelection]="true"
           placeholder="Type to search devices..."
-          (actionSelected)="onAddNew()"
+          (actionSelected)="onAddNew(deviceField)"
           (dataSourceError)="onError($event)">
         </tn-autocomplete>
       </tn-form-field>

--- a/projects/truenas-ui/src/stories/autocomplete.stories.ts
+++ b/projects/truenas-ui/src/stories/autocomplete.stories.ts
@@ -1,6 +1,7 @@
 import { signal } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { Observable } from 'rxjs';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnAutocompleteComponent, type TnAutocompleteOption } from '../lib/autocomplete/autocomplete.component';
@@ -466,6 +467,99 @@ export const AsyncOptions: Story = {
       </tn-form-field>
       @if (value()) {
         <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ value() }}</code></p>
+      }
+    `,
+    moduleMetadata: {
+      imports: [TnFormFieldComponent, ReactiveFormsModule],
+    },
+  }),
+  parameters: {
+    controls: { disable: true },
+  },
+};
+
+/**
+ * **The same picker, as a `[dataSource]`.** Everything the story above wires by
+ * hand — priming on open, debouncing the search, cancelling the in-flight
+ * request, tracking the page, holding `loading`, and recovering from a failed
+ * query — is done by the component when you bind a `(query, page)` function
+ * instead. Compare the two `props` blocks: the whole state machine collapses to
+ * one fetch.
+ *
+ * `[pageSize]` is how exhaustion is detected: a page shorter than it is the last
+ * one, and scrolling past it stops querying. `[actionOption]` pins a row above
+ * the results that runs a command rather than selecting a value — it survives
+ * filtering, and choosing it emits `actionSelected` **without** committing
+ * anything to the control, so no placeholder value can be submitted.
+ *
+ * Same simulated backend: 600 ms, 100 entries, pages of 20. Every fifth search
+ * fails, to show that an error reports once and leaves the field usable.
+ */
+export const DataSource: Story = {
+  render: () => ({
+    props: (() => {
+      const control = new FormControl<string | null>(null);
+      const value = signal<string | null>(null);
+      const lastError = signal<string | null>(null);
+      const added = signal<string[]>([]);
+      control.valueChanges.subscribe((committed) => value.set(committed));
+
+      let searches = 0;
+      const pageSize = 20;
+      const all = Array.from({ length: 100 }, (unused, i) => `device-${String(i).padStart(3, '0')}`);
+
+      return {
+        control,
+        value,
+        lastError,
+        added,
+        pageSize,
+        addNew: { label: 'Add a device…', value: '__add__' },
+        // The whole data layer: one function of (query, page).
+        devices: (query: string, page: number) => new Observable<TnAutocompleteOption<string>[]>((subscriber) => {
+          searches++;
+          const timer = setTimeout(() => {
+            if (searches % 5 === 0) {
+              subscriber.error(new Error(`Lookup failed for "${query}"`));
+              return;
+            }
+            const matches = all.filter((name) => name.includes(query));
+            subscriber.next(
+              matches.slice(page * pageSize, (page + 1) * pageSize)
+                .map((name) => ({ label: name, value: name })),
+            );
+            subscriber.complete();
+          }, 600);
+          return () => clearTimeout(timer);
+        }),
+        onError: (error: unknown) => lastError.set((error as Error).message),
+        onAddNew: () => {
+          const name = `device-custom-${added().length + 1}`;
+          added.update((current) => [...current, name]);
+          control.setValue(name);
+        },
+      };
+    })(),
+    template: `
+      <tn-form-field
+        label="Device"
+        hint="Scroll the open list to page in more; every fifth lookup fails on purpose">
+        <tn-autocomplete
+          [formControl]="control"
+          [dataSource]="devices"
+          [pageSize]="pageSize"
+          [actionOption]="addNew"
+          [requireSelection]="true"
+          placeholder="Type to search devices..."
+          (actionSelected)="onAddNew()"
+          (dataSourceError)="onError($event)">
+        </tn-autocomplete>
+      </tn-form-field>
+      @if (value()) {
+        <p style="margin-top: 1rem; font-size: 0.875rem;">Committed value: <code>{{ value() }}</code></p>
+      }
+      @if (lastError()) {
+        <p style="margin-top: 0.5rem; font-size: 0.875rem;">Last error: <code>{{ lastError() }}</code></p>
       }
     `,
     moduleMetadata: {

--- a/projects/truenas-ui/src/stories/chip-input.stories.ts
+++ b/projects/truenas-ui/src/stories/chip-input.stories.ts
@@ -235,6 +235,8 @@ export const AsyncSuggestions: Story = {
  * a lookup is out, the panel keeps showing the previous term's rows — a
  * `dataSource` is trusted to have applied the query, so they are not re-filtered
  * on the label — and says so with a spinner row and `aria-busy` on the listbox.
+ * `[loadingText]` is what that row says; left unset it reads "Loading...", or
+ * whatever an app-wide `TN_CHIP_INPUT_LABELS` provider supplies.
  *
  * Every fourth lookup fails on purpose, to show the field stays usable.
  */
@@ -278,6 +280,7 @@ export const DataSource: Story = {
           [formControl]="control"
           [dataSource]="languages"
           placeholder="Search languages…"
+          loadingText="Searching languages…"
           (dataSourceError)="onError($event)" />
       </tn-form-field>
       @if (lastError()) {

--- a/projects/truenas-ui/src/stories/chip-input.stories.ts
+++ b/projects/truenas-ui/src/stories/chip-input.stories.ts
@@ -1,6 +1,7 @@
 import { signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { Observable } from 'rxjs';
 import { TestIdInspectorComponent } from './testid-inspector.component';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
 import { TnChipInputComponent } from '../lib/chip-input/chip-input.component';
@@ -213,6 +214,75 @@ export const AsyncSuggestions: Story = {
           placeholder="Search languages…"
           (searchChange)="onSearch($event)" />
       </tn-form-field>
+    `,
+    moduleMetadata: { imports: [TnFormFieldComponent, ReactiveFormsModule] },
+  }),
+  parameters: { controls: { disable: true } },
+};
+
+/**
+ * **The same suggestions, as a `[dataSource]`.** Binding a `(query, page)`
+ * function replaces the story above's subject-and-timer entirely: the component
+ * owns the debounce, cancels the in-flight request when the term changes, and
+ * recovers from a failure without the field going dead. Unlike the hand-rolled
+ * version it also primes on focus, so an empty field already shows the first
+ * page rather than waiting for a keystroke.
+ *
+ * The chip dropdown is not paged, so `page` is always 0 — the parameter exists
+ * only so one source function can feed this and `tn-autocomplete` alike.
+ *
+ * The 350 ms latency is deliberate: it makes the in-flight state visible. While
+ * a lookup is out, the panel keeps showing the previous term's rows — a
+ * `dataSource` is trusted to have applied the query, so they are not re-filtered
+ * on the label — and says so with a spinner row and `aria-busy` on the listbox.
+ *
+ * Every fourth lookup fails on purpose, to show the field stays usable.
+ */
+export const DataSource: Story = {
+  render: () => ({
+    props: (() => {
+      const control = new FormControl<string[]>([]);
+      const lastError = signal<string | null>(null);
+      let lookups = 0;
+      const all = [
+        'JavaScript', 'TypeScript', 'Python', 'Rust', 'Go', 'Java', 'Kotlin',
+        'Swift', 'Ruby', 'Scala', 'Elixir', 'Haskell', 'Clojure', 'C#', 'C++',
+        'Dart', 'Lua', 'Perl', 'PHP', 'Zig',
+      ];
+
+      return {
+        control,
+        lastError,
+        languages: (query: string) => new Observable<{ label: string; value: string }[]>((subscriber) => {
+          lookups++;
+          const timer = setTimeout(() => {
+            if (lookups % 4 === 0) {
+              subscriber.error(new Error(`Lookup failed for "${query}"`));
+              return;
+            }
+            const term = query.trim().toLowerCase();
+            subscriber.next(
+              all.filter((name) => name.toLowerCase().includes(term))
+                .map((name) => ({ label: name, value: name })),
+            );
+            subscriber.complete();
+          }, 350);
+          return () => clearTimeout(timer);
+        }),
+        onError: (error: unknown) => lastError.set((error as Error).message),
+      };
+    })(),
+    template: `
+      <tn-form-field label="Languages" hint="Focus to see the first page; every fourth lookup fails">
+        <tn-chip-input
+          [formControl]="control"
+          [dataSource]="languages"
+          placeholder="Search languages…"
+          (dataSourceError)="onError($event)" />
+      </tn-form-field>
+      @if (lastError()) {
+        <p style="margin-top: 0.5rem; font-size: 0.875rem;">Last error: <code>{{ lastError() }}</code></p>
+      }
     `,
     moduleMetadata: { imports: [TnFormFieldComponent, ReactiveFormsModule] },
   }),


### PR DESCRIPTION
## Why

Every server-driven picker in the product hand-rolls the same state machine around `tn-autocomplete` / `tn-chip-input`: a `Subject` fed from `(searchChange)`, a `debounceTime`, a `distinctUntilChanged`, a `switchMap`, a page cursor, an exhaustion flag, an error latch, and a "keep the selected option listed" pass. Several of those copies get one of the edge cases wrong — a failed request that freezes the field for the life of the panel, a late page that overwrites a newer search, a cursor that steps over the page that errored, an edit form bound to an id that renders the raw number until someone clicks into it.

This PR moves that machine into the components. A consumer binds one function of `(query, page)` and forwards nothing.

```html
<tn-autocomplete
  [formControl]="deviceId"
  [dataSource]="fetchDevices"
  [pageSize]="20"
  [actionOption]="{ label: 'Add a device…', value: '__add__' }"
  (actionSelected)="createDevice(field)"
  (dataSourceError)="toast($event)" />
```

```ts
fetchDevices = (query: string, page: number): Observable<TnAutocompleteOption<string>[]> =>
  this.api.searchDevices(query, page, 20);
```

Compare `AsyncOptions` and `DataSource` in Storybook (Autocomplete, Chip Input) — same simulated backend, and the whole `props` block collapses to one fetch.

## What's in it

### `createTnOptionsDataSource` — the engine

New, exported from `public-api` (`projects/truenas-ui/src/lib/utils/options-data-source.ts`). Owns debounce, cancellation, the page cursor, exhaustion and error recovery; the *source* stays stateless, a plain `(query, page) => Observable<O[]>`, so it never has to track — or roll back — a cursor of its own.

| Behaviour | Why it's here |
| --- | --- |
| `catchError` **inside** the `switchMap` | A failed request reports and yields an empty page; the outer subscription survives. Outside it, one transient failure freezes the field for the life of the panel. |
| A failed term is retryable | `distinctUntilChanged` treats a repeat of a *failed* query as a change, so reopening a picker after an error refetches instead of being suppressed as a duplicate. |
| A failed page does not advance the cursor | The cursor tracks the *next* page to ask for, so page 0 rolls back like every other page rather than being silently skipped. |
| Generation stamping | Every response carries the generation it was requested in and is dropped if a search — or a `refresh()` — has since started. A `refresh()` that issues nothing still can't be contaminated by a page in flight. |
| `prime()` | Fetches page 0 once for click-to-open pickers, where `search` never fires until the user types. A no-op once a query has run *successfully*; a failed one is retried. |
| `refresh()` | Declares fetched rows stale **without** fetching. A `[dataSource]` is a fixed function reading live configuration — that stability is what keeps it from being swapped out from under a request. This is how a host says the configuration moved. It does not query, because only the host knows whether its panel is open. |

### New API surface

**`tn-autocomplete`**

| Member | |
| --- | --- |
| `[dataSource]` | `TnOptionsFetchFn<TnAutocompleteOption<T>>` |
| `[dataSourceDebounce]` | ms before a request goes out (default `250`) |
| `[pageSize]` | exhaustion detection only — a short page is the last one (default `50`) |
| `[keepSelectedOption]` | keep the committed value listed while the fetched pages lack it (default `true`) |
| `[actionOption]` | a row pinned above the results that runs a command instead of selecting a value |
| `(actionSelected)` | fires **without** committing anything, so no placeholder value can be submitted |
| `(dataSourceError)` | one emission per failed request |
| `refreshOptions()` | see `refresh()` above |
| `setSelectedOption(option)` | commit a value **and** its label — the other half of the `actionSelected` handoff |

**`tn-chip-input`**

`[dataSource]`, `[dataSourceDebounce]`, `[loadingText]`, `(dataSourceError)`, `refreshOptions()`, plus the `TN_CHIP_INPUT_LABELS` token (`placeholder` / `loading`), matching the one `tn-autocomplete` already had — a plain object or a `Signal`, so a language switch propagates.

`TnChipInputHarness.isLoading()` reports the dropdown's loading row.

### `setSelectedOption()`, and why `control.setValue()` isn't enough

The create-new flow hands an entity back to the field. A programmatic write carries no label, and no search will ever return that brand-new row to supply one — so committing through the CVA alone paints the raw value forever. `setSelectedOption()` commits the value and remembers the label with it.

## The recurring hazard in here

Nearly every bug fixed across this branch is one shape: **a list the field paints from is not the list it reads back.**

- With `[dataSource]` + `[options]`, the field would render `g-7` as `admins` and then refuse to recognise `admins` when typed — dropped under `allowCustomValue="false"`, committed as the raw string under the default `true`, beside the chip it duplicates. Both components now match typed text against *every* label they are willing to show.
- `tn-autocomplete`'s display-upgrade effect tracked one list and resolved from another; with `[keepSelectedOption]="false"` that made `[options]` not a dependency at all, so a late-arriving label never reached the screen.
- `commitCustomValue()` kept the previously selected option's label, so <kbd>Esc</kbd> repainted the old name over the user's custom text and the next blur committed the option it belonged to.
- With a `[dataSource]` and no pinned `[options]`, a chip's label only survived while the fetched page still carried its row — pick `admins`, type `dev`, and the chip reverted to `g-7`. `tn-chip-input` now remembers the label each value was committed from (the multi-value form of `tn-autocomplete`'s `selectedLabel`), consulted **last** so a live row or a host pin still wins, and pruned to the committed values so it stays bounded.

`[options]` alongside a `[dataSource]` is the deliberate expression of this: the host's rows stay part of the **lookup** even where they are not part of the **dropdown** (splicing them into results would append the same entries to every term, matching or not).

## Accessibility

- The listbox is the scrollport, and the loading / no-results rows are live-region siblings of it rather than children — a status row inside the listbox is announced as an option.
- `aria-busy` on the listbox while a request is in flight.
- `tn-chip-input` cues the round trip but **not** the debounce window: a spinner appearing and vanishing on every keystroke of a half-typed term is noise, and the request it announces may never be sent.
- The pinned action row is separated by a rule and a heavier weight, deliberately **not** the accent colour: it hovers and keyboard-highlights like any other row, so it also paints on `--tn-alt-bg2` / `--tn-alt-bg1`, where `--tn-primary-text` measures 2.37:1–4.23:1 across the shipped palettes — under the 4.5:1 this repo holds normal text to, and one <kbd>↓</kbd> away since `open()` highlights index 0. Same hazard already recorded for `tn-menu`.
- `text-token-surface-contrast` ledger updated for the chip-input loading row (`--tn-fg2` on the panel's own `--tn-bg1`).

## Testing

`yarn test` → **4511 passing, 162 suites**. `yarn lint` clean. Build, Storybook interaction tests green.

New suites: `options-data-source.spec.ts`, `autocomplete-data-source.spec.ts`, `chip-input-data-source.spec.ts`, `chip-input-labels.spec.ts`. Each case names the failure it prevents rather than the behaviour it asserts — including the stale-`loading` trio, the late-page contamination cases, and every paint/read asymmetry listed above.

## Compatibility

Additive. Every new input is optional and defaults to today's behaviour; with no `[dataSource]` bound both components behave exactly as before. The one public-API addition is the `options-data-source` export.