### PR TITLE
NAS-143342 / 27.0.0-BETA.1 / fix(date-input): keep the calendar popup content-sized instead of stretching across the viewport

### DIFF
--- a/projects/truenas-ui/src/lib/date-range-input/date-input.component.scss
+++ b/projects/truenas-ui/src/lib/date-range-input/date-input.component.scss
@@ -80,24 +80,28 @@
   }
 }
 
-// Global overlay styles (these are applied to overlay container)
-:host ::ng-deep .tn-datepicker-overlay {
-  .tn-calendar {
-    background: var(--tn-bg1, white);
-    border: 1px solid var(--tn-lines, #e0e0e0);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    padding: 24px;
-    min-width: 380px;
+// Popup calendar sizing. The calendar element belongs to this template, so the
+// scoped rule reaches it even though the overlay pane is portaled outside the
+// host (a `:host ::ng-deep .tn-datepicker-overlay` ancestor never matches
+// there). The pane is content-sized (see createOverlay), so the calendar must
+// declare its own width: its month table is `width: 100%` and would otherwise
+// fill whatever the pane offers.
+.tn-calendar {
+  box-sizing: content-box;
+  width: calc(7 * var(--calendar-cell-size));
+  background: var(--tn-bg1, white);
+  border: 1px solid var(--tn-lines, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 24px;
 
-    // Override calendar cell sizing for popup to make it larger
-    --calendar-cell-size: 48px;
-    --calendar-header-height: 44px;
-    --calendar-cell-font-size: 1rem;
-    --calendar-header-font-size: 14px;
+  // Override calendar cell sizing for popup to make it larger
+  --calendar-cell-size: 48px;
+  --calendar-header-height: 44px;
+  --calendar-cell-font-size: 1rem;
+  --calendar-header-font-size: 14px;
 
-    .tn-calendar-content {
-      padding: 0; // Remove default padding since we're adding it to the wrapper
-    }
+  ::ng-deep .tn-calendar-content {
+    padding: 0; // Remove default padding since we're adding it to the wrapper
   }
 }

--- a/projects/truenas-ui/src/lib/date-range-input/date-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-input.component.ts
@@ -261,11 +261,18 @@ export class TnDateInputComponent implements ControlValueAccessor, OnInit, OnDes
       },
     ];
 
+    // Rigid dimensions, like tn-select and tn-file-picker. With flexible
+    // dimensions on, CDK sizes the bounding box to the whole space between the
+    // trigger and the viewport edge and lets the pane grow into it, so the
+    // calendar (a block whose month table is `width: 100%`) stretched across
+    // the screen. Rigid + push keeps the pane content-sized and fully visible.
     const positionStrategy = this.overlay
       .position()
       .flexibleConnectedTo(this.wrapperEl())
-      .withPositions(positions)
-      .withPush(false);
+      .withFlexibleDimensions(false)
+      .withViewportMargin(8)
+      .withPush(true)
+      .withPositions(positions);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,

--- a/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.scss
+++ b/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.scss
@@ -87,24 +87,28 @@
   }
 }
 
-// Global overlay styles (these are applied to overlay container)
-:host ::ng-deep .tn-datepicker-overlay {
-  .tn-calendar {
-    background: var(--tn-bg1, white);
-    border: 1px solid var(--tn-lines, #e0e0e0);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    padding: 24px;
-    min-width: 380px;
+// Popup calendar sizing. The calendar element belongs to this template, so the
+// scoped rule reaches it even though the overlay pane is portaled outside the
+// host (a `:host ::ng-deep .tn-datepicker-overlay` ancestor never matches
+// there). The pane is content-sized (see createOverlay), so the calendar must
+// declare its own width: its month table is `width: 100%` and would otherwise
+// fill whatever the pane offers.
+.tn-calendar {
+  box-sizing: content-box;
+  width: calc(7 * var(--calendar-cell-size));
+  background: var(--tn-bg1, white);
+  border: 1px solid var(--tn-lines, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 24px;
 
-    // Override calendar cell sizing for popup to make it larger
-    --calendar-cell-size: 48px;
-    --calendar-header-height: 44px;
-    --calendar-cell-font-size: 1rem;
-    --calendar-header-font-size: 14px;
+  // Override calendar cell sizing for popup to make it larger
+  --calendar-cell-size: 48px;
+  --calendar-header-height: 44px;
+  --calendar-cell-font-size: 1rem;
+  --calendar-header-font-size: 14px;
 
-    .tn-calendar-content {
-      padding: 0; // Remove default padding since we're adding it to the wrapper
-    }
+  ::ng-deep .tn-calendar-content {
+    padding: 0; // Remove default padding since we're adding it to the wrapper
   }
 }

--- a/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.ts
+++ b/projects/truenas-ui/src/lib/date-range-input/date-range-input.component.ts
@@ -332,11 +332,18 @@ export class TnDateRangeInputComponent implements ControlValueAccessor, OnInit, 
       },
     ];
 
+    // Rigid dimensions, like tn-select and tn-file-picker. With flexible
+    // dimensions on, CDK sizes the bounding box to the whole space between the
+    // trigger and the viewport edge and lets the pane grow into it, so the
+    // calendar (a block whose month table is `width: 100%`) stretched across
+    // the screen. Rigid + push keeps the pane content-sized and fully visible.
     const positionStrategy = this.overlay
       .position()
       .flexibleConnectedTo(this.wrapperEl())
-      .withPositions(positions)
-      .withPush(false);
+      .withFlexibleDimensions(false)
+      .withViewportMargin(8)
+      .withPush(true)
+      .withPositions(positions);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,


### PR DESCRIPTION
## Problem

Opening the calendar on `tn-date-input` (seen in webui on the S3 access key and API key forms) renders it across the entire viewport width. `tn-date-range-input` has the same defect.

Two causes:

1. `createOverlay()` left CDK flexible dimensions on. CDK then sizes the connected-position bounding box to the whole space between the trigger and the viewport edge and lets the pane grow into it. `tn-calendar` is a block whose month table is `width: 100%`, so it filled the pane.
2. The popup sizing (`min-width`, padding, cell size) lived under `:host ::ng-deep .tn-datepicker-overlay`. The overlay pane is portaled outside the host, so that ancestor never matches and the rule was dead.

## Fix

- Both pickers now use the rigid strategy `tn-select` and `tn-file-picker` already use: `withFlexibleDimensions(false)`, `withViewportMargin(8)`, `withPush(true)`. The pane is content-sized and pushed back into view near an edge.
- The calendar sizing moved to a scoped `.tn-calendar` rule. The calendar element is part of the picker's own template, so the scoped rule reaches it in the overlay. It declares an explicit width of seven cells plus padding instead of relying on the pane.

## Verification

- `yarn test projects/truenas-ui/src/lib/date-range-input`: 26 passed.
- `yarn build` clean; synced into webui and the calendar renders as a normal popup anchored to the input.