### PR TITLE
NAS-143108 / 27.0.0-BETA.1 / feat(table): Let a table selection survive a dataSource change, and stop the pager aliasing the provider's pagination

### DIFF
--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.spec.ts
@@ -436,6 +436,25 @@ describe('TnTablePagerComponent — dataProvider mode', () => {
     expect(setPaginationSpy).toHaveBeenCalledWith({ pageNumber: 1, pageSize: 20 });
   });
 
+  it('should follow a page the provider changed in place', () => {
+    const { provider, emit } = createProvider({ totalRows: 100 });
+    fixture.componentRef.setInput('dataProvider', provider);
+    fixture.componentRef.setInput('pageSize', 20);
+    fixture.detectChanges();
+
+    component.goToPage(3);
+    expect(component.currentPage()).toBe(3);
+
+    // A provider that re-paginates in place — a filter resetting to page 1, say — mutates
+    // the very object the pager handed it. While the echo guard aliased that object, the
+    // provider's own change read back as the pager's push, and the label sat on page 3
+    // over page 1's rows.
+    provider.pagination.pageNumber = 1;
+    emit();
+
+    expect(component.currentPage()).toBe(1);
+  });
+
   it('should not loop on provider-driven sync (guard flag)', () => {
     const { provider, setPaginationSpy } = createProvider({ totalRows: 100 });
     fixture.componentRef.setInput('dataProvider', provider);

--- a/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
+++ b/projects/truenas-ui/src/lib/table-pager/table-pager.component.ts
@@ -497,6 +497,11 @@ export class TnTablePagerComponent {
       pageSize: this.pageSize(),
     };
     this.lastPushedPagination = pagination;
-    provider.setPagination(pagination);
+    // The provider gets its OWN object. Handing it this one aliases the echo guard to
+    // the provider's live pagination, and a provider that re-paginates in place — a
+    // filter that resets to page 1, say — silently rewrites what we think we pushed.
+    // The guard then reads the provider's own change back as our echo and leaves the
+    // pager showing a page the provider is no longer serving.
+    provider.setPagination({ ...pagination });
   }
 }

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -282,6 +282,119 @@ describe('TnTableComponent', () => {
       component.toggleRowSelection(testData[0]);
       expect(spy).toHaveBeenCalledWith([testData[0]]);
     });
+
+    it('clears the selection when the data reference changes', () => {
+      component.toggleRowSelection(testData[0]);
+      expect(component.selection.selected).toHaveLength(1);
+
+      fixture.componentRef.setInput('dataSource', [...testData]);
+      fixture.detectChanges();
+
+      expect(component.selection.selected).toHaveLength(0);
+    });
+  });
+
+  describe('selection with selectionKey', () => {
+    const pageOne = [{ id: 1 }, { id: 2 }];
+    const pageTwo = [{ id: 3 }, { id: 4 }];
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('dataSource', pageOne);
+      fixture.componentRef.setInput('selectable', true);
+      fixture.componentRef.setInput('selectionKey', (row: { id: number }) => row.id);
+      fixture.detectChanges();
+    });
+
+    it('keeps rows selected on a page the table is no longer showing', () => {
+      component.toggleRowSelection(pageOne[0]);
+
+      fixture.componentRef.setInput('dataSource', pageTwo);
+      fixture.detectChanges();
+
+      component.toggleRowSelection(pageTwo[1]);
+
+      expect(component.selection.selected).toEqual([pageTwo[1]]);
+      expect(component.isRowSelected(pageOne[0])).toBe(true);
+    });
+
+    it('emits the whole selection, including rows off the current page', () => {
+      const spy = jest.fn();
+      component.selectionChange.subscribe(spy);
+
+      component.toggleRowSelection(pageOne[0]);
+      fixture.componentRef.setInput('dataSource', pageTwo);
+      fixture.detectChanges();
+      component.toggleRowSelection(pageTwo[0]);
+
+      expect(spy).toHaveBeenLastCalledWith([pageOne[0], pageTwo[0]]);
+    });
+
+    it('re-checks the row when the page it was selected on comes back', () => {
+      component.toggleRowSelection(pageOne[0]);
+
+      fixture.componentRef.setInput('dataSource', pageTwo);
+      fixture.detectChanges();
+      fixture.componentRef.setInput('dataSource', pageOne);
+      fixture.detectChanges();
+
+      expect(component.selection.selected).toEqual([pageOne[0]]);
+      expect(component.isAllSelected()).toBe(false);
+      expect(component.isIndeterminate()).toBe(true);
+    });
+
+    it('re-points a retained selection at the row object a reload rebuilt', () => {
+      const spy = jest.fn();
+      component.toggleRowSelection(pageOne[0]);
+      component.selectionChange.subscribe(spy);
+
+      const reloaded = [{ id: 1 }, { id: 2 }];
+      fixture.componentRef.setInput('dataSource', reloaded);
+      fixture.detectChanges();
+
+      expect(component.selection.selected).toEqual([reloaded[0]]);
+      expect(spy).toHaveBeenLastCalledWith([reloaded[0]]);
+      expect(spy.mock.lastCall?.[0][0]).toBe(reloaded[0]);
+    });
+
+    it('scopes select-all to the visible page', () => {
+      component.toggleRowSelection(pageOne[0]);
+
+      fixture.componentRef.setInput('dataSource', pageTwo);
+      fixture.detectChanges();
+      component.toggleSelectAll();
+
+      expect(component.isAllSelected()).toBe(true);
+      expect(component.isRowSelected(pageOne[0])).toBe(true);
+
+      // Clearing the page drops only the rows it shows.
+      component.toggleSelectAll();
+      expect(component.isRowSelected(pageTwo[0])).toBe(false);
+      expect(component.isRowSelected(pageOne[0])).toBe(true);
+    });
+
+    it('does not resurrect retained rows when selectionKey is taken away and given back', () => {
+      component.toggleRowSelection(pageOne[0]);
+
+      fixture.componentRef.setInput('selectionKey', undefined);
+      fixture.detectChanges();
+      fixture.componentRef.setInput('selectionKey', (row: { id: number }) => row.id);
+      fixture.detectChanges();
+
+      expect(component.isRowSelected(pageOne[0])).toBe(false);
+    });
+
+    it('drops the retained rows too when clearSelection() is called', () => {
+      component.toggleRowSelection(pageOne[0]);
+      fixture.componentRef.setInput('dataSource', pageTwo);
+      fixture.detectChanges();
+
+      component.clearSelection();
+      fixture.componentRef.setInput('dataSource', pageOne);
+      fixture.detectChanges();
+
+      expect(component.selection.selected).toHaveLength(0);
+      expect(component.isRowSelected(pageOne[0])).toBe(false);
+    });
   });
 
   describe('clickable rows', () => {

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -395,6 +395,43 @@ describe('TnTableComponent', () => {
       expect(component.selection.selected).toHaveLength(0);
       expect(component.isRowSelected(pageOne[0])).toBe(false);
     });
+
+    it('emits the empty selection from clearSelection(), so a mirrored copy can follow', () => {
+      const spy = jest.fn();
+      component.toggleRowSelection(pageOne[0]);
+      component.selectionChange.subscribe(spy);
+
+      component.clearSelection();
+      expect(spy).toHaveBeenCalledWith([]);
+
+      // Nothing left to clear, nothing to say.
+      spy.mockClear();
+      component.clearSelection();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet when only the key function identity changes', () => {
+      const spy = jest.fn();
+      component.toggleRowSelection(pageOne[0]);
+      component.selectionChange.subscribe(spy);
+
+      fixture.componentRef.setInput('selectionKey', (row: { id: number }) => row.id);
+      fixture.detectChanges();
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(component.isRowSelected(pageOne[0])).toBe(true);
+    });
+
+    it('keeps detail rows open when only the key function identity changes', () => {
+      fixture.componentRef.setInput('expandable', true);
+      fixture.detectChanges();
+      component.toggleRowExpansion(pageOne[0]);
+
+      fixture.componentRef.setInput('selectionKey', (row: { id: number }) => row.id);
+      fixture.detectChanges();
+
+      expect(component.isRowExpanded(pageOne[0])).toBe(true);
+    });
   });
 
   describe('clickable rows', () => {

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -283,8 +283,10 @@ export class TnTableComponent<T = unknown> implements OnInit {
    *
    * This is deliberately separate from {@link trackBy}, which is a rendering concern
    * (`@for` identity, index-based by default) and is free to stay so on a table whose
-   * selection has to be stable. Pass a key that identifies the ROW, not its position:
-   * `[selectionKey]="(row) => row.id"`.
+   * selection has to be stable. Pass a key that identifies the ROW, not its position —
+   * and bind a stable member rather than writing the function in the template, since
+   * Angular's expression grammar has no arrow functions:
+   * `[selectionKey]="rowKey"` for a `rowKey = (row: User) => row.id` on the host.
    *
    * The select-all checkbox stays scoped to the visible page — it selects and clears
    * the rows the table is currently showing, and `isAllSelected` reflects only those,
@@ -600,6 +602,13 @@ export class TnTableComponent<T = unknown> implements OnInit {
 
   /** Number of selected rows present in the current `data()` — see {@link selection}. */
   private selectionCount = signal(0);
+
+  /**
+   * The array last handed to `selectionChange`, so a reconcile that leaves the selection
+   * exactly as the consumer already sees it can stay quiet — re-running because
+   * `selectionKey`'s identity changed is not news.
+   */
+  private lastEmittedSelection: T[] = [];
   private initialized = false;
 
   // Column def map as a computed signal
@@ -615,19 +624,30 @@ export class TnTableComponent<T = unknown> implements OnInit {
   });
 
   constructor() {
-    // Reconcile selection and clear expansion when the data reference changes.
+    // Collapse every open detail row when the data reference changes: the rows the
+    // expanded set holds belong to the array that is going away. This reads `data()`
+    // and nothing else, so an unrelated input — `selectionKey` above all, which a
+    // consumer may swap or re-create on any change-detection pass — cannot close what
+    // the user opened as a side effect of a selection concern.
+    effect(() => {
+      this.data();
+      if (!this.initialized) { return; }
+      this.expandedRows.set(new Set());
+    });
+
+    // Reconcile the retained selection against the rows now on screen. This has to
+    // react to `selectionKey` as well as to `data()` — a key being taken away must be
+    // noticed promptly — so the emit is guarded by whether the selection the consumer
+    // last saw actually changed, and a key swapped for an equivalent one stays silent.
     effect(() => {
       const rows = this.data();
       const selectionKey = this.selectionKey();
       if (!this.initialized) { return; }
 
-      this.expandedRows.set(new Set());
-
       if (!selectionKey) {
         // Also drop anything retained under a key, so a table whose `selectionKey` is
         // taken away cannot resurrect those rows if it is given one again.
         this.clearSelection();
-        this.selectionChange.emit([]);
         return;
       }
 
@@ -642,7 +662,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
         }
       }
       this.syncSelectionToData(rows, selectionKey);
-      this.selectionChange.emit(this.emittedSelection());
+      this.emitSelectionIfChanged();
     });
 
     // Clear expanded rows when expandable is toggled off
@@ -1285,7 +1305,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
     }
 
     this.selectionCount.set(this.selection.selected.length);
-    this.selectionChange.emit(this.emittedSelection());
+    this.emitSelection();
   }
 
   toggleRowSelection(row: T): void {
@@ -1302,7 +1322,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
     }
 
     this.selectionCount.set(this.selection.selected.length);
-    this.selectionChange.emit(this.emittedSelection());
+    this.emitSelection();
   }
 
   isRowSelected(row: T): boolean {
@@ -1320,15 +1340,18 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * Drops the whole selection, including rows retained from pages the table is not
    * showing. Use it after a batch action consumes the selection.
    *
-   * Deliberately silent — it does not emit `selectionChange`, because the caller is the
-   * one clearing and already knows the selection is now empty. Clearing
-   * {@link selection} directly is not enough once `selectionKey` is set: the retained
-   * rows would survive and come back on the next reconcile.
+   * Emits an empty `selectionChange` if anything was selected. The caller knows it
+   * cleared, but `selectionChange` is the only way anything else can: a toolbar bound to
+   * a mirrored copy of the selection a layer up would otherwise stay stale until the next
+   * `dataSource` change happened to correct it. Clearing {@link selection} directly is not
+   * enough once `selectionKey` is set: the retained rows would survive and come back on
+   * the next reconcile.
    */
   clearSelection(): void {
     this.selection.clear();
     this.selectedByKey.clear();
     this.selectionCount.set(0);
+    this.emitSelectionIfChanged();
   }
 
   /** Re-applies the retained selection to the rows currently on screen. */
@@ -1344,6 +1367,26 @@ export class TnTableComponent<T = unknown> implements OnInit {
   /** What `selectionChange` carries: the whole selection when keyed, the page's otherwise. */
   private emittedSelection(): T[] {
     return this.selectionKey() ? [...this.selectedByKey.values()] : this.selection.selected;
+  }
+
+  /** Emits the current selection and records it. For the paths that always change it. */
+  private emitSelection(): void {
+    this.lastEmittedSelection = this.emittedSelection();
+    this.selectionChange.emit(this.lastEmittedSelection);
+  }
+
+  /**
+   * Emits only if the selection differs from the one last emitted, by row identity — for
+   * the paths that may be re-run without anything having moved.
+   */
+  private emitSelectionIfChanged(): void {
+    const next = this.emittedSelection();
+    const previous = this.lastEmittedSelection;
+    if (next.length === previous.length && next.every((row, index) => row === previous[index])) {
+      return;
+    }
+    this.lastEmittedSelection = next;
+    this.selectionChange.emit(next);
   }
 
   // --- Card-mode computeds ---

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -269,6 +269,34 @@ export class TnTableComponent<T = unknown> implements OnInit {
   displayedColumns = input<string[]>([]);
   trackBy = input<((index: number, item: T) => unknown) | undefined>(undefined);
 
+  /**
+   * Identity function for SELECTION. When set, the table tracks selected rows by the
+   * key this returns rather than by object reference, and the selection survives a
+   * `dataSource` change: paging, sorting, filtering, or a background reload that hands
+   * back freshly-built row objects. Rows selected on a page the table is no longer
+   * showing stay selected and keep coming back in `selectionChange`.
+   *
+   * Without it the table keeps its historical behaviour — any `dataSource` reference
+   * change clears the selection and emits an empty `selectionChange` — because
+   * reference-keyed selections cannot be recognised in a new array and would otherwise
+   * leave the header checkbox counting rows that are no longer on screen.
+   *
+   * This is deliberately separate from {@link trackBy}, which is a rendering concern
+   * (`@for` identity, index-based by default) and is free to stay so on a table whose
+   * selection has to be stable. Pass a key that identifies the ROW, not its position:
+   * `[selectionKey]="(row) => row.id"`.
+   *
+   * The select-all checkbox stays scoped to the visible page — it selects and clears
+   * the rows the table is currently showing, and `isAllSelected` reflects only those,
+   * so it never claims to have selected rows the user cannot see.
+   *
+   * Retention is unconditional, and it has to be: the table sees one page and cannot
+   * tell a row that moved off-screen from one that was destroyed. A consumer whose rows
+   * can disappear for good owns that check — reconcile `selectionChange` against the
+   * full list it holds, and call {@link clearSelection} once a batch action is done.
+   */
+  selectionKey = input<((row: T) => unknown) | undefined>(undefined);
+
   emptyMessage = input<string>('No data available');
 
   /**
@@ -553,7 +581,24 @@ export class TnTableComponent<T = unknown> implements OnInit {
   private readonly instanceId = `tn-table-${TnTableComponent.instanceCount++}`;
 
   // --- Selection state ---
+  /**
+   * The rows of the CURRENT `data()` that are selected. With `selectionKey` set this is
+   * the visible slice of {@link selectedByKey} — it is what the row checkboxes and the
+   * select-all state read, so both stay scoped to the page on screen.
+   */
   selection = new SelectionModel<T>(true, []);
+
+  /**
+   * The whole selection, keyed by `selectionKey`, including rows that are no longer in
+   * `data()`. Empty (and unused) when no `selectionKey` is set.
+   *
+   * It holds the row objects, not just the keys, so `selectionChange` can hand a
+   * consumer the rows it selected on an earlier page — a batch action has to act on
+   * rows, and the table is the only thing that ever saw them.
+   */
+  private readonly selectedByKey = new Map<unknown, T>();
+
+  /** Number of selected rows present in the current `data()` — see {@link selection}. */
   private selectionCount = signal(0);
   private initialized = false;
 
@@ -570,15 +615,34 @@ export class TnTableComponent<T = unknown> implements OnInit {
   });
 
   constructor() {
-    // Clear selection and expansion when data reference changes
+    // Reconcile selection and clear expansion when the data reference changes.
     effect(() => {
-      this.data();
-      if (this.initialized) {
-        this.selection.clear();
-        this.selectionCount.set(0);
-        this.expandedRows.set(new Set());
+      const rows = this.data();
+      const selectionKey = this.selectionKey();
+      if (!this.initialized) { return; }
+
+      this.expandedRows.set(new Set());
+
+      if (!selectionKey) {
+        // Also drop anything retained under a key, so a table whose `selectionKey` is
+        // taken away cannot resurrect those rows if it is given one again.
+        this.clearSelection();
         this.selectionChange.emit([]);
+        return;
       }
+
+      // Re-point every retained selection at the row object the new data carries, so a
+      // reload that rebuilt its rows leaves the consumer holding live references rather
+      // than the stale ones it selected. Rows the new data does not carry (another page,
+      // or filtered out) keep the reference they were selected with.
+      for (const row of rows) {
+        const key = selectionKey(row);
+        if (this.selectedByKey.has(key)) {
+          this.selectedByKey.set(key, row);
+        }
+      }
+      this.syncSelectionToData(rows, selectionKey);
+      this.selectionChange.emit(this.emittedSelection());
     });
 
     // Clear expanded rows when expandable is toggled off
@@ -747,7 +811,7 @@ export class TnTableComponent<T = unknown> implements OnInit {
     this.initialized = true;
 
     this.destroyRef.onDestroy(() => {
-      this.selection.clear();
+      this.clearSelection();
       this.resizeObserver?.disconnect();
     });
   }
@@ -1199,23 +1263,87 @@ export class TnTableComponent<T = unknown> implements OnInit {
   }
 
   toggleSelectAll(): void {
-    if (this.isAllSelected()) {
-      this.selection.clear();
-    } else {
+    const selectAll = !this.isAllSelected();
+    if (selectAll) {
       this.selection.select(...this.data());
+    } else {
+      this.selection.clear();
     }
+
+    // Only the visible rows move: select-all is scoped to the page, so rows retained
+    // from elsewhere are neither selected nor dropped by it.
+    const selectionKey = this.selectionKey();
+    if (selectionKey) {
+      for (const row of this.data()) {
+        const key = selectionKey(row);
+        if (selectAll) {
+          this.selectedByKey.set(key, row);
+        } else {
+          this.selectedByKey.delete(key);
+        }
+      }
+    }
+
     this.selectionCount.set(this.selection.selected.length);
-    this.selectionChange.emit(this.selection.selected);
+    this.selectionChange.emit(this.emittedSelection());
   }
 
   toggleRowSelection(row: T): void {
     this.selection.toggle(row);
+
+    const selectionKey = this.selectionKey();
+    if (selectionKey) {
+      const key = selectionKey(row);
+      if (this.selection.isSelected(row)) {
+        this.selectedByKey.set(key, row);
+      } else {
+        this.selectedByKey.delete(key);
+      }
+    }
+
     this.selectionCount.set(this.selection.selected.length);
-    this.selectionChange.emit(this.selection.selected);
+    this.selectionChange.emit(this.emittedSelection());
   }
 
   isRowSelected(row: T): boolean {
+    const selectionKey = this.selectionKey();
+    if (selectionKey) {
+      // Read the keyed store rather than the model: a row object rebuilt by a reload is
+      // a different reference, and it should render checked before the reconciling
+      // effect has had a chance to re-point the model at it.
+      return this.selectedByKey.has(selectionKey(row));
+    }
     return this.selection.isSelected(row);
+  }
+
+  /**
+   * Drops the whole selection, including rows retained from pages the table is not
+   * showing. Use it after a batch action consumes the selection.
+   *
+   * Deliberately silent — it does not emit `selectionChange`, because the caller is the
+   * one clearing and already knows the selection is now empty. Clearing
+   * {@link selection} directly is not enough once `selectionKey` is set: the retained
+   * rows would survive and come back on the next reconcile.
+   */
+  clearSelection(): void {
+    this.selection.clear();
+    this.selectedByKey.clear();
+    this.selectionCount.set(0);
+  }
+
+  /** Re-applies the retained selection to the rows currently on screen. */
+  private syncSelectionToData(rows: readonly T[], selectionKey: (row: T) => unknown): void {
+    this.selection.clear();
+    const selected = rows.filter((row) => this.selectedByKey.has(selectionKey(row)));
+    if (selected.length) {
+      this.selection.select(...selected);
+    }
+    this.selectionCount.set(this.selection.selected.length);
+  }
+
+  /** What `selectionChange` carries: the whole selection when keyed, the page's otherwise. */
+  private emittedSelection(): T[] {
+    return this.selectionKey() ? [...this.selectedByKey.values()] : this.selection.selected;
   }
 
   // --- Card-mode computeds ---

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -98,7 +98,8 @@ const meta: Meta<TnTableComponent> = {
     selectable: { description: 'Show checkbox column for row selection', control: 'boolean' },
     selectionKey: {
       description:
-        'Identity function `(row) => key`. Tracks selection by key instead of by object reference, so it '
+        'Identity function `(row) => key`, bound as a stable member (`[selectionKey]="rowKey"`) since '
+        + 'Angular templates have no arrow functions. Tracks selection by key instead of by object reference, so it '
         + 'survives a `dataSource` change — paging, sorting, filtering, or a reload that rebuilt its rows. '
         + 'Select-all stays scoped to the visible page.',
       control: false,
@@ -288,19 +289,22 @@ export const SelectionAcrossPages: Story = {
       allData: sampleData,
       tableColumns: ['name', 'email', 'role'],
       selectionKey: (user: User) => user.id,
-      get pageData(): User[] {
-        const start = this['page'] * this['pageSize'];
-        return this['allData'].slice(start, start + this['pageSize']);
-      },
-      get selectedNames(): string {
-        return this['selected'].map((user: User) => user.name).join(', ') || 'none';
-      },
+      // Plain properties recomputed in the handlers, not getters: `@storybook/angular`
+      // applies story props with `Object.assign`, which invokes an accessor once and
+      // copies the value, so a getter here would freeze at its first result and neither
+      // paging nor selecting would ever show.
+      pageData: sampleData.slice(0, 2),
+      selectedNames: 'none',
       turnPage(delta: number) {
         const last = Math.ceil(this['allData'].length / this['pageSize']) - 1;
         this['page'] = Math.min(Math.max(this['page'] + delta, 0), last);
+        const start = this['page'] * this['pageSize'];
+        this['pageData'] = this['allData'].slice(start, start + this['pageSize']);
       },
       onSelect(users: User[]) {
+        // The mirrored copy a consumer keeps, and the label read off it.
         this['selected'] = users;
+        this['selectedNames'] = this['selected'].map((user: User) => user.name).join(', ') || 'none';
       },
     },
     template: `
@@ -330,6 +334,30 @@ export const SelectionAcrossPages: Story = {
       </div>
     `,
   }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The checkbox labels are page-relative ("Select row 1" is whichever row is on top),
+    // which is what makes them a fair check that the ticks come back on the way home.
+    const row = (position: number): HTMLElement => canvas.getByLabelText(`Select row ${position}`);
+    const summary = (): HTMLElement => canvas.getByText(/^Selected:/);
+
+    await userEvent.click(row(1));
+    await expect(summary()).toHaveTextContent('Selected: Alice Johnson');
+
+    // Page forward: a new `dataSource` array, and the tick on page one has to survive it.
+    await userEvent.click(canvas.getByRole('button', { name: 'Next page' }));
+    await expect(canvas.getByText('Carol Williams')).toBeInTheDocument();
+    await expect(row(1)).not.toBeChecked();
+
+    await userEvent.click(row(2));
+    await expect(summary()).toHaveTextContent('Selected: Alice Johnson, David Brown');
+
+    // ...and back: the row selected on page one is still checked.
+    await userEvent.click(canvas.getByRole('button', { name: 'Previous page' }));
+    await expect(canvas.getByText('Alice Johnson')).toBeInTheDocument();
+    await expect(row(1)).toBeChecked();
+    await expect(row(2)).not.toBeChecked();
+  },
 };
 
 export const ExpandableTable: Story = {

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -96,6 +96,13 @@ const meta: Meta<TnTableComponent> = {
     dataSource: { description: 'Data array or TnTableDataSource object', control: false },
     displayedColumns: { description: 'Column names to display in order', control: false },
     selectable: { description: 'Show checkbox column for row selection', control: 'boolean' },
+    selectionKey: {
+      description:
+        'Identity function `(row) => key`. Tracks selection by key instead of by object reference, so it '
+        + 'survives a `dataSource` change — paging, sorting, filtering, or a reload that rebuilt its rows. '
+        + 'Select-all stays scoped to the visible page.',
+      control: false,
+    },
     expandable: { description: 'Enable click-to-expand detail rows', control: 'boolean' },
     isRowExpandable: {
       description: 'Optional per-row predicate `(row) => boolean`; rows returning false show no expand control',
@@ -257,6 +264,70 @@ export const SelectableTable: Story = {
           <ng-template let-user tnCellDef>{{ user.role }}</ng-template>
         </ng-container>
       </tn-table>
+    `,
+  }),
+};
+
+export const SelectionAcrossPages: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `[selectionKey]` a `dataSource` change clears the selection, so a paged table loses '
+          + 'everything the user ticked the moment they turn the page. Passing an identity function keeps the '
+          + 'selection keyed by row, so it survives paging and comes back checked — while the header checkbox '
+          + 'stays scoped to the page on screen. Tick a row, page forward, tick another, and page back.',
+      },
+    },
+  },
+  render: () => ({
+    props: {
+      pageSize: 2,
+      page: 0,
+      selected: [] as User[],
+      allData: sampleData,
+      tableColumns: ['name', 'email', 'role'],
+      selectionKey: (user: User) => user.id,
+      get pageData(): User[] {
+        const start = this['page'] * this['pageSize'];
+        return this['allData'].slice(start, start + this['pageSize']);
+      },
+      get selectedNames(): string {
+        return this['selected'].map((user: User) => user.name).join(', ') || 'none';
+      },
+      turnPage(delta: number) {
+        const last = Math.ceil(this['allData'].length / this['pageSize']) - 1;
+        this['page'] = Math.min(Math.max(this['page'] + delta, 0), last);
+      },
+      onSelect(users: User[]) {
+        this['selected'] = users;
+      },
+    },
+    template: `
+      <p style="margin-bottom: 8px;">Selected: {{ selectedNames }}</p>
+      <tn-table
+        [dataSource]="pageData"
+        [displayedColumns]="tableColumns"
+        [selectable]="true"
+        [selectionKey]="selectionKey"
+        (selectionChange)="onSelect($event)">
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="role">
+          <ng-template tnHeaderCellDef>Role</ng-template>
+          <ng-template let-user tnCellDef>{{ user.role }}</ng-template>
+        </ng-container>
+      </tn-table>
+      <div style="display: flex; gap: 8px; margin-top: 8px;">
+        <tn-icon-button name="chevron-left" library="mdi" ariaLabel="Previous page" (onClick)="turnPage(-1)" />
+        <tn-icon-button name="chevron-right" library="mdi" ariaLabel="Next page" (onClick)="turnPage(1)" />
+      </div>
     `,
   }),
 };


### PR DESCRIPTION
Unblocks truenas/webui#14057. Two independent defects, one commit each.

## `fix(table-pager)`: stop aliasing the provider's pagination

`pushToProvider()` handed the provider the very object it had just recorded as `lastPushedPagination`, so the echo guard and the provider's live pagination were the same object.

A provider that re-paginates **in place** — `setFilter` resetting to the first page, say — then rewrote what the pager believed it had pushed. The guard read the provider's own change back as the pager's echo and ignored it, leaving the label on page 2 over page 1's rows. Observed in webui as "51 – 100 of 120" above the first fifty rows.

The provider gets its own copy, so the guard only ever matches a value the pager actually pushed.

## `feat(table)`: `selectionKey`

`tn-table` clears its selection whenever the `dataSource` reference changes. That's the only honest thing to do while selections are keyed by object reference — a row rebuilt by a reload is a different object, and rows from another page aren't in the array at all — but it means:

- a paged table loses everything the user ticked the moment they turn the page
- a background reload costs them a batch they were half way through building

`selectionKey` names the row's identity. Bind a stable member — Angular's template expression grammar has no arrow functions:

```ts
rowKey = (row: User): number => row.id;
```

```html
<tn-table [selectable]="true" [selectionKey]="rowKey" ...>
```

With one set, selection is tracked by key and survives paging, sorting, filtering and a reload that rebuilt its rows. `selectionChange` carries rows from pages the table is no longer showing — a batch action has to act on rows, and the table is the only thing that ever saw them. Retained rows are re-pointed at the fresh objects a reload hands back, so consumers are never left holding stale references.

**Select-all stays scoped to the visible page.** It selects and clears only the rows on screen, and `isAllSelected` reflects only those, so the header can never claim rows the user cannot see.

**`clearSelection()`** is new and drops the retained rows too. Clearing the `SelectionModel` alone is no longer enough — those rows would come back on the next reconcile. It emits an empty `selectionChange` if anything was selected, so a consumer's mirrored copy of the selection can follow it.

### Deliberate limitation

Retention is unconditional, and has to be: the table sees one page and cannot tell a row that moved off-screen from one that was destroyed. A consumer whose rows can vanish for good owns that check — reconcile `selectionChange` against the full list it holds. That's documented on the input, and it's what the webui snapshot list does.

## Compatibility

Without `selectionKey` nothing changes — same clear-on-`dataSource`-change behaviour, same `selectionChange` payload. `selectionKey` is deliberately separate from `trackBy`, which is a rendering concern and index-based by default; a table whose selection must be stable shouldn't be forced to change how it renders.

## Testing

Twelve new specs on `tn-table` (retention across pages, the emitted payload, re-pointing at rebuilt rows, page-scoped select-all, `clearSelection` and its emit, not resurrecting retained rows when `selectionKey` is taken away and given back, and the two decoupling cases below) and one on `tn-table-pager`, verified to fail against the unfixed code. Plus a `SelectionAcrossPages` story with a `play` function walking the tick-page-tick-page-back sequence.

Full suite green — lint, `yarn build` and the Storybook interaction tests clean.

## Review follow-ups

- The reconcile effect no longer resets `expandedRows`; expansion got its own `data()`-only effect, so swapping `selectionKey` (or handing back a fresh function each change-detection pass) can't collapse open detail rows.
- The reconcile effect's emit is guarded on the selection actually differing from the one last emitted, so a key swapped for an equivalent one is silent.
- `clearSelection()` now emits, so the two clearing paths agree.
- The `SelectionAcrossPages` story used getters on the `props` literal; `@storybook/angular` applies props with `Object.assign`, which freezes an accessor at its first value, so neither paging nor the selection summary updated. Both are plain properties recomputed in the handlers now, and a `play` function asserts the walk.
- The `[selectionKey]="(row) => row.id"` example is corrected to the member form in the JSDoc, the argType and above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAJZGPNRwm8NTy5DzUd6tg
