### PR TITLE
NAS-143108 / 27.0.0-BETA.1 / feat(table): keep detail rows open across a dataSource change via [expansionKey]

### DIFF
--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -801,6 +801,112 @@ describe('TnTableComponent', () => {
       expect(component.isRowExpanded(testData[0])).toBe(false);
     });
 
+    describe('expansionKey', () => {
+      const rowKey = (row: { id: number }): number => row.id;
+
+      it('collapses everything on a dataSource change when no key is set', () => {
+        component.toggleRowExpansion(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        const rebuilt = testData.map((row) => ({ ...row }));
+        fixture.componentRef.setInput('dataSource', rebuilt);
+        fixture.detectChanges();
+
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('keeps the row open across a reload that rebuilt its objects', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+
+        // What a background reload does: same rows, new objects.
+        const rebuilt = testData.map((row) => ({ ...row }));
+        fixture.componentRef.setInput('dataSource', rebuilt);
+        fixture.detectChanges();
+
+        // Re-pointed at the NEW object, not the one it was opened with.
+        expect(component.isRowExpanded(rebuilt[0])).toBe(true);
+        expect(component.isRowExpanded(testData[0])).toBe(false);
+        expect(component.expandedRows().size).toBe(1);
+      });
+
+      it('re-opens a retained row when it comes back to the current page', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+
+        // The row leaves the page — another tab, a filter. Nothing is on screen to open.
+        fixture.componentRef.setInput('dataSource', [testData[1]]);
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+
+        fixture.componentRef.setInput('dataSource', testData);
+        fixture.detectChanges();
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+      });
+
+      it('does not re-open a row the user collapsed while it was on screen', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+        component.toggleRowExpansion(testData[0]);
+
+        const rebuilt = testData.map((row) => ({ ...row }));
+        fixture.componentRef.setInput('dataSource', rebuilt);
+        fixture.detectChanges();
+
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('drops rows retained off-screen when the key is taken away', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+
+        fixture.componentRef.setInput('expansionKey', undefined);
+        fixture.detectChanges();
+        fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+
+        // Giving the key back must not resurrect it.
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.componentRef.setInput('dataSource', testData);
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('clearExpansion drops rows that are not on screen, expandedRows.set does not', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+        fixture.componentRef.setInput('dataSource', [testData[1]]);
+        fixture.detectChanges();
+
+        // Closing only what is visible leaves the retained row to come back.
+        component.expandedRows.set(new Set());
+        fixture.componentRef.setInput('dataSource', testData);
+        fixture.detectChanges();
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        component.clearExpansion();
+        fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('expandRow opens a row and stays a no-op on one already open', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+
+        component.expandRow(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        component.expandRow(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+      });
+    });
+
     describe('singleExpand', () => {
       it('collapses the previously expanded row', () => {
         fixture.componentRef.setInput('singleExpand', true);

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -895,6 +895,60 @@ describe('TnTableComponent', () => {
         expect(component.expandedRows().size).toBe(0);
       });
 
+      it('does not re-open rows that toggling expandable off closed', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+
+        // The table closes the row itself — no user action, so nothing may bring it back.
+        fixture.componentRef.setInput('expandable', false);
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+
+        fixture.componentRef.setInput('expandable', true);
+        fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('does not re-open a row the isRowExpandable prune rejected', () => {
+        const allowed = signal([1, 2]);
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.componentRef.setInput('isRowExpandable', (row: { id: number }) => allowed().includes(row.id));
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+
+        // The predicate stops allowing it: the prune closes it.
+        allowed.set([2]);
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+
+        // Allowing it again must not silently reappear it already expanded — the guarantee
+        // the prune exists for, which the retained map would otherwise defeat on the next
+        // dataSource change.
+        allowed.set([1, 2]);
+        fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('leaves the expanded set alone when only the key function identity changes', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+        const before = component.expandedRows();
+
+        // What an inline arrow in a template does on every change-detection pass.
+        fixture.componentRef.setInput('expansionKey', (row: { id: number }) => row.id);
+        fixture.detectChanges();
+
+        expect(component.isRowExpanded(testData[0])).toBe(true);
+        expect(component.expandedRows()).toBe(before);
+      });
+
       it('expandRow opens a row and stays a no-op on one already open', () => {
         fixture.componentRef.setInput('expansionKey', rowKey);
         fixture.detectChanges();

--- a/projects/truenas-ui/src/lib/table/table.component.spec.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.spec.ts
@@ -876,21 +876,52 @@ describe('TnTableComponent', () => {
         expect(component.expandedRows().size).toBe(0);
       });
 
-      it('clearExpansion drops rows that are not on screen, expandedRows.set does not', () => {
+      it('a direct expandedRows write closes the visible row but leaves its key', () => {
         fixture.componentRef.setInput('expansionKey', rowKey);
         fixture.detectChanges();
         component.toggleRowExpansion(testData[0]);
-        fixture.componentRef.setInput('dataSource', [testData[1]]);
-        fixture.detectChanges();
 
-        // Closing only what is visible leaves the retained row to come back.
+        // The row is ON SCREEN, which is the case that distinguishes the two paths: the write
+        // must actually close it, not be reverted by the reconcile.
         component.expandedRows.set(new Set());
-        fixture.componentRef.setInput('dataSource', testData);
         fixture.detectChanges();
-        expect(component.isRowExpanded(testData[0])).toBe(true);
+        expect(component.expandedRows().size).toBe(0);
+
+        // ...but it never touched the retained map, so the next reconcile brings it back. This
+        // is the documented sharp edge of leaving `expandedRows` writable.
+        fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(1);
+      });
+
+      it('clearExpansion drops the key as well, so nothing comes back', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
 
         component.clearExpansion();
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+
         fixture.componentRef.setInput('dataSource', testData.map((row) => ({ ...row })));
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+      });
+
+      it('closes a row that has paged away instead of re-adding it', () => {
+        fixture.componentRef.setInput('expansionKey', rowKey);
+        fixture.detectChanges();
+        component.toggleRowExpansion(testData[0]);
+
+        // Row 0 leaves the page while still open — retained, but not in the visible set.
+        fixture.componentRef.setInput('dataSource', [testData[1]]);
+        fixture.detectChanges();
+        expect(component.expandedRows().size).toBe(0);
+
+        // Identity against the visible set would read this as "closed" and re-add it. Keyed,
+        // it closes, so a consumer holding the row can still act on it without clearing all.
+        component.toggleRowExpansion(testData[0]);
+        fixture.componentRef.setInput('dataSource', testData);
         fixture.detectChanges();
         expect(component.expandedRows().size).toBe(0);
       });

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -616,6 +616,12 @@ export class TnTableComponent<T = unknown> implements OnInit {
    *
    * Replacing the data array collapses everything unless {@link expansionKey} is set, in
    * which case this is the visible slice of {@link expandedByKey} and survives the swap.
+   *
+   * Writable for consumers that predate {@link expansionKey}. **Adding a key to a consumer
+   * that writes this signal directly is a migration, not a drop-in**: `expandedRows.set(new
+   * Set())` closes only what is on screen, so a row retained off-screen re-opens on the next
+   * reconcile. Move those writes to {@link expandRow}, {@link toggleRowExpansion} and
+   * {@link clearExpansion}, which keep the retained map in step.
    */
   expandedRows = signal<Set<unknown>>(new Set());
 

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -119,6 +119,19 @@ function getExpandDuration(): string {
 }
 
 /**
+ * Same members, order-independent. Used to keep the expansion reconcile idempotent: it re-runs
+ * whenever `expansionKey`'s identity changes, and writing a fresh `Set` every time would churn
+ * the signal for a consumer that binds an inline arrow rather than a stable member.
+ */
+function isSameSet(a: ReadonlySet<unknown>, b: ReadonlySet<unknown>): boolean {
+  if (a.size !== b.size) { return false; }
+  for (const value of a) {
+    if (!b.has(value)) { return false; }
+  }
+  return true;
+}
+
+/**
  * Chrome copy `tn-table` renders itself. These were baked into the template as English literals,
  * which a consumer could not translate at all — there was no input to bind. Provide
  * {@link TN_TABLE_LABELS} at the app root to wire them to an i18n service.
@@ -659,11 +672,18 @@ export class TnTableComponent<T = unknown> implements OnInit {
   });
 
   constructor() {
-    // Collapse every open detail row when the data reference changes: the rows the
-    // expanded set holds belong to the array that is going away. This reads `data()`
-    // and nothing else, so an unrelated input — `selectionKey` above all, which a
-    // consumer may swap or re-create on any change-detection pass — cannot close what
-    // the user opened as a side effect of a selection concern.
+    // Reconcile open detail rows against the rows now on screen.
+    //
+    // Without `expansionKey` this collapses everything: the set holds rows from the array
+    // that is going away, and reference-keyed rows cannot be recognised in a new one.
+    //
+    // With a key it re-points them instead. It therefore has to read `expansionKey()` as
+    // well as `data()` — a key being taken away must be noticed promptly — which means an
+    // unrelated re-creation of that input (an inline arrow in a template, which the type
+    // permits) re-runs this. That must not churn the signal or, worse, close what the user
+    // opened, so the keyed branch derives `visible` from the retained map and writes only
+    // when the result actually differs. `selectionKey` is still never read here: a
+    // selection concern must not touch expansion.
     effect(() => {
       const rows = this.data();
       const expansionKey = this.expansionKey();
@@ -687,7 +707,9 @@ export class TnTableComponent<T = unknown> implements OnInit {
           visible.add(row);
         }
       }
-      this.expandedRows.set(visible);
+      if (!isSameSet(visible, this.expandedRows())) {
+        this.expandedRows.set(visible);
+      }
     });
 
     // Reconcile the retained selection against the rows now on screen. This has to
@@ -720,10 +742,12 @@ export class TnTableComponent<T = unknown> implements OnInit {
       this.emitSelectionIfChanged();
     });
 
-    // Clear expanded rows when expandable is toggled off
+    // Clear expanded rows when expandable is toggled off. Through `clearExpansion()`, so the
+    // rows retained under `expansionKey` go as well: clearing only the visible set would let
+    // the next `dataSource` change re-open rows the table itself had just closed.
     effect(() => {
       if (!this.expandable()) {
-        this.expandedRows.set(new Set());
+        this.clearExpansion();
       }
     });
 
@@ -735,15 +759,23 @@ export class TnTableComponent<T = unknown> implements OnInit {
     // before the predicate runs — there is nothing to prune, and the next toggle
     // re-runs this effect and re-tracks the predicate's signals. The
     // next.size !== expanded.size guard makes the self-write converge after one
-    // extra run, so there is no infinite loop.
+    // extra run, so there is no infinite loop. A rejected row leaves the retained
+    // `expansionKey` map as well — see below.
     effect(() => {
       const predicate = this.isRowExpandable();
       if (!predicate) { return; }
       const expanded = this.expandedRows();
       if (expanded.size === 0) { return; }
+      const expansionKey = this.expansionKey();
       const next = new Set<unknown>();
       for (const row of expanded) {
-        if (predicate(row as T)) { next.add(row); }
+        if (predicate(row as T)) {
+          next.add(row);
+        } else if (expansionKey) {
+          // Drop it from the retained map too, or the guarantee above holds only until the
+          // next `dataSource` change re-points the row and opens it again.
+          this.expandedByKey.delete(expansionKey(row as T));
+        }
       }
       if (next.size !== expanded.size) {
         this.expandedRows.set(next);

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -17,6 +17,7 @@ import {
   model,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import type { OnInit, Signal } from '@angular/core';
 import { tnScrollableRegion } from '../a11y/scrollable-region';
@@ -618,10 +619,11 @@ export class TnTableComponent<T = unknown> implements OnInit {
    * which case this is the visible slice of {@link expandedByKey} and survives the swap.
    *
    * Writable for consumers that predate {@link expansionKey}. **Adding a key to a consumer
-   * that writes this signal directly is a migration, not a drop-in**: `expandedRows.set(new
-   * Set())` closes only what is on screen, so a row retained off-screen re-opens on the next
-   * reconcile. Move those writes to {@link expandRow}, {@link toggleRowExpansion} and
-   * {@link clearExpansion}, which keep the retained map in step.
+   * that writes this signal directly is a migration, not a drop-in**: a write here closes
+   * what is on screen but never touches the retained map, so every row whose key is still in
+   * it re-opens on the next reconcile — the one it just closed included. Move those writes to
+   * {@link expandRow}, {@link toggleRowExpansion} and {@link clearExpansion}, which keep the
+   * two in step.
    */
   expandedRows = signal<Set<unknown>>(new Set());
 
@@ -713,7 +715,11 @@ export class TnTableComponent<T = unknown> implements OnInit {
           visible.add(row);
         }
       }
-      if (!isSameSet(visible, this.expandedRows())) {
+      // `untracked`: the guard needs the current value, not a subscription. Reading it
+      // tracked would make every write to `expandedRows` re-run this effect and rewrite it
+      // from the map — so a consumer closing a visible row with `expandedRows.set(new Set())`
+      // would have it put straight back, and the signal would be read-only in all but name.
+      if (!isSameSet(visible, untracked(this.expandedRows))) {
         this.expandedRows.set(visible);
       }
     });
@@ -1075,7 +1081,11 @@ export class TnTableComponent<T = unknown> implements OnInit {
     if (!this.canExpandRow(row)) { return; }
     const expanded = new Set(this.expandedRows());
     const expansionKey = this.expansionKey();
-    if (expanded.has(row)) {
+    if (this.isExpansionOpen(row)) {
+      // `delete` is a no-op for a row that has paged away — it is not in the visible set —
+      // and dropping the key is what actually closes it. Resolving through the key is why
+      // toggling a retained row closes it instead of re-adding it, matching
+      // `toggleRowSelection`.
       expanded.delete(row);
       if (expansionKey) { this.expandedByKey.delete(expansionKey(row)); }
     } else {
@@ -1090,13 +1100,24 @@ export class TnTableComponent<T = unknown> implements OnInit {
   }
 
   /**
+   * Whether `row`'s detail row counts as open for a toggle. With {@link expansionKey} that is
+   * the retained map, which includes rows this page is not showing; without one it is object
+   * identity against the visible set. Distinct from {@link isRowExpanded}, which drives
+   * rendering and must therefore stay about the row in front of the user.
+   */
+  private isExpansionOpen(row: T): boolean {
+    const expansionKey = this.expansionKey();
+    return expansionKey ? this.expandedByKey.has(expansionKey(row)) : this.expandedRows().has(row);
+  }
+
+  /**
    * Opens `row`'s detail row programmatically — the same thing a chevron click does, for a
    * consumer restoring expansion from somewhere else (a `?jobId=` query parameter, say).
    * Honours `singleExpand` and keeps {@link expansionKey}'s retained set in step, which
    * writing {@link expandedRows} directly does not.
    */
   expandRow(row: T): void {
-    if (this.isRowExpanded(row)) { return; }
+    if (this.isExpansionOpen(row)) { return; }
     this.toggleRowExpansion(row);
   }
 

--- a/projects/truenas-ui/src/lib/table/table.component.ts
+++ b/projects/truenas-ui/src/lib/table/table.component.ts
@@ -299,6 +299,34 @@ export class TnTableComponent<T = unknown> implements OnInit {
    */
   selectionKey = input<((row: T) => unknown) | undefined>(undefined);
 
+  /**
+   * Identifies a row for EXPANSION, so an open detail row survives a `dataSource` change.
+   *
+   * Detail rows are held by object identity, and a consumer that re-fetches hands back new
+   * objects for the same rows — so without a key a background reload closes the row the
+   * user opened, which is usually the moment its contents are worth watching (a running
+   * job's logs, say). With a key set, the table re-points the open rows at the new objects
+   * instead of collapsing them.
+   *
+   * A row the new `data()` does not carry — another page, another tab, filtered out — is
+   * kept, not dropped, and re-opens on its own once that row is listed again. Retention is
+   * unconditional for the same reason it is for {@link selectionKey}: the table sees one
+   * page and cannot tell a row that moved off-screen from one that is gone for good. Call
+   * {@link clearExpansion} when the consumer knows it is gone.
+   *
+   * Without it the table keeps its historical behaviour — any `dataSource` reference change
+   * collapses every open row.
+   *
+   * With a key set, drive expansion through {@link toggleRowExpansion}, {@link expandRow}
+   * and {@link clearExpansion} rather than writing {@link expandedRows} directly, or the
+   * retained set and the visible set drift apart.
+   *
+   * Pass a key that identifies the ROW, not its position, and bind a stable member rather
+   * than writing the function in the template: `[expansionKey]="rowKey"` for a
+   * `rowKey = (row: Job) => row.id` on the host.
+   */
+  expansionKey = input<((row: T) => unknown) | undefined>(undefined);
+
   emptyMessage = input<string>('No data available');
 
   /**
@@ -571,12 +599,19 @@ export class TnTableComponent<T = unknown> implements OnInit {
   sortDirection = model<'asc' | 'desc' | ''>('');
 
   /**
-   * Set of currently expanded row references.
-   * Note: uses object identity. If the consumer replaces the data array
-   * (e.g. after sorting), expanded state is lost. A future key-based
-   * approach could address this.
+   * The rows of the CURRENT `data()` whose detail row is open, by object identity.
+   *
+   * Replacing the data array collapses everything unless {@link expansionKey} is set, in
+   * which case this is the visible slice of {@link expandedByKey} and survives the swap.
    */
   expandedRows = signal<Set<unknown>>(new Set());
+
+  /**
+   * Every open detail row keyed by {@link expansionKey}, including rows no longer in
+   * `data()`. Empty (and unused) when no key is set. Holds the row objects so a row that
+   * comes back can be re-pointed at the object the new data carries.
+   */
+  private expandedByKey = new Map<unknown, T>();
 
   // Per-instance prefix for generated DOM ids, so two tables on a page can't collide.
   private static instanceCount = 0;
@@ -630,9 +665,29 @@ export class TnTableComponent<T = unknown> implements OnInit {
     // consumer may swap or re-create on any change-detection pass — cannot close what
     // the user opened as a side effect of a selection concern.
     effect(() => {
-      this.data();
+      const rows = this.data();
+      const expansionKey = this.expansionKey();
       if (!this.initialized) { return; }
-      this.expandedRows.set(new Set());
+
+      if (!expansionKey) {
+        // Also drop anything retained under a key, so a table whose `expansionKey` is taken
+        // away cannot re-open those rows if it is given one again.
+        this.expandedByKey.clear();
+        this.expandedRows.set(new Set());
+        return;
+      }
+
+      // Re-point each retained row at the object the new data carries and show the ones this
+      // page actually has. Rows it does not have stay in the map and re-open when they return.
+      const visible = new Set<unknown>();
+      for (const row of rows) {
+        const key = expansionKey(row);
+        if (this.expandedByKey.has(key)) {
+          this.expandedByKey.set(key, row);
+          visible.add(row);
+        }
+      }
+      this.expandedRows.set(visible);
     });
 
     // Reconcile the retained selection against the rows now on screen. This has to
@@ -981,15 +1036,40 @@ export class TnTableComponent<T = unknown> implements OnInit {
   toggleRowExpansion(row: T): void {
     if (!this.canExpandRow(row)) { return; }
     const expanded = new Set(this.expandedRows());
+    const expansionKey = this.expansionKey();
     if (expanded.has(row)) {
       expanded.delete(row);
+      if (expansionKey) { this.expandedByKey.delete(expansionKey(row)); }
     } else {
       if (this.singleExpand()) {
         expanded.clear();
+        if (expansionKey) { this.expandedByKey.clear(); }
       }
       expanded.add(row);
+      if (expansionKey) { this.expandedByKey.set(expansionKey(row), row); }
     }
     this.expandedRows.set(expanded);
+  }
+
+  /**
+   * Opens `row`'s detail row programmatically — the same thing a chevron click does, for a
+   * consumer restoring expansion from somewhere else (a `?jobId=` query parameter, say).
+   * Honours `singleExpand` and keeps {@link expansionKey}'s retained set in step, which
+   * writing {@link expandedRows} directly does not.
+   */
+  expandRow(row: T): void {
+    if (this.isRowExpanded(row)) { return; }
+    this.toggleRowExpansion(row);
+  }
+
+  /**
+   * Collapses every detail row, including rows retained under {@link expansionKey} that are
+   * not on screen. `expandedRows.set(new Set())` only closes what is visible, so with a key
+   * set the off-screen rows would re-open on the next reconcile.
+   */
+  clearExpansion(): void {
+    this.expandedByKey.clear();
+    this.expandedRows.set(new Set());
   }
 
   isRowExpanded(row: T): boolean {

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -452,18 +452,23 @@ export const ExpansionSurvivesReload: Story = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const [keyedExpand, unkeyedExpand] = canvas.getAllByLabelText('Expand row');
+    // Scope each query to its own table. Both render the same rows, so a document-order
+    // lookup across the whole canvas would take two buttons out of the keyed table and
+    // never touch the unkeyed one — which is the contrast this story exists to show.
+    const [keyedTable, unkeyedTable] = Array.from(canvasElement.querySelectorAll('tn-table')) as HTMLElement[];
+    const keyed = within(keyedTable);
+    const unkeyed = within(unkeyedTable);
 
-    await userEvent.click(keyedExpand);
-    await userEvent.click(unkeyedExpand);
-    await expect(canvas.getByText(/Still open after 0 reload/)).toBeInTheDocument();
-    await expect(canvas.getByText(/Closed by the next reload/)).toBeInTheDocument();
+    await userEvent.click(keyed.getAllByLabelText('Expand row')[0]);
+    await userEvent.click(unkeyed.getAllByLabelText('Expand row')[0]);
+    await expect(keyed.getByText(/Still open after 0 reload/)).toBeInTheDocument();
+    await expect(unkeyed.getByText(/Closed by the next reload/)).toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Reload' }));
 
     // The keyed table re-points its open row at the new object; the unkeyed one drops it.
-    await expect(canvas.getByText(/Still open after 1 reload/)).toBeInTheDocument();
-    await expect(canvas.queryByText(/Closed by the next reload/)).not.toBeInTheDocument();
+    await expect(keyed.getByText(/Still open after 1 reload/)).toBeInTheDocument();
+    await expect(unkeyed.queryByText(/Closed by the next reload/)).not.toBeInTheDocument();
   },
 };
 

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { expect, userEvent, within } from 'storybook/test';
 import { loadHarnessDoc } from '../../.storybook/harness-docs-loader';
+import { TnButtonComponent } from '../lib/button/button.component';
 import { TnCheckboxComponent } from '../lib/checkbox/checkbox.component';
 import { tnIconMarker } from '../lib/icon/icon-marker';
 import { TnIconComponent } from '../lib/icon/icon.component';
@@ -80,6 +81,7 @@ const meta: Meta<TnTableComponent> = {
         TnIconComponent,
         TnIconButtonComponent,
         TnInputComponent,
+        TnButtonComponent,
       ],
     }),
   ],
@@ -366,6 +368,102 @@ export const SelectionAcrossPages: Story = {
     await expect(canvas.getByText('Alice Johnson')).toBeInTheDocument();
     await expect(row(1)).toBeChecked();
     await expect(row(2)).not.toBeChecked();
+  },
+};
+
+export const ExpansionSurvivesReload: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Detail rows are held by object identity, so a background reload — which hands back new objects '
+          + 'for the same rows — collapses them, usually just when their contents are worth watching. '
+          + '`[expansionKey]` keys them instead, so they stay open across the swap. Open a row, hit Reload, '
+          + 'and compare the two tables: the keyed one keeps the row open, the unkeyed one closes it.',
+      },
+    },
+  },
+  render: () => ({
+    props: {
+      tableColumns: ['name', 'email', 'role'],
+      rowKey: (user: User) => user.id,
+      // Two independent copies, so the same Reload button can show both outcomes side by side.
+      keyedData: sampleData.slice(0, 3),
+      unkeyedData: sampleData.slice(0, 3),
+      reloads: 0,
+      reload() {
+        // Exactly what a re-fetch does: same rows, new objects.
+        this['reloads'] = this['reloads'] + 1;
+        this['keyedData'] = this['keyedData'].map((user: User) => ({ ...user }));
+        this['unkeyedData'] = this['unkeyedData'].map((user: User) => ({ ...user }));
+      },
+    },
+    template: `
+      <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 8px;">
+        <tn-button label="Reload" (onClick)="reload()" />
+        <span>Reloads: {{ reloads }}</span>
+      </div>
+
+      <p style="margin: 8px 0 4px;"><strong>With [expansionKey]</strong></p>
+      <tn-table
+        [dataSource]="keyedData"
+        [displayedColumns]="tableColumns"
+        [expandable]="true"
+        [expansionKey]="rowKey">
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="role">
+          <ng-template tnHeaderCellDef>Role</ng-template>
+          <ng-template let-user tnCellDef>{{ user.role }}</ng-template>
+        </ng-container>
+        <ng-template let-user tnDetailRowDef>
+          <div style="padding: 8px 0;">Still open after {{ reloads }} reload(s) — {{ user.email }}</div>
+        </ng-template>
+      </tn-table>
+
+      <p style="margin: 16px 0 4px;"><strong>Without it</strong></p>
+      <tn-table
+        [dataSource]="unkeyedData"
+        [displayedColumns]="tableColumns"
+        [expandable]="true">
+        <ng-container tnColumnDef="name">
+          <ng-template tnHeaderCellDef>Name</ng-template>
+          <ng-template let-user tnCellDef>{{ user.name }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="email">
+          <ng-template tnHeaderCellDef>Email</ng-template>
+          <ng-template let-user tnCellDef>{{ user.email }}</ng-template>
+        </ng-container>
+        <ng-container tnColumnDef="role">
+          <ng-template tnHeaderCellDef>Role</ng-template>
+          <ng-template let-user tnCellDef>{{ user.role }}</ng-template>
+        </ng-container>
+        <ng-template let-user tnDetailRowDef>
+          <div style="padding: 8px 0;">Closed by the next reload — {{ user.email }}</div>
+        </ng-template>
+      </tn-table>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [keyedExpand, unkeyedExpand] = canvas.getAllByLabelText('Expand row');
+
+    await userEvent.click(keyedExpand);
+    await userEvent.click(unkeyedExpand);
+    await expect(canvas.getByText(/Still open after 0 reload/)).toBeInTheDocument();
+    await expect(canvas.getByText(/Closed by the next reload/)).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Reload' }));
+
+    // The keyed table re-points its open row at the new object; the unkeyed one drops it.
+    await expect(canvas.getByText(/Still open after 1 reload/)).toBeInTheDocument();
+    await expect(canvas.queryByText(/Closed by the next reload/)).not.toBeInTheDocument();
   },
 };
 

--- a/projects/truenas-ui/src/stories/table.stories.ts
+++ b/projects/truenas-ui/src/stories/table.stories.ts
@@ -105,6 +105,15 @@ const meta: Meta<TnTableComponent> = {
       control: false,
     },
     expandable: { description: 'Enable click-to-expand detail rows', control: 'boolean' },
+    expansionKey: {
+      description:
+        'Identity function `(row) => key`, bound as a stable member (`[expansionKey]="rowKey"`) since '
+        + 'Angular templates have no arrow functions. Keys open detail rows instead of holding them by object '
+        + 'reference, so a background reload that rebuilt its rows leaves them open rather than collapsing them. '
+        + 'A row that leaves the page is retained and re-opens when it comes back; call `clearExpansion()` when '
+        + 'it is gone for good.',
+      control: false,
+    },
     isRowExpandable: {
       description: 'Optional per-row predicate `(row) => boolean`; rows returning false show no expand control',
       control: false,


### PR DESCRIPTION
## The problem

`tn-table` holds open detail rows by object identity. A consumer that re-fetches gets them collapsed — the store hands back new objects for the same rows, and the data-change effect drops the set. The row closes exactly when its contents are worth watching: a running job's log output, for instance.

## Why now

0.7.5 (#313) made this reachable. Before it, the expansion reset and the selection reset shared one effect, and the selection emit that came with it was a hook consumers could hang a re-open off. Splitting them — so a `selectionKey` swap can't collapse what the user opened — left a table with no selection emitting nothing at all.

webui's `jobs-list` piggybacks on exactly that emit:

```html
(selectionChange)="onTableReset()"
```

and says so in a TEMP comment that ends *"Drop once `tn-table` keys expansion through `trackBy` (or exposes a row-expanded output) instead of row identity."* On 0.7.5 it stopped re-opening its row: 3 specs fail there.

## The fix

`expansionKey`, mirroring `selectionKey` and doing what `expandedRows`' own doc comment has been pointing at (*"uses object identity… A future key-based approach could address this"*).

With a key set, the data-change effect re-points open rows at the objects the new data carries instead of collapsing them. A row the new data lacks is **retained, not dropped**, and re-opens once it is listed again — the table sees one page and can't tell "moved off-screen" from "destroyed", so the consumer owns that call.

Also adds:

- `expandRow(row)` — restore expansion from outside (a `?jobId=` query parameter), honouring `singleExpand` and keeping the retained set in step.
- `clearExpansion()` — writing `expandedRows` directly only touches the visible set, so a retained off-screen row would come back on the next reconcile.

**Opt-in.** Without a key the historical collapse-on-change behaviour is unchanged, so no existing consumer moves.

## Testing

7 new cases covering: no-key collapse still happens; open row survives a rebuild and is re-pointed at the new object; a row that leaves and returns re-opens; a row the user collapsed stays collapsed; taking the key away drops retained rows so giving it back can't resurrect them; `clearExpansion` vs `expandedRows.set` differ on off-screen rows; `expandRow` is idempotent.

Full suite green (4539), lint clean. Storybook argType added.

## Consumer note for the release

`expandedRows` stays a public `WritableSignal`, so this invariant is held by documentation, not by the compiler: **adding `[expansionKey]` to a consumer that writes `expandedRows` directly is a migration, not a drop-in.** `expandedRows.set(new Set())` closes only what is on screen, so a row retained off-screen re-opens on the next reconcile — the `clearExpansion drops rows that are not on screen, expandedRows.set does not` spec pins exactly that difference.

Direct writes should move to `expandRow()`, `toggleRowExpansion()` and `clearExpansion()`, which keep the retained map in step. Narrowing `expandedRows` to `Signal<ReadonlySet<unknown>>` plus an explicit setter would make the compiler hold it, but that is a breaking change and belongs in the next major.

## Follow-up

Once this releases, webui's `jobs-list` can bind `[expansionKey]` and delete its TEMP `onTableReset` dance entirely. That unblocks truenas/webui#14057, which is red only because its 0.7.5 pin surfaces this.
