### PR TITLE
NAS-143448 / 27.0.0-BETA.1 / ci(release): let a comma-separated scope reach the release

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,8 +19,13 @@ jobs:
         run: |
           # Conventional Commit title, optionally prefixed with "<anything> / " segments
           # (e.g. "NAS-141240 / 27.0.0-BETA.1 / feat(form-field): ..."). The prefix is
-          # optional so plain "feat(scope): ..." titles still pass. Keep this pattern in
-          # sync with parserOpts.headerPattern in .releaserc.json.
+          # optional so plain "feat(scope): ..." titles still pass.
+          #
+          # A title this accepts MUST also be parsed by parserOpts.headerPattern in
+          # .releaserc.json — a title that passes here and matches nothing there merges
+          # and is then dropped from the release and its changelog, silently (#315).
+          # projects/truenas-ui/scripts/release-config/commit-header-pattern.spec.ts
+          # reads both files and fails when they drift apart.
           pattern='^(.+ / )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'
           if [[ "$PR_TITLE" =~ $pattern ]]; then
             echo "PR title OK: $PR_TITLE"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,17 +11,17 @@
         { "breaking": true, "release": "minor" }
       ],
       "parserOpts": {
-        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!?: (.+)$",
+        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([^)]*)\\))?!?: (.+)$",
         "headerCorrespondence": ["type", "scope", "subject"],
-        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!: (.+)$"
+        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([^)]*)\\))?!: (.+)$"
       }
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits",
       "parserOpts": {
-        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!?: (.+)$",
+        "headerPattern": "^(?:.+ / )?(\\w*)(?:\\(([^)]*)\\))?!?: (.+)$",
         "headerCorrespondence": ["type", "scope", "subject"],
-        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([\\w$.\\-*/ ]*)\\))?!: (.+)$"
+        "breakingHeaderPattern": "^(?:.+ / )?(\\w*)(?:\\(([^)]*)\\))?!: (.+)$"
       },
       "presetConfig": {
         "types": [

--- a/projects/truenas-ui/scripts/jest.config.ts
+++ b/projects/truenas-ui/scripts/jest.config.ts
@@ -1,17 +1,21 @@
 import type { Config } from 'jest';
 
 /**
- * `yarn test:scripts` — every build script under this directory that has tests.
+ * `yarn test:scripts` — the repo's node-environment tests: every build script under this
+ * directory that has tests, plus `release-config`, which tests repo-root configuration
+ * rather than a script and lives here because this is where a node-environment Jest
+ * project already runs.
  *
- * One Jest project per script package rather than one config rooted here, because
- * `<rootDir>` inside a project config resolves to that project's own directory: each
- * package keeps pointing ts-jest at its own `tsconfig.json`, and adding the next one
- * costs a line here rather than a merge of compiler options.
+ * One Jest project per package rather than one config rooted here, because `<rootDir>`
+ * inside a project config resolves to that project's own directory: each package keeps
+ * pointing ts-jest at its own `tsconfig.json`, and adding the next one costs a line here
+ * rather than a merge of compiler options.
  */
 const config: Config = {
   projects: [
     '<rootDir>/harness-docs/jest.config.ts',
     '<rootDir>/icon-sprite/jest.config.ts',
+    '<rootDir>/release-config/jest.config.ts',
   ],
 };
 

--- a/projects/truenas-ui/scripts/release-config/commit-header-pattern.spec.ts
+++ b/projects/truenas-ui/scripts/release-config/commit-header-pattern.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * The PR title check and the release step both decide what a commit header means, from
+ * two patterns written in two files, and nothing made them agree. A scope naming two
+ * components with a comma — `feat(autocomplete,chip-input): …` — passed the title check,
+ * merged, and then matched no header pattern at all, so the commit analyzer read it as
+ * having no type: it triggered no release and appeared in no changelog (#315).
+ *
+ * These tests read both files rather than restating either pattern, so drift in either
+ * one fails here instead of silently dropping a merged commit from the next release.
+ *
+ * They live under the library's script tests because `yarn test:scripts` is where this
+ * repo runs Jest in a node environment; what they cover is repo-root release
+ * configuration, which is why they reach four directories up.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = join(__dirname, '..', '..', '..', '..');
+
+interface ParserOpts {
+  headerPattern: string;
+  headerCorrespondence: string[];
+  breakingHeaderPattern: string;
+}
+
+type PluginEntry = string | [string, { parserOpts?: ParserOpts }];
+
+const releaseConfig = JSON.parse(
+  readFileSync(join(repoRoot, '.releaserc.json'), 'utf8')
+) as { plugins: PluginEntry[] };
+
+/** Every semantic-release plugin that parses commit headers, with its plugin name. */
+const parsingPlugins: [string, ParserOpts][] = [];
+
+for (const plugin of releaseConfig.plugins) {
+  if (Array.isArray(plugin)) {
+    const [name, options] = plugin;
+
+    if (options.parserOpts) {
+      parsingPlugins.push([name, options.parserOpts]);
+    }
+  }
+}
+
+/**
+ * The Bash pattern the PR title check runs, lifted from the workflow that runs it.
+ *
+ * `[[ =~ ]]` and `RegExp` both leave the end unanchored and the pattern anchors its own
+ * start, so a JS `RegExp` accepts what the check accepts for the constructs it uses:
+ * groups, alternation, character classes and `?`.
+ */
+function readPrTitlePattern(): RegExp {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/pr-title.yml'), 'utf8');
+  const assignment = /^\s*pattern='([^']+)'\s*$/m.exec(workflow);
+
+  if (!assignment) {
+    throw new Error('no `pattern=<...>` assignment found in .github/workflows/pr-title.yml');
+  }
+
+  return new RegExp(assignment[1]);
+}
+
+const prTitleCheck = readPrTitlePattern();
+
+/** What the release step reads out of a header, or null when it matches nothing. */
+function parseHeader(opts: ParserOpts, header: string): Record<string, string | undefined> | null {
+  const match = new RegExp(opts.headerPattern).exec(header);
+
+  if (!match) {
+    return null;
+  }
+
+  return Object.fromEntries(
+    opts.headerCorrespondence.map((field, index) => [field, match[index + 1]])
+  );
+}
+
+const commaScopeHeader =
+  'NAS-142381 / 27.0.0-BETA.1 / feat(autocomplete,chip-input): drive options from an async [dataSource] (#312)';
+
+/**
+ * Headers the PR title check accepts. Every one is asserted to pass the check as well as
+ * to parse, so a case that stops being realistic fails rather than passing vacuously.
+ */
+const acceptedHeaders: { name: string; header: string; type: string; scope?: string }[] = [
+  {
+    name: 'a single-word scope',
+    header: 'feat(table): let a selection survive a dataSource change',
+    type: 'feat',
+    scope: 'table',
+  },
+  {
+    name: 'the ticket and version prefix a squash commit carries',
+    header: 'NAS-143108 / 27.0.0-BETA.1 / fix(table): stop the pager aliasing pagination',
+    type: 'fix',
+    scope: 'table',
+  },
+  {
+    name: 'no scope at all',
+    header: 'chore: bump the toolchain',
+    type: 'chore',
+    scope: undefined,
+  },
+  {
+    name: 'two components separated by a comma (#315)',
+    header: commaScopeHeader,
+    type: 'feat',
+    scope: 'autocomplete,chip-input',
+  },
+  {
+    name: 'a comma and a space between components',
+    header: 'feat(autocomplete, chip-input): drive options from an async [dataSource]',
+    type: 'feat',
+    scope: 'autocomplete, chip-input',
+  },
+  {
+    name: 'a scope with a slash',
+    header: 'refactor(a11y/labels): fold the fallback into one helper',
+    type: 'refactor',
+    scope: 'a11y/labels',
+  },
+];
+
+describe('.releaserc.json', () => {
+  it('has more than one plugin parsing commit headers, one of them the commit analyzer', () => {
+    expect(parsingPlugins.length).toBeGreaterThan(1);
+    expect(parsingPlugins.map(([name]) => name)).toContain('@semantic-release/commit-analyzer');
+  });
+
+  it('gives all of them the same parser options, so notes and version bumps agree', () => {
+    const [[, first]] = parsingPlugins;
+
+    // The plugin name rides along in the assertion so a failure says which one drifted.
+    for (const [name, opts] of parsingPlugins) {
+      expect([name, opts]).toEqual([name, first]);
+    }
+  });
+});
+
+describe.each(parsingPlugins)('%s', (_pluginName, opts) => {
+  it.each(acceptedHeaders)('parses $name', ({ header, type, scope }) => {
+    expect(parseHeader(opts, header)).toMatchObject({ type, scope, subject: expect.any(String) });
+  });
+
+  it('reads a comma scope as one scope, leaving the subject whole', () => {
+    expect(parseHeader(opts, commaScopeHeader)?.subject).toBe(
+      'drive options from an async [dataSource] (#312)'
+    );
+  });
+
+  it('recognises a breaking change whose scope contains a comma', () => {
+    const breaking = new RegExp(opts.breakingHeaderPattern).exec(
+      'feat(autocomplete,chip-input)!: options are now a dataSource'
+    );
+
+    expect(breaking?.[1]).toBe('feat');
+    expect(breaking?.[2]).toBe('autocomplete,chip-input');
+  });
+});
+
+describe('the PR title check and the release step', () => {
+  it.each(acceptedHeaders)('agree on $name', ({ header, type }) => {
+    expect(prTitleCheck.test(header)).toBe(true);
+
+    for (const [, opts] of parsingPlugins) {
+      expect(parseHeader(opts, header)).toMatchObject({ type });
+    }
+  });
+
+  it('agree on every scope character the check allows, not a narrower set', () => {
+    // The check's scope is `\([^)]+\)`. A release pattern with a narrower scope class is
+    // what produced #315: the title passed, the commit merged, the release dropped it.
+    const scopes = ['a,b', 'a, b', 'a/b', 'a.b', 'a-b', 'a b', 'a:b', 'a+b', 'a&b', 'a#b', '@scope/pkg'];
+
+    for (const scope of scopes) {
+      const header = `feat(${scope}): a subject`;
+
+      expect(prTitleCheck.test(header)).toBe(true);
+
+      for (const [, opts] of parsingPlugins) {
+        expect(parseHeader(opts, header)).toEqual({
+          type: 'feat',
+          scope,
+          subject: 'a subject',
+        });
+      }
+    }
+  });
+});

--- a/projects/truenas-ui/scripts/release-config/jest.config.ts
+++ b/projects/truenas-ui/scripts/release-config/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.json',
+    }],
+  },
+  testMatch: ['<rootDir>/**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};
+
+export default config;

--- a/projects/truenas-ui/scripts/release-config/tsconfig.json
+++ b/projects/truenas-ui/scripts/release-config/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "strict": true,
+    "types": ["jest", "node"],
+    "rootDir": ".",
+    "outDir": "../../dist/out-tsc/scripts"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Fixes #315.

## What was wrong

Both commit-parsing plugins in `.releaserc.json` matched the scope with
`(?:\(([\w$.\-*/ ]*)\))?`. That character class has no comma, so a header like

```
NAS-142381 / 27.0.0-BETA.1 / feat(autocomplete,chip-input): drive options from an async [dataSource] (#312)
```

matched the header pattern nowhere — not a scope-less match, no match at all. The
commit analyzer therefore saw no type and logged *"The commit should not trigger a
release"*, and the notes generator left the commit out of the changelog.

The PR title check allows any scope (`\([^)]+\)`), so the pull request passed its
check and merged normally. v0.7.5 was cut by #313 alone, with #312's code in the tag
and in the published tarball but in no release note.

## Reproduction

`re`-based probe reading the two patterns verbatim out of `.releaserc.json` and
`.github/workflows/pr-title.yml`, against the two commit subjects from the report:

```
c2ea3a2 (#312)
  passes pr-title check: True
  @semantic-release/commit-analyzer: NO MATCH -> type=None, scope=None (commit dropped)
  @semantic-release/release-notes-generator: NO MATCH -> type=None, scope=None (commit dropped)

dc4678e (#313)
  passes pr-title check: True
  @semantic-release/commit-analyzer: type='feat' scope='table'
```

After the change both parse as `type='feat'`, `#312` with `scope='autocomplete,chip-input'`.

## The change

- **`.releaserc.json`** — scope class widened to `[^)]*` in all four patterns
  (`headerPattern` and `breakingHeaderPattern`, in the commit analyzer and in the
  release-notes generator). `[^)]*` is what the title check already allows, so the two
  now agree by construction; adding a comma alone would have left the next unlisted
  character to be discovered the same way this one was.
- **`projects/truenas-ui/scripts/release-config/commit-header-pattern.spec.ts`** — new,
  and the point of it: it reads both files rather than restating either pattern, and
  asserts that every header the title check accepts parses with a type the release rules
  can match, in every plugin that parses commits. Drift between the two files now fails
  a check instead of silently dropping a merged commit.
- **`.github/workflows/pr-title.yml`** — the comment said "keep this in sync with
  `.releaserc.json`" with nothing enforcing it; it now states what the invariant is and
  which test enforces it.
- **`projects/truenas-ui/scripts/jest.config.ts`** — registers the new Jest project.
  Its docstring said "every build script under this directory"; the new project is
  configuration rather than a build script, so the docstring is corrected too.

The commit type is `ci` deliberately: no library code changed, so this should not itself
cut a release. The fix takes effect for every commit analyzed after it merges — the
published v0.7.5 notes are not rewritten by it.

## What I could not run

**There is no `node` on the machine this cycle ran on**, so `yarn lint`, `yarn test`,
`yarn test:scripts` and `yarn build` could not be run locally — including the new spec.
Please treat the CI run as the first execution of it. What was verified locally instead:

- the reproduction above, and the same corpus the spec asserts (every accepted header,
  the breaking-change pattern, and each scope character in the last test), replayed
  through python's `re` against the patterns read from the two files — all pass;
- `.releaserc.json` parses as JSON and `pr-title.yml` parses as YAML with its `run:`
  script unchanged apart from the comment.

Python and JS regex agree on the constructs these patterns use, and the spec's Jest and
TypeScript surface is copied from the existing `harness-docs` project, but neither is a
substitute for running it.

`local-review.py` ran the shared reviewer for real (a separate process, $1.40) and
returned **no finding at MEDIUM or above**. Its threshold-scoring step then crashed for
the same reason as everything else — it shells out to `node` — so the exit code was a
traceback rather than a verdict; the findings file it wrote is the reviewer's own output
and both findings in it are LOW.

## LOW findings not acted on

- The new spec, its `jest.config.ts` and its `tsconfig.json` are under
  `projects/truenas-ui/scripts/`, which `ng-package.json` copies into `dist` as an asset,
  so they ship in the npm tarball with no runtime role. That is already true of the
  existing `harness-docs` and `icon-sprite` specs and configs; excluding test files from
  the packaged assets is a separate change to `ng-package.json` that would affect files
  this ticket did not touch.
- The scope-character test samples eleven characters rather than deriving the set the
  title check allows, and every fixture uses the same `<ticket> / <version> / ` prefix
  separator, so drift in the prefix rather than the scope would go unnoticed.
